### PR TITLE
fix(api): JSON streaming limit crash

### DIFF
--- a/server/api/profile/export.get.ts
+++ b/server/api/profile/export.get.ts
@@ -1,12 +1,86 @@
+import { Readable } from 'node:stream'
+
 import { requireAuth } from '../../utils/auth-guard'
 import { prisma } from '../../utils/db'
 import { UserUniverseCollector } from '../../utils/data-management/collector'
 
+function* serializeJsonChunks(value: unknown): Generator<string> {
+  if (value === null || typeof value !== 'object') {
+    yield JSON.stringify(value)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    yield '['
+
+    for (const [index, item] of value.entries()) {
+      if (index > 0) {
+        yield ','
+      }
+
+      yield* serializeJsonChunks(item)
+    }
+
+    yield ']'
+    return
+  }
+
+  if (typeof (value as { toJSON?: () => unknown }).toJSON === 'function') {
+    yield* serializeJsonChunks((value as { toJSON: () => unknown }).toJSON())
+    return
+  }
+
+  yield '{'
+
+  let isFirstProperty = true
+
+  for (const [key, propertyValue] of Object.entries(value)) {
+    if (propertyValue === undefined || typeof propertyValue === 'function') {
+      continue
+    }
+
+    if (!isFirstProperty) {
+      yield ','
+    }
+
+    isFirstProperty = false
+    yield JSON.stringify(key)
+    yield ':'
+    yield* serializeJsonChunks(propertyValue)
+  }
+
+  yield '}'
+}
+
+async function* createExportJsonStream(userId: string) {
+  const collector = new UserUniverseCollector(prisma, userId)
+
+  yield '{'
+  yield '"metadata":'
+  yield* serializeJsonChunks({
+    userId,
+    exportedAt: new Date().toISOString(),
+    version: '1.0.0'
+  })
+  yield ',"profile":'
+  yield* serializeJsonChunks(await collector.collectProfile())
+  yield ',"plans":'
+  yield* serializeJsonChunks(await collector.collectPlans())
+  yield ',"activities":'
+  yield* serializeJsonChunks(await collector.collectActivities())
+  yield ',"health":'
+  yield* serializeJsonChunks(await collector.collectHealth())
+  yield ',"nutrition":'
+  yield* serializeJsonChunks(await collector.collectNutrition())
+  yield ',"ai":'
+  yield* serializeJsonChunks(await collector.collectAI())
+  yield ',"system":'
+  yield* serializeJsonChunks(await collector.collectSystem())
+  yield '}'
+}
+
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event)
-
-  const collector = new UserUniverseCollector(prisma, user.id)
-  const bundle = await collector.bundle()
 
   // Set headers for file download
   const filename = `watts_export_${user.email.replace(/[@.]/g, '_')}_${new Date().toISOString().split('T')[0]}.json`
@@ -19,5 +93,5 @@ export default defineEventHandler(async (event) => {
     Expires: '0'
   })
 
-  return bundle
+  return sendStream(event, Readable.from(createExportJsonStream(user.id)))
 })

