### PR TITLE
Localized currency with profile override

### DIFF
--- a/app/components/PricingPlanCard.vue
+++ b/app/components/PricingPlanCard.vue
@@ -27,7 +27,7 @@
       <h3 :class="compact ? 'text-lg' : 'text-xl'" class="font-bold">{{ plan.name }}</h3>
       <div :class="compact ? 'mt-2' : 'mt-4'" class="flex items-baseline gap-1">
         <span :class="compact ? 'text-2xl' : 'text-4xl'" class="font-extrabold">
-          {{ formatPrice(plan.monthlyPrice) }}
+          {{ formatPriceLocalized(plan.monthlyPrice, currencyContext) }}
         </span>
         <span class="text-sm text-gray-500 dark:text-gray-400"> / month </span>
       </div>
@@ -70,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-  import { formatPrice, type PricingPlan } from '~/utils/pricing'
+  import { formatPriceLocalized, type PricingPlan } from '~/utils/pricing'
 
   interface Props {
     plan: PricingPlan
@@ -90,8 +90,18 @@
   }>()
 
   const userStore = useUserStore()
+  const { data } = useAuth()
   const config = useRuntimeConfig()
   const subscriptionsEnabled = computed(() => config.public.subscriptionsEnabled)
+  const { timezone } = useFormat()
+
+  const currencyContext = computed(() => ({
+    country: userStore.profile?.country,
+    preferredCurrency: userStore.profile?.currencyPreference,
+    profileTimezone: (data.value?.user as any)?.timezone || timezone.value,
+    browserTimezone: import.meta.client ? Intl.DateTimeFormat().resolvedOptions().timeZone : null,
+    locale: import.meta.client ? navigator.language : null
+  }))
 
   const isCurrentPlan = computed(() => {
     const currentTier = userStore.user?.subscriptionTier?.toLowerCase()

--- a/app/pages/profile/settings.vue
+++ b/app/pages/profile/settings.vue
@@ -105,7 +105,8 @@
     city: '',
     state: '',
     country: '',
-    timezone: ''
+    timezone: '',
+    currencyPreference: null
   })
 
   const sportSettings = ref<any[]>([])

--- a/app/plugins/currency.client.ts
+++ b/app/plugins/currency.client.ts
@@ -1,0 +1,12 @@
+import { setCurrencyRates } from '~/utils/currency'
+
+export default defineNuxtPlugin(async () => {
+  try {
+    const data = await $fetch<{ rates: Record<string, number> }>('/api/currency/rates')
+    if (data?.rates) {
+      setCurrencyRates(data.rates)
+    }
+  } catch (error) {
+    console.warn('[CurrencyRates] Failed to load rates on client.', error)
+  }
+})

