### PR TITLE
feat(intervals): replace OAuth provider with API-key integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,12 @@ NUXT_PUBLIC_STRAVA_ENABLED=true
 WHOOP_CLIENT_ID="your-whoop-client-id"
 WHOOP_CLIENT_SECRET="your-whoop-client-secret"
 
-INTERVALS_CLIENT_ID="your-intervals-client-id"
-INTERVALS_CLIENT_SECRET="your-intervals-client-secret"
 INTERVALS_WEBHOOK_SECRET="your-intervals-webhook-secret"
+# Optional bootstrap credentials: if both are set and the database holds a single
+# user with no Intervals integration, a startup plugin seeds the Integration row.
+# Intended for self-hosted single-user deploys. Find both at intervals.icu/settings.
+INTERVALS_API_KEY=""
+INTERVALS_ATHLETE_ID=""
 
 WITHINGS_CLIENT_ID=""
 WITHINGS_CLIENT_SECRET=""

--- a/app/components/dashboard/OnboardingView.vue
+++ b/app/components/dashboard/OnboardingView.vue
@@ -54,7 +54,7 @@
                 color="primary"
                 class="font-bold px-8"
                 icon="i-heroicons-link"
-                @click="signIn('intervals')"
+                @click="navigateTo('/connect-intervals')"
               >
                 {{ t('connect_now') }}
               </UButton>
@@ -337,7 +337,6 @@
   import { useTranslate } from '@tolgee/vue'
 
   const { t } = useTranslate('onboarding')
-  const { signIn } = useAuth()
 
   const isStravaDisabled = computed(() => {
     const config = useRuntimeConfig()

--- a/app/components/settings/ConnectedApps.vue
+++ b/app/components/settings/ConnectedApps.vue
@@ -21,24 +21,10 @@
       <div
         class="flex items-center justify-end gap-2 pt-4 border-t border-gray-100 dark:border-gray-800 mt-auto"
       >
-        <div v-if="!intervalsConnected" class="flex flex-col items-end gap-2">
+        <div v-if="!intervalsConnected">
           <UButton
             color="neutral"
             variant="outline"
-            @click="
-              () => {
-                trackIntegrationConnectStart('intervals')
-                signIn('intervals')
-              }
-            "
-          >
-            Connect
-          </UButton>
-          <UButton
-            color="neutral"
-            variant="link"
-            size="xs"
-            :padded="false"
             @click="
               () => {
                 trackIntegrationConnectStart('intervals')
@@ -46,7 +32,7 @@
               }
             "
           >
-            Connect manually (API Key)
+            Connect
           </UButton>
         </div>
         <div v-else class="flex items-center gap-2">

--- a/app/pages/join.vue
+++ b/app/pages/join.vue
@@ -252,26 +252,6 @@
                 </span>
               </UButton>
 
-              <!-- Intervals.icu Button -->
-              <UButton
-                block
-                size="xl"
-                color="neutral"
-                variant="outline"
-                class="relative overflow-hidden group border-white/10 hover:border-white/20 py-5 rounded-2xl h-14 min-w-full"
-                :loading="loadingIntervals || isInitializing"
-                @click="handleIntervalsLogin"
-              >
-                <template #leading>
-                  <img src="/images/logos/intervals.png" alt="Intervals.icu Logo" class="w-5 h-5" />
-                </template>
-                <span
-                  class="relative z-10 font-black uppercase tracking-[0.2em] text-[11px] text-white"
-                >
-                  {{ isInitializing ? 'CALIBRATING...' : joinIntervals }}
-                </span>
-              </UButton>
-
               <p
                 class="text-center lg:text-left text-[11px] font-black italic uppercase tracking-[0.18em] text-primary-500"
               >
@@ -440,7 +420,6 @@
 
   const loading = ref(false)
   const loadingStrava = ref(false)
-  const loadingIntervals = ref(false)
   const isInitializing = ref(false)
   const isTyping = ref(true)
   const starStyles = ref<any[]>([])
@@ -462,7 +441,6 @@
   )
   const joinGoogle = translateOrFallback('join.google', 'Create Account with Google')
   const joinStrava = translateOrFallback('join.strava', 'Create Account with Strava')
-  const joinIntervals = translateOrFallback('join.intervals', 'Create Account with Intervals.icu')
   const joinFreeForeverNote = translateOrFallback(
     'join.free_forever_note',
     'Free forever with optional upgrades when you need more.'
@@ -552,20 +530,6 @@
       console.error('Strava login error:', error)
       isInitializing.value = false
       loadingStrava.value = false
-    }
-  }
-
-  async function handleIntervalsLogin() {
-    isInitializing.value = true
-    loadingIntervals.value = true
-    try {
-      // Simulate technical delay for the animation
-      await new Promise((resolve) => setTimeout(resolve, 1500))
-      await signIn('intervals', { callbackUrl })
-    } catch (error: any) {
-      console.error('Intervals login error:', error)
-      isInitializing.value = false
-      loadingIntervals.value = false
     }
   }
 </script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -179,35 +179,6 @@
                 />
               </UButton>
 
