### PR TITLE
 Fix fueling plan timezone handling (planned workout start times)

### DIFF
--- a/app/utils/nutrition-timeline.ts
+++ b/app/utils/nutrition-timeline.ts
@@ -51,7 +51,7 @@ function getWorkoutDate(workout: any): number {
     if (typeof workout.startTime === 'string' && workout.startTime.includes(':')) {
       const [h, m] = workout.startTime.split(':').map(Number)
       const d = new Date(workout.date)
-      d.setUTCHours(h || 0, m || 0, 0, 0)
+      d.setHours(h || 0, m || 0, 0, 0)
       return d.getTime()
     }
     // If it's already a full date
@@ -59,7 +59,7 @@ function getWorkoutDate(workout: any): number {
   }
   // Default to 10am UTC for consistency with calculator
   const d = new Date(workout.date)
-  d.setUTCHours(10, 0, 0, 0)
+  d.setHours(10, 0, 0, 0)
   return d.getTime()
 }
 

--- a/server/api/calendar/index.get.ts
+++ b/server/api/calendar/index.get.ts
@@ -4,7 +4,8 @@ import {
   getUserLocalDate,
   getUserTimezone,
   getStartOfDayUTC,
-  getEndOfDayUTC
+  getEndOfDayUTC,
+  buildZonedDateTimeFromUtcDate
 } from '../../utils/date'
 import { nutritionRepository } from '../../utils/repositories/nutritionRepository'
 import { wellnessRepository } from '../../utils/repositories/wellnessRepository'
@@ -261,9 +262,13 @@ export default defineEventHandler(async (event) => {
           typeof primaryWorkout.startTime === 'string' &&
           primaryWorkout.startTime.includes(':')
         ) {
-          const [h, m] = primaryWorkout.startTime.split(':').map(Number)
-          startTimeDate = new Date(primaryWorkout.date)
-          startTimeDate.setUTCHours(h || 10, m || 0, 0, 0)
+          startTimeDate = buildZonedDateTimeFromUtcDate(
+            primaryWorkout.date,
+            primaryWorkout.startTime,
+            timezone,
+            10,
+            0
+          )
         }
 
         const estimate = calculateFuelingStrategy(profile, {

--- a/server/api/nutrition/[id].get.ts
+++ b/server/api/nutrition/[id].get.ts
@@ -4,6 +4,7 @@ import { nutritionRepository } from '../../utils/repositories/nutritionRepositor
 import { getUserNutritionSettings } from '../../utils/nutrition/settings'
 import { calculateFuelingStrategy } from '../../utils/nutrition/fueling'
 import { plannedWorkoutRepository } from '../../utils/repositories/plannedWorkoutRepository'
+import { buildZonedDateTimeFromUtcDate, getUserTimezone } from '../../utils/date'
 
 defineRouteMeta({
   openAPI: {
@@ -99,15 +100,20 @@ export default defineEventHandler(async (event) => {
         const settings = await getUserNutritionSettings(userId)
 
         // Convert HH:mm string to a Date object relative to the workout date
+        const timezone = await getUserTimezone(userId)
         let startTimeDate: Date | null = null
         if (
           workout.startTime &&
           typeof workout.startTime === 'string' &&
           workout.startTime.includes(':')
         ) {
-          const [h, m] = workout.startTime.split(':').map(Number)
-          startTimeDate = new Date(workout.date)
-          startTimeDate.setUTCHours(h || 10, m || 0, 0, 0)
+          startTimeDate = buildZonedDateTimeFromUtcDate(
+            workout.date,
+            workout.startTime,
+            timezone,
+            10,
+            0
+          )
         }
 
         const estimate = calculateFuelingStrategy(

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -128,6 +128,38 @@ export function formatDateUTC(date: Date, formatStr: string = 'yyyy-MM-dd'): str
 }
 
 /**
+ * Build a UTC Date from a stored UTC-midnight date and a local HH:mm time.
+ * This preserves the user's intended local clock time across timezones.
+ */
+export function buildZonedDateTimeFromUtcDate(
+  date: Date,
+  time: string | null | undefined,
+  timezone: string,
+  fallbackHour: number = 10,
+  fallbackMinute: number = 0
+): Date {
+  let hour = fallbackHour
+  let minute = fallbackMinute
+
+  if (time && time.includes(':')) {
+    const [h, m] = time.split(':').map(Number)
+    if (Number.isFinite(h)) hour = h
+    if (Number.isFinite(m)) minute = m
+  }
+
+  const dateStr = formatDateUTC(date, 'yyyy-MM-dd')
+  const hh = String(hour).padStart(2, '0')
+  const mm = String(minute).padStart(2, '0')
+  const localDate = new Date(`${dateStr}T${hh}:${mm}:00`)
+
+  try {
+    return fromZonedTime(localDate, timezone)
+  } catch (e) {
+    return localDate
+  }
+}
+
+/**
  * Get the user's current local date as a Date object set to UTC midnight.
  * This is useful for querying Prisma @db.Date columns.
  */


### PR DESCRIPTION
## Summary
This PR fixes a timezone offset bug that caused the fueling timeline to show the workout starting later than scheduled (e.g., a 12:30 workout rendering as 21:00 in AEDT). The root issue was converting planned workout `startTime` (stored as `HH:mm`) to UTC without respecting the user’s timezone when building fueling plan windows.

## What changed
- Added a timezone-aware helper to construct UTC timestamps from a date-only value + local `HH:mm` time.
- Updated fueling plan generation to use the user’s timezone when building workout start times.
- Updated calendar/nutrition estimate paths so generated or estimated plans align with local time.

## Why this fixes it
Planned workouts store a local `HH:mm` time alongside a date-only field. Previously, the code used `setUTCHours` which treated `HH:mm` as UTC. That shifted local times forward by the user’s timezone offset when the UI rendered them. The new helper builds a local datetime in the user’s timezone and converts it to the correct UTC instant before storing it in the fueling plan, so the UI shows the correct local start time.

## Files touched
- `server/utils/date.ts`: added `buildZonedDateTimeFromUtcDate`.
- `trigger/generate-fueling-plan.ts`: use timezone-aware start time conversion.
- `server/api/nutrition/[id].get.ts`: use timezone-aware conversion for estimates.
- `server/api/calendar/index.get.ts`: use timezone-aware conversion for calendar estimates.

## Testing
- Manual: regenerated fueling plan for 2026-02-11 in AEDT (Australia/Melbourne). Timeline now shows the correct workout start time (12:30 local) instead of 21:00.

## Notes
- Existing plans generated with the old logic will still have shifted timestamps; regenerate those plans to correct them.