--- a/app/utils/currency.ts
+++ b/app/utils/currency.ts
@@ -1,0 +1,228 @@
+export interface CurrencyContext {
+  country?: string | null
+  preferredCurrency?: string | null
+  profileTimezone?: string | null
+  browserTimezone?: string | null
+  locale?: string | null
+}
+
+const COUNTRY_ALIASES: Record<string, string> = {
+  'united states': 'US',
+  'united states of america': 'US',
+  usa: 'US',
+  uk: 'GB',
+  'united kingdom': 'GB',
+  england: 'GB',
+  scotland: 'GB',
+  wales: 'GB',
+  'northern ireland': 'GB',
+  russia: 'RU',
+  korea: 'KR',
+  'south korea': 'KR',
+  'republic of korea': 'KR',
+  'north korea': 'KP',
+  'new zealand': 'NZ'
+}
+
+const COUNTRY_TO_CURRENCY: Record<string, string> = {
+  US: 'USD',
+  CA: 'CAD',
+  MX: 'MXN',
+  BR: 'BRL',
+  AR: 'ARS',
+  CL: 'CLP',
+  GB: 'GBP',
+  IE: 'EUR',
+  FR: 'EUR',
+  DE: 'EUR',
+  ES: 'EUR',
+  IT: 'EUR',
+  NL: 'EUR',
+  BE: 'EUR',
+  PT: 'EUR',
+  AT: 'EUR',
+  FI: 'EUR',
+  NO: 'NOK',
+  SE: 'SEK',
+  DK: 'DKK',
+  CH: 'CHF',
+  JP: 'JPY',
+  KR: 'KRW',
+  IN: 'INR',
+  AU: 'AUD',
+  NZ: 'NZD',
+  SG: 'SGD',
+  HK: 'HKD',
+  ZA: 'ZAR'
+}
+
+const CURRENCY_LABELS: Record<string, string> = {
+  USD: 'US Dollar',
+  EUR: 'Euro',
+  GBP: 'British Pound',
+  CAD: 'Canadian Dollar',
+  AUD: 'Australian Dollar',
+  NZD: 'New Zealand Dollar',
+  JPY: 'Japanese Yen',
+  CHF: 'Swiss Franc',
+  SEK: 'Swedish Krona',
+  NOK: 'Norwegian Krone',
+  DKK: 'Danish Krone',
+  INR: 'Indian Rupee',
+  BRL: 'Brazilian Real',
+  MXN: 'Mexican Peso',
+  KRW: 'South Korean Won',
+  SGD: 'Singapore Dollar',
+  HKD: 'Hong Kong Dollar',
+  ZAR: 'South African Rand',
+  ARS: 'Argentine Peso',
+  CLP: 'Chilean Peso'
+}
+
+const DEFAULT_CURRENCY_RATES: Record<string, number> = {
+  USD: 1,
+  EUR: 0.92,
+  GBP: 0.79,
+  CAD: 1.35,
+  AUD: 1.55,
+  NZD: 1.65,
+  JPY: 147,
+  CHF: 0.9,
+  SEK: 10.2,
+  NOK: 10.6,
+  DKK: 6.9,
+  INR: 83,
+  BRL: 4.95,
+  MXN: 17.2,
+  KRW: 1340,
+  SGD: 1.34,
+  HKD: 7.8,
+  ZAR: 18.4,
+  ARS: 1100,
+  CLP: 960
+}
+
+let dynamicRates: Record<string, number> | null = null
+
+const TIMEZONE_HINTS: Array<[string, string]> = [
+  ['Europe/London', 'GBP'],
+  ['Europe/Dublin', 'EUR'],
+  ['Europe/', 'EUR'],
+  ['America/Toronto', 'CAD'],
+  ['America/Vancouver', 'CAD'],
+  ['America/Montreal', 'CAD'],
+  ['America/Edmonton', 'CAD'],
+  ['America/Winnipeg', 'CAD'],
+  ['America/Mexico', 'MXN'],
+  ['America/Sao_Paulo', 'BRL'],
+  ['America/Argentina', 'ARS'],
+  ['America/Santiago', 'CLP'],
+  ['America/', 'USD'],
+  ['Asia/Tokyo', 'JPY'],
+  ['Asia/Seoul', 'KRW'],
+  ['Asia/Kolkata', 'INR'],
+  ['Asia/Singapore', 'SGD'],
+  ['Asia/Hong_Kong', 'HKD'],
+  ['Australia/', 'AUD'],
+  ['Pacific/Auckland', 'NZD'],
+  ['Africa/Johannesburg', 'ZAR']
+]
+
+export const ACCEPTED_CURRENCIES = Object.keys(DEFAULT_CURRENCY_RATES)
+  .sort()
+  .map((code) => ({
+    code,
+    label: `${code} - ${CURRENCY_LABELS[code] || code}`
+  }))
+
+export function setCurrencyRates(rates: Record<string, number>) {
+  dynamicRates = { ...rates }
+}
+
+function getRates(): Record<string, number> {
+  return dynamicRates || DEFAULT_CURRENCY_RATES
+}
+
+function normalizeCountryCode(country?: string | null): string | undefined {
+  if (!country) return undefined
+  const trimmed = country.trim()
+  if (!trimmed) return undefined
+  if (trimmed.length === 2 || trimmed.length === 3) {
+    return trimmed.toUpperCase()
+  }
+  const normalized = trimmed.toLowerCase()
+  return COUNTRY_ALIASES[normalized] || undefined
+}
+
+function resolveCurrencyFromTimezone(timezone?: string | null): string | undefined {
+  if (!timezone) return undefined
+  const normalized = timezone.trim()
+  for (const [hint, currency] of TIMEZONE_HINTS) {
+    if (normalized.startsWith(hint)) return currency
+  }
+  return undefined
+}
+
+function resolveCountryFromLocale(locale?: string | null): string | undefined {
+  if (!locale) return undefined
+  const normalized = locale.trim()
+  if (!normalized) return undefined
+  const parts = normalized.split(/[-_]/)
+  const region = parts[parts.length - 1]
+  if (region && region.length === 2) return region.toUpperCase()
+  return undefined
+}
+
+function getDefaultLocale(): string {
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language
+  }
+  return 'en-US'
+}
+
+export function resolveCurrencyContext(context: CurrencyContext) {
+  const countryCode = normalizeCountryCode(context.country)
+  const preferredCurrency = context.preferredCurrency
+    ? context.preferredCurrency.trim().toUpperCase()
+    : undefined
+  const rates = getRates()
+  const hasPreferred = preferredCurrency && rates[preferredCurrency]
+  const currencyFromCountry = countryCode ? COUNTRY_TO_CURRENCY[countryCode] : undefined
+  const currencyFromProfileTz = resolveCurrencyFromTimezone(context.profileTimezone)
+  const currencyFromBrowserTz = resolveCurrencyFromTimezone(context.browserTimezone)
+  const localeCountry = resolveCountryFromLocale(context.locale)
+  const currencyFromLocale = localeCountry ? COUNTRY_TO_CURRENCY[localeCountry] : undefined
+  const currency =
+    (hasPreferred ? preferredCurrency : undefined) ||
+    currencyFromCountry ||
+    currencyFromProfileTz ||
+    currencyFromBrowserTz ||
+    currencyFromLocale ||
+    'USD'
+  const rate = rates[currency] || 1
+  const locale = context.locale || getDefaultLocale()
+
+  return {
+    currency,
+    rate,
+    locale,
+    countryCode
+  }
+}
+
+export function getCurrencyLabel(currency: string): string {
+  return CURRENCY_LABELS[currency] || currency
+}
+
+export function formatCurrencyFromUsd(amountUsd: number, context: CurrencyContext): string {
+  const { currency, rate, locale } = resolveCurrencyContext(context)
+  const converted = amountUsd * rate
+  const fractionDigits = converted % 1 === 0 ? 0 : 2
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits
+  }).format(converted)
+}

