### PR TITLE
fix(nutrition): clarify synthetic meal labels in horizon - bad wording

### DIFF
--- a/app/components/nutrition/MultiDayEnergyChart.vue
+++ b/app/components/nutrition/MultiDayEnergyChart.vue
@@ -329,7 +329,9 @@
               if (p.eventType === 'workout') {
                 lines.push(`Workout: ${p.event || 'Planned Activity'}`)
               } else if (p.eventType === 'meal') {
-                lines.push(`Event: ${p.event || 'Food Logged'}`)
+                const mealLabel =
+                  p.event || (p.dataType === 'future' ? 'Planned Meal' : 'Food Logged')
+                lines.push(`Event: ${mealLabel}`)
                 if (p.eventCarbs) lines.push(`Carbs: ${p.eventCarbs}g`)
               }
 

--- a/server/utils/nutrition-domain/metabolic-simulation.ts
+++ b/server/utils/nutrition-domain/metabolic-simulation.ts
@@ -473,7 +473,11 @@ export function calculateEnergyTimeline(
     const activeWorkout = workoutEvents.find((w) => currentTime >= w.start && currentTime < w.end)
     const hasEvents = intervalEvents.length > 0
     const primaryType = intervalEvents.find((e) => e.type === 'workout') ? 'workout' : 'meal'
-    const combinedName = intervalEvents.map((e) => e.name).join(' + ')
+    const eventNames = intervalEvents
+      .map((e) => (typeof e.name === 'string' ? e.name.trim() : ''))
+      .filter((name) => name.length > 0)
+    const combinedName =
+      eventNames.join(' + ') || (primaryType === 'meal' ? 'Planned Meal' : 'Planned Workout')
     const totalEventCarbs = intervalEvents.reduce((sum, e) => sum + (e.carbs || 0), 0)
     const totalEventFluid = intervalEvents.reduce((sum, e) => sum + (e.fluid || 0), 0)
 

--- a/server/utils/nutrition-domain/synthetic-intake.ts
+++ b/server/utils/nutrition-domain/synthetic-intake.ts
@@ -31,8 +31,20 @@ export function synthesizeRefills(
 
   for (const window of plan.windows) {
     if (window.targetCarbs > 0) {
+      const windowName =
+        window.type === 'PRE_WORKOUT'
+          ? 'Pre-Workout'
+          : window.type === 'INTRA_WORKOUT'
+            ? 'Intra-Workout'
+            : window.type === 'POST_WORKOUT'
+              ? 'Post-Workout'
+              : window.type === 'TRANSITION'
+                ? 'Transition'
+                : 'Meal'
+
       syntheticMeals.push({
         time: new Date(window.startTime),
+        name: `Synthetic ${windowName}`,
         totalCarbs: window.targetCarbs,
         totalKcal: window.targetCarbs * 4,
         profile:
@@ -57,6 +69,7 @@ export function synthesizeRefills(
     for (const p of pattern) {
       syntheticMeals.push({
         time: buildZonedDateTimeFromUtcDate(date, p.time, timezone),
+        name: `Synthetic ${p.name}`,
         totalCarbs: carbPerMeal,
         totalKcal: carbPerMeal * 4,
         profile: ABSORPTION_PROFILES.BALANCED,


### PR DESCRIPTION
The dotted line and future markers are projection mode; the confusing part was label fallback. Some synthetic meals had no name, so tooltip defaulted to “Food Logged.”

- synthetic-intake.ts: synthetic meals now always get explicit names (Synthetic Breakfast, Synthetic Pre-Workout, etc.).
- metabolic-simulation.ts: empty event names now default to Planned Meal/Planned Workout.
- MultiDayEnergyChart.vue: tooltip fallback uses Planned Meal for future points (instead of Food Logged).
- So conceptually: future “meal events” are expected; the wording was the bug.