-              <!-- Intervals.icu Button -->
-              <UButton
-                block
-                size="xl"
-                color="neutral"
-                variant="outline"
-                class="relative overflow-hidden group border-white/10 hover:border-white/20 py-5 rounded-2xl h-14 min-w-full hover:shadow-[0_0_20px_rgba(0,220,130,0.1)] transition-all duration-300"
-                :loading="loadingIntervals || isInitializing"
-                @click="handleIntervalsLogin"
-                @mouseenter="isHovering = true"
-                @mouseleave="isHovering = false"
-              >
-                <template #leading>
-                  <img
-                    src="/images/logos/intervals.png"
-                    alt="Intervals.icu Logo"
-                    class="w-5 h-5 group-hover:scale-110 transition-transform"
-                  />
-                </template>
-                <span
-                  class="relative z-10 font-black uppercase tracking-[0.2em] text-[11px] text-white"
-                >
-                  {{ isInitializing ? 'CONNECTING...' : t('login.intervals') }}
-                </span>
-                <div
-                  class="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent -translate-x-full animate-shine [animation-delay:2s] pointer-events-none"
-                />
-              </UButton>
-
               <div class="relative py-4">
                 <div class="absolute inset-0 flex items-center">
                   <span class="w-full border-t border-white/5" />
@@ -365,7 +336,6 @@
 
   const loading = ref(false)
   const loadingStrava = ref(false)
-  const loadingIntervals = ref(false)
   const isInitializing = ref(false)
   const isHovering = ref(false)
   const starStyles = ref<any[]>([])
@@ -490,24 +460,6 @@
       })
       isInitializing.value = false
       loadingStrava.value = false
-    }
-  }
-
-  async function handleIntervalsLogin() {
-    trackLogin('intervals')
-    isInitializing.value = true
-    loadingIntervals.value = true
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 1500))
-      await signIn('intervals', { callbackUrl })
-    } catch (error: any) {
-      toast.add({
-        title: 'Login Failed',
-        description: error.message || 'Could not initiate Intervals login.',
-        color: 'error'
-      })
-      isInitializing.value = false
-      loadingIntervals.value = false
     }
   }
 </script>

--- a/prisma/migrations/20260519120000_remove_intervals_oauth_accounts/migration.sql
+++ b/prisma/migrations/20260519120000_remove_intervals_oauth_accounts/migration.sql
@@ -1,0 +1,9 @@
+-- Remove obsolete Intervals.icu OAuth Account rows.
+-- Intervals.icu no longer offers self-service OAuth client registration; the integration now
+-- uses HTTP Basic auth with a per-athlete API key persisted on the Integration table.
+DELETE FROM "Account" WHERE "provider" = 'intervals';
+
+-- Drop any residual OAuth metadata on existing Intervals Integration rows so the
+-- credentials are treated as API-key only by getIntervalsHeaders/getIntervalsAthleteId.
+UPDATE "Integration" SET "scope" = NULL, "refreshToken" = NULL, "expiresAt" = NULL
+WHERE "provider" = 'intervals';

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -28,69 +28,6 @@ adapter.deleteSession = async (sessionToken: string) => {
   }
 }
 