--- a/app/utils/pricing.ts
+++ b/app/utils/pricing.ts
@@ -1,3 +1,5 @@
+import { formatCurrencyFromUsd, type CurrencyContext } from '~/utils/currency'
+
 export type BillingInterval = 'monthly' | 'annual'
 export type PricingTier = 'free' | 'supporter' | 'pro'
 
@@ -82,6 +84,13 @@ export function formatPrice(price: number): string {
     currency: 'USD',
     minimumFractionDigits: price % 1 === 0 ? 0 : 2
   }).format(price)
+}
+
+/**
+ * Format price using a localized currency context.
+ */
+export function formatPriceLocalized(price: number, context: CurrencyContext): string {
+  return formatCurrencyFromUsd(price, context)
 }
 
 /**

--- a/prisma/migrations/20260208120500_add_currency_preference/migration.sql
+++ b/prisma/migrations/20260208120500_add_currency_preference/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "currencyPreference" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   nickname                           String?
   nutritionTrackingEnabled           Boolean                      @default(true)
   recoverySensitivity                String?                      @default("MEDIUM")
+  currencyPreference                 String?
   lastLoginAt                        DateTime?
   lastLoginIp                        String?
   stripeCustomerId                   String?                      @unique

--- a/server/api/currency/rates.get.ts
+++ b/server/api/currency/rates.get.ts
@@ -1,0 +1,5 @@
+import { getCurrencyRates } from '../../utils/currencyRates'
+
+export default defineEventHandler(() => {
+  return getCurrencyRates()
+})

--- a/server/api/profile/dashboard.get.ts
+++ b/server/api/profile/dashboard.get.ts
@@ -23,6 +23,7 @@ export default defineEventHandler(async (event) => {
         id: true,
         name: true,
         country: true,
+        currencyPreference: true,
         ftp: true,
         weight: true,
         maxHr: true,
@@ -249,6 +250,7 @@ export default defineEventHandler(async (event) => {
       profile: {
         name: user.name,
         country: user.country,
+        currencyPreference: user.currencyPreference,
         age: age,
         weight: recentWeight,
         ftp: effectiveFtp,

--- a/server/api/profile/index.get.ts
+++ b/server/api/profile/index.get.ts
@@ -77,7 +77,8 @@ export default defineEventHandler(async (event) => {
         city: true,
         state: true,
         country: true,
-        timezone: true
+        timezone: true,
+        currencyPreference: true
       }
     })
 
@@ -123,6 +124,7 @@ export default defineEventHandler(async (event) => {
         state: user.state,
         country: user.country,
         timezone: user.timezone,
+        currencyPreference: user.currencyPreference,
         sportSettings: sportSettings
       }
     }

--- a/server/plugins/currency-rates.ts
+++ b/server/plugins/currency-rates.ts
@@ -1,0 +1,5 @@
+import { refreshCurrencyRates } from '../utils/currencyRates'
+
+export default defineNitroPlugin(async () => {
+  await refreshCurrencyRates()
+})

--- a/server/utils/currencyRates.ts
+++ b/server/utils/currencyRates.ts
@@ -1,0 +1,89 @@
+const SUPPORTED_CURRENCIES = [
+  'USD',
+  'EUR',
+  'GBP',
+  'CAD',
+  'AUD',
+  'NZD',
+  'JPY',
+  'CHF',
+  'SEK',
+  'NOK',
+  'DKK',
+  'INR',
+  'BRL',
+  'MXN',
+  'KRW',
+  'SGD',
+  'HKD',
+  'ZAR',
+  'ARS',
+  'CLP'
+]
+
+const FALLBACK_RATES: Record<string, number> = {
+  USD: 1,
+  EUR: 0.92,
+  GBP: 0.79,
+  CAD: 1.35,
+  AUD: 1.55,
+  NZD: 1.65,
+  JPY: 147,
+  CHF: 0.9,
+  SEK: 10.2,
+  NOK: 10.6,
+  DKK: 6.9,
+  INR: 83,
+  BRL: 4.95,
+  MXN: 17.2,
+  KRW: 1340,
+  SGD: 1.34,
+  HKD: 7.8,
+  ZAR: 18.4,
+  ARS: 1100,
+  CLP: 960
+}
+
+let cachedRates: Record<string, number> = { ...FALLBACK_RATES }
+let lastUpdated: string | null = null
+let source = 'fallback'
+
+interface FrankfurterResponse {
+  amount: number
+  base: string
+  date: string
+  rates: Record<string, number>
+}
+
+export async function refreshCurrencyRates() {
+  try {
+    const response = await fetch('https://api.frankfurter.app/latest?from=USD')
+    if (!response.ok) {
+      throw new Error(`Frankfurter responded with ${response.status}`)
+    }
+    const data = (await response.json()) as FrankfurterResponse
+    const nextRates: Record<string, number> = { USD: 1 }
+
+    for (const code of SUPPORTED_CURRENCIES) {
+      if (code === 'USD') continue
+      const rate = data.rates?.[code]
+      if (typeof rate === 'number') {
+        nextRates[code] = rate
+      }
+    }
+
+    cachedRates = { ...FALLBACK_RATES, ...nextRates }
+    lastUpdated = data.date || new Date().toISOString().slice(0, 10)
+    source = 'frankfurter'
+  } catch (error) {
+    console.warn('[CurrencyRates] Failed to refresh rates, using fallback.', error)
+  }
+}
+
+export function getCurrencyRates() {
+  return {
+    rates: cachedRates,
+    lastUpdated,
+    source
+  }
+}

--- a/server/utils/schemas/profile.ts
+++ b/server/utils/schemas/profile.ts
@@ -22,6 +22,7 @@ export const profileUpdateSchema = z.object({
   state: z.string().nullable().optional(),
   country: z.string().nullable().optional(),
   timezone: z.string().nullable().optional(),
+  currencyPreference: z.string().nullable().optional(),
 
   // AI Context
   aiContext: z.string().nullable().optional(),


### PR DESCRIPTION
## Benefits
- Shows pricing in a region-appropriate currency, improving clarity and conversion for non-USD users.
- Lets users override currency explicitly, which avoids confusing locale heuristics.
- Refreshes FX rates on app restart without requiring API keys.

## Architecture
- A server-side rates cache pulls USD-based rates from Frankfurter on startup (Nitro plugin) and exposes them via an internal API.
- The client loads rates once on boot and stores them in memory for formatting.
- Currency resolution order is: profile country -> profile timezone -> browser timezone -> browser language. A profile override short-circuits all heuristics.
- Pricing formatters read from a shared currency utility with fallback static rates if the refresh fails.

## Code Changes
- Currency resolution, labels, accepted list, and dynamic rate injection in [app/utils/currency.ts](app/utils/currency.ts).
- New startup fetch + API endpoint for Frankfurter rates in [server/plugins/currency-rates.ts](server/plugins/currency-rates.ts) and [server/api/currency/rates.get.ts](server/api/currency/rates.get.ts).
- Client bootstrap for rates in [app/plugins/currency.client.ts](app/plugins/currency.client.ts).
- Profile settings UI adds currency display + override selector in [app/components/profile/BasicSettings.vue](app/components/profile/BasicSettings.vue).
- Profile API and schema updates to persist with migration [prisma/migrations/20260208120500_add_currency_preference/migration.sql](prisma/migrations/20260208120500_add_currency_preference/migration.sql).
- Pricing components now use localized formatting in [app/components/landing/PricingPlans.vue](app/components/landing/PricingPlanCard.vue).

## Notes
- If Frankfurter is down, the app falls back to static rates.