--- a/tests/unit/server/api/profile/export.get.test.ts
+++ b/tests/unit/server/api/profile/export.get.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setHeadersMock = vi.fn()
+const sendStreamMock = vi.fn((_event: any, stream: any) => stream)
+const requireAuthMock = vi.fn()
+const collectProfileMock = vi.fn()
+const collectPlansMock = vi.fn()
+const collectActivitiesMock = vi.fn()
+const collectHealthMock = vi.fn()
+const collectNutritionMock = vi.fn()
+const collectAIMock = vi.fn()
+const collectSystemMock = vi.fn()
+const collectorConstructorMock = vi.fn()
+const prismaMock = {}
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('setHeaders', setHeadersMock)
+vi.stubGlobal('sendStream', sendStreamMock)
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: requireAuthMock
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: prismaMock
+}))
+
+vi.mock('../../../../../server/utils/data-management/collector', () => ({
+  UserUniverseCollector: vi.fn().mockImplementation((prisma: unknown, userId: string) => {
+    collectorConstructorMock(prisma, userId)
+
+    return {
+      collectProfile: collectProfileMock,
+      collectPlans: collectPlansMock,
+      collectActivities: collectActivitiesMock,
+      collectHealth: collectHealthMock,
+      collectNutrition: collectNutritionMock,
+      collectAI: collectAIMock,
+      collectSystem: collectSystemMock
+    }
+  })
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/profile/export.get')
+  return mod.default
+}
+
+async function readStream(stream: AsyncIterable<unknown>) {
+  let output = ''
+
+  for await (const chunk of stream) {
+    output += typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString('utf8')
+  }
+
+  return output
+}
+
+describe('GET /api/profile/export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('streams a JSON export bundle with download headers', async () => {
+    const handler = await getHandler()
+
+    requireAuthMock.mockResolvedValue({
+      id: 'user-1',
+      email: 'athlete@example.com'
+    })
+    collectProfileMock.mockResolvedValue({ email: 'athlete@example.com', name: 'Athlete' })
+    collectPlansMock.mockResolvedValue({ goals: [{ id: 'goal-1' }] })
+    collectActivitiesMock.mockResolvedValue({ workouts: [{ id: 'workout-1', title: 'Long Ride' }] })
+    collectHealthMock.mockResolvedValue({ wellness: [{ id: 'wellness-1' }] })
+    collectNutritionMock.mockResolvedValue({ nutritionPlans: [{ id: 'plan-1' }] })
+    collectAIMock.mockResolvedValue({ rooms: [{ id: 'room-1', messages: [{ id: 'message-1' }] }] })
+    collectSystemMock.mockResolvedValue({ integrations: [{ id: 'integration-1' }] })
+
+    const event = {}
+    const stream = await handler(event as any)
+    const payload = JSON.parse(await readStream(stream))
+
+    expect(collectorConstructorMock).toHaveBeenCalledWith(prismaMock, 'user-1')
+    expect(sendStreamMock).toHaveBeenCalledWith(event, expect.anything())
+    expect(setHeadersMock).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({
+        'Content-Type': 'application/json',
+        'Content-Disposition': expect.stringContaining('watts_export_athlete_example_com_'),
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        Pragma: 'no-cache',
+        Expires: '0'
+      })
+    )
+    expect(payload).toMatchObject({
+      metadata: {
+        userId: 'user-1',
+        version: '1.0.0'
+      },
+      profile: {
+        email: 'athlete@example.com',
+        name: 'Athlete'
+      },
+      plans: {
+        goals: [{ id: 'goal-1' }]
+      },
+      activities: {
+        workouts: [{ id: 'workout-1', title: 'Long Ride' }]
+      },
+      health: {
+        wellness: [{ id: 'wellness-1' }]
+      },
+      nutrition: {
+        nutritionPlans: [{ id: 'plan-1' }]
+      },
+      ai: {
+        rooms: [{ id: 'room-1', messages: [{ id: 'message-1' }] }]
+      },
+      system: {
+        integrations: [{ id: 'integration-1' }]
+      }
+    })
+    expect(payload.metadata.exportedAt).toEqual(expect.any(String))
+  })
+})


### PR DESCRIPTION
JSON Export crash:

```ERROR  [request error] [unhandled] [GET] http://localhost:3099/api/profile/export


ℹ Error: Invalid string length

 ⁃ at handleHandlerResponse (node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2116:29)
 ⁃ (node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2012:15)
 ⁃ at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
 ⁃ at async Object.callAsync (node_modules/.pnpm/unctx@2.5.0/node_modules/unctx/dist/index.mjs:72:16)
 ⁃ (async file://.nuxt/dev/sentry.server.config.mjs:48853:18)
 ⁃ at async Object.callAsync (node_modules/.pnpm/unctx@2.5.0/node_modules/unctx/dist/index.mjs:72:16)
 ⁃ at async Server.toNodeHandle (node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2296:7)

[CAUSE]
RangeError {
  stack: 'Invalid string length\n' +
  'at handleHandlerResponse (./node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2116:29)\n' +
  'at ./node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2012:15)\n' +
  '    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n' +
  'at async Object.callAsync (./node_modules/.pnpm/unctx@2.5.0/node_modules/unctx/dist/index.mjs:72:16)\n' +
  'at async file://./.nuxt/dev/sentry.server.config.mjs:48853:18)\n' +
  'at async Object.callAsync (./node_modules/.pnpm/unctx@2.5.0/node_modules/unctx/dist/index.mjs:72:16)\n' +
  'at async Server.toNodeHandle (./node_modules/.pnpm/h3@1.15.4/node_modules/h3/dist/index.mjs:2296:7)',
  message: 'Invalid string length',

}

```
The failure was caused by the export route returning one very large object, which let h3 try to stringify the entire payload in-memory. 

I changed server/api/profile/export.get.ts to stream the JSON export section by section instead. The response shape and download headers stay the same, but the handler no longer builds one giant response string, which removes the Invalid string length failure path.

I also added a regression test in tests/unit/server/api/profile/export.get.test.ts that verifies the route streams valid JSON and still sets the attachment headers. Validation passed with the focused test run: pnpm vitest run tests/unit/server/api/profile/export.get.test.ts.