-const syncIntervalsIntegration = async (user: any, account: any) => {
-  try {
-    await prisma.integration.upsert({
-      where: {
-        userId_provider: {
-          userId: user.id,
-          provider: 'intervals'
-        }
-      },
-      update: {
-        accessToken: account.access_token!,
-        refreshToken: account.refresh_token,
-        expiresAt: account.expires_at ? new Date(account.expires_at * 1000) : undefined,
-        externalUserId: account.providerAccountId,
-        scope: account.scope,
-        lastSyncAt: new Date(),
-        syncStatus: 'SUCCESS'
-      },
-      create: {
-        userId: user.id,
-        provider: 'intervals',
-        accessToken: account.access_token!,
-        refreshToken: account.refresh_token,
-        expiresAt: account.expires_at ? new Date(account.expires_at * 1000) : undefined,
-        externalUserId: account.providerAccountId,
-        scope: account.scope,
-        syncStatus: 'SUCCESS',
-        lastSyncAt: new Date(),
-        ingestWorkouts: true
-      }
-    })
-    console.log('Successfully synced Intervals.icu integration')
-
-    // Trigger initial sync (last 365 days)
-    const endDate = new Date().toISOString()
-    const startDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString()
-
-    await tasks.trigger(
-      'ingest-intervals',
-      {
-        userId: user.id,
-        startDate,
-        endDate
-      },
-      {
-        concurrencyKey: user.id,
-        tags: [`user:${user.id}`]
-      }
-    )
-    console.log('Triggered initial Intervals.icu sync')
-
-    // Trigger profile auto-detection
-    await tasks.trigger(
-      'autodetect-intervals-profile',
-      { userId: user.id },
-      { concurrencyKey: user.id, tags: [`user:${user.id}`] }
-    )
-    console.log('Triggered Intervals.icu profile auto-detection')
-  } catch (error) {
-    console.error('Failed to sync Intervals.icu integration:', error)
-  }
-}
-
 const syncStravaIntegration = async (user: any, account: any) => {
   try {
     await prisma.integration.upsert({
@@ -187,48 +124,7 @@ export default NuxtAuthHandler({
         }
       },
       allowDangerousEmailAccountLinking: true
-    }),
-    {
-      id: 'intervals',
-      name: 'Intervals.icu',
-      type: 'oauth',
-      authorization: {
-        url: 'https://intervals.icu/oauth/authorize',
-        params: { scope: 'ACTIVITY:WRITE,CALENDAR:WRITE,WELLNESS:WRITE,SETTINGS:WRITE' }
-      },
-      token: 'https://intervals.icu/api/oauth/token',
-      userinfo: 'https://intervals.icu/api/v1/athlete/0',
-      clientId: process.env.INTERVALS_CLIENT_ID,
-      clientSecret: process.env.INTERVALS_CLIENT_SECRET,
-      client: {
-        token_endpoint_auth_method: 'client_secret_post'
-      },
-      allowDangerousEmailAccountLinking: true,
-      async profile(profile: any) {
-        // Similar lookup for Intervals.icu
-        const existingIntegration = await prisma.integration.findFirst({
-          where: {
-            provider: 'intervals',
-            externalUserId: profile.id.toString()
-          },
-          include: { user: true }
-        })
-
-        const email =
-          existingIntegration?.user?.email ||
-          profile.email ||
-          `${profile.id}@intervals.coachwatts.com`
-
-        console.log(`[Auth] Intervals profile mapping for ${profile.id}: using email ${email}`)
-
-        return {
-          id: profile.id,
-          name: profile.name,
-          email,
-          image: profile.profile_medium || profile.profile
-        }
-      }
-    }
+    })
   ],
   secret: process.env.NUXT_AUTH_SECRET,
   callbacks: {
@@ -279,17 +175,11 @@ export default NuxtAuthHandler({
     },
     async linkAccount({ user, account }: any) {
       console.log(`[Auth] Linking account: ${account.provider} to user ${user.id} (${user.email})`)
-      if (account.provider === 'intervals') {
-        await syncIntervalsIntegration(user, account)
-      }
       if (account.provider === 'strava') {
         await syncStravaIntegration(user, account)
       }
     },
     async signIn({ user, account }: any) {
-      if (account?.provider === 'intervals') {
-        await syncIntervalsIntegration(user, account)
-      }
       if (account?.provider === 'strava') {
         await syncStravaIntegration(user, account)
       }

--- a/server/plugins/bootstrap-intervals.ts
+++ b/server/plugins/bootstrap-intervals.ts
@@ -1,0 +1,41 @@
+import { prisma } from '../utils/db'
+
+export default defineNitroPlugin(() => {
+  const apiKey = process.env.INTERVALS_API_KEY
+  const athleteId = process.env.INTERVALS_ATHLETE_ID
+  if (!apiKey || !athleteId) return
+
+  setTimeout(async () => {
+    try {
+      const userCount = await prisma.user.count()
+      if (userCount !== 1) {
+        console.log(
+          `[bootstrap-intervals] Skipping seed: expected exactly 1 user, found ${userCount}.`
+        )
+        return
+      }
+
+      const user = await prisma.user.findFirstOrThrow({ select: { id: true } })
+      const existing = await prisma.integration.findUnique({
+        where: { userId_provider: { userId: user.id, provider: 'intervals' } }
+      })
+      if (existing) return
+
+      await prisma.integration.create({
+        data: {
+          userId: user.id,
+          provider: 'intervals',
+          accessToken: apiKey,
+          externalUserId: athleteId,
+          syncStatus: 'SUCCESS',
+          lastSyncAt: new Date(),
+          initialSyncCompleted: false,
+          ingestWorkouts: true
+        }
+      })
+      console.log(`[bootstrap-intervals] Seeded Intervals.icu integration for user ${user.id}.`)
+    } catch (error) {
+      console.error('[bootstrap-intervals] Failed to seed Intervals.icu integration:', error)
+    }
+  }, 0)
+})

--- a/server/utils/intervals.test.ts
+++ b/server/utils/intervals.test.ts
@@ -153,8 +153,7 @@ It has multiple lines.
 
       const integration = {
         accessToken: 'token',
-        scope: 'CALENDAR:WRITE',
-        refreshToken: null
+        externalUserId: 'i12345'
       } as any
 
       await createIntervalsPlannedWorkout(integration, {

--- a/server/utils/intervals.ts
+++ b/server/utils/intervals.ts
@@ -12,21 +12,11 @@ import {
 } from './swim-structure'
 
 function getIntervalsHeaders(integration: Integration): Record<string, string> {
-  // If we have a scope or refresh token, it's an OAuth integration
-  if (integration.scope || integration.refreshToken) {
-    return { Authorization: `Bearer ${integration.accessToken}` }
-  }
-
-  // Otherwise, assume it's a legacy API Key integration
   const auth = Buffer.from(`API_KEY:${integration.accessToken}`).toString('base64')
   return { Authorization: `Basic ${auth}` }
 }
 
 function getIntervalsAthleteId(integration: Integration): string {
-  // Use '0' for OAuth integrations as recommended by Intervals.icu docs for Bearer tokens
-  if (integration.scope || integration.refreshToken) {
-    return '0'
-  }
   return integration.externalUserId || 'i0'
 }
 


### PR DESCRIPTION
Intervals.icu no longer offers self-service OAuth client registration, so the OAuth provider in nuxt-auth is replaced with the existing API-key connect form at /connect-intervals. The auth handler drops the intervals OAuth block and its sync/link helpers; the login and join pages drop the "Sign in with Intervals" buttons (Google/Strava remain). The intervals util collapses to a single Basic-auth path keyed off externalUserId.

A migration removes orphan Account rows where provider='intervals' and nulls out the OAuth columns on existing Intervals Integration rows so pre-migration users are treated as API-key from the next request onward.

For self-hosted single-user deploys, a new Nitro plugin seeds the Integration row from INTERVALS_API_KEY / INTERVALS_ATHLETE_ID env vars when the database has exactly one user and no existing intervals integration.