### PR TITLE
Fix usability issues with birthdate input widget

### DIFF
--- a/app/components/profile/BasicSettings.vue
+++ b/app/components/profile/BasicSettings.vue
@@ -614,16 +614,24 @@
           </button>
         </div>
         <div v-if="editingField === 'dob'" class="flex gap-2">
-          <UInput
-            :model-value="editValue ? formatUserDate(editValue, timezone, 'yyyy-MM-dd') : ''"
-            type="date"
-            size="sm"
+          <UPopover
+            :popper="{ placement: 'bottom-start' }"
             class="w-full"
-            autofocus
-            @update:model-value="(val) => (editValue = val)"
-            @keyup.enter="saveField"
-            @keyup.esc="cancelEdit"
-          />
+            @keydown.enter="saveField"
+            @keydown.esc="cancelEdit"
+          >
+            <UButton
+              icon="i-heroicons-calendar-days-20-solid"
+              :label="editValue ? formatUserDate(editValue, timezone, 'MMM d, yyyy') : 'Select date'"
+              color="gray"
+              variant="outline"
+              class="w-full"
+              autofocus
+            />
+            <template #panel="{ close }">
+              <DatePicker v-model="editValue" is-required @update:model-value="close" />
+            </template>
+          </UPopover>
           <UButton
             size="xs"
             color="primary"
@@ -640,7 +648,7 @@
           />
         </div>
         <p v-else class="font-medium text-lg">
-          {{ modelValue.dob ? formatDate(modelValue.dob) : 'Not set' }}
+          {{ modelValue.dob ? formatUserDate(modelValue.dob, timezone, 'MMM d, yyyy') : 'Not set' }}
         </p>
       </div>
 
@@ -872,6 +880,8 @@
 </template>
 
 <script setup lang="ts">
+  import { DatePicker } from 'v-calendar'
+  import 'v-calendar/dist/style.css'
   import { countries } from '~/utils/countries'
   const props = defineProps<{
     modelValue: any
@@ -879,7 +889,7 @@
   }>()
 
   const emit = defineEmits(['update:modelValue', 'autodetect'])
-  const { formatDate, formatUserDate, timezone } = useFormat()
+  const { formatUserDate, timezone } = useFormat()
 
   const editingField = ref<string | null>(null)
   const editValue = ref<any>(null)


### PR DESCRIPTION
The current date entry widget for birthdates (UInput type="date") is difficult to use. Users report that it does not accurately record digits entered via the keyboard, and selecting a year from several decades ago using the native picker is cumbersome. This change replaces the native date input with a more user-friendly DatePicker component.

Fixes #133

---
*PR created automatically by Jules for task [4775074737378634818](https://jules.google.com/task/4775074737378634818) started by @hdkiller*