### PR TITLE
fix(calendar): ensure wellness data visibility on empty days

### DIFF
--- a/server/api/calendar/index.get.ts
+++ b/server/api/calendar/index.get.ts
@@ -354,6 +354,26 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  // Ensure days with only wellness or nutrition data are included
+  const allDates = new Set([...wellnessByDate.keys(), ...nutritionByDate.keys()])
+  for (const dateKey of allDates) {
+    if (!activitiesByDate.has(dateKey)) {
+      const date = new Date(dateKey)
+      activitiesByDate.set(dateKey, [
+        {
+          id: dateKey,
+          title: 'Wellness',
+          date: date.toISOString(),
+          type: 'wellness',
+          source: 'wellness',
+          status: 'completed',
+          nutrition: nutritionByDate.get(dateKey) || null,
+          wellness: wellnessByDate.get(dateKey) || null
+        }
+      ])
+    }
+  }
+
   // Flatten activities array and ensure nutrition and wellness are attached to all activities
   const activities = []
   for (const [dateKey, dateActivities] of activitiesByDate.entries()) {


### PR DESCRIPTION
Resolves #62.

**Changes:**
- Updates logic to ensure wellness data is visible on the Activities calendar even for days that have no completed or planned workouts.
- Ensures the API returns day entries populated with wellness data alone.