### PR TITLE
fix: handle non-numeric Intervals event IDs for planned workout sync

### DIFF
--- a/server/api/planned-workouts/[id].patch.ts
+++ b/server/api/planned-workouts/[id].patch.ts
@@ -1,5 +1,6 @@
 import { getServerSession } from '../../utils/session'
 import { syncPlannedWorkoutToIntervals } from '../../utils/intervals-sync'
+import { isIntervalsEventId } from '../../utils/intervals'
 import { plannedWorkoutRepository } from '../../utils/repositories/plannedWorkoutRepository'
 import { metabolicService } from '../../utils/services/metabolicService'
 import { getUserLocalDate, getUserTimezone } from '../../utils/date'
@@ -133,11 +134,7 @@ export default defineEventHandler(async (event) => {
     }
 
     // Determine if it's a local-only workout that needs CREATE instead of UPDATE
-    const isLocal =
-      existing.syncStatus === 'LOCAL_ONLY' ||
-      existing.externalId.startsWith('ai_gen_') ||
-      existing.externalId.startsWith('ai-gen-') ||
-      existing.externalId.startsWith('adhoc-')
+    const isLocal = existing.syncStatus === 'LOCAL_ONLY' || !isIntervalsEventId(existing.externalId)
 
     let finalWorkout = updated
 

--- a/server/api/recommendations/[id]/accept.post.ts
+++ b/server/api/recommendations/[id]/accept.post.ts
@@ -2,6 +2,7 @@ import { getServerSession } from '../../../utils/session'
 import { prisma } from '../../../utils/db'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { syncPlannedWorkoutToIntervals } from '../../../utils/intervals-sync'
+import { isIntervalsEventId } from '../../../utils/intervals'
 
 defineRouteMeta({
   openAPI: {
@@ -147,10 +148,7 @@ export default defineEventHandler(async (event) => {
 
   // Sync to Intervals.icu if it's already published (not local-only)
   const isLocal =
-    updatedWorkout.syncStatus === 'LOCAL_ONLY' ||
-    updatedWorkout.externalId.startsWith('ai_gen_') ||
-    updatedWorkout.externalId.startsWith('ai-gen-') ||
-    updatedWorkout.externalId.startsWith('adhoc-')
+    updatedWorkout.syncStatus === 'LOCAL_ONLY' || !isIntervalsEventId(updatedWorkout.externalId)
 
   if (!isLocal) {
     await syncPlannedWorkoutToIntervals(

--- a/server/api/workouts/planned/[id]/publish.post.ts
+++ b/server/api/workouts/planned/[id]/publish.post.ts
@@ -2,7 +2,8 @@ import { prisma } from '../../../../utils/db'
 import {
   createIntervalsPlannedWorkout,
   updateIntervalsPlannedWorkout,
-  cleanIntervalsDescription
+  cleanIntervalsDescription,
+  isIntervalsEventId
 } from '../../../../utils/intervals'
 import { WorkoutConverter } from '../../../../utils/workout-converter'
 import { getServerSession } from '../../../../utils/session'
@@ -51,11 +52,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Check if already published/synced
-  const isLocal =
-    workout.syncStatus === 'LOCAL_ONLY' ||
-    workout.externalId.startsWith('ai_gen_') ||
-    workout.externalId.startsWith('ai-gen-') ||
-    workout.externalId.startsWith('adhoc-')
+  const isLocal = workout.syncStatus === 'LOCAL_ONLY' || !isIntervalsEventId(workout.externalId)
 
   // Fetch sport settings to check preferences
   const sportSettings = await sportSettingsRepository.getForActivityType(userId, intervalsType)

--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -8,7 +8,8 @@ import { WorkoutConverter } from '../../utils/workout-converter'
 import {
   cleanIntervalsDescription,
   createIntervalsPlannedWorkout,
-  updateIntervalsPlannedWorkout
+  updateIntervalsPlannedWorkout,
+  isIntervalsEventId
 } from '../../utils/intervals'
 import { tags } from '@trigger.dev/sdk/v3'
 import { plannedWorkoutRepository } from '../repositories/plannedWorkoutRepository'
@@ -365,11 +366,7 @@ export const planningTools = (userId: string, timezone: string) => ({
 
       if (!integration) return { error: 'Intervals.icu integration not found' }
 
-      const isLocal =
-        workout.syncStatus === 'LOCAL_ONLY' ||
-        workout.externalId.startsWith('ai_gen_') ||
-        workout.externalId.startsWith('ai-gen-') ||
-        workout.externalId.startsWith('adhoc-')
+      const isLocal = workout.syncStatus === 'LOCAL_ONLY' || !isIntervalsEventId(workout.externalId)
 
       // Fetch sport settings to check preferences
       const sportSettings = await sportSettingsRepository.getForActivityType(

--- a/server/utils/intervals.ts
+++ b/server/utils/intervals.ts
@@ -23,6 +23,10 @@ function getIntervalsAthleteId(integration: Integration): string {
   return integration.externalUserId || 'i0'
 }
 
+export function isIntervalsEventId(eventId: string | null | undefined): eventId is string {
+  return typeof eventId === 'string' && /^\d+$/.test(eventId.trim())
+}
+
 interface IntervalsActivity {
   id: string
   start_date: string // UTC timestamp
@@ -341,6 +345,10 @@ export async function deleteIntervalsPlannedWorkout(
   integration: Integration,
   eventId: string
 ): Promise<void> {
+  if (!isIntervalsEventId(eventId)) {
+    throw new Error(`Invalid Intervals event ID: ${eventId}`)
+  }
+
   const athleteId = getIntervalsAthleteId(integration)
 
   const url = `https://intervals.icu/api/v1/athlete/${athleteId}/events/${eventId}`
@@ -372,6 +380,10 @@ export async function updateIntervalsPlannedWorkout(
     startTime?: string | null
   }
 ): Promise<IntervalsPlannedWorkout> {
+  if (!isIntervalsEventId(eventId)) {
+    throw new Error(`Invalid Intervals event ID: ${eventId}`)
+  }
+
   const athleteId = getIntervalsAthleteId(integration)
 
   // Map workout types to Intervals.icu format


### PR DESCRIPTION
## Summary
- add shared Intervals event-id validator and enforce numeric event IDs for update/delete calls
- treat any non-numeric externalId as local-only in publish/update sync flows
- harden sync queue processing to fail invalid UPDATE/DELETE items early instead of retrying 422s

## Why
Intervals API requires eventId path param to be an integer. Some local IDs (for example plan_* values) were routed to UPDATE and caused HTTP 422.

## Validation
- linted changed files with eslint
- checked editor diagnostics for changed files

Fixes #172