### PR TITLE
perf: slim structure generation prompts and AI retries (033–038)

### DIFF
--- a/docs/issues/001-zero-step-structure-persistence.md
+++ b/docs/issues/001-zero-step-structure-persistence.md
@@ -1,0 +1,80 @@
+# 001 — Empty structures can persist as successful generation
+
+**Type:** Bug  
+**Priority:** Critical  
+**Area:** `ai`, `workouts`, `backend`  
+**Status:** Open
+
+## Description
+
+The structured workout generation pipeline can persist a `structuredWorkout` object that contains narrative fields (`description`, `coachInstructions`) but **no renderable steps, exercises, or blocks**. The task completes with `{ success: true }`, leaving users with workouts that appear to have been generated but show no interval chart or executable structure.
+
+This matches an active production defect family documented in support tickets (accounts with large counts of `step_count = 0` structured workouts).
+
+## Root Cause
+
+Final validation in `generate-structured-workout.ts` only rejects zero duration/TSS when steps or exercises **exist**:
+
+```1708:1715:trigger/generate-structured-workout.ts
+    const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
+    const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
+    if ((hasSteps || hasExercises) && totalDuration <= 0) {
+      throw new Error('Generated structured workout has zero total duration')
+    }
+    if ((hasSteps || hasExercises) && totalTSS <= 0) {
+      throw new Error('Generated structured workout has zero total TSS')
+    }
+```
+
+When the AI returns `{ description, coachInstructions, steps: [] }` (and no exercises/blocks counted), **none of these guards fire** and the structure is written to the database.
+
+The same pattern exists in `trigger/adjust-structured-workout.ts`.
+
+Coverage validation during the retry loop may catch some cases (zero duration vs planned duration), but:
+
+- Strength workouts using `blocks` instead of `steps`/`exercises` may not be fully covered (see [011](./011-strength-blocks-validation-gap.md)).
+- Historical records may predate stricter validation.
+- Partial/description-only payloads may have been written through other code paths.
+
+## Steps to Reproduce
+
+1. Trigger structure generation for a planned workout (Build Structure or via chat).
+2. Simulate or observe an AI response with empty `steps: []`, valid description text, and no blocks/exercises.
+3. Task completes successfully.
+4. Planned workout details page shows coach text but no interval structure or chart.
+
+## Expected Behavior
+
+- Generation should **fail** if the result has no previewable structure (steps, exercises, or strength blocks).
+- Task output should be `{ success: false }` with a clear error.
+- No empty `structuredWorkout` should be persisted.
+
+## Actual Behavior
+
+- Empty or description-only structures can be saved.
+- UI may show narrative guidance with no chart (mitigated partially by frontend empty-state handling added 2026-06-26, but root cause remains in generation/persistence).
+
+## Affected Files
+
+- `trigger/generate-structured-workout.ts` (~1708–1715, persistence block ~1759)
+- `trigger/adjust-structured-workout.ts` (equivalent validation)
+- `server/utils/planned-workout-structure-sync.ts` (`buildStructureEditFields`)
+
+## Suggested Fix
+
+1. Add a shared `assertRenderableStructure(structure, workoutType)` helper used by both generate and adjust tasks.
+2. Require at least one of: non-empty `steps`, non-empty `exercises`, or non-empty strength `blocks`.
+3. Return `{ success: false, error: '...' }` instead of persisting.
+4. Consider a one-time backfill/re-generation job for existing zero-step records (separate maintenance task).
+
+## Related
+
+- Support cluster 3 in [support-ticket-task-list-2026-06-16.md](../06-plans/support-ticket-task-list-2026-06-16.md)
+- [plans/training/workout-safety-layer-plan.md](../../plans/training/workout-safety-layer-plan.md) — proposed validation layer before persistence
+
+## Acceptance Criteria
+
+- [ ] Generate and adjust tasks reject structures with zero renderable content
+- [ ] Failed rejection surfaces as `{ success: false }` to the UI
+- [ ] Regression test covers empty steps array with description-only payload
+- [ ] Production zero-step rate measurable after deploy

--- a/docs/issues/002-missing-planned-workout-run-tags.md
+++ b/docs/issues/002-missing-planned-workout-run-tags.md
@@ -1,0 +1,88 @@
+# 002 — Manual/API triggers missing `planned-workout:` run tags
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ui/ux`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+The Planned Workout Details page tracks in-progress structure jobs by matching Trigger.dev runs tagged with `planned-workout:${workoutId}`. Several entry points only tag runs with `user:${userId}`, so the UI cannot detect active generation for workouts triggered through those paths.
+
+## Root Cause
+
+The details page filters active runs like this:
+
+```1453:1464:app/pages/workouts/planned/[id]/index.vue
+  const activeStructureRun = computed(() => {
+    const workoutId = workout.value?.id
+    if (!workoutId) return null
+
+    return (
+      runs.value.find((run) => {
+        return (
+          STRUCTURE_TASK_IDENTIFIERS.has(run.taskIdentifier) &&
+          Array.isArray(run.tags) &&
+          run.tags.includes(`planned-workout:${workoutId}`)
+        )
+      }) || null
+    )
+  })
+```
+
+But the primary manual API only tags the user:
+
+```78:86:server/api/workouts/planned/[id]/generate-structure.post.ts
+    const handle = await tasks.trigger(
+      'generate-structured-workout',
+      { plannedWorkoutId: id },
+      {
+        concurrencyKey: userId,
+        tags: [`user:${userId}`]
+      }
+    )
+```
+
+Chat planning tools **do** include the correct tag (`server/utils/ai-tools/planning.ts` lines ~917, 1007).
+
+## Affected Trigger Sites (missing `planned-workout:` tag)
+
+| File | Task |
+|------|------|
+| `server/api/workouts/planned/[id]/generate-structure.post.ts` | `generate-structured-workout` |
+| `server/api/workouts/planned/[id]/adjust.post.ts` | `adjust-structured-workout` |
+| `server/api/recommendations/[id]/accept.post.ts` | `generate-structured-workout` |
+| `trigger/generate-training-block.ts` (~638–643) | `generate-structured-workout` (batch loop) |
+| `trigger/generate-ad-hoc-workout.ts` (~224–232) | `generate-structured-workout` |
+
+## Steps to Reproduce
+
+1. Open a planned workout details page.
+2. Click **Build Structure** (uses `generate-structure.post.ts`).
+3. While generation is running, observe the page — no "Structure generation running" badge from `activeStructureRun`.
+4. Compare with creating a workout via chat (which does show run tracking when tags are present).
+
+## Expected Behavior
+
+All structure generation entry points tag runs with `planned-workout:${id}` so the UI can show consistent in-progress state.
+
+## Actual Behavior
+
+Manual Build Structure, Adjust, recommendation accept, training block batch, and ad-hoc flows do not tag per-workout runs. UI status indicators and `activeStructureRun` are unreliable for the most common user action.
+
+## Suggested Fix
+
+1. Standardize tags: `[`user:${userId}`, `planned-workout:${workoutId}`]` for all planned workout structure tasks.
+2. Pass the same tags to `publishTaskRunStartedEvent` where applicable.
+3. Add a small helper e.g. `structureRunTags(userId, plannedWorkoutId)` to avoid drift.
+
+## Related
+
+- [004](./004-no-task-failure-handling.md) — failure handling on same page
+- [005](./005-page-reload-loses-generation-state.md) — state recovery depends on run visibility
+
+## Acceptance Criteria
+
+- [ ] Every `generate-structured-workout` / `adjust-structured-workout` trigger from API and nested tasks includes `planned-workout:` tag
+- [ ] Planned Workout Details page shows in-progress badge for Build Structure
+- [ ] Unit or integration test asserts tag presence on API trigger

--- a/docs/issues/003-free-tier-skip-reports-success.md
+++ b/docs/issues/003-free-tier-skip-reports-success.md
@@ -1,0 +1,58 @@
+# 003 — Free-tier skip returns `success: true` → misleading toast
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When a free-tier user triggers structure generation for a workout more than 4 weeks in the future, the trigger task returns `{ success: true, skipped: true }`. The Planned Workout Details page treats any non-false success as a win and shows **"Structure Generated"**.
+
+## Root Cause
+
+Inside the trigger (defense in depth after API already checks):
+
+```1041:1045:trigger/generate-structured-workout.ts
+        return {
+          success: true,
+          skipped: true,
+          message: 'Structured workout generation is limited to 4 weeks in advance for free users.'
+        }
+```
+
+Frontend completion handler:
+
+```1379:1406:app/pages/workouts/planned/[id]/index.vue
+  onTaskCompleted('generate-structured-workout', async (run) => {
+    ...
+    if (output?.success === false) { ... return }
+
+    toast.add({
+      title: 'Structure Generated',
+      description: 'Workout structure is ready.',
+      ...
+    })
+  })
+```
+
+The handler never checks `output.skipped`.
+
+Note: The API endpoint `generate-structure.post.ts` already returns 403 for this case at request time, so this bug mainly affects **nested triggers** (training block, ad-hoc, chat) that bypass the API guard or race with tier/date changes.
+
+## Expected Behavior
+
+- Skipped generation should show an informational or warning toast with the skip reason.
+- Task output should use `success: false` with reason `SKIPPED` or the UI should explicitly handle `skipped: true`.
+
+## Suggested Fix
+
+Either:
+
+- **Backend:** Return `{ success: false, skipped: true, reason: 'FREE_TIER_LIMIT' }`, or
+- **Frontend:** Check `output?.skipped` and show appropriate messaging.
+
+## Acceptance Criteria
+
+- [ ] Skipped free-tier runs never show "Structure Generated"
+- [ ] User sees clear upgrade/limit message

--- a/docs/issues/004-no-task-failure-handling.md
+++ b/docs/issues/004-no-task-failure-handling.md
@@ -1,0 +1,63 @@
+# 004 — No `onTaskFailed` handler — stuck "Generating..." state
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+The Planned Workout Details page sets `generating.value = true` when starting structure generation but only clears it in `onTaskCompleted`. There is no `onTaskFailed` handler for `generate-structured-workout` or `adjust-structured-workout`.
+
+If a Trigger.dev run **FAILS**, **TIMED_OUT** (180s task cap), or is **CANCELLED**, the Build Structure button can remain stuck on **"Generating..."** until the user reloads the page.
+
+## Root Cause
+
+```1379:1407:app/pages/workouts/planned/[id]/index.vue
+  onTaskCompleted('generate-structured-workout', async (run) => {
+    await fetchWorkout()
+    generating.value = false
+    ...
+  })
+  // No onTaskFailed registered
+```
+
+Compare with `app/pages/profile/goals.vue`, which registers both `onTaskCompleted` and `onTaskFailed` for its tasks.
+
+`useUserRunsState()` exposes `onTaskFailed` (`app/composables/useUserRuns.ts` ~421).
+
+## Steps to Reproduce
+
+1. Start structure generation on a complex workout (or simulate a failing trigger run).
+2. Let the Trigger.dev task fail or time out at 180s.
+3. Observe the UI — button stays in loading state.
+
+## Expected Behavior
+
+- On task failure/timeout/cancel: clear `generating` / `adjusting`, show error toast with actionable message.
+- Optionally link to developer run logs for support.
+
+## Suggested Fix
+
+```typescript
+onTaskFailed('generate-structured-workout', async (run) => {
+  generating.value = false
+  toast.add({ title: 'Generation Failed', description: '...', color: 'error' })
+})
+onTaskFailed('adjust-structured-workout', async (run) => {
+  adjusting.value = false
+  ...
+})
+```
+
+Filter failures by `planned-workout:${id}` tag once [002](./002-missing-planned-workout-run-tags.md) is fixed.
+
+## Related
+
+- [002](./002-missing-planned-workout-run-tags.md)
+- [012](./012-ai-in-triggers-architecture-rethink.md) — timeout failures at task level
+
+## Acceptance Criteria
+
+- [ ] Failed/timed-out structure runs reset UI loading state
+- [ ] User sees error feedback without requiring page reload

--- a/docs/issues/005-page-reload-loses-generation-state.md
+++ b/docs/issues/005-page-reload-loses-generation-state.md
@@ -1,0 +1,51 @@
+# 005 — Page reload does not restore in-progress generation UI
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+If a user reloads the Planned Workout Details page while structure generation is in progress, the UI does not restore the generating state. The `generating` ref defaults to `false` and `onMounted` only calls `fetchWorkout()` — it does not sync from active Trigger.dev runs.
+
+## Root Cause
+
+```2546:2550:app/pages/workouts/planned/[id]/index.vue
+  onMounted(() => {
+    trackWorkoutViewDetail('planned')
+    fetchWorkout()
+    fetchIntegrationStatus()
+  })
+```
+
+`activeStructureRun` computed property exists but is **not** used to initialize `generating.value` or `adjusting.value`.
+
+Combined with [002](./002-missing-planned-workout-run-tags.md), manual Build Structure runs may not appear in `activeStructureRun` at all, making recovery impossible even if sync logic were added.
+
+## Expected Behavior
+
+On mount (and when `runs` updates):
+
+1. If `activeStructureRun` exists for this workout → set `generating` or `adjusting` accordingly.
+2. Show "Structure generation running" badge (already wired to `activeStructureRun` / `structureJobStatusLabel`).
+
+## Suggested Fix
+
+```typescript
+watch(activeStructureRun, (run) => {
+  if (!run) {
+    // Don't clear generating here — wait for completion/failure handlers
+    return
+  }
+  if (run.taskIdentifier === 'adjust-structured-workout') adjusting.value = true
+  else generating.value = true
+}, { immediate: true })
+```
+
+Requires [002](./002-missing-planned-workout-run-tags.md) for manual API paths.
+
+## Acceptance Criteria
+
+- [ ] Reload during chat-triggered generation shows in-progress state
+- [ ] Reload during manual generation shows in-progress state (after tag fix)

--- a/docs/issues/006-ui-timeout-messaging-mismatch.md
+++ b/docs/issues/006-ui-timeout-messaging-mismatch.md
@@ -1,0 +1,43 @@
+# 006 — UI timeout messaging mismatch
+
+**Type:** Bug  
+**Priority:** Low  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+The Planned Workout Details page tells users structure generation "may take up to **30 seconds**", but the actual pipeline can take significantly longer.
+
+## Actual Timings
+
+| Layer | Limit |
+|-------|-------|
+| AI call per attempt | 45s (`STRUCTURED_WORKOUT_TIMEOUT_MS`) |
+| Retry attempts | Up to 2 (Flash → Pro with high thinking) |
+| Coverage/strength validation retries | Additional loop iterations inside attempt budget |
+| Trigger.dev task `maxDuration` | 180s |
+| Post-AI processing | Strength library matching, normalization, Intervals sync |
+
+Worst case: ~90s+ of AI time alone, plus processing — up to the **180s task cap**.
+
+## Location
+
+```2336:2339:app/pages/workouts/planned/[id]/index.vue
+      toast.add({
+        title: 'Generation Started',
+        description: 'AI is generating the workout structure. This may take up to 30 seconds.',
+```
+
+## Expected Behavior
+
+Copy should reflect realistic timing (e.g. "up to 2 minutes") or use indeterminate progress messaging tied to run status.
+
+## Suggested Fix
+
+- Update toast copy to match 180s cap or show run-linked progress.
+- Consider showing attempt/retry state if exposed in run metadata.
+
+## Acceptance Criteria
+
+- [ ] User-facing timing expectations align with backend limits

--- a/docs/issues/007-workout-messages-no-ai-timeout.md
+++ b/docs/issues/007-workout-messages-no-ai-timeout.md
@@ -1,0 +1,41 @@
+# 007 — `generate-workout-messages` has no explicit AI timeout
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+The coaching messages trigger calls `generateStructuredAnalysis` without `timeoutMs`, while the main structure generation tasks use a 45s per-attempt timeout. The task `maxDuration` is 300s, so a hung AI call could consume most of the task budget with default SDK retry behavior.
+
+## Location
+
+```76:86:trigger/generate-workout-messages.ts
+    const result = await generateStructuredAnalysis<{ messages: any[] }>(
+      prompt,
+      messageGenerationSchema,
+      'flash',
+      {
+        userId: workout.userId,
+        operation: 'generate_workout_messages',
+        entityType: 'PlannedWorkout',
+        entityId: plannedWorkoutId
+      }
+    )
+```
+
+Compare with `generate-structured-workout.ts` which passes `timeoutMs: 45_000` and `maxRetries: 0`.
+
+## Expected Behavior
+
+All workout-related AI operations in triggers should use consistent, explicit timeouts aligned with [012](./012-ai-in-triggers-architecture-rethink.md).
+
+## Suggested Fix
+
+Pass `timeoutMs: 45_000` (or a dedicated constant) and `maxRetries: 0` with optional single manual retry.
+
+## Acceptance Criteria
+
+- [ ] `generate-workout-messages` cannot hang indefinitely within a 300s task
+- [ ] Timeout failures surface as task failure with user-visible error on details page

--- a/docs/issues/008-chat-silent-trigger-failures.md
+++ b/docs/issues/008-chat-silent-trigger-failures.md
@@ -1,0 +1,56 @@
+# 008 — Chat tools swallow structure trigger failures
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When chat planning tools create or update a planned workout and fail to enqueue structure generation, the error is logged but the tool still returns `{ success: true }` with a message implying generation started.
+
+## Location
+
+```910:937:server/utils/ai-tools/planning.ts
+        try {
+          const handle = await generateStructuredWorkoutTask.trigger(...)
+          ...
+          runId = handle.id
+        } catch (e) {
+          console.error('Failed to trigger structured workout generation:', e)
+        }
+
+      return {
+        success: true,
+        workout_id: workout.id,
+        message: 'Planned workout created and structured generation started.'
+      }
+```
+
+Same pattern in `update_planned_workout` (~1015–1017).
+
+## Impact
+
+- User sees chat confirmation that structure generation started.
+- Workout exists with no structure and no background job.
+- Hard to diagnose without server logs.
+
+## Expected Behavior
+
+- If trigger fails: return `{ success: false, error: '...' }` or `{ success: true, workout_id, structure_generation: 'failed', error: '...' }`.
+- Chat assistant should communicate the partial success clearly.
+
+## Suggested Fix
+
+1. Propagate trigger errors to tool return value.
+2. Optionally still create the workout but flag `structurePending: true` with failed enqueue for retry UI.
+
+## Related
+
+- Chat correctly uses async triggers (good pattern) — failure visibility is the gap.
+- [012](./012-ai-in-triggers-architecture-rethink.md)
+
+## Acceptance Criteria
+
+- [ ] Trigger enqueue failure is visible in chat tool result
+- [ ] Assistant message reflects partial vs full success

--- a/docs/issues/009-double-quota-consumption.md
+++ b/docs/issues/009-double-quota-consumption.md
@@ -1,0 +1,44 @@
+# 009 — Quota checked at API and again inside trigger
+
+**Type:** Maintenance  
+**Priority:** Medium  
+**Area:** `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Structured workout generation quota (`generate_structured_workout`) is enforced at the API layer and again inside the Trigger.dev task. This creates ambiguous consumption behavior on failures and duplicates logic.
+
+## Locations
+
+**API** — `server/api/workouts/planned/[id]/generate-structure.post.ts` (~47–48):
+
+```typescript
+await checkQuota(userId, 'generate_structured_workout')
+```
+
+**Trigger** — `trigger/generate-structured-workout.ts` (~963–970):
+
+```typescript
+await checkQuota(workout.userId, 'generate_structured_workout')
+// on failure: return { success: false, reason: 'QUOTA_EXCEEDED' }
+```
+
+Chat tools also check quota before triggering (`planning.ts`).
+
+## Concerns
+
+1. **Double charge?** — Depends on whether `checkQuota` increments on check vs on success. Needs verification in `server/utils/quotas/engine`.
+2. **API passes, trigger fails quota** — User gets 200 from API but task returns `QUOTA_EXCEEDED` asynchronously.
+3. **Nested triggers** (training block, chat) may skip API check but hit trigger check.
+
+## Suggested Fix
+
+- Single source of truth: enforce quota at enqueue time OR at task start, not both unless idempotent.
+- Document quota consumption timing in [llm-quotas-and-limits.md](../06-plans/llm-quotas-and-limits.md).
+
+## Acceptance Criteria
+
+- [ ] Quota consumed exactly once per successful generation
+- [ ] Failed generations do not consume quota (or policy is documented)
+- [ ] No duplicate check logic without clear reason

--- a/docs/issues/009-double-quota-consumption.md
+++ b/docs/issues/009-double-quota-consumption.md
@@ -28,9 +28,10 @@ Chat tools also check quota before triggering (`planning.ts`).
 
 ## Concerns
 
-1. **Double charge?** — Depends on whether `checkQuota` increments on check vs on success. Needs verification in `server/utils/quotas/engine`.
+1. **Double check, not double charge** — `checkQuota` in `server/utils/quotas/engine.ts` is read-only (throws if over limit; does not increment usage). Actual LLM cost comes from successful generations recorded separately. Duplicate **triggers** from chat ([013](./013-chat-duplicate-structure-generation-triggers.md)) are the main quota/cost multiplier.
 2. **API passes, trigger fails quota** — User gets 200 from API but task returns `QUOTA_EXCEEDED` asynchronously.
 3. **Nested triggers** (training block, chat) may skip API check but hit trigger check.
+4. **Chat multi-tool turns** — Each tool call may invoke `checkQuota` before enqueue even when only one generation should run.
 
 ## Suggested Fix
 

--- a/docs/issues/010-batch-generation-loading-state.md
+++ b/docs/issues/010-batch-generation-loading-state.md
@@ -1,0 +1,43 @@
+# 010 — Batch week generation clears loading before jobs finish
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `planning`  
+**Status:** Open
+
+## Description
+
+On the Plan Dashboard, `generateAllStructureForWeek()` sets `generatingAllStructures.value = false` in a `finally` block immediately after **queuing** all generation jobs — not when tasks complete.
+
+## Location
+
+```1590:1649:app/components/plans/PlanDashboard.vue
+    generatingAllStructures.value = true
+    ...
+    } finally {
+      generatingAllStructures.value = false
+    }
+```
+
+Per-workout tracking via `generatingStructureForWorkoutId` is cleared on `onTaskCompleted`, but the global batch loading flag drops early.
+
+## Impact
+
+- Batch button re-enables while many structure jobs may still be running.
+- User may trigger duplicate batch runs or navigate away thinking work is done.
+- Toast says "Waiting for AI to finish" but UI no longer reflects batch-in-progress.
+
+## Expected Behavior
+
+`generatingAllStructures` remains true until all queued workout IDs for that batch have completed or failed (track pending set).
+
+## Suggested Fix
+
+- Maintain `pendingStructureWorkoutIds: Set<string>` for the batch.
+- Clear global flag when set is empty.
+- Handle partial batch failure (quota mid-batch already stops on first error).
+
+## Acceptance Criteria
+
+- [ ] Batch loading state covers full async duration
+- [ ] User cannot accidentally double-trigger batch for same week while jobs run

--- a/docs/issues/011-strength-blocks-validation-gap.md
+++ b/docs/issues/011-strength-blocks-validation-gap.md
@@ -1,0 +1,55 @@
+# 011 — Final validation ignores `blocks`-only strength structures
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Strength workouts are instructed to use a canonical `blocks` schema, but final pre-persist validation only checks `steps` and `exercises` arrays for presence and duration/TSS. A structure with valid `blocks` but empty `steps`/`exercises` may bypass guards or fail coverage validation incorrectly.
+
+## Evidence
+
+**Prompt instructs blocks:**
+
+```1116:1127:trigger/generate-structured-workout.ts
+    - Prefer the canonical strength schema: provide 'blocks' instead of a flat 'exercises' list.
+    - CRITICAL: Return native 'blocks' for strength. Do NOT return interval-style top-level 'steps' for WeightTraining.
+```
+
+**Final validation only checks steps/exercises:**
+
+```1708:1715:trigger/generate-structured-workout.ts
+    const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
+    const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
+```
+
+**Coverage validation uses steps only:**
+
+```1411:1420:trigger/generate-structured-workout.ts
+      totals = normalizeAndCalculate(structure.steps || [])
+      ...
+      const coverageValidation = validateStructuredCoverage({
+        ...
+        steps: structure.steps || [],
+```
+
+Strength-specific validation (`validateStrengthStructuredWorkout`) runs inside the retry loop but the final empty-structure guard does not consider `blocks`.
+
+## Impact
+
+- Inconsistent validation between strength and endurance workouts.
+- May contribute to zero-step WeightTraining records in production (support data shows WeightTraining as top zero-step type on affected accounts).
+
+## Suggested Fix
+
+1. Extend renderable-structure check to include `blocks` with nested exercise steps.
+2. Include block duration in coverage totals for strength types.
+3. Share logic with frontend preview guards (`CalendarDayCell`, mini charts).
+
+## Acceptance Criteria
+
+- [ ] Strength structures with blocks-only pass validation when blocks are non-empty
+- [ ] Empty blocks fail the same way as empty steps
+- [ ] Coverage validation accounts for strength block duration

--- a/docs/issues/012-ai-in-triggers-architecture-rethink.md
+++ b/docs/issues/012-ai-in-triggers-architecture-rethink.md
@@ -1,0 +1,151 @@
+# 012 — Rethink AI-in-triggers pattern and timeout strategy
+
+**Type:** Architecture  
+**Priority:** High  
+**Area:** `ai`, `backend`, `infra`, `workouts`  
+**Status:** Open
+
+## Summary
+
+The current design offloads heavy work to Trigger.dev (correct), but still runs **synchronous, multi-attempt AI calls inside task bodies**. Timeout configuration is **inconsistent** across tasks, and the UI has **no durable generation status model** on the workout record itself. This combination causes timeouts, stuck UI states, and silent partial failures — especially when generation is triggered from chat or batch plan flows.
+
+This issue captures the user's concern: *"Sometimes I have AI generation in triggers which times out — maybe we need to rethink how we will do this."*
+
+## Current State
+
+### What works well
+
+| Pattern | Detail |
+|---------|--------|
+| Chat → async trigger | Planning tools enqueue `generate-structured-workout` instead of blocking the 60s chat turn |
+| Two-stage planning | `generate-training-block` creates workout shells; structure is a separate task |
+| Retry with model upgrade | 45s timeout, attempt 1 Flash → attempt 2 Pro + high thinking |
+| WebSocket run updates | `useUserRuns` + `publishTaskRunStartedEvent` for live status |
+
+### What causes pain
+
+| Problem | Detail |
+|---------|--------|
+| **Synchronous AI in long tasks** | Up to 2×45s AI + strength matching + coverage retries + DB + Intervals sync in one 180s task |
+| **Inconsistent timeouts** | `generate-structured-workout`: 45s explicit; `generate-ad-hoc-workout`, `generate-workout-messages`: no `timeoutMs` |
+| **Task timeout vs AI timeout** | Task fails at 180s with unclear user message; UI may stay stuck ([004](./004-no-task-failure-handling.md)) |
+| **No persisted generation status** | UI infers state from Trigger.dev run tags — fragile ([002](./002-missing-planned-workout-run-tags.md), [005](./005-page-reload-loses-generation-state.md)) |
+| **Chat success without structure** | Workout created, trigger fails silently ([008](./008-chat-silent-trigger-failures.md)) |
+| **Batch fan-out** | `generate-training-block` loops `tasks.trigger` for many workouts — queue pressure, no per-block progress |
+| **Validation after AI spend** | Empty or invalid structures can still persist in edge cases ([001](./001-zero-step-structure-persistence.md)) |
+
+### Timeout matrix (workout-related triggers)
+
+| Task | maxDuration | AI timeoutMs | Notes |
+|------|-------------|--------------|-------|
+| `generate-structured-workout` | 180s | 45s × 2 attempts | Manual retry at task level |
+| `adjust-structured-workout` | 180s | 45s × 2 attempts | Same |
+| `generate-workout-messages` | 300s | **None** | Default SDK retries |
+| `generate-ad-hoc-workout` | 300s | **None** on first AI call | Then chains structure task |
+| `generate-training-block` | 600s | 40s DB tx timeout | Fans out N structure tasks |
+| `execute-chat-turn` | 300s | 60s execution abort | Separate from structure gen |
+
+Chat turn limits (`server/utils/chat/turns.ts`):
+
+- `CHAT_TURN_EXECUTION_TIMEOUT_MS = 60_000`
+- `CHAT_TURN_HEARTBEAT_TIMEOUT_MS = 120_000`
+
+Chat tool spec still mentions "5s max" for tools (`docs/02-features/chat/tool-calling-spec.md`) — outdated vs actual async trigger pattern.
+
+## Architectural Options
+
+### Option A — Harden current async trigger model (incremental)
+
+**Keep** Trigger.dev tasks as the unit of work. **Improve**:
+
+1. **Unified AI timeout policy** — shared constant, all trigger AI calls use `timeoutMs` + bounded retries.
+2. **Pre-persist validation gate** — shared `assertRenderableStructure()` ([001](./001-zero-step-structure-persistence.md), workout safety layer plan).
+3. **`PlannedWorkout.structureGenerationStatus` field** — `idle | queued | running | failed | complete` + `lastError` + `lastRunId`. UI reads DB first, runs second.
+4. **Standard run tags** — helper for all enqueue sites ([002](./002-missing-planned-workout-run-tags.md)).
+5. **Split long tasks** — move Intervals sync to a separate chained task so AI budget isn't shared with network I/O.
+
+**Pros:** Smallest migration, fits existing Trigger.dev investment.  
+**Cons:** Still synchronous AI within tasks; complex workouts may keep hitting 180s.
+
+### Option B — Two-step trigger chain (AI job → persist job)
+
+Split each generation into:
+
+1. **`generate-structure-draft`** — AI only, returns draft JSON to task output / object storage.
+2. **`persist-structure-draft`** — deterministic compile, validate, quota, DB write, sync.
+
+On AI timeout, retry **only** step 1 without re-loading full workout context.
+
+**Pros:** Clear failure boundaries, cheaper retries, easier observability.  
+**Cons:** More tasks, need draft storage contract.
+
+### Option C — Queue worker with slot-based concurrency
+
+Dedicated queue for structure generation with:
+
+- Per-user concurrency = 1 (already partially via `concurrencyKey`)
+- Global rate limit for Gemini
+- Priority lanes (user-initiated > batch block > backfill)
+
+**Pros:** Protects against batch block stampedes.  
+**Cons:** Infrastructure complexity.
+
+### Option D — Chat returns immediately with explicit follow-up contract
+
+Chat tools always:
+
+1. Create/update planned workout shell.
+2. Enqueue structure task.
+3. Return `{ workout_id, run_id, structure_status: 'queued' }`.
+4. Chat assistant tells user structure is **building in background** — link to planned workout page.
+
+Never imply structure is ready in the same turn.
+
+**Pros:** Sets correct user expectations; aligns with 60s chat limit.  
+**Cons:** Requires chat prompt/card UX updates.
+
+## Recommended Direction
+
+**Phase 1 (short term):** Option A + D
+
+- Fix validation, tags, failure handlers, chat error propagation.
+- Add `structureGenerationStatus` on `PlannedWorkout`.
+- Standardize timeouts across all workout AI triggers.
+
+**Phase 2 (medium term):** Option B for `generate-structured-workout`
+
+- Separate AI draft from persist/sync.
+- Implement workout safety layer from [workout-safety-layer-plan.md](../../plans/training/workout-safety-layer-plan.md).
+
+**Phase 3:** Option C if batch generation or Pro tier volume causes queue saturation.
+
+## Chat Integration Notes
+
+From product chat review (not stored transcripts — runtime chat history only):
+
+- Chat **should not** wait for structure completion in-tool (would hit 60s execution timeout).
+- Chat **should** surface trigger enqueue failures ([008](./008-chat-silent-trigger-failures.md)).
+- Chat cards (`ChatPlannedWorkoutCard`) could show structure status from `structureGenerationStatus` once added.
+- Tool-calling spec timeout guidance (5s) should be updated to reflect async trigger pattern.
+
+## Open Questions
+
+1. Should quota consume on enqueue or on successful persist?
+2. Should failed structure generation auto-retry with backoff, or require user action?
+3. For batch block generation, generate week 1 only synchronously and defer later weeks?
+4. Should `draft_json_v1` become the only path (drop `legacy_json`) to reduce prompt size and timeout rate?
+
+## Acceptance Criteria (architecture track)
+
+- [ ] Documented timeout policy applied to all workout AI triggers
+- [ ] Persisted generation status on `PlannedWorkout` (or equivalent)
+- [ ] Chat and UI show consistent async "building structure" state
+- [ ] Task failure rate and P95 duration tracked per operation in LLM ops panel
+- [ ] Zero-step persistence rate trends down after validation gate
+
+## References
+
+- [issues.md](./issues.md) — full issue index
+- [goal-driven-training.md](../02-features/goal-driven-training.md) — two-stage plan architecture
+- [workout-safety-layer-plan.md](../../plans/training/workout-safety-layer-plan.md)
+- [llm-ops-control-panel.md](../06-plans/llm-ops-control-panel.md)

--- a/docs/issues/013-chat-duplicate-structure-generation-triggers.md
+++ b/docs/issues/013-chat-duplicate-structure-generation-triggers.md
@@ -1,0 +1,140 @@
+# 013 — Chat can enqueue multiple structure generations for one workout
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ai`, `workouts`, `backend`, `ui/ux`  
+**Status:** Open  
+**Reported:** User observed multiple workout-details/structure generation jobs when asking chat to create a running workout.
+
+## Summary
+
+When a user asks chat to **create a planned workout** (e.g. a run), the assistant can accidentally enqueue **multiple `generate-structured-workout` Trigger.dev runs** for the **same workout** in a single turn. This is a **real bug**, not expected behavior.
+
+One user message should result in **at most one** structure generation job per workout.
+
+## Why this happens
+
+The `planning_write` skill exposes **several tools that each trigger structure generation independently**, and nothing deduplicates or coalesces them at the workout level.
+
+### Tools that trigger `generate-structured-workout`
+
+| Tool | When it triggers | Default |
+|------|------------------|---------|
+| `create_planned_workout` | After creating the workout shell | **`generate_structure` defaults to `true`** |
+| `update_planned_workout` | After updating metadata | **`generate_structure` omitted → treated as `true`** (`undefined !== false`) |
+| `generate_planned_workout_structure` | Explicit full rebuild | Always triggers |
+
+All three are available together in `server/utils/chat/skills.ts` (`planning_write` tool list).
+
+### Typical duplicate pattern (single chat turn)
+
+The model often chains tools like this when creating a run:
+
+```
+1. create_planned_workout(type: "Run", ...)     → trigger #1
+2. generate_planned_workout_structure(workout_id) → trigger #2  (redundant)
+```
+
+Or:
+
+```
+1. create_planned_workout(...)                  → trigger #1
+2. update_planned_workout(title/description...) → trigger #2  (generate_structure not set to false)
+```
+
+Each call runs quota check + `generateStructuredWorkoutTask.trigger()` separately.
+
+### No workout-level deduplication in the trigger task
+
+`generate-structured-workout` has **no guard** for an already-queued or in-progress run for the same `plannedWorkoutId`. Multiple runs can queue back-to-back (serialized per user via `concurrencyKey`, but still all execute).
+
+### Idempotency gaps in chat tool wrapper
+
+`wrapChatToolsForExecution` (`server/utils/chat/tool-execution.ts`) dedupes **mutating** tools by `(lineageId, toolName, argsHash)`.
+
+- `create_planned_workout` → **protected** (starts with `create_`)
+- `update_planned_workout` → **protected** per exact args
+- `generate_planned_workout_structure` → **NOT protected** (`generate_` prefix not in `isMutatingChatTool`)
+
+So repeated `generate_planned_workout_structure` calls with the same args can each enqueue a new run.
+
+Different tools (`create_*` vs `generate_*`) never share idempotency keys even for the same workout.
+
+### UI amplifies the confusion
+
+Each tool invocation renders its own `ChatPlannedWorkoutCard` (`app/components/chat/ChatMessageContent.vue`). A turn with `create_planned_workout` + `generate_planned_workout_structure` shows **two cards**, each polling run status — looks like "multiple workout details" were triggered.
+
+```322:328:app/components/chat/ChatMessageContent.vue
+      <ChatPlannedWorkoutCard
+        v-else-if="showTools && shouldRenderPlannedWorkoutCard(part)"
+        :tool-name="getPartToolName(part)"
+        :response="getPartToolResponse(part)"
+        :args="getPartToolArgs(part)"
+      />
+```
+
+### Skill instructions don't prevent it
+
+`planning_write` skill fragment (`server/utils/chat/skills.ts`) does **not** tell the model:
+
+- "Do not call `generate_planned_workout_structure` after `create_planned_workout` — creation already starts structure generation."
+- "Pass `generate_structure: false` on `update_planned_workout` unless the user asked to rebuild intervals."
+
+## Side effects
+
+- **2–3× quota consumption** for one user request ([009](./009-double-quota-consumption.md))
+- **Race on persist** — later runs overwrite earlier structure; wasted LLM cost
+- **Timeout noise** — multiple 45s×2 AI attempts in parallel queue
+- **User confusion** — multiple "Structure generation running" indicators in chat
+
+## How to verify (for your case)
+
+If you still have the chat message, check the assistant turn for tool calls:
+
+1. Open the message in chat (expand tools if shown).
+2. Look for multiple cards or tool names among:
+   - `create_planned_workout`
+   - `update_planned_workout`
+   - `generate_planned_workout_structure`
+3. In Trigger.dev / developer runs, filter `generate-structured-workout` around that timestamp — you may see **multiple runs** tagged with the same `planned-workout:<id>`.
+
+If only **one** tool ran but **multiple runs** appear, check for chat turn retry or a failed-then-retried user message (new `lineageId` → new workout + new generation).
+
+## Expected behavior
+
+- `create_planned_workout` with default `generate_structure: true` → **one** background generation job.
+- Follow-up tools in the same turn should **not** re-trigger unless the user explicitly asked to regenerate structure.
+- Chat UI should show **one** in-progress structure job per workout.
+
+## Suggested fixes
+
+### Quick wins
+
+1. **Skill instruction** — Add explicit rule in `planning_write`:
+   - After `create_planned_workout`, do not call `generate_planned_workout_structure`.
+   - On `update_planned_workout`, default to `generate_structure: false` unless duration/type/intensity changed or user asked for rebuild.
+
+2. **`update_planned_workout` schema** — Change default to `generate_structure: false` (opt-in regen, not opt-out).
+
+3. **Trigger dedup** — At start of `generate-structured-workout`, skip or coalesce if another active run exists for same `plannedWorkoutId` (check Trigger.dev tags or persist `structureGenerationRunId` on workout).
+
+4. **Include `generate_*` in mutating idempotency** — Add `generate_planned_workout_structure` and `adjust_planned_workout` to `isMutatingChatTool` (or a dedicated structure-trigger allowlist).
+
+### Medium term
+
+5. **Single structure trigger helper** — `enqueueStructureGeneration(plannedWorkoutId, { reason, force })` used by all tools; returns existing run id if already queued.
+
+6. **Chat card consolidation** — One card per `workout_id` per message, not one per tool call.
+
+## Related issues
+
+- [008](./008-chat-silent-trigger-failures.md) — trigger failures hidden
+- [009](./009-double-quota-consumption.md) — quota hit multiple times
+- [012](./012-ai-in-triggers-architecture-rethink.md) — persisted generation status
+
+## Acceptance criteria
+
+- [ ] Single "create me a run" chat request enqueues exactly one `generate-structured-workout` run
+- [ ] Model skill/tests discourage redundant `generate_planned_workout_structure` after create
+- [ ] `update_planned_workout` does not regenerate structure unless explicitly requested
+- [ ] Chat shows one structure-in-progress indicator per workout per turn

--- a/docs/issues/014-idempotent-create-skips-structure-retrigger.md
+++ b/docs/issues/014-idempotent-create-skips-structure-retrigger.md
@@ -1,0 +1,42 @@
+# 014 — Idempotent `create_planned_workout` replay never re-enqueues structure
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When `create_planned_workout` hits an existing workout via deterministic `externalId` (idempotent replay), it returns success but **does not** check whether structure exists, re-trigger generation, or return a `run_id`.
+
+## Root Cause
+
+```867:876:server/utils/ai-tools/planning.ts
+      if (existingByExternalId) {
+        return {
+          success: true,
+          workout_id: existingByExternalId.id,
+          message:
+            args.generate_structure !== false
+              ? 'Planned workout already exists for this chat turn.'
+              : 'Planned workout already exists.'
+        }
+      }
+```
+
+The trigger block (lines 907–928) is skipped on cache hit.
+
+## How this combines with other bugs
+
+1. First attempt creates workout but trigger enqueue fails ([008](./008-chat-silent-trigger-failures.md)) → `{ success: true }` without `run_id`.
+2. Idempotent replay (same `lineageId` + args) returns “already exists” → still no structure, no new job.
+3. User/chat card stuck waiting forever ([016](./016-chat-card-infinite-poll-without-run-id.md)).
+
+## Expected Behavior
+
+On idempotent hit, if `generate_structure !== false` and workout has no renderable structure and no active generation run → re-enqueue and return `run_id` / `structure_status`.
+
+## Acceptance Criteria
+
+- [ ] Idempotent replay recovers from failed first trigger
+- [ ] Response distinguishes `created` vs `already_exists` vs `structure_queued`

--- a/docs/issues/015-approval-turn-duplicate-workouts.md
+++ b/docs/issues/015-approval-turn-duplicate-workouts.md
@@ -1,0 +1,56 @@
+# 015 — Approval turns break workout deduplication (duplicate creates)
+
+**Type:** Bug  
+**Priority:** Critical  
+**Area:** `ai`, `backend`, `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+When tool approval is enabled, duplicate approvals or parallel approval submissions can create **multiple planned workouts** for a single user intent.
+
+## Root Causes
+
+### 1. Approval turns get a new `lineageId`
+
+`create_planned_workout` keys `externalId` from chat `lineageId`:
+
+```847:856:server/utils/ai-tools/planning.ts
+      const deterministicExternalId = chatContext.lineageId
+        ? `ai-turn-${hashToolArgs(
+            buildToolIdempotencyKey(
+              chatContext.lineageId,
+              'create_planned_workout',
+              hashToolArgs(args)
+            )
+          ).slice(0, 24)}`
+```
+
+Approval continuation runs on a **new turn** created from the approval tool message (`server/api/chat/messages.post.ts` ~183–198), which gets `lineageId = turn.id` (new UUID) in `chatTurnService.createTurn`.
+
+Same args on two approval turns → **two different `externalId` values** → two workouts.
+
+### 2. Double approval submission has no server guard
+
+`ChatToolApproval.vue` sets `submitting = true` but `onToolApproval` in `app/pages/chat.vue` always appends a new tool message and calls `sendMessage()` with no deduplication by `approvalId`.
+
+Double-click **Approve** → two turns → two creates (when combined with #1).
+
+## Reproduction
+
+1. Enable `aiRequireToolApproval`.
+2. Ask chat to create a running workout.
+3. Double-click Approve quickly.
+4. Observe two planned workouts on the same date (or two structure generation jobs).
+
+## Expected Behavior
+
+- One approval → one workout maximum.
+- Duplicate approval for same `approvalId` rejected server-side.
+- `lineageId` inherited from originating user-message turn for deterministic `externalId`.
+
+## Acceptance Criteria
+
+- [ ] Double approval cannot create duplicate workouts
+- [ ] Approval turns inherit stable lineage for idempotency
+- [ ] Client disables approve button after first submit until result

--- a/docs/issues/016-chat-card-infinite-poll-without-run-id.md
+++ b/docs/issues/016-chat-card-infinite-poll-without-run-id.md
@@ -1,0 +1,30 @@
+# 016 — Chat card polls forever when structure enqueue fails without `run_id`
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+If `create_planned_workout` or `update_planned_workout` returns `success: true` but no `run_id` (trigger swallowed per [008](./008-chat-silent-trigger-failures.md)), `ChatPlannedWorkoutCard` shows perpetual **“Waiting for structured workout”** with no timeout or failure state.
+
+## Root Cause
+
+```242:248:app/components/chat/ChatPlannedWorkoutCard.vue
+  const isOperationComplete = computed(() => {
+    ...
+    if (expectsStructure.value && !hasVisualization.value) return false
+```
+
+Workout polling continues while structure is expected but missing (lines 487–491), with no max duration and no terminal path when `run_id` is absent.
+
+## Expected Behavior
+
+- Missing `run_id` + elapsed time + empty structure → show failure, not infinite spinner.
+- Surface enqueue error from tool result when [008](./008-chat-silent-trigger-failures.md) is fixed.
+
+## Acceptance Criteria
+
+- [ ] Card stops polling after bounded time or explicit failure
+- [ ] User sees actionable error instead of endless “Waiting…”

--- a/docs/issues/017-modify-plan-structure-planservice-crash.md
+++ b/docs/issues/017-modify-plan-structure-planservice-crash.md
@@ -1,0 +1,33 @@
+# 017 — `modify_training_plan_structure` crashes (`planService` undefined)
+
+**Type:** Bug  
+**Priority:** Critical  
+**Area:** `ai`, `backend`, `planning`  
+**Status:** Open
+
+## Description
+
+Chat tool `modify_training_plan_structure` references `planService.replanStructure` but **`planService` is never imported** in `planning.ts`. Any chat request to modify plan block structure throws at runtime.
+
+## Root Cause
+
+```1529:1531:server/utils/ai-tools/planning.ts
+        await planService.replanStructure(userId, plan_id, finalBlocks)
+```
+
+Imports (lines 1–47) include repositories and `metabolicService`, but not `planService` from `server/utils/services/planService.ts` (used correctly in `server/api/plans/[id]/replan-structure.post.ts`).
+
+## Reproduction
+
+Ask chat to restructure a training plan (add/remove/reorder blocks) → tool fails with `ReferenceError: planService is not defined`.
+
+## Suggested Fix
+
+```typescript
+import { planService } from '../services/planService'
+```
+
+## Acceptance Criteria
+
+- [ ] Tool executes without ReferenceError
+- [ ] Unit test covers import and happy path

--- a/docs/issues/018-structure-tools-bypass-approval.md
+++ b/docs/issues/018-structure-tools-bypass-approval.md
@@ -1,0 +1,33 @@
+# 018 — `adjust_planned_workout` and `generate_planned_workout_structure` bypass approval
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When `aiRequireToolApproval` is enabled, expensive structure mutations can run **without user approval**, unlike `create_planned_workout`, `patch_planned_workout_structure`, etc.
+
+## Root Cause
+
+Neither tool defines `needsApproval`:
+
+- `adjust_planned_workout` (~1143)
+- `generate_planned_workout_structure` (~1202)
+
+Both are also **absent** from `planning_write.approvalToolNames` in `server/utils/chat/skills.ts` (lines 185–195).
+
+## Impact
+
+- User asks chat to “regenerate tomorrow’s run intervals” → immediate quota use + Trigger enqueue with no approval UI.
+- Contributes to duplicate generation when combined with [013](./013-chat-duplicate-structure-generation-triggers.md) (create already triggered structure, model also calls generate).
+
+## Expected Behavior
+
+Respect `aiSettings.aiRequireToolApproval` like other planning write tools.
+
+## Acceptance Criteria
+
+- [ ] Both tools require approval when setting enabled
+- [ ] Listed in skill approval instructions

--- a/docs/issues/019-chat-ui-ignores-strength-blocks.md
+++ b/docs/issues/019-chat-ui-ignores-strength-blocks.md
@@ -1,0 +1,35 @@
+# 019 — Chat UI treats blocks-only strength structures as “no structure”
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open  
+**Related:** [011](./011-strength-blocks-validation-gap.md) (backend validation)
+
+## Description
+
+`ChatPlannedWorkoutCard` and `ChatMessageContent` only check `steps` and `exercises` when deciding if a workout has structure. Canonical strength **`blocks`** are ignored.
+
+## Root Cause
+
+```146:152:app/components/chat/ChatPlannedWorkoutCard.vue
+    return (
+      (Array.isArray(structured.steps) && structured.steps.length > 0) ||
+      (Array.isArray(structured.exercises) && structured.exercises.length > 0)
+    )
+```
+
+Same in `ChatMessageContent.vue` (~127–130).
+
+## Impact
+
+Chat-generated WeightTraining with valid `blocks` stays on **“Waiting for structured workout”** even after generation completes.
+
+## Suggested Fix
+
+Shared `hasRenderableStructure()` helper including `blocks[].steps` (align with `structured-workout-persistence.ts`).
+
+## Acceptance Criteria
+
+- [ ] Strength blocks-only workouts show as complete in chat cards
+- [ ] Mini chart / step preview works or shows appropriate strength UI

--- a/docs/issues/020-intervals-publish-before-structure-ready.md
+++ b/docs/issues/020-intervals-publish-before-structure-ready.md
@@ -1,0 +1,55 @@
+# 020 — Chat publishes Intervals shell before structure exists
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `integrations`, `workouts`, `ai`  
+**Status:** Open
+
+## Description
+
+Chat `create_planned_workout` uploads a **structure-less shell** to Intervals.icu immediately, then async generation fills structure later via UPDATE. Users and devices can see an empty workout during the gap; chat may also call `publish_planned_workout` before structure exists.
+
+## Root Causes
+
+### Early Intervals CREATE (no `workout_doc`)
+
+```893:905:server/utils/ai-tools/planning.ts
+      await autoUploadPlannedWorkoutToIntervalsIfEnabled({ ... })
+
+      if (args.generate_structure !== false) {
+        ... generateStructuredWorkoutTask.trigger(...)
+```
+
+`autoUploadPlannedWorkoutToIntervalsIfEnabled` (`intervals-sync.ts` ~190–205) sends CREATE without interval steps.
+
+Generation task later runs UPDATE when `syncStatus === 'SYNCED'` (else branch ~1863+ in `generate-structured-workout.ts`) — this works but leaves a window with empty Intervals content.
+
+### `publish_planned_workout` allows empty `workout_doc`
+
+```1279:1308:server/utils/ai-tools/planning.ts
+      let workoutDoc = ''
+      if (workout.structuredWorkout) {
+        workoutDoc = WorkoutConverter.toIntervalsICU(workoutData)
+      }
+      ...
+            workout_doc: workoutDoc,
+```
+
+No guard requiring renderable structure before publish.
+
+## Impact
+
+- Intervals shows metadata-only workout while chat card still “generating”.
+- Model may chain `create` → `publish` in one turn → permanent empty export if generation fails.
+- User perception: “workout created but no details in Intervals.”
+
+## Suggested Fix
+
+- Defer Intervals CREATE until structure ready (or single CREATE with structure).
+- Reject `publish_planned_workout` when `!hasRenderableStructure(workout)`.
+- Skill instruction: do not publish until structure job completes.
+
+## Acceptance Criteria
+
+- [ ] Chat-created workouts do not appear empty on Intervals during normal flow
+- [ ] Publish tool fails clearly when structure missing

--- a/docs/issues/021-recommend-workout-stub-data.md
+++ b/docs/issues/021-recommend-workout-stub-data.md
@@ -1,0 +1,42 @@
+# 021 — `recommend_workout` chat tool returns hardcoded stub
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `workouts`  
+**Status:** Open
+
+## Description
+
+The chat `recommend_workout` tool always returns a fixed fake ride recommendation, not real AI/repository output. Users asking “what should I run today?” may get wrong guidance; follow-up “create it” flows can produce mismatched workouts.
+
+## Root Cause
+
+```19:32:server/utils/ai-tools/recommendations.ts
+    execute: async (args) => {
+      return {
+        created: false,
+        ...
+        recommendation: {
+          title: 'Zone 2 Endurance Ride',
+          duration_minutes: 90,
+          description: 'Steady state ride at 65-75% FTP.',
+          tss: 60
+        }
+      }
+    }
+```
+
+Tool description says read-only and points to `create_planned_workout`, but the stub is always cycling-oriented regardless of user sport/request.
+
+## Impact on structure generation
+
+User asks for a **run** → stub says **90min Zone 2 Ride** → model may `create_planned_workout(type: "Ride", ...)` then trigger structure generation for wrong sport/parameters.
+
+## Suggested Fix
+
+Wire to real recommendation pipeline (`list_pending_recommendations`, `recommend-today-activity` trigger) or remove tool until implemented. Update skill routing to prefer pending recommendations over stub.
+
+## Acceptance Criteria
+
+- [ ] No hardcoded recommendation payload in production chat path
+- [ ] Run vs ride requests route to correct sport type before structure generation

--- a/docs/issues/022-patch-vs-async-generation-race.md
+++ b/docs/issues/022-patch-vs-async-generation-race.md
@@ -1,0 +1,37 @@
+# 022 — Patch/set structure vs async generate/adjust race (last writer wins)
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open  
+**Related:** [013](./013-chat-duplicate-structure-generation-triggers.md)
+
+## Description
+
+In one chat turn, the model can call synchronous structure tools (`patch_planned_workout_structure`, `set_planned_workout_structure`) and async tools (`generate_planned_workout_structure`, `adjust_planned_workout`) on the same workout. There is no lock, epoch, or job cancellation — **whichever finishes last wins**.
+
+## Root Cause
+
+Independent code paths in `planning.ts`:
+
+- **Sync:** patch (~786–793), set — immediate DB write via `buildStructureEditFields`
+- **Async:** generate (~1216–1221), adjust (~1171–1184) — Trigger.dev tasks overwrite full structure on completion
+
+No shared `structureGenerationStatus` or in-flight guard ([012](./012-ai-in-triggers-architecture-rethink.md)).
+
+## Reproduction
+
+Single chat turn:
+
+1. `patch_planned_workout_structure` — user-visible “patched successfully”
+2. `generate_planned_workout_structure` — async job overwrites patch when complete
+
+## Expected Behavior
+
+- Reject patch/set while generation in flight, or cancel superseded jobs.
+- Skill rule: never patch and full-regenerate same workout in one turn.
+
+## Acceptance Criteria
+
+- [ ] Concurrent sync edit + async generate cannot silently discard user-visible edits
+- [ ] Tool results indicate when a later async job may overwrite changes

--- a/docs/issues/023-structure-tools-idempotency-gaps.md
+++ b/docs/issues/023-structure-tools-idempotency-gaps.md
@@ -1,0 +1,47 @@
+# 023 — Structure trigger tools lack chat idempotency protection
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `backend`  
+**Status:** Open  
+**Related:** [013](./013-chat-duplicate-structure-generation-triggers.md)
+
+## Description
+
+Chat tool wrapper dedupes mutating tools by `(lineageId, toolName, argsHash)`. Several structure-related tools are **not** classified as mutating, so identical repeated calls in one conversation lineage each execute fully.
+
+## Root Cause
+
+```113:129:server/utils/chat/turns.ts
+export function isMutatingChatTool(toolName: string) {
+  return (
+    ...
+    toolName.startsWith('patch_') ||
+    ...
+  )
+}
+```
+
+**Not covered:**
+
+| Tool | Prefix | Triggers structure? |
+|------|--------|---------------------|
+| `generate_planned_workout_structure` | `generate_` | Yes (async) |
+| `adjust_planned_workout` | `adjust_` | Yes (async adjust task) |
+| `set_planned_workout_structure` | `set_` | No (sync replace) |
+
+`patch_planned_workout_structure` **is** covered; `set_planned_workout_structure` is not.
+
+## Impact
+
+- Model retries same `generate_planned_workout_structure` call → multiple Trigger runs ([013](./013-chat-duplicate-structure-generation-triggers.md)).
+- Approved continuation for `set_*` is not short-circuited as mutating in `turn-executor.ts` (~695), so LLM stream may continue and issue follow-up writes.
+
+## Suggested Fix
+
+Extend mutating/idempotency list for structure enqueue and replace tools, or dedicated `isStructureMutatingTool()` helper.
+
+## Acceptance Criteria
+
+- [ ] Duplicate identical generate/adjust calls in one lineage return cached result / existing run id
+- [ ] `set_planned_workout_structure` idempotent within lineage

--- a/docs/issues/024-chat-card-wrong-workout-fallback.md
+++ b/docs/issues/024-chat-card-wrong-workout-fallback.md
@@ -1,0 +1,35 @@
+# 024 — Chat card fuzzy workout ID fallback can attach to wrong workout
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`, `workouts`  
+**Status:** Open
+
+## Description
+
+When `create_planned_workout` response lacks `workout_id`, `ChatPlannedWorkoutCard` guesses the workout by scoring same-day candidates on title/type/duration — which can bind polling and display to the **wrong workout**.
+
+## Root Cause
+
+```387:445:app/components/chat/ChatPlannedWorkoutCard.vue
+  const resolveWorkoutIdFromCreateArgs = async () => {
+    ...
+      const byScore = [...workouts].map((w) => { let score = 0; ... })
+      const best = byScore[0]?.workout
+      if (best?.id) {
+        fallbackWorkoutId.value = best.id
+      }
+```
+
+## Reproduction
+
+Two runs on the same calendar day → card without explicit `workout_id` polls/displays highest-scoring unrelated workout’s structure status.
+
+## Suggested Fix
+
+Only use explicit `workout_id` / `run_id`; show error state instead of guessing. Fix upstream ([008](./008-chat-silent-trigger-failures.md), [014](./014-idempotent-create-skips-structure-retrigger.md)) so `workout_id` is always returned.
+
+## Acceptance Criteria
+
+- [ ] Card never attaches to wrong workout via heuristic matching
+- [ ] Missing id shows clear error, not misleading progress

--- a/docs/issues/025-planned-workout-details-context-bloat.md
+++ b/docs/issues/025-planned-workout-details-context-bloat.md
@@ -1,0 +1,39 @@
+# 025 — `get_planned_workout_details` dumps unbounded context into chat
+
+**Type:** Bug  
+**Priority:** Low  
+**Area:** `ai`, `backend`  
+**Status:** Open
+
+## Description
+
+Unlike focused `get_planned_workout_structure`, `get_planned_workout_details` spreads the full Prisma record (nested `trainingWeek.block.plan`, entire `structuredWorkout`) into the LLM tool result — bloating tokens, slowing turns, and confusing the model between read vs mutate tools.
+
+## Root Cause
+
+```606:624:server/utils/ai-tools/planning.ts
+      const workout = await plannedWorkoutRepository.getById(workout_id, userId, {
+        include: {
+          trainingWeek: { include: { block: { include: { plan: true } } } }
+        }
+      })
+      ...
+      return {
+        ...workout,
+        date: formatDateUTC(workout.date)
+      }
+```
+
+## Impact on structure generation
+
+- Large step trees echoed back into context → model may over-call `generate_planned_workout_structure` or patch incorrectly.
+- Slower chat turns increase timeout risk ([012](./012-ai-in-triggers-architecture-rethink.md)).
+
+## Suggested Fix
+
+Return curated summary (metadata, structure summary, generation status); direct model to `get_planned_workout_structure` for step-level work.
+
+## Acceptance Criteria
+
+- [ ] Tool result size bounded for typical workouts
+- [ ] Structure edits routed to structure-specific tools

--- a/docs/issues/026-structure-tools-missing-preflight.md
+++ b/docs/issues/026-structure-tools-missing-preflight.md
@@ -1,0 +1,24 @@
+# 026 — `generate_planned_workout_structure` / `adjust_planned_workout` skip sync existence check
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Both tools enqueue Trigger.dev jobs without verifying the workout exists and belongs to the user. Chat returns `{ success: true, run_id }`; the task fails asynchronously.
+
+## Root Cause
+
+No `plannedWorkoutRepository.getById` preflight before trigger in `planning.ts` (~1169–1225). Contrast `patch_planned_workout_structure` (~737) which checks existence first.
+
+## Impact
+
+- Hallucinated `workout_id` → chat card shows “Job running”, task fails with “Workout not found”.
+- Wastes queue time; poor error UX vs synchronous `{ success: false }`.
+
+## Acceptance Criteria
+
+- [ ] Invalid/missing workout_id returns synchronous error in chat tool result
+- [ ] No Trigger run enqueued for non-existent workouts

--- a/docs/issues/027-cross-user-runs-on-identity-switch.md
+++ b/docs/issues/027-cross-user-runs-on-identity-switch.md
@@ -1,0 +1,75 @@
+# 027 — Trigger monitor leaks runs after coaching act-as / impersonation switch
+
+**Type:** Bug  
+**Priority:** Critical  
+**Area:** `ui/ux`, `backend`, `infra`  
+**Status:** Open
+
+## Description
+
+Users (especially coaches using **Act As**, or admins using **impersonation**) can see **another user's Trigger.dev runs** in the in-app Trigger Monitor after switching back to their own account.
+
+This matches reports of “seeing other users' triggers” in the monitor.
+
+## Root Cause
+
+`useUserRuns.fetchActiveRuns()` **always merges** new API results into the existing in-memory run list — it never clears runs from a previous session identity.
+
+```90:123:app/composables/useUserRuns.ts
+      const mergedRunsMap = new Map<string, TriggerRun>()
+      runs.value.forEach((r) => mergedRunsMap.set(r.id, r))  // ← previous user's runs kept
+
+      data.forEach((run: any) => {
+        mergedRunsMap.set(run.id, run)
+      })
+      ...
+      runs.value = finalRuns.slice(0, 50)
+```
+
+When `session.user.id` changes (coaching act-as or admin impersonation), the watcher calls `init()` but **does not clear** `runs.value` first:
+
+```296:311:app/composables/useUserRuns.ts
+    watch(
+      () => (session.value?.user as any)?.id,
+      (newId) => {
+        if (newId) {
+          void init()   // ← no runs.value = []
+        } else {
+          runs.value = []
+        }
+      }
+    )
+```
+
+### Example flow
+
+1. Coach (user A) opens app → monitor shows A's runs.
+2. Coach enables **Act As** athlete (user B) → API fetch returns B's runs → merge keeps **A + B**.
+3. Coach disables act-as → API fetch returns A's runs → merge keeps **A + B** → coach still sees athlete jobs.
+
+Same pattern for admin impersonation (`server/utils/session.ts` swaps `session.user.id` to target user).
+
+## Security notes
+
+- `/api/runs/active` and `/api/runs/[id]` **do** filter by `user:${session.user.id}` tag — direct API access is scoped correctly.
+- The leak is **client-side stale state**, not Trigger.dev returning other users' runs from the API.
+- `/api/runs/[id]` cancel/retrieve still checks tags — cancelling a leaked stale run ID would 404 if tagged for another user (good).
+
+## Expected Behavior
+
+On any identity switch (`session.user.id` change):
+
+1. Clear `runs.value` immediately.
+2. Re-fetch active runs for the new identity only.
+3. Optionally reconnect/re-auth WebSocket (see [031](./031-websocket-not-reauth-on-identity-switch.md)).
+
+## Acceptance Criteria
+
+- [ ] Switching act-as off removes athlete runs from monitor within one refresh cycle
+- [ ] Impersonation start/stop shows only the active identity's runs
+- [ ] `handleRunUpdate` ignores runs whose tags don't match current user (defense in depth)
+
+## Related
+
+- [031](./031-websocket-not-reauth-on-identity-switch.md)
+- [028](./028-trigger-monitor-stale-run-merge.md)

--- a/docs/issues/028-trigger-monitor-stale-run-merge.md
+++ b/docs/issues/028-trigger-monitor-stale-run-merge.md
@@ -1,0 +1,49 @@
+# 028 — Trigger monitor merge never evicts stale runs
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `ui/ux`  
+**Status:** Open
+
+## Description
+
+The Trigger Monitor can show **old completed runs long after** the server stopped returning them from `/api/runs/active`, because the client merge strategy only adds/updates — never removes runs missing from the API payload.
+
+## Root Cause
+
+`/api/runs/active` returns active runs plus completed runs from the **last 60 seconds** only:
+
+```34:57:server/api/runs/active.get.ts
+    const RECENT_THRESHOLD_MS = 60 * 1000
+    ...
+    const filteredRuns = activeRuns.data.filter((run) => {
+      const isActive = [...].includes(run.status)
+      if (isActive) return true
+      if (run.finishedAt) {
+        return now.getTime() - finishedTime < RECENT_THRESHOLD_MS
+      }
+      return false
+    })
+```
+
+But `fetchActiveRuns` seeds the merge map from **all** existing `runs.value` entries (up to 50), so completed jobs from minutes or hours ago remain visible until pushed out by newer runs.
+
+WebSocket `handleRunUpdate` also adds runs without pruning.
+
+## Impact
+
+- Monitor history feels “stuck” or cluttered.
+- Combined with [027](./027-cross-user-runs-on-identity-switch.md), stale runs from a prior identity persist indefinitely.
+
+## Suggested Fix
+
+Replace merge-with-retain with one of:
+
+- **Replace mode:** `runs.value = data` on full fetch (plus WS patch overlay for in-flight updates), or
+- **TTL prune:** drop completed runs older than 60s on each fetch, or
+- **Identity-aware reset:** clear on user id change (required for 027).
+
+## Acceptance Criteria
+
+- [ ] Completed runs disappear from monitor ~1 minute after finish (matching API policy)
+- [ ] Active runs still update in real time via WebSocket

--- a/docs/issues/029-triggers-missing-user-tags.md
+++ b/docs/issues/029-triggers-missing-user-tags.md
@@ -1,0 +1,44 @@
+# 029 — Some triggers missing `user:{userId}` tags
+
+**Type:** Bug  
+**Priority:** High  
+**Area:** `backend`, `infra`  
+**Status:** Open
+
+## Description
+
+The run monitor and `/api/runs/*` ownership checks rely on every user-scoped run being tagged with `user:{userId}`. Several trigger sites omit this tag, causing inconsistent monitoring, broken cancel/status APIs, and blind spots in ownership enforcement.
+
+## Confirmed examples
+
+| Location | Task | Tags |
+|----------|------|------|
+| `server/api/nutrition/analyze-all.post.ts` | `analyze-nutrition` | **None** (only `concurrencyKey`) |
+| `server/api/chat/rooms/[id]/summarize.post.ts` | `summarize-chat` | **None** |
+| `server/utils/email-service.ts` | `send-email` | **None** |
+| `server/api/stripe/webhook.post.ts` | `send-email` | **None** |
+| `server/api/admin/debug/trigger-test.post.ts` | test tasks | **None** (admin-only; OK) |
+
+Compare with correct pattern in `server/api/workouts/[id]/analyze.post.ts`:
+
+```typescript
+tags: [`user:${user.id}`],
+concurrencyKey: user.id,
+```
+
+## Impact
+
+- Runs without `user:` tag **never appear** in `/api/runs/active` (filtered by tag).
+- If a WS event is published with wrong/missing tags, ownership checks on `/api/runs/[id]` return 404.
+- Harder to audit or debug per-user job volume in Trigger.dev.
+
+## Suggested Fix
+
+1. Add shared helper `buildUserRunTags(userId, extras?: string[])` used at every `tasks.trigger` call site.
+2. Lint/check script: fail CI if `tasks.trigger` in `server/` lacks `user:` tag (except explicit system tasks).
+3. Backfill documentation in `docs/04-guides/background-task-monitoring.md`.
+
+## Acceptance Criteria
+
+- [ ] All user-initiated API triggers include `user:{userId}` tag
+- [ ] Audit list documented and enforced in CI or code review checklist

--- a/docs/issues/030-library-run-tags-template-owner.md
+++ b/docs/issues/030-library-run-tags-template-owner.md
@@ -1,0 +1,48 @@
+# 030 — Library structure jobs tag template owner, not session actor
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `backend`, `workouts`, `ui/ux`  
+**Status:** Open
+
+## Description
+
+Library workout structure generation tags runs with **`user:${template.userId}`**, not the logged-in user who clicked the button. This creates monitor visibility mismatches in coaching scenarios.
+
+## Root Cause
+
+```35:43:server/api/library/workouts/[id]/generate-structure.post.ts
+  const handle = await tasks.trigger(
+    'generate-structured-workout',
+    { workoutTemplateId: id },
+    {
+      tags: [`user:${template.userId}`, `workout-template:${id}`],
+      concurrencyKey: template.userId
+    }
+  )
+```
+
+No `publishTaskRunStartedEvent` is called — monitor relies on polling `/api/runs/active`.
+
+## Scenarios
+
+| Actor | Template owner | Who sees run in monitor |
+|-------|----------------|-------------------------|
+| Athlete | Self | Athlete ✓ |
+| Coach (act-as athlete) | Athlete | Athlete session ✓ |
+| Coach (own account, library scope `all`) | Athlete | **Nobody** (tagged athlete, session is coach) |
+| Coach generating own template | Coach | Coach ✓ |
+
+## Expected Behavior
+
+Tag runs with **both**:
+
+- `user:{sessionUserId}` — monitor ownership for whoever triggered
+- `user:{subjectUserId}` or `template-owner:{id}` — billing/quota subject if different
+
+Or always tag the **session actor** and pass subject in payload only.
+
+## Acceptance Criteria
+
+- [ ] Coach triggering library generation sees the job in their monitor
+- [ ] Tag policy documented for coach vs athlete ownership

--- a/docs/issues/031-websocket-not-reauth-on-identity-switch.md
+++ b/docs/issues/031-websocket-not-reauth-on-identity-switch.md
@@ -1,0 +1,54 @@
+# 031 — WebSocket not re-authenticated on identity switch
+
+**Type:** Bug  
+**Priority:** Medium  
+**Area:** `infra`, `ui/ux`  
+**Status:** Open  
+**Related:** [027](./027-cross-user-runs-on-identity-switch.md)
+
+## Description
+
+The WebSocket connection authenticates **once on open** with a short-lived token. When the user switches identity (coaching act-as, impersonation), the socket is **not** re-authenticated — `peerContext.userId` may remain the original login user.
+
+## Root Cause
+
+Client sends auth only in `onopen`:
+
+```185:194:app/composables/useUserRuns.ts
+    ws.onopen = async () => {
+      ...
+      const { token } = await ($fetch as any)('/api/websocket-token')
+      ws?.send(JSON.stringify({ type: 'authenticate', token }))
+      ws?.send(JSON.stringify({ type: 'subscribe_user' }))
+```
+
+`subscribe_user` is sent but **not handled** by `server/api/websocket.ts` (noop).
+
+Session identity watch calls `init()` without reconnecting the socket:
+
+```296:301:app/composables/useUserRuns.ts
+        if (newId) {
+          void init()
+```
+
+WS token is generated from `session.user.id` at connect time (`server/api/websocket-token.get.ts`). After act-as toggle without reconnect, realtime delivery targets the wrong peer userId.
+
+## Impact
+
+- While acting as athlete, coach may **not** receive athlete run WS updates (relies on polling).
+- After switching back, coach may still receive events routed to stale peer context in edge cases.
+- Contributes to confusing monitor state combined with [027](./027-cross-user-runs-on-identity-switch.md).
+
+## Suggested Fix
+
+On `session.user.id` change:
+
+1. Close and reconnect WebSocket (re-auth with fresh token), or
+2. Send `reauthenticate` message handled server-side to update `peerContext.userId`.
+
+Remove dead `subscribe_user` client message or implement it server-side.
+
+## Acceptance Criteria
+
+- [ ] Act-as toggle reconnects WS with correct user id
+- [ ] Realtime run updates match active session identity

--- a/docs/issues/032-trigger-tag-taxonomy-inconsistent.md
+++ b/docs/issues/032-trigger-tag-taxonomy-inconsistent.md
@@ -1,0 +1,68 @@
+# 032 — Trigger tag taxonomy inconsistent for workout structure jobs
+
+**Type:** Maintenance  
+**Priority:** Medium  
+**Area:** `backend`, `workouts`, `infra`  
+**Status:** Open  
+**Related:** [002](./002-missing-planned-workout-run-tags.md), [013](./013-chat-duplicate-structure-generation-triggers.md)
+
+## Description
+
+`user:{userId}` tagging exists for ownership, but **secondary entity tags** for workout structure generation are applied inconsistently across entry points — making per-workout monitoring, filtering, and debugging unreliable.
+
+## Tag matrix (`generate-structured-workout`)
+
+| Entry point | Trigger tags | `publishTaskRunStartedEvent` tags |
+|-------------|--------------|-----------------------------------|
+| Chat `create_planned_workout` | `user`, **`planned-workout:{id}`** | Same ✓ |
+| Chat `generate_planned_workout_structure` | `user`, **`planned-workout:{id}`** | Same ✓ |
+| API `generate-structure.post.ts` | **`user` only** | **`user` only** |
+| API `adjust.post.ts` | **`user` only** | **`user` only** |
+| `accept.post.ts` (recommendations) | **`user` only** | Not published |
+| `generate-training-block` loop | **`user` only** | Not published |
+| `generate-ad-hoc-workout` chain | **`user` only** | Not published |
+| Library template API | `user:{templateOwner}`, **`workout-template:{id}`** | Not published |
+
+## Impact
+
+- Planned Workout Details page `activeStructureRun` only matches `planned-workout:` tag ([002](./002-missing-planned-workout-run-tags.md)).
+- Trigger Monitor shows generic “Generate Structured Workout” with no entity context.
+- Trigger.dev dashboard searches by tag are harder.
+- Cannot cancel/filter all structure jobs for one workout reliably.
+
+## Recommended standard
+
+```typescript
+type StructureRunTags = [
+  `user:${string}`,
+  `planned-workout:${string}` | `workout-template:${string}`,
+  ...(optional: `source:chat` | `source:api` | `source:block`)
+]
+```
+
+Single helper:
+
+```typescript
+function structureGenerationRunTags(opts: {
+  userId: string
+  plannedWorkoutId?: string
+  workoutTemplateId?: string
+  source?: string
+}): string[]
+```
+
+Use in **both** `tasks.trigger` and `publishTaskRunStartedEvent`.
+
+## Also missing tags on related tasks
+
+| Task | Suggested extra tag |
+|------|---------------------|
+| `adjust-structured-workout` | `planned-workout:{id}` |
+| `generate-workout-messages` | `planned-workout:{id}` |
+| `generate-ad-hoc-workout` | `planned-workout:{id}` after create |
+
+## Acceptance Criteria
+
+- [ ] One helper used by all structure-related enqueue sites
+- [ ] Trigger Monitor or workout UI can correlate runs to a specific planned workout
+- [ ] Document tag conventions in `docs/04-guides/background-task-monitoring.md`

--- a/docs/issues/033-retire-legacy-structure-generator.md
+++ b/docs/issues/033-retire-legacy-structure-generator.md
@@ -1,0 +1,64 @@
+# 033 — Retire `legacy_json` structure generator for ride/run/swim
+
+**Type:** Performance  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Structure generation maintains **two parallel prompt + schema paths**: `legacy_json` (large `workoutStructureSchema`, ~70-line prompt) and `draft_json_v1` (compact draft schema + server-side compile). The default for ride/run/swim is already `draft_json_v1`, but legacy remains as fallback and doubles maintenance, token cost, and timeout surface area.
+
+## Current State
+
+```916:924:trigger/generate-structured-workout.ts
+    const generatorMode =
+      requestedGeneratorMode === 'draft_json_v1' &&
+      isDraftStructuredWorkoutSupported(workout.type || '')
+        ? requestedGeneratorMode
+        : 'legacy_json'
+```
+
+```264:269:server/utils/structured-workout-draft.ts
+export function isDraftStructuredWorkoutSupported(workoutType: unknown) {
+  const normalized = String(workoutType || '').trim().toLowerCase()
+  return normalized.includes('ride') || normalized.includes('run') || normalized.includes('swim')
+}
+```
+
+- **Ride / Run / Swim** → `draft_json_v1` when feature flag allows (default).
+- **WeightTraining / Gym** → always `legacy_json` (draft unsupported).
+- **Explicit override** or unsupported type → legacy path with full schema.
+
+The same dual-path logic is duplicated in `trigger/adjust-structured-workout.ts`.
+
+## Why This Hurts
+
+| Problem | Detail |
+|---------|--------|
+| **Token bloat** | Legacy schema is ~400+ lines with nested property descriptions sent to structured-output API |
+| **Prompt duplication** | Two full prompt templates (`prompt` + `draftPrompt`) maintained in sync |
+| **Retry cost** | Validation/coverage retries on legacy resend the larger prompt ([037](./037-structure-generation-lightweight-retries.md)) |
+| **Drift risk** | Sport rules and targeting instructions must be edited in two places |
+
+## Suggested Fix
+
+1. **Make `draft_json_v1` mandatory** for ride/run/swim in `generate-structured-workout` and `adjust-structured-workout`.
+2. **Remove** the legacy prompt branch and `workoutStructureSchema` from those tasks for supported sports (or move legacy to a dedicated strength-only module).
+3. **Keep `legacy_json`** only for strength until a blocks draft schema exists ([future strength pipeline]).
+4. **Remove or narrow** `generatorOverride` feature flag once parity is confirmed in LLM ops metrics.
+5. Update unit tests in `tests/unit/server/utils/structured-workout-draft.test.ts` and any generator-mode integration tests.
+
+## Acceptance Criteria
+
+- [ ] Ride, Run, Swim always use `draft_json_v1`; no silent fallback to legacy unless sport is unsupported
+- [ ] Legacy schema/prompt removed from generate/adjust tasks for supported endurance sports
+- [ ] Strength / WeightTraining still generates valid structures (legacy or dedicated path)
+- [ ] `promptChars` P50 decreases measurably for ride/run/swim in LLM ops
+- [ ] No regression in coverage validation pass rate on first attempt
+
+## References
+
+- [012](./012-ai-in-triggers-architecture-rethink.md) — open question on dropping legacy
+- `server/utils/structured-workout-generator.ts` — mode resolution
+- `server/utils/structured-workout-draft.ts` — draft schema + compile

--- a/docs/issues/034-deduplicate-structure-prompt-targeting.md
+++ b/docs/issues/034-deduplicate-structure-prompt-targeting.md
@@ -1,0 +1,67 @@
+# 034 — Deduplicate targeting instructions in structure-generation prompts
+
+**Type:** Performance  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Structure-generation prompts repeat **targeting and format rules multiple times** in the same request: dedicated policy formatters, zone blocks, INSTRUCTIONS bullets, and sport-specific paragraphs all restate primary metric, fallback order, range vs value preference, and mixed-target policy. This adds input tokens without improving output quality and can slow generation.
+
+## Root Cause
+
+Prompt assembly in `trigger/generate-structured-workout.ts` (mirrored in `adjust-structured-workout.ts`):
+
+```1064:1067:trigger/generate-structured-workout.ts
+    const targetPolicyPrompt = formatTargetPolicyPrompt(targetPolicy, loadPreference)
+    const targetFormatPolicyPrompt = formatTargetFormatPolicyPrompt(targetFormatPolicy)
+```
+
+These blocks are injected into the prompt, then **repeated** in INSTRUCTIONS:
+
+```1191:1196:trigger/generate-structured-workout.ts
+    - **METRIC PRIORITY**: Respect the user's TARGET POLICY and preferred order (${loadPreference}).
+      - Priority Order: ${priorityText}.
+      - Primary metric for each step should be: ${targetPolicy.primaryMetric}.
+      - ${targetPolicy.strictPrimary ? 'Strict primary is enabled...' : 'Fallback metrics are allowed...'}
+      - ${targetPolicy.allowMixedTargetsPerStep ? 'Mixed targets...' : 'Do not include multiple intensity targets...'}
+```
+
+Sport-specific blocks add a third pass (e.g. running repeats priority order and pace unit rules).
+
+`formatTargetPolicyPrompt` alone emits 6 bullet lines (`trigger/utils/workout-targeting.ts`).
+
+## Impact
+
+- Higher prompt token count on every structure job (×2 attempts on retry).
+- Model attention split across redundant constraints instead of workout-specific design.
+- Harder to maintain — rule changes require editing 3+ locations.
+
+## Suggested Fix
+
+1. Extract a single **`formatCompactTargetingBlock()`** (~5–8 lines) used once per prompt.
+2. Remove the INSTRUCTIONS **METRIC PRIORITY** subsection when the compact block is present.
+3. Trim sport rules to sport-only constraints (cadence for cycling, distance for running, send-off for swim) — drop targeting restatements already in the compact block.
+4. Apply the same refactor to both `prompt` / `draftPrompt` paths (or only `draftPrompt` after [033](./033-retire-legacy-structure-generator.md)).
+5. Optionally move static JSON rules (“omit null”, “valid JSON only”) to a shared constant included once.
+
+Example compact block shape:
+
+```
+TARGETING: primary=power (% FTP), fallback=HR > RPE, steady=single value, one metric per step.
+FORMAT: HR=LTHR fractions (0.80), power=% FTP (0.95), pace=Pace or /km per policy.
+```
+
+## Acceptance Criteria
+
+- [ ] Target policy appears **once** in generate/adjust prompts (not 3×)
+- [ ] Sport-specific sections contain no duplicate priority-order text
+- [ ] `promptChars` reduced vs baseline (log at `prompt-built` stage)
+- [ ] Spot-check: ride/run/swim outputs still respect user sport settings and targeting overrides
+- [ ] Adjust task prompts stay in sync with generate task
+
+## References
+
+- `trigger/utils/workout-targeting.ts` — `formatTargetPolicyPrompt`, `formatTargetFormatPolicyPrompt`
+- [033](./033-retire-legacy-structure-generator.md) — reduces to one prompt path

--- a/docs/issues/035-remove-unused-streams-from-structure-context.md
+++ b/docs/issues/035-remove-unused-streams-from-structure-context.md
@@ -1,0 +1,72 @@
+# 035 — Remove unused stream data from structure-generation context fetch
+
+**Type:** Performance  
+**Priority:** Low  
+**Area:** `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When building context for structure generation, the task fetches the user's **4 most recent workouts** with nested `streams` (HR/power zone times), but the prompt summary **never uses stream data**. This adds unnecessary DB load and payload size on every generation.
+
+## Root Cause
+
+```1005:1017:trigger/generate-structured-workout.ts
+    const recentWorkouts = await workoutRepository.getForUser(workout.userId, {
+      limit: 4,
+      orderBy: { date: 'desc' },
+      include: {
+        streams: {
+          select: {
+            hrZoneTimes: true,
+            powerZoneTimes: true
+          }
+        }
+      }
+    })
+```
+
+Summary builder ignores streams:
+
+```821:832:server/utils/gemini.ts
+export function buildConciseWorkoutSummary(workouts: any[], timezone?: string): string {
+  return workouts
+    .map((w, idx) => {
+      const dateStr = formatDateUTC(w.date, 'MMM d')
+      const duration = Math.round(w.durationSec / 60)
+      ...
+      return `${idx + 1}. ${dateStr}: ${w.type} - ${w.title} [${duration}m${tss}${intensity}${power}]`
+    })
+    .join('\n')
+}
+```
+
+Same pattern exists in `trigger/adjust-structured-workout.ts`.
+
+Comment says “Limit to 7” but code uses `limit: 4` — stale comment.
+
+## Impact
+
+- Extra join/query cost per structure job (× all batch block fan-out jobs).
+- Streams loaded into memory then discarded.
+- No corresponding prompt benefit.
+
+## Suggested Fix
+
+**Option A (minimal):** Remove `include: { streams: ... }` from both generate and adjust tasks.
+
+**Option B (if recent context is valuable):** Keep the 4-workout summary but fetch only fields used by `buildConciseWorkoutSummary` (`date`, `type`, `title`, `durationSec`, `tss`, `intensity`, `averageWatts`).
+
+**Option C (future):** If zone-time context is desired, add a **one-line** aggregate to the summary (e.g. “last ride: 45m, 62% time Z2”) — do not load full stream objects unless used.
+
+## Acceptance Criteria
+
+- [ ] Structure generate/adjust no longer queries `streams` for recent workouts
+- [ ] Prompt output for `RECENT WORKOUTS (brief)` unchanged for typical users
+- [ ] Stale “Limit to 7” comment updated or removed
+- [ ] Measurable reduction in DB query time for structure task `loaded-recent-workouts` stage (optional benchmark)
+
+## References
+
+- [034](./034-deduplicate-structure-prompt-targeting.md) — complementary prompt slimming
+- `workoutRepository.getForUser` usage in generate/adjust tasks

--- a/docs/issues/036-bound-aicontext-in-structure-generation.md
+++ b/docs/issues/036-bound-aicontext-in-structure-generation.md
@@ -1,0 +1,53 @@
+# 036 — Bound `aiContext` in structure-generation prompts
+
+**Type:** Performance  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Structure generation injects the user's full **`aiContext`** string (global “About me / special instructions” from AI settings) into every structure job. Users can store long, chat-oriented context that is rarely needed to place interval targets for a specific planned workout — and it can dominate prompt size.
+
+## Root Cause
+
+```1025:1025:trigger/generate-structured-workout.ts
+    const aiContext = workout.user.aiContext || ''
+```
+
+```1154:1154:trigger/generate-structured-workout.ts
+    ${aiContext ? `- User Preferences/Context: ${aiContext}` : ''}
+```
+
+Same injection in `draftPrompt` and in `adjust-structured-workout.ts`.
+
+By contrast, chat and analysis tasks use the full blob appropriately; structure gen already has workout `title`, `description`, goal/phase/focus, zones, and targeting policy.
+
+## Impact
+
+- Unbounded prompt growth when `aiContext` is large (injury history, race plans, nutrition notes, etc.).
+- Slower Flash calls and higher timeout/retry rate ([037](./037-structure-generation-lightweight-retries.md)).
+- Global context may **conflict** with the specific workout prescription (e.g. “focus on swimming” in aiContext for a Run workout).
+
+## Suggested Fix
+
+1. **Hard cap** — e.g. first 400–600 characters with ellipsis, or token-budget helper shared with chat context utilities.
+2. **Relevance filter (optional)** — include lines matching sport keywords, injury/constraint terms, or intensity preferences; drop narrative fluff.
+3. **Skip when redundant** — if workout `description` is non-empty and > N chars (chat-created shells), omit `aiContext` or use minimal cap.
+4. **Structured extraction (later)** — parse aiContext into tagged sections at settings save time; structure gen reads only `training_constraints` slice.
+
+Centralize in a helper, e.g. `formatAiContextForStructureGen({ aiContext, workoutType, description })`, used by generate + adjust.
+
+## Acceptance Criteria
+
+- [ ] Structure prompts never include unbounded `aiContext`
+- [ ] Injury/constraint info still reachable when present in first N chars or matched keywords
+- [ ] `promptChars` P95 decreases for users with long aiContext
+- [ ] No regression for users who rely on aiContext for cadence/zone preferences (spot-check cycling users)
+- [ ] Helper covered by unit tests with long input and sport-specific cases
+
+## References
+
+- [025](./025-planned-workout-details-context-bloat.md) — chat-side context bloat (related, separate path)
+- `server/api/settings/ai.post.ts` — where aiContext is stored
+- `server/utils/services/chatContextService.ts` — full context usage in chat

--- a/docs/issues/037-structure-generation-lightweight-retries.md
+++ b/docs/issues/037-structure-generation-lightweight-retries.md
@@ -1,0 +1,87 @@
+# 037 — Lightweight corrective retries for structure generation
+
+**Type:** Performance  
+**Priority:** High  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+When structure generation fails validation or times out, retries **resend the entire prompt** and upgrade to **Gemini Pro with high thinking** — up to ~90s of AI time inside a 180s task. Corrective feedback is generic and does not include the failed draft, so the model often re-derives the full workout from scratch.
+
+## Current Behavior
+
+```1270:1291:trigger/generate-structured-workout.ts
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      ...
+        if (isRetry) actualModelUsed = 'pro'
+        ...
+          const draft = await generateStructuredAnalysis(
+            isRetry
+              ? `${draftPrompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous draft was rejected or incomplete.\n- Keep the same compact schema.\n- Stay inside duration tolerance and include a complete main set.`
+              : draftPrompt,
+            ...
+              modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
+              thinkingLevelOverride: isRetry ? 'high' : undefined
+```
+
+Coverage validation retry (attempt 2) prepends the same full `prompt` + reason:
+
+```1444:1444:trigger/generate-structured-workout.ts
+      promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous structure was rejected because ${coverageValidation.reason}.\n- ...`
+```
+
+Strength validation uses the same full-prompt pattern.
+
+## Why This Hurts
+
+| Issue | Effect |
+|-------|--------|
+| Full prompt on retry | Pays full input tokens again (~4k–10k+ chars) |
+| Pro + high thinking on attempt 2 | Slowest model tier for what is often a small fix (duration trim, add main set) |
+| No failed draft in retry | Model cannot patch; must regenerate entire structure |
+| Generic feedback | Does not tell model *which* steps failed coverage or strength rules |
+
+## Suggested Fix
+
+### Retry prompt shape
+
+On attempt 2+, send a **short corrective prompt**:
+
+- Workout metadata (title, duration, type) — ~10 lines
+- **Previous draft JSON** (truncated if huge)
+- **Specific failure**: `coverageValidation.reason`, strength validation reason, or timeout
+- Compact schema only
+- Instruction: “Fix the issues below; preserve valid steps where possible.”
+
+### Model/thinking escalation
+
+1. Attempt 1: Flash, low/minimal thinking ([038](./038-disable-thinking-flash-structure-generation.md))
+2. Attempt 2: Flash or Pro with **low** thinking first
+3. Attempt 3 (optional): Pro + high thinking only for strength/swim or repeated failure — requires task budget review
+
+### Failure-type routing
+
+| Failure | Retry strategy |
+|---------|----------------|
+| Timeout | Smaller prompt + same model, or split coach copy from steps (future) |
+| Coverage under/over | Patch prompt with computed duration delta |
+| Empty steps | Full regen but still compact prompt |
+| Strength blocks invalid | Strength-specific corrective block only |
+
+Store last draft in task scope between attempts (in-memory; no DB required).
+
+## Acceptance Criteria
+
+- [ ] Attempt-2 prompt is materially smaller than attempt-1 (`promptChars` logged separately)
+- [ ] Retry prompt includes previous draft JSON and specific validation reason when available
+- [ ] Pro + high thinking not used as default for all attempt-2 cases (configurable escalation)
+- [ ] P95 `aiDurationMs` for successful first-attempt generations unchanged or improved
+- [ ] P95 total task duration decreases for jobs that previously needed attempt 2
+- [ ] Same behavior applied in `adjust-structured-workout.ts`
+
+## References
+
+- [012](./012-ai-in-triggers-architecture-rethink.md) — timeout/retry architecture
+- [006](./006-ui-timeout-messaging-mismatch.md) — user-visible duration expectations
+- [033](./033-retire-legacy-structure-generator.md) — smaller base prompt helps all retries

--- a/docs/issues/038-disable-thinking-flash-structure-generation.md
+++ b/docs/issues/038-disable-thinking-flash-structure-generation.md
@@ -1,0 +1,73 @@
+# 038 — Reduce or disable thinking budget for Flash structure generation
+
+**Type:** Performance  
+**Priority:** Medium  
+**Area:** `ai`, `backend`, `workouts`  
+**Status:** Open
+
+## Description
+
+Structure generation uses **`generateStructuredAnalysis`** with JSON schema enforcement — the model output shape is largely constrained. Despite that, Flash calls inherit **thinking budget/level** from LLM operation settings (default Flash: `thinkingLevel: 'low'`, `thinkingBudget: 2000`), which adds latency and reasoning tokens without clear benefit for codifying intervals.
+
+## Current Behavior
+
+```517:546:server/utils/gemini.ts
+export async function generateStructuredAnalysis<T>(...) {
+  const opSettings = await getLlmOperationSettings(
+    trackingContext?.userId,
+    trackingContext?.operation
+  )
+  ...
+  const thinkingLevel = trackingContext?.thinkingLevelOverride || opSettings.thinkingLevel
+  const thinkingBudget = trackingContext?.thinkingBudgetOverride || opSettings.thinkingBudget
+  ...
+  const providerOptions = trackingContext?.disableThinking
+    ? {}
+    : buildGoogleProviderOptions(modelName, thinkingLevel, thinkingBudget)
+```
+
+Structure tasks pass `operation: 'generate_structured_workout'` / `'adjust_structured_workout'` but do **not** set `disableThinking` on attempt 1. Attempt 2 explicitly sets `thinkingLevelOverride: 'high'`.
+
+Default Flash settings:
+
+```18:24:server/utils/ai-operation-settings.ts
+const DEFAULT_FLASH_SETTINGS: LlmOperationSettings = {
+  model: 'flash',
+  modelId: 'gemini-2.5-flash',
+  thinkingBudget: 2000,
+  thinkingLevel: 'low',
+  maxSteps: 3
+}
+```
+
+Usage logging already captures `reasoningTokens` — can validate before/after.
+
+## Impact
+
+- Extra seconds on every structure job (attempt 1 is the common case).
+- Reasoning tokens billed on top of structured output completion.
+- Compounds with large prompts ([034](./034-deduplicate-structure-prompt-targeting.md), [036](./036-bound-aicontext-in-structure-generation.md)).
+
+## Suggested Fix
+
+**Option A (code-level, fastest to ship):** Pass `disableThinking: true` on attempt 1 for `generate_structured_workout` and `adjust_structured_workout` in both generate and adjust tasks.
+
+**Option B (ops-level):** Add `llmOperationOverride` rows for `generate_structured_workout` / `adjust_structured_workout` with `thinkingLevel: 'minimal'` or zero budget on Flash tier.
+
+**Option C (hybrid):** Disable thinking for `draft_json_v1`; keep low thinking for legacy/strength if still needed.
+
+Reserve thinking for attempt-2 corrective calls only when patch retry fails ([037](./037-structure-generation-lightweight-retries.md)).
+
+## Acceptance Criteria
+
+- [ ] Attempt-1 structure Flash calls use minimal or no thinking budget
+- [ ] `reasoningTokens` in LLM ops drops for successful first-attempt structure jobs
+- [ ] `aiDurationMs` P50 improves without increase in validation failure rate
+- [ ] Strength/swim edge cases spot-checked (complex sessions still pass coverage validation)
+- [ ] Document override in LLM ops panel or `docs/06-plans/llm-ops-control-panel.md`
+
+## References
+
+- [037](./037-structure-generation-lightweight-retries.md) — retry thinking escalation
+- `docs/06-plans/llm-ops-control-panel.md` — operation list includes `generate_structured_workout`
+- [012](./012-ai-in-triggers-architecture-rethink.md) — unified AI timeout/thinking policy

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,0 +1,111 @@
+# Workout Details Generation — Issue Tracker
+
+Last reviewed: 2026-07-07
+
+This tracker documents bugs, UX gaps, and architectural concerns found during a code review of **planned workout structure generation** (the AI pipeline that produces interval steps, strength blocks, coach instructions, and related metadata for the Planned Workout Details page).
+
+No code changes were made as part of this review — only issue documentation.
+
+## Scope
+
+**In scope**
+
+- `generate-structured-workout` and related Trigger.dev tasks
+- API endpoints that enqueue structure generation
+- Planned Workout Details UI monitoring and feedback
+- Chat planning tools that trigger background generation
+- Timeout and retry behavior for AI calls inside triggers
+
+**Out of scope (related but separate)**
+
+- Completed workout AI analysis (`analyze-workout`)
+- Read-only chat tools (`get_workout_details`, `get_planned_workout_details`)
+- Intervals.icu publish/sync failures (deferred in support tracker)
+
+## Architecture Summary
+
+```mermaid
+flowchart LR
+    subgraph entry [Entry Points]
+        UI[Planned Workout Details]
+        Dashboard[Plan Dashboard]
+        Chat[Chat Planning Tools]
+        Block[generate-training-block]
+        AdHoc[generate-ad-hoc-workout]
+    end
+
+    subgraph trigger [Trigger.dev]
+        GSW[generate-structured-workout<br/>maxDuration 180s]
+        ASW[adjust-structured-workout<br/>maxDuration 180s]
+    end
+
+    subgraph ai [AI Layer]
+        Gemini[generateStructuredAnalysis<br/>45s timeout per attempt]
+    end
+
+    UI --> GSW
+    Dashboard --> GSW
+    Chat --> GSW
+    Block --> GSW
+    AdHoc --> GSW
+    GSW --> Gemini
+    ASW --> Gemini
+```
+
+Chat turns have a separate **60s execution timeout** (`CHAT_TURN_EXECUTION_TIMEOUT_MS`). Structure generation is correctly offloaded to Trigger.dev in most paths, but several triggers still run **synchronous multi-attempt AI** inside the task body, which can approach the 180s task cap.
+
+## Production Context
+
+Prior support investigation confirms an active defect family around **zero-step structured workouts** (description-only `structuredWorkout` payloads with `step_count = 0`). See:
+
+- [support-ticket-task-list-2026-06-16.md](../06-plans/support-ticket-task-list-2026-06-16.md) — cluster 3
+- [support-ticket-handoff-2026-06-25.md](../06-plans/support-ticket-handoff-2026-06-25.md)
+
+Anchor support tickets: `0d62fa04-884d-4fcd-a328-2226f2eb4ad5`, `a232e0ab-245e-4e95-ac37-e03fa7db6e37`, `10565730-46cd-4422-bef3-edf8b16d7df7`
+
+## Issues
+
+| ID | Title | Priority | Type | Status |
+|----|-------|----------|------|--------|
+| [001](./001-zero-step-structure-persistence.md) | Empty structures can persist as successful generation | Critical | Bug | Open |
+| [002](./002-missing-planned-workout-run-tags.md) | Manual/API triggers missing `planned-workout:` run tags | High | Bug | Open |
+| [003](./003-free-tier-skip-reports-success.md) | Free-tier skip returns `success: true` → misleading toast | Medium | Bug | Open |
+| [004](./004-no-task-failure-handling.md) | No `onTaskFailed` handler — stuck "Generating..." state | High | Bug | Open |
+| [005](./005-page-reload-loses-generation-state.md) | Page reload does not restore in-progress generation UI | Medium | Bug | Open |
+| [006](./006-ui-timeout-messaging-mismatch.md) | UI says "30 seconds" but task can take up to ~180s | Low | Bug | Open |
+| [007](./007-workout-messages-no-ai-timeout.md) | `generate-workout-messages` has no explicit AI timeout | Medium | Bug | Open |
+| [008](./008-chat-silent-trigger-failures.md) | Chat tools swallow structure trigger failures | High | Bug | Open |
+| [009](./009-double-quota-consumption.md) | Quota checked at API and again inside trigger | Medium | Maintenance | Open |
+| [010](./010-batch-generation-loading-state.md) | Batch week generation clears loading before jobs finish | Medium | Bug | Open |
+| [011](./011-strength-blocks-validation-gap.md) | Final validation ignores `blocks`-only strength structures | Medium | Bug | Open |
+| [012](./012-ai-in-triggers-architecture-rethink.md) | Rethink AI-in-triggers pattern and timeout strategy | High | Architecture | Open |
+
+## Recommended Fix Order
+
+1. **001** — Add a hard pre-persist guard rejecting empty/non-renderable structures (blocks the production zero-step pattern).
+2. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page (one cohesive UX fix).
+3. **008** — Surface trigger failures in chat tool responses.
+4. **012** — Align timeout policy across all trigger AI calls; consider async status model on `PlannedWorkout`.
+5. Remaining medium/low items.
+
+## Key Files
+
+| Area | Path |
+|------|------|
+| Main generation task | `trigger/generate-structured-workout.ts` |
+| Adjustment task | `trigger/adjust-structured-workout.ts` |
+| AI wrapper | `server/utils/gemini.ts` |
+| Manual trigger API | `server/api/workouts/planned/[id]/generate-structure.post.ts` |
+| Chat planning tools | `server/utils/ai-tools/planning.ts` |
+| Details page UI | `app/pages/workouts/planned/[id]/index.vue` |
+| Run monitoring | `app/composables/useUserRuns.ts` |
+| Chat turn timeouts | `server/utils/chat/turns.ts`, `server/utils/chat/turn-executor.ts` |
+
+## Chat / Trigger Timeout Notes
+
+From this review and the user's concern about **AI generation inside triggers timing out**:
+
+- Chat tools correctly **enqueue** structure generation rather than waiting for completion — this avoids the 60s chat turn limit for the heavy AI work.
+- The timeout pain is more likely in **Trigger.dev tasks** running synchronous AI with 45s × 2 attempts plus post-processing (strength library matching, coverage validation retries), approaching the **180s `maxDuration`**.
+- Several related triggers (`generate-ad-hoc-workout`, `generate-workout-messages`) call `generateStructuredAnalysis` **without `timeoutMs`**, creating inconsistent hang behavior.
+- See [012](./012-ai-in-triggers-architecture-rethink.md) for proposed direction.

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -79,14 +79,16 @@ Anchor support tickets: `0d62fa04-884d-4fcd-a328-2226f2eb4ad5`, `a232e0ab-245e-4
 | [010](./010-batch-generation-loading-state.md) | Batch week generation clears loading before jobs finish | Medium | Bug | Open |
 | [011](./011-strength-blocks-validation-gap.md) | Final validation ignores `blocks`-only strength structures | Medium | Bug | Open |
 | [012](./012-ai-in-triggers-architecture-rethink.md) | Rethink AI-in-triggers pattern and timeout strategy | High | Architecture | Open |
+| [013](./013-chat-duplicate-structure-generation-triggers.md) | Chat creates multiple structure generation jobs for one workout | High | Bug | Open |
 
 ## Recommended Fix Order
 
 1. **001** — Add a hard pre-persist guard rejecting empty/non-renderable structures (blocks the production zero-step pattern).
-2. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page (one cohesive UX fix).
-3. **008** — Surface trigger failures in chat tool responses.
-4. **012** — Align timeout policy across all trigger AI calls; consider async status model on `PlannedWorkout`.
-5. Remaining medium/low items.
+2. **013** — Stop duplicate structure triggers from chat tool chains (create + generate/update).
+3. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page (one cohesive UX fix).
+4. **008** — Surface trigger failures in chat tool responses.
+5. **012** — Align timeout policy across all trigger AI calls; consider async status model on `PlannedWorkout`.
+6. Remaining medium/low items.
 
 ## Key Files
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,6 +1,6 @@
 # Workout Details Generation — Issue Tracker
 
-Last reviewed: 2026-07-07
+Last reviewed: 2026-07-07 (second pass — chat + structure generation)
 
 This tracker documents bugs, UX gaps, and architectural concerns found during a code review of **planned workout structure generation** (the AI pipeline that produces interval steps, strength blocks, coach instructions, and related metadata for the Planned Workout Details page).
 
@@ -80,15 +80,59 @@ Anchor support tickets: `0d62fa04-884d-4fcd-a328-2226f2eb4ad5`, `a232e0ab-245e-4
 | [011](./011-strength-blocks-validation-gap.md) | Final validation ignores `blocks`-only strength structures | Medium | Bug | Open |
 | [012](./012-ai-in-triggers-architecture-rethink.md) | Rethink AI-in-triggers pattern and timeout strategy | High | Architecture | Open |
 | [013](./013-chat-duplicate-structure-generation-triggers.md) | Chat creates multiple structure generation jobs for one workout | High | Bug | Open |
+| [014](./014-idempotent-create-skips-structure-retrigger.md) | Idempotent create replay never re-enqueues structure | High | Bug | Open |
+| [015](./015-approval-turn-duplicate-workouts.md) | Approval turns / double-submit create duplicate workouts | Critical | Bug | Open |
+| [016](./016-chat-card-infinite-poll-without-run-id.md) | Chat card polls forever when enqueue fails without run_id | Medium | Bug | Open |
+| [017](./017-modify-plan-structure-planservice-crash.md) | `modify_training_plan_structure` crashes (missing import) | Critical | Bug | Open |
+| [018](./018-structure-tools-bypass-approval.md) | `adjust` / `generate_planned_workout_structure` bypass approval | High | Bug | Open |
+| [019](./019-chat-ui-ignores-strength-blocks.md) | Chat UI ignores blocks-only strength structures | Medium | Bug | Open |
+| [020](./020-intervals-publish-before-structure-ready.md) | Intervals shell published before structure exists | Medium | Bug | Open |
+| [021](./021-recommend-workout-stub-data.md) | `recommend_workout` returns hardcoded stub data | Medium | Bug | Open |
+| [022](./022-patch-vs-async-generation-race.md) | Patch/set vs async generate race (last writer wins) | Medium | Bug | Open |
+| [023](./023-structure-tools-idempotency-gaps.md) | `generate_` / `adjust_` / `set_` tools skip chat idempotency | Medium | Bug | Open |
+| [024](./024-chat-card-wrong-workout-fallback.md) | Chat card fuzzy ID fallback attaches wrong workout | Medium | Bug | Open |
+| [025](./025-planned-workout-details-context-bloat.md) | `get_planned_workout_details` bloats LLM context | Low | Bug | Open |
+| [026](./026-structure-tools-missing-preflight.md) | Generate/adjust tools skip sync workout existence check | Medium | Bug | Open |
+
+## Chat + Structure Generation — Issue Clusters
+
+These groups help explain user-reported symptoms like “multiple workout details triggered when I asked chat to create a run.”
+
+### Duplicate jobs / duplicate workouts
+
+- [013](./013-chat-duplicate-structure-generation-triggers.md) — tool chain: `create` + `generate_planned_workout_structure` + `update`
+- [015](./015-approval-turn-duplicate-workouts.md) — double Approve / new approval turn lineage
+- [023](./023-structure-tools-idempotency-gaps.md) — repeated generate/adjust calls not deduped
+
+### Failed generation with misleading success UI
+
+- [008](./008-chat-silent-trigger-failures.md) — trigger failure swallowed
+- [014](./014-idempotent-create-skips-structure-retrigger.md) — replay cannot recover
+- [016](./016-chat-card-infinite-poll-without-run-id.md) — infinite “Waiting for structure”
+- [024](./024-chat-card-wrong-workout-fallback.md) — polls wrong workout
+
+### Wrong or incomplete structure display
+
+- [019](./019-chat-ui-ignores-strength-blocks.md) — blocks-only strength
+- [001](./001-zero-step-structure-persistence.md) — empty steps persisted
+- [020](./020-intervals-publish-before-structure-ready.md) — empty Intervals export window
+
+### Model / tool routing confusion
+
+- [021](./021-recommend-workout-stub-data.md) — stub recommends Ride when user asked Run
+- [025](./025-planned-workout-details-context-bloat.md) — oversized tool results
+- [022](./022-patch-vs-async-generation-race.md) — conflicting edits in one turn
 
 ## Recommended Fix Order
 
 1. **001** — Add a hard pre-persist guard rejecting empty/non-renderable structures (blocks the production zero-step pattern).
-2. **013** — Stop duplicate structure triggers from chat tool chains (create + generate/update).
-3. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page (one cohesive UX fix).
-4. **008** — Surface trigger failures in chat tool responses.
-5. **012** — Align timeout policy across all trigger AI calls; consider async status model on `PlannedWorkout`.
-6. Remaining medium/low items.
+2. **017** — Fix `planService` import (runtime crash on plan structure edits via chat).
+3. **013 + 015 + 023** — Stop duplicate structure triggers and duplicate workouts from chat.
+4. **008 + 014 + 016** — Failed enqueue recovery (server errors + chat card terminal states).
+5. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page.
+6. **018** — Align approval policy for expensive structure tools.
+7. **012** — Align timeout policy; persisted generation status on `PlannedWorkout`.
+8. Remaining medium/low items (019–022, 020–021, 024–026).
 
 ## Key Files
 

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,6 +1,6 @@
 # Workout Details Generation — Issue Tracker
 
-Last reviewed: 2026-07-07 (second pass — chat + structure generation)
+Last reviewed: 2026-07-07 (third pass — trigger tags & monitor)
 
 This tracker documents bugs, UX gaps, and architectural concerns found during a code review of **planned workout structure generation** (the AI pipeline that produces interval steps, strength blocks, coach instructions, and related metadata for the Planned Workout Details page).
 
@@ -93,6 +93,42 @@ Anchor support tickets: `0d62fa04-884d-4fcd-a328-2226f2eb4ad5`, `a232e0ab-245e-4
 | [024](./024-chat-card-wrong-workout-fallback.md) | Chat card fuzzy ID fallback attaches wrong workout | Medium | Bug | Open |
 | [025](./025-planned-workout-details-context-bloat.md) | `get_planned_workout_details` bloats LLM context | Low | Bug | Open |
 | [026](./026-structure-tools-missing-preflight.md) | Generate/adjust tools skip sync workout existence check | Medium | Bug | Open |
+| [027](./027-cross-user-runs-on-identity-switch.md) | Monitor shows other user's runs after act-as / impersonation | Critical | Bug | Open |
+| [028](./028-trigger-monitor-stale-run-merge.md) | Client merge never evicts stale completed runs | Medium | Bug | Open |
+| [029](./029-triggers-missing-user-tags.md) | Some triggers omit required `user:{userId}` tag | High | Bug | Open |
+| [030](./030-library-run-tags-template-owner.md) | Library jobs tag template owner, not session actor | Medium | Bug | Open |
+| [031](./031-websocket-not-reauth-on-identity-switch.md) | WebSocket not re-authenticated on identity switch | Medium | Bug | Open |
+| [032](./032-trigger-tag-taxonomy-inconsistent.md) | Inconsistent secondary tags for structure jobs | Medium | Maintenance | Open |
+
+## Trigger Monitor & Tags — Issue Clusters
+
+Reports of “seeing other users' triggers” in the in-app monitor are **usually explainable by bugs/UX gaps below**, not by Trigger.dev API returning cross-tenant data (the API filters by `user:${session.user.id}` tag).
+
+### Cross-user or “wrong user” runs in monitor
+
+- [027](./027-cross-user-runs-on-identity-switch.md) — **most likely** if you use coaching **Act As** or admin impersonation: client merge keeps prior user's runs when identity switches
+- [031](./031-websocket-not-reauth-on-identity-switch.md) — WS stays authenticated as original user after act-as
+- [030](./030-library-run-tags-template-owner.md) — coach triggers library job tagged for athlete → invisible or mismatched
+
+### Also looks like “someone else's job” but isn't
+
+- **Background webhooks** (Strava, Withings, etc.) enqueue ingest tasks tagged for your account while you aren't actively clicking anything
+- **Plan activation / training block** fans out many `generate-structured-workout` jobs — monitor shows a burst of similar tasks
+- [028](./028-trigger-monitor-stale-run-merge.md) — old completed runs linger in UI up to 50 entries
+
+### Tagging gaps (monitor + workout UI)
+
+- [002](./002-missing-planned-workout-run-tags.md) + [032](./032-trigger-tag-taxonomy-inconsistent.md) — structure jobs missing `planned-workout:` entity tags
+- [029](./029-triggers-missing-user-tags.md) — some tasks untagged entirely
+
+### How ownership is enforced (today)
+
+| Layer | Behavior |
+|-------|----------|
+| `/api/runs/active` | Lists runs filtered by `tags: [user:{sessionUserId}]` |
+| `/api/runs/[id]` GET/DELETE | 404 unless run.tags includes `user:{sessionUserId}` |
+| WebSocket `run_update` | Routed via `sendToUser(userId, …)` per peer auth |
+| **Client `useUserRuns`** | **Does not re-check tags** on merge/WS update ([027](./027-cross-user-runs-on-identity-switch.md)) |
 
 ## Chat + Structure Generation — Issue Clusters
 
@@ -125,14 +161,16 @@ These groups help explain user-reported symptoms like “multiple workout detail
 
 ## Recommended Fix Order
 
-1. **001** — Add a hard pre-persist guard rejecting empty/non-renderable structures (blocks the production zero-step pattern).
-2. **017** — Fix `planService` import (runtime crash on plan structure edits via chat).
-3. **013 + 015 + 023** — Stop duplicate structure triggers and duplicate workouts from chat.
-4. **008 + 014 + 016** — Failed enqueue recovery (server errors + chat card terminal states).
-5. **002 + 004 + 005** — Fix run tagging and failure/state recovery on the Planned Workout Details page.
-6. **018** — Align approval policy for expensive structure tools.
-7. **012** — Align timeout policy; persisted generation status on `PlannedWorkout`.
-8. Remaining medium/low items (019–022, 020–021, 024–026).
+1. **027 + 028 + 031** — Fix trigger monitor identity/stale-state bugs (cross-user run display).
+2. **001** — Add a hard pre-persist guard rejecting empty/non-renderable structures (blocks the production zero-step pattern).
+3. **017** — Fix `planService` import (runtime crash on plan structure edits via chat).
+4. **032 + 002 + 029** — Standardize trigger tags (`user:` + entity tags on all enqueue sites).
+5. **013 + 015 + 023** — Stop duplicate structure triggers and duplicate workouts from chat.
+6. **008 + 014 + 016** — Failed enqueue recovery (server errors + chat card terminal states).
+7. **004 + 005** — Failure/state recovery on the Planned Workout Details page.
+8. **018** — Align approval policy for expensive structure tools.
+9. **012** — Align timeout policy; persisted generation status on `PlannedWorkout`.
+10. Remaining medium/low items.
 
 ## Key Files
 
@@ -144,7 +182,10 @@ These groups help explain user-reported symptoms like “multiple workout detail
 | Manual trigger API | `server/api/workouts/planned/[id]/generate-structure.post.ts` |
 | Chat planning tools | `server/utils/ai-tools/planning.ts` |
 | Details page UI | `app/pages/workouts/planned/[id]/index.vue` |
-| Run monitoring | `app/composables/useUserRuns.ts` |
+| Run monitoring | `app/composables/useUserRuns.ts`, `app/components/dashboard/TriggerMonitor.vue` |
+| Run API / ownership | `server/api/runs/active.get.ts`, `server/api/runs/[id].get.ts` |
+| Run WS publish | `server/utils/task-run-events.ts`, `server/utils/ws-state.ts` |
+| Session / act-as | `server/utils/session.ts` |
 | Chat turn timeouts | `server/utils/chat/turns.ts`, `server/utils/chat/turn-executor.ts` |
 
 ## Chat / Trigger Timeout Notes

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -1,6 +1,6 @@
 # Workout Details Generation — Issue Tracker
 
-Last reviewed: 2026-07-07 (third pass — trigger tags & monitor)
+Last reviewed: 2026-07-07 (fourth pass — structure prompt / speed)
 
 This tracker documents bugs, UX gaps, and architectural concerns found during a code review of **planned workout structure generation** (the AI pipeline that produces interval steps, strength blocks, coach instructions, and related metadata for the Planned Workout Details page).
 
@@ -99,6 +99,36 @@ Anchor support tickets: `0d62fa04-884d-4fcd-a328-2226f2eb4ad5`, `a232e0ab-245e-4
 | [030](./030-library-run-tags-template-owner.md) | Library jobs tag template owner, not session actor | Medium | Bug | Open |
 | [031](./031-websocket-not-reauth-on-identity-switch.md) | WebSocket not re-authenticated on identity switch | Medium | Bug | Open |
 | [032](./032-trigger-tag-taxonomy-inconsistent.md) | Inconsistent secondary tags for structure jobs | Medium | Maintenance | Open |
+| [033](./033-retire-legacy-structure-generator.md) | Retire `legacy_json` generator for ride/run/swim | Medium | Performance | Open |
+| [034](./034-deduplicate-structure-prompt-targeting.md) | Deduplicate targeting instructions in structure prompts | Medium | Performance | Open |
+| [035](./035-remove-unused-streams-from-structure-context.md) | Remove unused stream fetch from structure context | Low | Performance | Open |
+| [036](./036-bound-aicontext-in-structure-generation.md) | Bound `aiContext` in structure-generation prompts | Medium | Performance | Open |
+| [037](./037-structure-generation-lightweight-retries.md) | Lightweight corrective retries for structure generation | High | Performance | Open |
+| [038](./038-disable-thinking-flash-structure-generation.md) | Disable/minimize Flash thinking for structure generation | Medium | Performance | Open |
+
+## Structure Generation Speed & Prompt — Issue Clusters
+
+User-selected improvements from prompt/context review (2026-07-07). Goal: reduce tokens, DB load, and retry cost without changing the async Trigger.dev architecture.
+
+### Prompt slimming (do first — low risk)
+
+- [033](./033-retire-legacy-structure-generator.md) — one schema path for ride/run/swim
+- [034](./034-deduplicate-structure-prompt-targeting.md) — targeting rules stated once
+- [035](./035-remove-unused-streams-from-structure-context.md) — drop dead streams query
+- [036](./036-bound-aicontext-in-structure-generation.md) — cap global user context
+
+### Model call efficiency
+
+- [038](./038-disable-thinking-flash-structure-generation.md) — no thinking on attempt-1 Flash
+- [037](./037-structure-generation-lightweight-retries.md) — small patch retries instead of full prompt + Pro/high thinking
+
+### Suggested implementation order
+
+1. **035** — trivial DB win, no prompt behavior change
+2. **038** — one-line flag change per task; validate via LLM ops `reasoningTokens`
+3. **034 + 036** — prompt builder refactor
+4. **033** — remove legacy branch after draft parity check
+5. **037** — retry redesign (depends on compact base prompt from 033–034)
 
 ## Trigger Monitor & Tags — Issue Clusters
 
@@ -170,7 +200,8 @@ These groups help explain user-reported symptoms like “multiple workout detail
 7. **004 + 005** — Failure/state recovery on the Planned Workout Details page.
 8. **018** — Align approval policy for expensive structure tools.
 9. **012** — Align timeout policy; persisted generation status on `PlannedWorkout`.
-10. Remaining medium/low items.
+10. **035 + 038 + 034 + 036 + 033 + 037** — Structure prompt/speed cluster (see above).
+11. Remaining medium/low items.
 
 ## Key Files
 

--- a/server/utils/structured-workout-generator.ts
+++ b/server/utils/structured-workout-generator.ts
@@ -1,4 +1,5 @@
 import { prisma } from './db'
+import { isDraftStructuredWorkoutSupported } from './structured-workout-draft'
 
 export const STRUCTURED_WORKOUT_GENERATOR_MODES = ['legacy_json', 'draft_json_v1'] as const
 
@@ -45,4 +46,14 @@ export async function resolveStructuredWorkoutGeneratorMode(
   })
 
   return readStructuredWorkoutGeneratorModeFromFeatureFlags(user?.featureFlags)
+}
+
+/**
+ * Resolve the generator mode for a specific workout type.
+ * Endurance sports (ride/run/swim) always use the compact draft path.
+ */
+export function resolveStructureGeneratorModeForWorkout(
+  workoutType: unknown
+): StructuredWorkoutGeneratorMode {
+  return isDraftStructuredWorkoutSupported(workoutType) ? 'draft_json_v1' : 'legacy_json'
 }

--- a/server/utils/structured-workout-validation.ts
+++ b/server/utils/structured-workout-validation.ts
@@ -1,0 +1,45 @@
+function hasNonEmptySteps(steps: unknown): boolean {
+  return Array.isArray(steps) && steps.length > 0
+}
+
+function hasRenderableStrengthBlocks(blocks: unknown): boolean {
+  if (!Array.isArray(blocks) || blocks.length === 0) return false
+  return blocks.some(
+    (block) =>
+      block &&
+      typeof block === 'object' &&
+      Array.isArray((block as any).steps) &&
+      (block as any).steps.length > 0
+  )
+}
+
+export function assertRenderableStructure(
+  structure: unknown,
+  workoutType?: string | null
+): { valid: boolean; reason: string | null } {
+  if (!structure || typeof structure !== 'object' || Array.isArray(structure)) {
+    return { valid: false, reason: 'structure payload is missing or invalid' }
+  }
+
+  const payload = structure as Record<string, unknown>
+  const hasSteps = hasNonEmptySteps(payload.steps)
+  const hasExercises = hasNonEmptySteps(payload.exercises)
+  const hasBlocks = hasRenderableStrengthBlocks(payload.blocks)
+
+  if (hasSteps || hasExercises || hasBlocks) {
+    return { valid: true, reason: null }
+  }
+
+  const normalizedType = String(workoutType || '').toLowerCase()
+  if (normalizedType.includes('gym') || normalizedType.includes('weight')) {
+    return {
+      valid: false,
+      reason: 'strength structure has no blocks with exercise steps'
+    }
+  }
+
+  return {
+    valid: false,
+    reason: 'structure has no steps, exercises, or blocks'
+  }
+}

--- a/tests/unit/server/utils/structured-workout-generator.test.ts
+++ b/tests/unit/server/utils/structured-workout-generator.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { prisma } from '../../../../server/utils/db'
 import {
   readStructuredWorkoutGeneratorModeFromFeatureFlags,
-  resolveStructuredWorkoutGeneratorMode
+  resolveStructuredWorkoutGeneratorMode,
+  resolveStructureGeneratorModeForWorkout
 } from '../../../../server/utils/structured-workout-generator'
 
 vi.mock('../../../../server/utils/db', () => ({
@@ -50,5 +51,10 @@ describe('structured workout generator resolver', () => {
         structuredWorkout: { generator: 'something_else' }
       })
     ).toBe('draft_json_v1')
+  })
+
+  it('resolves workout-type-specific generator mode', () => {
+    expect(resolveStructureGeneratorModeForWorkout('Run')).toBe('draft_json_v1')
+    expect(resolveStructureGeneratorModeForWorkout('WeightTraining')).toBe('legacy_json')
   })
 })

--- a/tests/unit/trigger/structure-generation-prompt.test.ts
+++ b/tests/unit/trigger/structure-generation-prompt.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveStructureGeneratorModeForWorkout } from '../../../server/utils/structured-workout-generator'
+import { assertRenderableStructure } from '../../../server/utils/structured-workout-validation'
 import {
   buildCorrectiveStructureRetryPrompt,
   buildStructureAiCallOptions,
-  formatAiContextForStructureGen
+  filterZonesForWorkout,
+  formatAiContextForStructureGen,
+  looksLikeSteadyStateWorkout,
+  resolveStructureContextProfile
 } from '../../../trigger/utils/structure-generation-prompt'
 import { formatCompactTargetingBlock } from '../../../trigger/utils/workout-targeting'
 import { normalizeTargetFormatPolicy } from '../../../server/utils/workout-target-format-policy'
@@ -13,15 +16,22 @@ import { normalizeTargetPolicy } from '../../../server/utils/workout-target-poli
 describe('structure generation prompt helpers', () => {
   it('caps aiContext and skips when description is long enough', () => {
     const longContext = 'x'.repeat(800)
-    expect(formatAiContextForStructureGen({ aiContext: longContext })).toContain('…')
-    expect(formatAiContextForStructureGen({ aiContext: longContext })).not.toContain(
-      'x'.repeat(800)
-    )
+    expect(
+      formatAiContextForStructureGen({ aiContext: longContext, profile: 'standard' })
+    ).toContain('…')
 
     expect(
       formatAiContextForStructureGen({
         aiContext: 'Prefer cadence 85-90 on endurance rides.',
-        workoutDescription: 'A'.repeat(150)
+        workoutDescription: 'A'.repeat(150),
+        profile: 'standard'
+      })
+    ).toBe('')
+
+    expect(
+      formatAiContextForStructureGen({
+        aiContext: 'Prefer cadence 85-90.',
+        profile: 'minimal'
       })
     ).toBe('')
   })
@@ -42,11 +52,45 @@ describe('structure generation prompt helpers', () => {
     expect(block).not.toContain('TARGET POLICY (source')
   })
 
-  it('forces draft mode for endurance sports only', () => {
-    expect(resolveStructureGeneratorModeForWorkout('Run')).toBe('draft_json_v1')
-    expect(resolveStructureGeneratorModeForWorkout('Ride')).toBe('draft_json_v1')
-    expect(resolveStructureGeneratorModeForWorkout('Swim')).toBe('draft_json_v1')
-    expect(resolveStructureGeneratorModeForWorkout('WeightTraining')).toBe('legacy_json')
+  it('resolves context profiles from workout metadata', () => {
+    expect(
+      resolveStructureContextProfile({
+        workout: { title: 'Zone 2 Endurance Ride', description: 'Easy aerobic session' }
+      })
+    ).toBe('minimal')
+
+    expect(
+      resolveStructureContextProfile({
+        workout: { title: 'VO2 Intervals', description: '5x3min hard' }
+      })
+    ).toBe('standard')
+
+    expect(
+      resolveStructureContextProfile({
+        workout: { title: 'Long Ride', description: 'Steady' },
+        preserveExistingStructure: true
+      })
+    ).toBe('rich')
+
+    expect(looksLikeSteadyStateWorkout({ title: 'Threshold repeats', description: '' })).toBe(false)
+  })
+
+  it('filters zones to workout-relevant bands', () => {
+    const zones = [
+      { name: 'Z1 Recovery', min: 100, max: 120 },
+      { name: 'Z2 Endurance', min: 121, max: 150 },
+      { name: 'Z3 Tempo', min: 151, max: 170 },
+      { name: 'Z4 Threshold', min: 171, max: 185 }
+    ]
+
+    const filtered = filterZonesForWorkout(
+      zones,
+      { title: 'Zone 2 ride', description: 'Aerobic endurance' },
+      3
+    )
+
+    expect(filtered.some((zone) => String(zone.name).includes('Z2'))).toBe(true)
+    expect(filtered.length).toBeLessThanOrEqual(3)
   })
 
   it('builds lightweight corrective retry prompts with previous draft', () => {
@@ -59,7 +103,6 @@ describe('structure generation prompt helpers', () => {
 
     expect(prompt).toContain('FAILURE: duration undershoot too low')
     expect(prompt).toContain('PREVIOUS DRAFT')
-    expect(prompt).toContain('compact JSON')
     expect(prompt.length).toBeLessThan(2000)
   })
 
@@ -82,9 +125,41 @@ describe('structure generation prompt helpers', () => {
     })
 
     expect(first.disableThinking).toBe(true)
-    expect(first.modelOverride).toBeUndefined()
-    expect(second.modelOverride).toBe('gemini-3-pro-preview')
     expect(second.thinkingLevelOverride).toBe('low')
-    expect(second.disableThinking).toBeUndefined()
+  })
+})
+
+describe('assertRenderableStructure', () => {
+  it('rejects description-only payloads', () => {
+    expect(
+      assertRenderableStructure(
+        { description: 'Easy ride', coachInstructions: 'Stay smooth', steps: [] },
+        'Ride'
+      ).valid
+    ).toBe(false)
+  })
+
+  it('accepts steps, exercises, or strength blocks', () => {
+    expect(
+      assertRenderableStructure(
+        { steps: [{ type: 'Warmup', name: 'Easy', durationSeconds: 600 }] },
+        'Run'
+      ).valid
+    ).toBe(true)
+
+    expect(
+      assertRenderableStructure(
+        {
+          blocks: [
+            {
+              type: 'single_exercise',
+              title: 'Squat',
+              steps: [{ name: 'Back Squat', setRows: [{ value: 8 }] }]
+            }
+          ]
+        },
+        'WeightTraining'
+      ).valid
+    ).toBe(true)
   })
 })

--- a/tests/unit/trigger/structure-generation-prompt.test.ts
+++ b/tests/unit/trigger/structure-generation-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveStructureGeneratorModeForWorkout } from '../../../server/utils/structured-workout-generator'
+import {
+  buildCorrectiveStructureRetryPrompt,
+  buildStructureAiCallOptions,
+  formatAiContextForStructureGen
+} from '../../../trigger/utils/structure-generation-prompt'
+import { formatCompactTargetingBlock } from '../../../trigger/utils/workout-targeting'
+import { normalizeTargetFormatPolicy } from '../../../server/utils/workout-target-format-policy'
+import { normalizeTargetPolicy } from '../../../server/utils/workout-target-policy'
+
+describe('structure generation prompt helpers', () => {
+  it('caps aiContext and skips when description is long enough', () => {
+    const longContext = 'x'.repeat(800)
+    expect(formatAiContextForStructureGen({ aiContext: longContext })).toContain('…')
+    expect(formatAiContextForStructureGen({ aiContext: longContext })).not.toContain(
+      'x'.repeat(800)
+    )
+
+    expect(
+      formatAiContextForStructureGen({
+        aiContext: 'Prefer cadence 85-90 on endurance rides.',
+        workoutDescription: 'A'.repeat(150)
+      })
+    ).toBe('')
+  })
+
+  it('builds a compact targeting block once', () => {
+    const targetPolicy = normalizeTargetPolicy({
+      primaryMetric: 'power',
+      fallbackOrder: ['power', 'heartRate', 'rpe'],
+      strictPrimary: false,
+      allowMixedTargetsPerStep: false,
+      defaultTargetStyle: 'value'
+    })
+    const targetFormatPolicy = normalizeTargetFormatPolicy(null)
+    const block = formatCompactTargetingBlock(targetPolicy, targetFormatPolicy, 'POWER > HR > RPE')
+
+    expect(block).toContain('primary=Power')
+    expect(block).toContain('order=POWER > HR > RPE')
+    expect(block).not.toContain('TARGET POLICY (source')
+  })
+
+  it('forces draft mode for endurance sports only', () => {
+    expect(resolveStructureGeneratorModeForWorkout('Run')).toBe('draft_json_v1')
+    expect(resolveStructureGeneratorModeForWorkout('Ride')).toBe('draft_json_v1')
+    expect(resolveStructureGeneratorModeForWorkout('Swim')).toBe('draft_json_v1')
+    expect(resolveStructureGeneratorModeForWorkout('WeightTraining')).toBe('legacy_json')
+  })
+
+  it('builds lightweight corrective retry prompts with previous draft', () => {
+    const prompt = buildCorrectiveStructureRetryPrompt({
+      workout: { title: 'Z2 Ride', type: 'Ride', durationSec: 3600 },
+      reason: 'duration undershoot too low',
+      previousDraft: { steps: [{ type: 'Warmup', name: 'Easy', durationSeconds: 600 }] },
+      generatorMode: 'draft_json_v1'
+    })
+
+    expect(prompt).toContain('FAILURE: duration undershoot too low')
+    expect(prompt).toContain('PREVIOUS DRAFT')
+    expect(prompt).toContain('compact JSON')
+    expect(prompt.length).toBeLessThan(2000)
+  })
+
+  it('disables thinking on first attempt and uses low thinking on retry', () => {
+    const first = buildStructureAiCallOptions({
+      attempt: 1,
+      userId: 'user-1',
+      operation: 'generate_structured_workout',
+      entityType: 'PlannedWorkout',
+      entityId: 'pw-1',
+      timeoutMs: 45_000
+    })
+    const second = buildStructureAiCallOptions({
+      attempt: 2,
+      userId: 'user-1',
+      operation: 'generate_structured_workout',
+      entityType: 'PlannedWorkout',
+      entityId: 'pw-1',
+      timeoutMs: 45_000
+    })
+
+    expect(first.disableThinking).toBe(true)
+    expect(first.modelOverride).toBeUndefined()
+    expect(second.modelOverride).toBe('gemini-3-pro-preview')
+    expect(second.thinkingLevelOverride).toBe('low')
+    expect(second.disableThinking).toBeUndefined()
+  })
+})

--- a/trigger/adjust-structured-workout.ts
+++ b/trigger/adjust-structured-workout.ts
@@ -43,8 +43,11 @@ import {
   buildCorrectiveStructureRetryPrompt,
   buildDraftOutputRules,
   buildSportSpecificInstructions,
-  buildStructureAiCallOptions
+  buildStructureAiCallOptions,
+  looksLikeIntervalWorkout,
+  resolveStructureContextProfile
 } from './utils/structure-generation-prompt'
+import { assertRenderableStructure } from '../server/utils/structured-workout-validation'
 import {
   estimateStepDistanceMeters,
   estimateStepDurationSeconds,
@@ -552,11 +555,6 @@ function hasRepeatBlock(steps: any[]): boolean {
   )
 }
 
-function looksLikeIntervalWorkout(workout: any) {
-  const text = `${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
-  return /\b(vo2|threshold|tempo|interval|repeats?|x\d+|\d+x)\b/.test(text)
-}
-
 function getCoverageBounds(workout: any, plannedDurationSec: number) {
   const workoutType = String(workout?.type || '').toLowerCase()
   if (workoutType.includes('gym') || workoutType.includes('weight')) {
@@ -782,12 +780,20 @@ export const adjustStructuredWorkoutTask = task({
     const timezone = await getUserTimezone(workout.userId)
     logStage('resolved-timezone', { timezone, userAge: userAge || null })
 
-    // Fetch recent workouts for context
-    const recentWorkouts = await workoutRepository.getForUser(workout.userId, {
-      limit: 4,
-      orderBy: { date: 'desc' }
+    const contextProfile = resolveStructureContextProfile({
+      workout,
+      preserveExistingStructure: Boolean(workout.structuredWorkout)
     })
-    logStage('loaded-recent-workouts', { count: recentWorkouts.length })
+    logStage('resolved-context-profile', { contextProfile })
+
+    let recentWorkouts: any[] = []
+    if (contextProfile === 'rich') {
+      recentWorkouts = await workoutRepository.getForUser(workout.userId, {
+        limit: 4,
+        orderBy: { date: 'desc' }
+      })
+    }
+    logStage('loaded-recent-workouts', { count: recentWorkouts.length, contextProfile })
 
     // Resolve Metrics
     const ftp = sportSettings?.ftp || workout.user.ftp || 250
@@ -801,7 +807,9 @@ export const adjustStructuredWorkoutTask = task({
       primaryMetric: targetPolicy.primaryMetric,
       loadPreference,
       ftp,
-      lthr
+      lthr,
+      workout,
+      contextProfile
     })
     const targetingBlock = formatCompactTargetingBlock(
       targetPolicy,
@@ -822,7 +830,8 @@ export const adjustStructuredWorkoutTask = task({
     const durationMinutes = Math.round((workout.durationSec || 3600) / 60)
     const feedback =
       adjustments.feedback || 'Please regenerate with the new duration/intensity parameters.'
-    const recentWorkoutsSummary = buildConciseWorkoutSummary(recentWorkouts, timezone)
+    const recentWorkoutsSummary =
+      contextProfile === 'rich' ? buildConciseWorkoutSummary(recentWorkouts, timezone) : ''
     const sharedAdjustHeader = `ORIGINAL WORKOUT:
 - Title: ${workout.title}
 - Duration: ${durationMinutes} minutes
@@ -843,8 +852,7 @@ ${zoneDefinitions}
 
 ${targetingBlock}
 
-RECENT WORKOUTS (brief):
-${recentWorkoutsSummary}`
+${recentWorkoutsSummary ? `RECENT WORKOUTS (brief):\n${recentWorkoutsSummary}\n` : ''}`
 
     const draftPrompt = `Adjust this structured ${workout.type} workout plan using the compact planning format.
 
@@ -884,6 +892,7 @@ OUTPUT JSON matching the schema.`
     logStage('prompt-built', {
       promptChars: promptForAttempt.length,
       generatorMode,
+      contextProfile,
       targetDurationMinutes: durationMinutes
     })
 
@@ -1299,6 +1308,13 @@ OUTPUT JSON matching the schema.`
       totalTSS: Math.round(totalTSS * 100) / 100
     })
 
+    const renderableValidation = assertRenderableStructure(structure, workout.type)
+    if (!renderableValidation.valid) {
+      throw new Error(
+        `Adjusted structured workout failed renderable validation: ${renderableValidation.reason}`
+      )
+    }
+
     const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
     const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
     if ((hasSteps || hasExercises) && totalDuration <= 0) {
@@ -1331,6 +1347,7 @@ OUTPUT JSON matching the schema.`
       phase: workout.trainingWeek?.block.type || 'General',
       focus: workout.trainingWeek?.block.primaryFocus || 'Fitness',
       persona: workout.user.aiPersona || undefined,
+      contextProfile,
       adjustments
     })
 

--- a/trigger/adjust-structured-workout.ts
+++ b/trigger/adjust-structured-workout.ts
@@ -13,8 +13,7 @@ import { enforceCyclingCadenceVariation, resolveCyclingCadence } from './utils/c
 import {
   resolveWorkoutTargeting,
   type WorkoutTargetingOverride,
-  formatTargetPolicyPrompt,
-  formatTargetFormatPolicyPrompt,
+  formatCompactTargetingBlock,
   STEP_INTENTS,
   applyTargetPolicyToStep,
   applyTargetFormatPolicyToStep,
@@ -34,15 +33,18 @@ import {
   applyStrengthLibraryDefaultsToWorkout,
   validateStrengthStructuredWorkout
 } from '../server/utils/strength-exercise-matching'
-import {
-  resolveStructuredWorkoutGeneratorMode,
-  type StructuredWorkoutGeneratorMode
-} from '../server/utils/structured-workout-generator'
+import { resolveStructureGeneratorModeForWorkout } from '../server/utils/structured-workout-generator'
 import {
   compileWorkoutPlanDraftToStructure,
-  isDraftStructuredWorkoutSupported,
   workoutPlanDraftSchema
 } from '../server/utils/structured-workout-draft'
+import {
+  buildCompactZoneDefinitions,
+  buildCorrectiveStructureRetryPrompt,
+  buildDraftOutputRules,
+  buildSportSpecificInstructions,
+  buildStructureAiCallOptions
+} from './utils/structure-generation-prompt'
 import {
   estimateStepDistanceMeters,
   estimateStepDurationSeconds,
@@ -615,74 +617,6 @@ function validateStructuredCoverage(params: {
   return { valid: true, reason: null }
 }
 
-function buildCompactZoneDefinitions(params: {
-  workoutType: string
-  sportSettings: any
-  primaryMetric: string
-  loadPreference: string
-  ftp: number
-  lthr: number
-}) {
-  const { workoutType, sportSettings, primaryMetric, loadPreference, ftp, lthr } = params
-  const parts: string[] = []
-  const addZones = (label: string, zones: any[], unit: string, limit = 5) => {
-    if (!Array.isArray(zones) || zones.length === 0) return
-    const compact = zones
-      .slice(0, limit)
-      .map((z: any) => `${z.name}: ${z.min}-${z.max}${unit}`)
-      .join(' | ')
-    if (compact) parts.push(`${label}: ${compact}`)
-  }
-
-  if (primaryMetric === 'heartRate')
-    addZones(`${workoutType} HR Zones`, sportSettings?.hrZones, ' bpm')
-  if (primaryMetric === 'power')
-    addZones(`${workoutType} Power Zones`, sportSettings?.powerZones, ' W')
-  if (primaryMetric === 'pace')
-    addZones(`${workoutType} Pace Zones`, sportSettings?.paceZones, ' m/s')
-
-  if (
-    primaryMetric !== 'heartRate' &&
-    Array.isArray(sportSettings?.hrZones) &&
-    sportSettings.hrZones.length > 0
-  ) {
-    addZones(`${workoutType} HR Zones`, sportSettings.hrZones, ' bpm', 3)
-  }
-  if (
-    primaryMetric !== 'power' &&
-    Array.isArray(sportSettings?.powerZones) &&
-    sportSettings.powerZones.length > 0
-  ) {
-    addZones(`${workoutType} Power Zones`, sportSettings.powerZones, ' W', 3)
-  }
-  if (
-    primaryMetric !== 'pace' &&
-    Array.isArray(sportSettings?.paceZones) &&
-    sportSettings.paceZones.length > 0
-  ) {
-    addZones(`${workoutType} Pace Zones`, sportSettings.paceZones, ' m/s', 3)
-  }
-
-  if (lthr) parts.push(`Reference LTHR: ${lthr} bpm`)
-  if (ftp) parts.push(`Reference FTP: ${ftp} W`)
-  if (sportSettings?.thresholdPace) {
-    const metersPerSecond = Number(sportSettings.thresholdPace)
-    if (metersPerSecond > 0) {
-      const secondsPerKm = 1000 / metersPerSecond
-      const minutes = Math.floor(secondsPerKm / 60)
-      const seconds = Math.round(secondsPerKm % 60)
-      parts.push(
-        `Reference Threshold Pace: ${metersPerSecond} m/s (${minutes}:${seconds
-          .toString()
-          .padStart(2, '0')}/km)`
-      )
-    }
-  }
-  parts.push(`Preferred Load Metric: ${loadPreference}`)
-
-  return parts.join('\n')
-}
-
 export const adjustStructuredWorkoutTask = task({
   id: 'adjust-structured-workout',
   queue: userReportsQueue,
@@ -692,7 +626,6 @@ export const adjustStructuredWorkoutTask = task({
     workoutTemplateId?: string
     adjustments: any
     targetingOverride?: WorkoutTargetingOverride | null
-    generatorOverride?: StructuredWorkoutGeneratorMode | null
   }) => {
     const { plannedWorkoutId, workoutTemplateId, adjustments } = payload
     const entityId = plannedWorkoutId || workoutTemplateId
@@ -778,50 +711,20 @@ export const adjustStructuredWorkoutTask = task({
       durationSec: workout.durationSec
     })
 
-    const requestedGeneratorMode = await resolveStructuredWorkoutGeneratorMode(
-      workout.userId,
-      payload?.generatorOverride || null
-    )
-    const generatorMode =
-      requestedGeneratorMode === 'draft_json_v1' &&
-      isDraftStructuredWorkoutSupported(workout.type || '')
-        ? requestedGeneratorMode
-        : 'legacy_json'
+    const generatorMode = resolveStructureGeneratorModeForWorkout(workout.type || '')
     console.log('[AdjustStructuredWorkout] Generator mode resolved', {
       entityId,
       entityType,
       workoutType: workout.type,
-      requestedGeneratorMode,
-      generatorMode,
-      explicitOverride: payload?.generatorOverride || null
+      generatorMode
     })
     logStage('resolved-generator-mode', {
-      generatorMode,
-      requestedGeneratorMode,
-      explicitOverride: payload?.generatorOverride || null
+      generatorMode
     })
-    if (requestedGeneratorMode === 'draft_json_v1' && generatorMode !== requestedGeneratorMode) {
-      console.log('[AdjustStructuredWorkout] Falling back to legacy generator', {
-        entityId,
-        workoutType: workout.type,
-        requestedGeneratorMode,
-        fallbackMode: generatorMode
-      })
-      logStage('generator-mode-fallback', {
-        requestedGeneratorMode,
-        fallbackMode: generatorMode,
-        workoutType: workout.type
-      })
-    } else if (generatorMode === 'draft_json_v1') {
-      console.log('[AdjustStructuredWorkout] Using compact draft generator', {
-        entityId,
-        workoutType: workout.type
-      })
-      logStage('generator-mode-branch', {
-        generatorMode,
-        implementation: 'compact_draft_v1'
-      })
-    }
+    logStage('generator-mode-branch', {
+      generatorMode,
+      implementation: generatorMode === 'draft_json_v1' ? 'compact_draft_v1' : 'legacy_json'
+    })
 
     // Fetch Sport Specific Settings
     const sportSettings = await sportSettingsRepository.getForActivityType(
@@ -882,15 +785,7 @@ export const adjustStructuredWorkoutTask = task({
     // Fetch recent workouts for context
     const recentWorkouts = await workoutRepository.getForUser(workout.userId, {
       limit: 4,
-      orderBy: { date: 'desc' },
-      include: {
-        streams: {
-          select: {
-            hrZoneTimes: true,
-            powerZoneTimes: true
-          }
-        }
-      }
+      orderBy: { date: 'desc' }
     })
     logStage('loaded-recent-workouts', { count: recentWorkouts.length })
 
@@ -908,188 +803,92 @@ export const adjustStructuredWorkoutTask = task({
       ftp,
       lthr
     })
-    const targetPolicyPrompt = formatTargetPolicyPrompt(targetPolicy, loadPreference)
-    const targetFormatPolicyPrompt = formatTargetFormatPolicyPrompt(targetFormatPolicy)
+    const targetingBlock = formatCompactTargetingBlock(
+      targetPolicy,
+      targetFormatPolicy,
+      priorityText
+    )
     const steadyTargetStyleRule =
       targetPolicy.defaultTargetStyle === 'value'
         ? 'Prefer single-value targets for steady aerobic/endurance/tempo blocks. Use ranges only when the workout explicitly asks for a range or ramp.'
         : 'Prefer metric ranges for steady aerobic/endurance/tempo blocks.'
-    const workoutType = String(workout.type || '').toLowerCase()
-    const isCycling = workoutType.includes('ride')
-    const isRun = workoutType.includes('run')
-    const isSwim = workoutType.includes('swim')
-    const isStrength = workoutType.includes('gym') || workoutType.includes('weight')
-    const runPaceUnitInstruction =
-      targetFormatPolicy.pace.mode === 'absolutePace'
-        ? '- CRITICAL: If the user requests absolute pace or provides pace examples like "5:20-5:40 min/km", encode those as explicit pace targets. Use `pace.units` = "/km" with decimal minute values (for example 5.33-5.67 for 5:20-5:40/km), set `primaryTarget` to "pace" for those steps, and do NOT fall back to bare percentages or power targets.'
-        : '- Use `heartRate.units` = "LTHR" for percentage HR targets and `pace.units` = "Pace" for percentage pace targets.'
-    const sportSpecificInstructions = isCycling
-      ? `FOR CYCLING (Ride/VirtualRide):
-    - Use % of FTP for power targets (e.g. 0.95 = 95%).
-    - Set \`power.units\` to "%" unless the user explicitly requested watts.
-    - Include target cadence (RPM).
-    - For cadence-focus steps, cadence MUST differ from surrounding steady steps.
-    - If HR zones are available, include at least one HR guardrail in coachInstructions.
-    - Keep hard interval work recoverable and repeatable.`
-      : isRun
-        ? `FOR RUNNING (Run):
-    - ALWAYS include 'distance' (meters) for each step (estimate if needed).
-    - Target selection MUST follow TARGET POLICY priority order: ${priorityText}.
-    - ${runPaceUnitInstruction}
-    - ${targetPolicy.allowMixedTargetsPerStep ? 'Mixed metrics in one step are allowed, but primaryTarget still must follow policy.' : 'Use one intensity metric per step unless user feedback explicitly asks for mixed cues.'}
-    - ${steadyTargetStyleRule}
-    - If user specifies "Zone 2", refer to the provided zones before using generic percentages.
-    - Steps must represent runnable in-session segments only (jog, run, walk recoveries, drills performed during the run).
-    - Do NOT add static stretching or off-feet recovery blocks to the structured plan.
-    - Do not stack maximal efforts without sufficient recovery.`
-        : isSwim
-          ? `FOR SWIMMING (Swim):
-    - Prefer 'distanceMeters' for pool reps and lengths. Use 'durationSeconds' only when time-based structure is genuinely better.
-    - Use 'stroke' to specify: Free, Back, Breast, Fly, IM, Choice, Kick, Pull.
-    - Use 'equipment' array for gear: Fins, Paddles, Snorkel, Pull Buoy.
-    - Use 'sendoffSeconds' when the set is written on a send-off and 'restSeconds' when explicit rest matters.
-    - Use 'targetSplit' (e.g. "1:40/100m") or 'cssPercent' when swim pacing is central to the set.
-    - Use one intensity cue per step when possible. Do NOT force heart-rate targets for every swim step.
-    - Technical/drill steps can omit target intensity if stroke, distance, send-off, or rest already defines the task clearly.
-    - CRITICAL: The full pool session must realistically land near the planned duration once swim pace, send-offs, and rests are considered.
-    - For sessions 45 minutes or longer, include enough total volume and explicit recoveries/send-offs to fill the assigned time.
-    - Prefer explicit 'sendoffSeconds' or 'restSeconds' on repeated sets instead of leaving recovery implied.
-    - Before returning, sanity-check the total session time yourself and expand or trim the set so it stays close to the planned duration.`
-          : isStrength
-            ? `FOR STRENGTH (Gym/WeightTraining):
-    - Prefer the canonical strength schema: provide 'blocks' instead of a flat 'exercises' list.
-    - Each block should have: 'type', 'title', optional 'notes', and 'steps'.
-    - Use block types like 'warmup', 'single_exercise', 'superset', 'circuit', 'cooldown'.
-    - Each step should have 'name', optional 'notes', optional 'intent'/'movementPattern', and 'setRows'.
-    - Each step should also set a shared 'prescriptionMode' (default 'reps'), optional 'loadMode', and optional 'defaultRest'.
-    - Each entry in 'setRows' represents one set and may contain:
-      * 'value' for reps, reps/side, duration, or distance depending on prescriptionMode
-      * 'loadValue' for load/weight when relevant
-      * 'restOverride' only when a specific set differs from defaultRest
-    - CRITICAL: Return native 'blocks' for strength. Do NOT return interval-style top-level 'steps' for WeightTraining.
-    - CRITICAL: Loaded lifts must use real per-set prescription. Do NOT prescribe main lifts as one long duration row such as 1 x 900 seconds.
-    - Keep the same workout intent while expressing the prescription in native blocks/setRows whenever possible.
-    - Time-based mobility should use prescriptionMode='duration' with setRows.value in seconds.
-    - Only fall back to a flat 'exercises' list if you truly cannot express the workout as blocks.`
-            : `FOR THIS SPORT TYPE:
-    - Use only sport-relevant fields and targets.
-    - Keep steps explicit, measurable, and safe with clear work/recovery structure.`
+    const workoutTypeLower = String(workout.type || '').toLowerCase()
+    const isStrength = workoutTypeLower.includes('gym') || workoutTypeLower.includes('weight')
+    const sportSpecificInstructions = buildSportSpecificInstructions({
+      workoutType: workout.type || '',
+      targetFormatPolicy,
+      steadyTargetStyleRule
+    })
+    const durationMinutes = Math.round((workout.durationSec || 3600) / 60)
+    const feedback =
+      adjustments.feedback || 'Please regenerate with the new duration/intensity parameters.'
+    const recentWorkoutsSummary = buildConciseWorkoutSummary(recentWorkouts, timezone)
+    const sharedAdjustHeader = `ORIGINAL WORKOUT:
+- Title: ${workout.title}
+- Duration: ${durationMinutes} minutes
+- Intensity: ${adjustments.intensity || 'Same as before'}
+- Description: ${workout.description || 'No specific description'}
 
-    const prompt = `Adjust this structured ${workout.type} workout based on user feedback.
-    
-    ORIGINAL WORKOUT:
-    - Title: ${workout.title}
-    - Duration: ${Math.round((workout.durationSec || 3600) / 60)} minutes
-    - Intensity: ${adjustments.intensity || 'Same as before'}
-    - Description: ${workout.description || 'No specific description'}
-    
-    USER FEEDBACK / ADJUSTMENTS:
-    "${adjustments.feedback || 'Please regenerate with the new duration/intensity parameters.'}"
-    
-    USER PROFILE:
-    - Age: ${userAge || 'Unknown'}
-    - Sex: ${workout.user.sex || 'Unknown'}
-    - FTP: ${ftp}W
-    - LTHR: ${lthr} bpm
-    - METRIC PRIORITY ORDER: ${priorityText}
-    
-    USER ZONES:
-    ${zoneDefinitions}
+USER FEEDBACK / ADJUSTMENTS:
+"${feedback}"
 
-    ${targetPolicyPrompt}
+USER PROFILE:
+- Age: ${userAge || 'Unknown'}
+- Sex: ${workout.user.sex || 'Unknown'}
+- FTP: ${ftp}W
+- LTHR: ${lthr} bpm
 
-    ${targetFormatPolicyPrompt}
+USER ZONES:
+${zoneDefinitions}
 
-    RECENT WORKOUTS (brief):
-    ${buildConciseWorkoutSummary(recentWorkouts, timezone)}
-    
-    JSON RULES:
-    - Omit null/empty properties.
-    - No placeholder values.
-    - Include only sport-relevant keys.
-    - Output valid JSON.
+${targetingBlock}
 
-    INSTRUCTIONS:
-    - Create a NEW JSON structure defining the exact steps (Warmup, Intervals, Rest, Cooldown).
-    - Ensure total duration matches the target duration (${Math.round((workout.durationSec || 3600) / 60)}m).
-    - Respect the user's feedback.
-    - Preserve the workout's core objective unless the user explicitly requests changing it.
-    - Ensure each block has a clear physiological purpose and logical stress/recovery flow.
-    - Do NOT create adjacent steps with identical duration + intensity + cadence unless they are explicitly nested in a repeat block.
-    - If a step name implies a focus change, at least one target (power/HR/pace/cadence/RPE) MUST differ from the prior step.
-    - Include only in-session workout steps the athlete performs as part of the session itself.
-    - Do NOT include stretching, foam rolling, mobility, breathing exercises, or post-workout recovery as structured steps.
-    - Put post-workout recovery guidance in coachInstructions, not in steps.
-    - **METRIC PRIORITY**:
-      - Priority Order: ${priorityText}.
-      - Primary metric: ${targetPolicy.primaryMetric}.
-      - ${targetPolicy.strictPrimary ? 'Strict primary is enabled: avoid fallback metrics unless absolutely necessary.' : 'Fallback metrics are allowed when the primary metric is unavailable for a step.'}
-      - ${targetPolicy.allowMixedTargetsPerStep ? 'Mixed targets in one step are allowed when useful.' : 'Keep one intensity metric per step unless explicitly requested.'}
-    - **description**: Use ONLY complete sentences to describe the overall purpose and strategy. **NEVER use bullet points or list the steps here**.
-    - MANDATORY: Every step MUST include an \`intent\` enum value (warmup/recovery/easy/endurance/tempo/threshold/vo2/anaerobic/sprint/cooldown/drills/strides).
-    - **coachInstructions**: Provide a personalized 2-3 sentence message explaining what changed, why, and the key execution cue.
-    - For aerobic/endurance sessions, keep main-set blocks distinct (settle/sustain/technique) rather than generic duplicates.
+RECENT WORKOUTS (brief):
+${recentWorkoutsSummary}`
 
-    ${sportSpecificInstructions}
-
-    Final check: stay within target duration, avoid redundant adjacent steps, and give every step a clear purpose and valid target.
-
-    OUTPUT JSON matching the schema.`
     const draftPrompt = `Adjust this structured ${workout.type} workout plan using the compact planning format.
 
-    ORIGINAL WORKOUT:
-    - Title: ${workout.title}
-    - Duration: ${Math.round((workout.durationSec || 3600) / 60)} minutes
-    - Intensity: ${adjustments.intensity || 'Same as before'}
-    - Description: ${workout.description || 'No specific description'}
+${sharedAdjustHeader}
 
-    USER FEEDBACK / ADJUSTMENTS:
-    "${adjustments.feedback || 'Please regenerate with the new duration/intensity parameters.'}"
+${buildDraftOutputRules({ preserveExistingStructure: false })}
 
-    USER PROFILE:
-    - Age: ${userAge || 'Unknown'}
-    - Sex: ${workout.user.sex || 'Unknown'}
-    - FTP: ${ftp}W
-    - LTHR: ${lthr} bpm
-    - METRIC PRIORITY ORDER: ${priorityText}
+INSTRUCTIONS:
+- Respect the user's feedback; preserve the workout objective unless explicitly changed.
+- Match target duration (${durationMinutes}m).
+- coachInstructions: explain what changed and the key execution cue (2-3 sentences).
+- Every step needs an intent and valid target.
 
-    USER ZONES:
-    ${zoneDefinitions}
+SPORT RULES:
+${sportSpecificInstructions}
 
-    ${targetPolicyPrompt}
+OUTPUT JSON matching the compact draft schema.`
 
-    ${targetFormatPolicyPrompt}
+    const legacyPrompt = `Adjust this structured ${workout.type} workout based on user feedback.
 
-    RECENT WORKOUTS (brief):
-    ${buildConciseWorkoutSummary(recentWorkouts, timezone)}
+${sharedAdjustHeader}
 
-    OUTPUT RULES:
-    - Return compact JSON only.
-    - Use ONE \`target\` object per step, never multiple metric objects.
-    - \`target.metric\` must be one of: power, heartRate, pace, rpe.
-    - Use \`target.units\` from this set only: %, w, bpm, LTHR, Pace, /km.
-    - CRITICAL: For percentage targets, use decimal fractions, not whole percents. Example: 80% LTHR must be \`0.80\` with \`units: "LTHR"\`; 95% FTP must be \`0.95\` with \`units: "%"\`.
-    - Use \`durationSeconds\` for timed steps.
-    - Use \`distanceMeters\` only when distance is central to the prescription.
-    - Use nested \`steps\` plus \`reps\` for repeats.
-    - Respect the user's feedback while preserving the workout objective unless explicitly changed.
-    - Include only in-session workout steps. Do NOT include stretching, foam rolling, mobility, breathing exercises, or post-workout recovery as steps.
-    - Put post-workout recovery guidance in \`coachInstructions\`, not in \`steps\`.
-    - Keep total duration within the planned target.
-    - Keep the plan compact and avoid redundant adjacent steps.
-    - Every step must have a clear purpose and an \`intent\`.
+JSON RULES:
+- Omit null/empty properties. Output valid JSON only.
 
-    SPORT RULES:
-    ${sportSpecificInstructions}
+INSTRUCTIONS:
+- Create a NEW structure matching ${durationMinutes} minutes.
+- Respect feedback; preserve objective unless explicitly changed.
+- In-session steps only. coachInstructions: what changed and why.
 
-    OUTPUT JSON matching the compact draft schema.`
+SPORT RULES:
+${sportSpecificInstructions}
+
+OUTPUT JSON matching the schema.`
+
+    let promptForAttempt = generatorMode === 'draft_json_v1' ? draftPrompt : legacyPrompt
     logStage('prompt-built', {
-      promptChars: generatorMode === 'draft_json_v1' ? draftPrompt.length : prompt.length,
-      targetDurationMinutes: Math.round((workout.durationSec || 3600) / 60)
+      promptChars: promptForAttempt.length,
+      generatorMode,
+      targetDurationMinutes: durationMinutes
     })
 
     let structure: any
-    let promptToUse = prompt
+    let lastAiOutputForRetry: any = null
     let totals: { distance: number; duration: number; tss: number } | null = null
     let actualModelUsed = 'flash'
     for (let attempt = 1; attempt <= 2; attempt++) {
@@ -1097,24 +896,22 @@ export const adjustStructuredWorkoutTask = task({
         const aiStartedAt = Date.now()
         const isRetry = attempt > 1
         if (isRetry) actualModelUsed = 'pro'
+        const aiOptions = buildStructureAiCallOptions({
+          attempt,
+          userId: workout.userId,
+          operation: 'adjust_structured_workout',
+          entityType,
+          entityId: entityId!,
+          timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS
+        })
         if (generatorMode === 'draft_json_v1') {
           const draft = await generateStructuredAnalysis(
-            isRetry
-              ? `${draftPrompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous draft was rejected or incomplete.\n- Keep the same compact schema.\n- Stay inside duration tolerance and include a complete main set.`
-              : draftPrompt,
+            promptForAttempt,
             workoutPlanDraftSchema,
             'flash',
-            {
-              userId: workout.userId,
-              operation: 'adjust_structured_workout',
-              entityType,
-              entityId: entityId!,
-              maxRetries: 0,
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
-              modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
-              thinkingLevelOverride: isRetry ? 'high' : undefined
-            }
+            aiOptions
           )
+          lastAiOutputForRetry = draft
           console.log('[AdjustStructuredWorkout] Compact draft generated', {
             entityId,
             attempt,
@@ -1130,25 +927,18 @@ export const adjustStructuredWorkoutTask = task({
           })
         } else {
           structure = (await generateStructuredAnalysis(
-            promptToUse,
+            promptForAttempt,
             workoutStructureSchema,
             'flash',
-            {
-              userId: workout.userId,
-              operation: 'adjust_structured_workout',
-              entityType,
-              entityId: entityId!,
-              maxRetries: 0, // We handle retries manually here to change models
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
-              modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
-              thinkingLevelOverride: isRetry ? 'high' : undefined
-            }
+            aiOptions
           )) as any
+          lastAiOutputForRetry = structure
         }
         const aiDurationMs = Date.now() - aiStartedAt
         logStage('ai-structure-generated', {
           aiDurationMs,
           attempt,
+          promptChars: promptForAttempt.length,
           model: isRetry ? 'gemini-3-pro-preview' : 'default',
           hasSteps: Array.isArray(structure?.steps),
           stepsCount: Array.isArray(structure?.steps) ? structure.steps.length : 0,
@@ -1160,7 +950,12 @@ export const adjustStructuredWorkoutTask = task({
           attempt
         })
         if (attempt === 1) {
-          promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous generation attempt failed (possibly due to complexity or timeout).\n- I am retrying with a more capable model and more thinking budget.\n- Please ensure a complete and valid structure now.`
+          promptForAttempt = buildCorrectiveStructureRetryPrompt({
+            workout,
+            reason: aiError.message,
+            previousDraft: lastAiOutputForRetry,
+            generatorMode
+          })
           continue
         }
         throw aiError
@@ -1209,7 +1004,14 @@ export const adjustStructuredWorkoutTask = task({
             )
           }
 
-          promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous strength structure was rejected because ${strengthValidation.reason}.\n- Return native strength 'blocks' with exercise 'steps' and per-set 'setRows'.\n- Loaded lifts must use real sets/reps/load, not one long duration block.\n- Retry with a complete and realistic strength prescription now.`
+          promptForAttempt = buildCorrectiveStructureRetryPrompt({
+            workout,
+            reason: strengthValidation.reason,
+            previousDraft: lastAiOutputForRetry,
+            generatorMode,
+            extraInstructions:
+              "Return native strength 'blocks' with exercise 'steps' and per-set 'setRows'. Loaded lifts must use real sets/reps/load."
+          })
           logStage('strength-validation-retry-requested', {
             attempt,
             reason: strengthValidation.reason
@@ -1263,9 +1065,15 @@ export const adjustStructuredWorkoutTask = task({
 
       const swimCoverageFeedback =
         workout.type === 'Swim'
-          ? '\n- For swim workouts, explicitly account for pool time using total volume plus sendoffSeconds/restSeconds and targetSplit when appropriate.\n- If the previous swim plan was too short, add enough distance, repeats, or explicit recovery to reach the planned session time.\n- Do not leave repeated swim set recovery implied if it affects total duration.'
-          : ''
-      promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous structure was rejected because ${coverageValidation.reason}.\n- You MUST keep the workout within the allowed duration tolerance and include a complete main set matching the workout objective.${swimCoverageFeedback}\n- I am retrying with a more capable model and more thinking budget.\n- Retry with a complete structure now.`
+          ? 'For swim workouts, account for sendoffSeconds/restSeconds and targetSplit so total pool time matches the planned duration.'
+          : undefined
+      promptForAttempt = buildCorrectiveStructureRetryPrompt({
+        workout,
+        reason: coverageValidation.reason,
+        previousDraft: lastAiOutputForRetry,
+        generatorMode,
+        extraInstructions: swimCoverageFeedback
+      })
       logStage('ai-structure-retry-requested', {
         attempt,
         reason: coverageValidation.reason
@@ -1404,9 +1212,9 @@ export const adjustStructuredWorkoutTask = task({
         }
         normalizeCooldownRampDirection(step)
 
-        let stepDistance = 0
-        let stepDuration = 0
-        let stepTSS = 0
+        let stepDistance: number
+        let stepDuration: number
+        let stepTSS: number
 
         if (step.steps && Array.isArray(step.steps) && step.steps.length > 0) {
           const nested = normalizeAndCalculate(step.steps, depth + 1, step)

--- a/trigger/generate-structured-workout.ts
+++ b/trigger/generate-structured-workout.ts
@@ -44,8 +44,12 @@ import {
   buildDraftOutputRules,
   buildSportSpecificInstructions,
   buildStructureAiCallOptions,
-  formatAiContextForStructureGen
+  buildStructureGoalContextBlock,
+  formatAiContextForStructureGen,
+  looksLikeIntervalWorkout,
+  resolveStructureContextProfile
 } from './utils/structure-generation-prompt'
+import { assertRenderableStructure } from '../server/utils/structured-workout-validation'
 import {
   estimateStepDistanceMeters,
   estimateStepDurationSeconds,
@@ -626,11 +630,6 @@ function hasRepeatBlock(steps: any[]): boolean {
   )
 }
 
-function looksLikeIntervalWorkout(workout: any) {
-  const text = `${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
-  return /\b(vo2|threshold|tempo|interval|repeats?|x\d+|\d+x)\b/.test(text)
-}
-
 function getCoverageBounds(workout: any, plannedDurationSec: number, preserveStructure?: boolean) {
   if (preserveStructure) {
     return { minCoverage: 0.95, maxCoverage: 1.05 }
@@ -916,12 +915,21 @@ export const generateStructuredWorkoutTask = task({
     const timezone = await getUserTimezone(workout.userId)
     logStage('resolved-timezone', { timezone })
 
-    // Fetch recent workouts for context (concise summary only — no stream data needed)
-    const recentWorkouts = await workoutRepository.getForUser(workout.userId, {
-      limit: 4,
-      orderBy: { date: 'desc' }
+    const preserveExistingStructure = Boolean(workout.structuredWorkout)
+    const contextProfile = resolveStructureContextProfile({
+      workout,
+      preserveExistingStructure
     })
-    logStage('loaded-recent-workouts', { count: recentWorkouts.length })
+    logStage('resolved-context-profile', { contextProfile })
+
+    let recentWorkouts: any[] = []
+    if (contextProfile === 'rich') {
+      recentWorkouts = await workoutRepository.getForUser(workout.userId, {
+        limit: 4,
+        orderBy: { date: 'desc' }
+      })
+    }
+    logStage('loaded-recent-workouts', { count: recentWorkouts.length, contextProfile })
 
     // Resolve Metrics
     const ftp = sportSettings?.ftp || workout.user.ftp || 250
@@ -930,7 +938,8 @@ export const generateStructuredWorkoutTask = task({
     const thresholdPace = sportSettings?.thresholdPace || 0
     const aiContextBlock = formatAiContextForStructureGen({
       aiContext: workout.user.aiContext,
-      workoutDescription: workout.description
+      workoutDescription: workout.description,
+      profile: contextProfile
     })
 
     // Subscription Limit Check
@@ -958,7 +967,6 @@ export const generateStructuredWorkoutTask = task({
 
     const warmupTime = sportSettings?.warmupTime || 10
     const cooldownTime = sportSettings?.cooldownTime || 5
-    const preserveExistingStructure = Boolean(workout.structuredWorkout)
     const existingStructureSummary = preserveExistingStructure
       ? summarizeStructuredWorkoutForPrompt(workout.structuredWorkout)
       : ''
@@ -968,7 +976,9 @@ export const generateStructuredWorkoutTask = task({
       primaryMetric: targetPolicy.primaryMetric,
       loadPreference,
       ftp,
-      lthr
+      lthr,
+      workout,
+      contextProfile
     })
     const targetingBlock = formatCompactTargetingBlock(
       targetPolicy,
@@ -988,7 +998,15 @@ export const generateStructuredWorkoutTask = task({
     })
     const durationMinutes = Math.round((workout.durationSec || 3600) / 60)
     const language = workout.user.language || 'English'
-    const recentWorkoutsSummary = buildConciseWorkoutSummary(recentWorkouts, timezone)
+    const recentWorkoutsSummary =
+      contextProfile === 'rich' ? buildConciseWorkoutSummary(recentWorkouts, timezone) : ''
+    const goalContextBlock = buildStructureGoalContextBlock({
+      profile: contextProfile,
+      goal,
+      phase,
+      focus,
+      persona
+    })
     const sharedWorkoutHeader = `TITLE: ${workout.title}
 DURATION: ${durationMinutes} minutes
 INTENSITY: ${workout.workIntensity || 'Moderate'}
@@ -998,16 +1016,10 @@ USER LTHR: ${lthr} bpm
 TYPE: ${workout.type}
 PREFERRED LANGUAGE: ${language} (all text fields must use this language)
 
-CONTEXT:
-- Goal: ${goal}
-- Phase: ${phase}
-- Focus: ${focus}
-- Coach Persona: ${persona}
+${goalContextBlock}
 ${aiContextBlock}
 
-RECENT WORKOUTS (brief):
-${recentWorkoutsSummary}
-
+${recentWorkoutsSummary ? `RECENT WORKOUTS (brief):\n${recentWorkoutsSummary}\n` : ''}
 ${preserveExistingStructure ? `EXISTING STRUCTURE TO PRESERVE:\n${existingStructureSummary}\n` : ''}
 ${zoneDefinitions}
 
@@ -1065,6 +1077,7 @@ OUTPUT JSON matching the schema.`
     logStage('prompt-built', {
       promptChars: promptForAttempt.length,
       generatorMode,
+      contextProfile,
       targetDurationMinutes: durationMinutes
     })
 
@@ -1519,6 +1532,13 @@ OUTPUT JSON matching the schema.`
       totalTSS: Math.round(totalTSS * 100) / 100
     })
 
+    const renderableValidation = assertRenderableStructure(structure, workout.type)
+    if (!renderableValidation.valid) {
+      throw new Error(
+        `Generated structured workout failed renderable validation: ${renderableValidation.reason}`
+      )
+    }
+
     const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
     const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
     if ((hasSteps || hasExercises) && totalDuration <= 0) {
@@ -1547,7 +1567,8 @@ OUTPUT JSON matching the schema.`
       goal,
       phase,
       focus,
-      persona
+      persona,
+      contextProfile
     })
 
     const updateData: any = {

--- a/trigger/generate-structured-workout.ts
+++ b/trigger/generate-structured-workout.ts
@@ -13,8 +13,7 @@ import { enforceCyclingCadenceVariation, resolveCyclingCadence } from './utils/c
 import {
   resolveWorkoutTargeting,
   type WorkoutTargetingOverride,
-  formatTargetPolicyPrompt,
-  formatTargetFormatPolicyPrompt,
+  formatCompactTargetingBlock,
   STEP_INTENTS,
   applyTargetPolicyToStep,
   applyTargetFormatPolicyToStep,
@@ -34,15 +33,19 @@ import {
   applyStrengthLibraryDefaultsToWorkout,
   validateStrengthStructuredWorkout
 } from '../server/utils/strength-exercise-matching'
-import {
-  resolveStructuredWorkoutGeneratorMode,
-  type StructuredWorkoutGeneratorMode
-} from '../server/utils/structured-workout-generator'
+import { resolveStructureGeneratorModeForWorkout } from '../server/utils/structured-workout-generator'
 import {
   compileWorkoutPlanDraftToStructure,
-  isDraftStructuredWorkoutSupported,
   workoutPlanDraftSchema
 } from '../server/utils/structured-workout-draft'
+import {
+  buildCompactZoneDefinitions,
+  buildCorrectiveStructureRetryPrompt,
+  buildDraftOutputRules,
+  buildSportSpecificInstructions,
+  buildStructureAiCallOptions,
+  formatAiContextForStructureGen
+} from './utils/structure-generation-prompt'
 import {
   estimateStepDistanceMeters,
   estimateStepDurationSeconds,
@@ -748,76 +751,6 @@ function summarizeStructuredWorkoutForPrompt(structuredWorkout: any): string {
   return lines.join('\n') || 'None.'
 }
 
-function buildCompactZoneDefinitions(params: {
-  workoutType: string
-  sportSettings: any
-  primaryMetric: string
-  loadPreference: string
-  ftp: number
-  lthr: number
-}) {
-  const { workoutType, sportSettings, primaryMetric, loadPreference, ftp, lthr } = params
-  const parts: string[] = []
-  const addZones = (label: string, zones: any[], unit: string, limit = 5) => {
-    if (!Array.isArray(zones) || zones.length === 0) return
-    const compact = zones
-      .slice(0, limit)
-      .map((z: any) => `${z.name}: ${z.min}-${z.max}${unit}`)
-      .join(' | ')
-    if (compact) parts.push(`${label}: ${compact}`)
-  }
-
-  if (primaryMetric === 'heartRate')
-    addZones(`${workoutType} HR Zones`, sportSettings?.hrZones, ' bpm')
-  if (primaryMetric === 'power')
-    addZones(`${workoutType} Power Zones`, sportSettings?.powerZones, ' W')
-  if (primaryMetric === 'pace')
-    addZones(`${workoutType} Pace Zones`, sportSettings?.paceZones, ' m/s')
-
-  if (
-    primaryMetric !== 'heartRate' &&
-    Array.isArray(sportSettings?.hrZones) &&
-    sportSettings.hrZones.length > 0
-  ) {
-    addZones(`${workoutType} HR Zones`, sportSettings.hrZones, ' bpm', 3)
-  }
-  if (
-    primaryMetric !== 'power' &&
-    Array.isArray(sportSettings?.powerZones) &&
-    sportSettings.powerZones.length > 0
-  ) {
-    addZones(`${workoutType} Power Zones`, sportSettings.powerZones, ' W', 3)
-  }
-  if (
-    primaryMetric !== 'pace' &&
-    Array.isArray(sportSettings?.paceZones) &&
-    sportSettings.paceZones.length > 0
-  ) {
-    addZones(`${workoutType} Pace Zones`, sportSettings.paceZones, ' m/s', 3)
-  }
-
-  if (lthr) parts.push(`Reference LTHR: ${lthr} bpm`)
-  if (ftp) parts.push(`Reference FTP: ${ftp} W`)
-  if (sportSettings?.thresholdPace) {
-    const metersPerSecond = Number(sportSettings.thresholdPace)
-    if (metersPerSecond > 0) {
-      const secondsPerKm = 1000 / metersPerSecond
-      const minutes = Math.floor(secondsPerKm / 60)
-      const seconds = Math.round(secondsPerKm % 60)
-      parts.push(
-        `Reference Threshold Pace: ${metersPerSecond} m/s (${minutes}:${seconds
-          .toString()
-          .padStart(2, '0')}/km)`
-      )
-    }
-  }
-  parts.push(`Preferred Load Metric: ${loadPreference}`)
-  if (sportSettings?.warmupTime) parts.push(`Default Warmup: ${sportSettings.warmupTime} min`)
-  if (sportSettings?.cooldownTime) parts.push(`Default Cooldown: ${sportSettings.cooldownTime} min`)
-
-  return parts.join('\n')
-}
-
 export const generateStructuredWorkoutTask = task({
   id: 'generate-structured-workout',
   queue: userReportsQueue,
@@ -826,7 +759,6 @@ export const generateStructuredWorkoutTask = task({
     plannedWorkoutId?: string
     workoutTemplateId?: string
     targetingOverride?: WorkoutTargetingOverride | null
-    generatorOverride?: StructuredWorkoutGeneratorMode | null
   }) => {
     const { plannedWorkoutId, workoutTemplateId } = payload
     const entityId = plannedWorkoutId || workoutTemplateId
@@ -913,41 +845,18 @@ export const generateStructuredWorkoutTask = task({
       isTemplate: entityType === 'WorkoutTemplate'
     })
 
-    const requestedGeneratorMode = await resolveStructuredWorkoutGeneratorMode(
-      workout.userId,
-      payload?.generatorOverride || null
-    )
-    const generatorMode =
-      requestedGeneratorMode === 'draft_json_v1' &&
-      isDraftStructuredWorkoutSupported(workout.type || '')
-        ? requestedGeneratorMode
-        : 'legacy_json'
+    const requestedGeneratorMode = resolveStructureGeneratorModeForWorkout(workout.type || '')
+    const generatorMode = requestedGeneratorMode
     console.log('[GenerateStructuredWorkout] Generator mode resolved', {
       entityId,
       entityType,
       workoutType: workout.type,
-      requestedGeneratorMode,
-      generatorMode,
-      explicitOverride: payload?.generatorOverride || null
+      generatorMode
     })
     logStage('resolved-generator-mode', {
-      generatorMode,
-      requestedGeneratorMode,
-      explicitOverride: payload?.generatorOverride || null
+      generatorMode
     })
-    if (requestedGeneratorMode === 'draft_json_v1' && generatorMode !== requestedGeneratorMode) {
-      console.log('[GenerateStructuredWorkout] Falling back to legacy generator', {
-        entityId,
-        workoutType: workout.type,
-        requestedGeneratorMode,
-        fallbackMode: generatorMode
-      })
-      logStage('generator-mode-fallback', {
-        requestedGeneratorMode,
-        fallbackMode: generatorMode,
-        workoutType: workout.type
-      })
-    } else if (generatorMode === 'draft_json_v1') {
+    if (generatorMode === 'draft_json_v1') {
       console.log('[GenerateStructuredWorkout] Using compact draft generator', {
         entityId,
         workoutType: workout.type
@@ -955,6 +864,11 @@ export const generateStructuredWorkoutTask = task({
       logStage('generator-mode-branch', {
         generatorMode,
         implementation: 'compact_draft_v1'
+      })
+    } else {
+      logStage('generator-mode-branch', {
+        generatorMode,
+        implementation: 'legacy_json'
       })
     }
 
@@ -1002,18 +916,10 @@ export const generateStructuredWorkoutTask = task({
     const timezone = await getUserTimezone(workout.userId)
     logStage('resolved-timezone', { timezone })
 
-    // Fetch recent workouts for context (Limit to 7 with concise summary to balance context vs speed)
+    // Fetch recent workouts for context (concise summary only — no stream data needed)
     const recentWorkouts = await workoutRepository.getForUser(workout.userId, {
       limit: 4,
-      orderBy: { date: 'desc' },
-      include: {
-        streams: {
-          select: {
-            hrZoneTimes: true,
-            powerZoneTimes: true
-          }
-        }
-      }
+      orderBy: { date: 'desc' }
     })
     logStage('loaded-recent-workouts', { count: recentWorkouts.length })
 
@@ -1022,7 +928,10 @@ export const generateStructuredWorkoutTask = task({
     const lthr = sportSettings?.lthr || workout.user.lthr || 160
     const maxHr = sportSettings?.maxHr || workout.user.maxHr || 190
     const thresholdPace = sportSettings?.thresholdPace || 0
-    const aiContext = workout.user.aiContext || ''
+    const aiContextBlock = formatAiContextForStructureGen({
+      aiContext: workout.user.aiContext,
+      workoutDescription: workout.description
+    })
 
     // Subscription Limit Check
     // Free users cannot generate structured workouts more than 4 weeks (28 days) in the future
@@ -1061,210 +970,106 @@ export const generateStructuredWorkoutTask = task({
       ftp,
       lthr
     })
-    const targetPolicyPrompt = formatTargetPolicyPrompt(targetPolicy, loadPreference)
-    const targetFormatPolicyPrompt = formatTargetFormatPolicyPrompt(targetFormatPolicy)
+    const targetingBlock = formatCompactTargetingBlock(
+      targetPolicy,
+      targetFormatPolicy,
+      priorityText
+    )
     const steadyTargetStyleRule =
       targetPolicy.defaultTargetStyle === 'value'
-        ? "Prefer 'heartRate.value', 'pace.value', or 'power.value' for steady aerobic/endurance/tempo blocks. Use ranges only when the workout explicitly asks for a range or ramp."
-        : "Prefer 'heartRate.range', 'pace.range', or 'power.range' for steady aerobic/endurance/tempo blocks."
-    const workoutType = String(workout.type || '').toLowerCase()
-    const isCycling = workoutType.includes('ride')
-    const isRun = workoutType.includes('run')
-    const isSwim = workoutType.includes('swim')
-    const isStrength = workoutType.includes('gym') || workoutType.includes('weight')
-    const runPaceUnitInstruction =
-      targetFormatPolicy.pace.mode === 'absolutePace'
-        ? `- CRITICAL: If the workout request calls for absolute pace or includes examples like "5:20-5:40 min/km", encode those as explicit pace targets. Use 'pace.units' = "/km" with decimal minute values (for example 5.33-5.67 for 5:20-5:40/km), set 'primaryTarget' to 'pace' for those steps, and do NOT fall back to unlabeled percentages or power targets.`
-        : `- Use 'heartRate.units' = "LTHR" for percentage HR targets and 'pace.units' = "Pace" for percentage pace targets.`
-    const sportSpecificInstructions = isCycling
-      ? `FOR CYCLING (Ride/VirtualRide):
-    - MANDATORY: Use % of FTP for power targets (e.g. 0.95 = 95%) for EVERY step.
-    - Set 'power.units' to "%" unless there is an explicit reason to use "w".
-    - For ramps (Warmup/Cooldown), use "range" with "start" and "end" values (e.g. start: 0.50, end: 0.75 for warmup).
-    - MANDATORY: Include target "cadence" (RPM) for EVERY step (including Warmup/Rest). 
-      * Use 85-95 for active, 80 for rest UNLESS specific user preferences are provided in the CONTEXT above (e.g. "70-85rpm").
-    - For cadence-focus steps, cadence MUST differ from surrounding steady steps (e.g. steady 85-90, focus 95-100) and power should be adjusted if needed.
-    - For aerobic rides, avoid repeated identical 20+ minute blocks unless deliberate repeats are requested.
-    - If HR zones are available, include at least one HR guardrail in coachInstructions (e.g. cap near top of aerobic zone).
-    - For interval sets, include realistic recovery between hard repetitions and maintain repeatability of quality efforts.`
-      : isRun
-        ? `FOR RUNNING (Run):
-    - Steps should have 'type', 'durationSeconds', 'name'.
-    - ALWAYS include 'distance' (meters) for each step. If duration-based, ESTIMATE the distance based on the intensity/pace.
-    - Target selection MUST follow TARGET POLICY priority order: ${priorityText}.
-    - ${runPaceUnitInstruction}
-    - ${targetPolicy.allowMixedTargetsPerStep ? 'Mixed metrics in one step are allowed, but the policy primary metric must still be explicit as primaryTarget.' : 'Use one intensity metric per step unless the workout request explicitly asks for mixed cues.'}
-    - ${steadyTargetStyleRule}
-    - DO NOT rely solely on description for intensity. Provide an estimated target object for every step.
-    - Steps must represent runnable in-session segments only (jog, run, walk recoveries, drills performed during the run).
-    - Do NOT add static stretching or off-feet recovery blocks to the structured plan.
-    - Respect quality spacing: avoid stacking maximal efforts without enough recovery.`
-        : isSwim
-          ? `FOR SWIMMING (Swim):
-    - Prefer 'distanceMeters' for pool reps and lengths. Use 'durationSeconds' only when time-based structure is genuinely better.
-    - Use 'stroke' to specify: Free, Back, Breast, Fly, IM, Choice, Kick, Pull.
-    - Use 'equipment' array for gear: Fins, Paddles, Snorkel, Pull Buoy.
-    - Use 'sendoffSeconds' when the set is written on a send-off and 'restSeconds' when explicit rest matters.
-    - Use 'targetSplit' (e.g. "1:40/100m") or 'cssPercent' when swim pacing is central to the set.
-    - Use one intensity cue per step when possible. Do NOT force heart-rate targets for every swim step.
-    - Technical/drill steps can omit target intensity if stroke, distance, send-off, or rest already defines the task clearly.
-    - CRITICAL: The full pool session must realistically land near the planned duration once swim pace, send-offs, and rests are considered.
-    - For sessions 45 minutes or longer, include enough total volume and explicit recoveries/send-offs to fill the assigned time.
-    - Prefer explicit 'sendoffSeconds' or 'restSeconds' on repeated sets instead of leaving recovery implied.
-    - Before returning, sanity-check the total session time yourself and expand or trim the set so it stays close to the planned duration.`
-          : isStrength
-            ? `FOR STRENGTH (Gym/WeightTraining):
-    - Prefer the canonical strength schema: provide 'blocks' instead of a flat 'exercises' list.
-    - Each block should have: 'type', 'title', optional 'notes', and 'steps'.
-    - Use block types like 'warmup', 'single_exercise', 'superset', 'circuit', 'cooldown'.
-    - Each step should have 'name', optional 'notes', optional 'intent'/'movementPattern', and 'setRows'.
-    - Each step should also set a shared 'prescriptionMode' (default 'reps'), optional 'loadMode', and optional 'defaultRest'.
-    - Each entry in 'setRows' represents one set and may contain:
-      * 'value' for reps, reps/side, duration, or distance depending on prescriptionMode
-      * 'loadValue' for load/weight when relevant
-      * 'restOverride' only when a specific set differs from defaultRest
-    - Example: a 3x8 squat with ramping load should use one step with 3 setRows, not 3 separate exercises.
-    - CRITICAL: Return native 'blocks' for strength. Do NOT return interval-style top-level 'steps' for WeightTraining.
-    - CRITICAL: Loaded lifts must use real per-set prescription. Do NOT prescribe main lifts as one long duration row such as 1 x 900 seconds.
-    - Time-based mobility like foam rolling should use prescriptionMode='duration' with setRows.value in seconds.
-    - Structure the session as Warmup -> Main Lifts -> Accessories -> Cooldown when appropriate.
-    - Only fall back to a flat 'exercises' list if you truly cannot express the workout as blocks.`
-            : `FOR THIS SPORT TYPE:
-    - Use only sport-relevant fields and targets.
-    - Keep steps explicit, measurable, and safe with clear work/recovery structure.`
+        ? 'Prefer single-value targets for steady aerobic/endurance/tempo blocks. Use ranges only when the workout explicitly asks for a range or ramp.'
+        : 'Prefer metric ranges for steady aerobic/endurance/tempo blocks.'
+    const workoutTypeLower = String(workout.type || '').toLowerCase()
+    const isStrength = workoutTypeLower.includes('gym') || workoutTypeLower.includes('weight')
+    const sportSpecificInstructions = buildSportSpecificInstructions({
+      workoutType: workout.type || '',
+      targetFormatPolicy,
+      steadyTargetStyleRule
+    })
+    const durationMinutes = Math.round((workout.durationSec || 3600) / 60)
+    const language = workout.user.language || 'English'
+    const recentWorkoutsSummary = buildConciseWorkoutSummary(recentWorkouts, timezone)
+    const sharedWorkoutHeader = `TITLE: ${workout.title}
+DURATION: ${durationMinutes} minutes
+INTENSITY: ${workout.workIntensity || 'Moderate'}
+DESCRIPTION: ${workout.description || 'No specific description'}
+USER FTP: ${ftp}W
+USER LTHR: ${lthr} bpm
+TYPE: ${workout.type}
+PREFERRED LANGUAGE: ${language} (all text fields must use this language)
 
-    const prompt = `Design a structured ${workout.type} workout for ${workout.user.name || 'Athlete'}.
-    
-    TITLE: ${workout.title}
-    DURATION: ${Math.round((workout.durationSec || 3600) / 60)} minutes
-    INTENSITY: ${workout.workIntensity || 'Moderate'}
-    DESCRIPTION: ${workout.description || 'No specific description'}
-    USER FTP: ${ftp}W
-    USER LTHR: ${lthr} bpm
-    TYPE: ${workout.type}
-    PREFERRED INTENSITY METRIC: ${loadPreference}
-    METRIC PRIORITY ORDER: ${priorityText}
-    PREFERRED LANGUAGE: ${workout.user.language || 'English'} (CRITICAL: ALL text fields like "description" and "coachInstructions" MUST be written in this language)
-    
-    CONTEXT:
-    - Goal: ${goal}
-    - Phase: ${phase}
-    - Focus: ${focus}
-    - Coach Persona: ${persona}
-    ${aiContext ? `- User Preferences/Context: ${aiContext}` : ''}
-    
-    RECENT WORKOUTS (brief):
-    ${buildConciseWorkoutSummary(recentWorkouts, timezone)}
+CONTEXT:
+- Goal: ${goal}
+- Phase: ${phase}
+- Focus: ${focus}
+- Coach Persona: ${persona}
+${aiContextBlock}
 
-    ${preserveExistingStructure ? `EXISTING STRUCTURE TO PRESERVE:\n${existingStructureSummary}` : ''}
+RECENT WORKOUTS (brief):
+${recentWorkoutsSummary}
 
-    Use the user's specific zones and references below for this activity type.
+${preserveExistingStructure ? `EXISTING STRUCTURE TO PRESERVE:\n${existingStructureSummary}\n` : ''}
+${zoneDefinitions}
 
-    ${zoneDefinitions}
+${targetingBlock}
 
-    ${targetPolicyPrompt}
+For Zone 2 workouts, target the user's defined Z2 range for this sport before generic percentages.`
 
-    ${targetFormatPolicyPrompt}
+    const draftPrompt =
+      generatorMode === 'draft_json_v1'
+        ? `Design a structured ${workout.type} workout plan for ${workout.user.name || 'Athlete'} using a compact planning format.
 
-    When generating "[Zone 2]" workouts, target ONLY the user's defined Z2 range for this specific sport. Never use generic percentages - always reference the provided zones first.
-    
-    JSON RULES:
-    - Omit null/empty properties.
-    - Every step must have non-zero durationSeconds.
-    - Output valid JSON only.
-    - No placeholder values.
-    - Include only sport-relevant keys.
+${sharedWorkoutHeader}
 
-    INSTRUCTIONS:
-    - Create a JSON structure defining the exact steps (Warmup, Intervals, Rest, Cooldown).
-    - Ensure total duration matches the target duration exactly.
-    - ${preserveExistingStructure ? 'This is a REGENERATION of an existing workout structure. Preserve the same session identity: keep the overall objective, block order, repeat/set pattern, and approximate work/recovery distribution unless the workout title or description clearly requires a different design.' : 'If no prior structure exists, build the session from scratch.'}
-    - ${preserveExistingStructure ? 'Improve clarity, targeting, and coach cues without inventing a materially different workout.' : 'Build a complete structure that fits the planned session.'}
-    - Use repeat blocks with "reps" for repetitive interval sets.
-    - Every workout must have a clear physiological objective (e.g. aerobic endurance, threshold, VO2, neuromuscular, recovery) and each block should support that objective.
-    - Sequence intensity logically (warm-up -> quality work -> recovery -> cooldown). Avoid random intensity jumps.
-    - Do NOT create adjacent steps with identical duration + intensity + cadence unless they are explicitly nested in a repeat block.
-    - If a step name implies a focus change (e.g. cadence focus), at least one target (power/HR/pace/cadence/RPE) MUST differ from the prior step.
-    - Include only in-session workout steps the athlete performs as part of the session itself.
-    - Do NOT include stretching, foam rolling, mobility, breathing exercises, or post-workout recovery as structured steps.
-    - Put post-workout recovery guidance in coachInstructions, not in steps.
-    - **METRIC PRIORITY**: Respect the user's TARGET POLICY and preferred order (${loadPreference}).
-      - Priority Order: ${priorityText}.
-      - Primary metric for each step should be: ${targetPolicy.primaryMetric}.
-      - ${targetPolicy.strictPrimary ? 'Strict primary is enabled: avoid fallback metrics unless absolutely necessary.' : 'Fallback metrics are allowed when the primary metric is not usable for a specific step.'}
-      - ${targetPolicy.allowMixedTargetsPerStep ? 'Mixed targets in one step are allowed when they add useful execution context.' : 'Do not include multiple intensity targets in a single step unless explicitly requested.'}
-      - NEVER duplicate a workout step just to provide a different intensity metric. One step = one time block.
-    - **steps**: All rules below (targets, etc.) apply to BOTH top-level steps AND nested steps inside repeats.
-    - MANDATORY: Every step MUST include an \`intent\` enum value (warmup/recovery/easy/endurance/tempo/threshold/vo2/anaerobic/sprint/cooldown/drills/strides).
-    - **description**: Use ONLY complete sentences to describe the overall purpose and strategy. **NEVER use bullet points or list the steps here**.
-    - **coachInstructions**: Provide a personalized 2-3 sentence message explaining why this workout matters and the key execution cue. Use the "${persona}" persona tone.
-    - **Warmup/Cooldown**: Use the user's default durations (${warmupTime} minutes for Warmup, ${cooldownTime} minutes for Cooldown) unless the workout TITLE or DESCRIPTION explicitly asks for a different specific duration.
-    - For aerobic/endurance workouts, create at least 2 distinct main-set sub-blocks with clear purpose (settle, sustain, technique/cadence or control), not one repeated generic block.
-    - For Zone 2 workouts, keep primary targets inside the user's provided endurance/aerobic zones whenever available.
+${buildDraftOutputRules({ preserveExistingStructure })}
 
-    ${sportSpecificInstructions}
+INSTRUCTIONS:
+- Create steps (Warmup, Active, Rest, Cooldown) matching the target duration.
+- Use repeat blocks with reps for interval sets.
+- Every step needs an intent and a valid target.
+- description: complete sentences only (no bullet lists of steps).
+- coachInstructions: 2-3 sentences in the "${persona}" persona tone.
+- Warmup/Cooldown defaults: ${warmupTime}m / ${cooldownTime}m unless title/description specify otherwise.
 
-    Final check: stay within target duration, avoid redundant adjacent steps, give every step a clear purpose and valid primary target.
+SPORT RULES:
+${sportSpecificInstructions}
 
-    OUTPUT JSON matching the schema.`
-    const draftPrompt = `Design a structured ${workout.type} workout plan for ${workout.user.name || 'Athlete'} using a compact planning format.
+OUTPUT JSON matching the compact draft schema.`
+        : ''
 
-    TITLE: ${workout.title}
-    DURATION: ${Math.round((workout.durationSec || 3600) / 60)} minutes
-    INTENSITY: ${workout.workIntensity || 'Moderate'}
-    DESCRIPTION: ${workout.description || 'No specific description'}
-    USER FTP: ${ftp}W
-    USER LTHR: ${lthr} bpm
-    TYPE: ${workout.type}
-    PREFERRED INTENSITY METRIC: ${loadPreference}
-    METRIC PRIORITY ORDER: ${priorityText}
-    PREFERRED LANGUAGE: ${workout.user.language || 'English'} (CRITICAL: All text fields must use this language)
+    const legacyPrompt =
+      generatorMode === 'legacy_json'
+        ? `Design a structured ${workout.type} workout for ${workout.user.name || 'Athlete'}.
 
-    CONTEXT:
-    - Goal: ${goal}
-    - Phase: ${phase}
-    - Focus: ${focus}
-    - Coach Persona: ${persona}
-    ${aiContext ? `- User Preferences/Context: ${aiContext}` : ''}
+${sharedWorkoutHeader}
 
-    RECENT WORKOUTS (brief):
-    ${buildConciseWorkoutSummary(recentWorkouts, timezone)}
+JSON RULES:
+- Omit null/empty properties.
+- Every step must have non-zero durationSeconds.
+- Output valid JSON only.
 
-    ${preserveExistingStructure ? `EXISTING STRUCTURE TO PRESERVE:\n${existingStructureSummary}` : ''}
+INSTRUCTIONS:
+- Create steps (Warmup, Intervals, Rest, Cooldown) matching ${durationMinutes} minutes.
+- ${preserveExistingStructure ? 'Regenerate while preserving session identity unless title/description require change.' : 'Build the session from scratch.'}
+- Every step needs an intent and valid primary target.
+- description: complete sentences only. coachInstructions: 2-3 sentences in "${persona}" tone.
+- In-session steps only; no stretching/mobility as steps.
 
-    ${zoneDefinitions}
+SPORT RULES:
+${sportSpecificInstructions}
 
-    ${targetPolicyPrompt}
+OUTPUT JSON matching the schema.`
+        : ''
 
-    ${targetFormatPolicyPrompt}
-
-    OUTPUT RULES:
-    - Return compact JSON only.
-    - Use ONE \`target\` object per step, never multiple metric objects.
-    - \`target.metric\` must be one of: power, heartRate, pace, rpe.
-    - Use \`target.units\` from this set only: %, w, bpm, LTHR, Pace, /km.
-    - CRITICAL: For percentage targets, use decimal fractions, not whole percents. Example: 80% LTHR must be \`0.80\` with \`units: "LTHR"\`; 95% FTP must be \`0.95\` with \`units: "%"\`.
-    - Use \`durationSeconds\` for timed steps.
-    - Use \`distanceMeters\` only when distance is central to the prescription.
-    - Use nested \`steps\` plus \`reps\` for repeats.
-    - Every step must have a clear purpose and an \`intent\`.
-    - Include only in-session workout steps. Do NOT include stretching, foam rolling, mobility, breathing exercises, or post-workout recovery as steps.
-    - Put post-workout recovery guidance in \`coachInstructions\`, not in \`steps\`.
-    - Keep total duration within the planned target.
-    - Keep the plan compact and avoid redundant adjacent steps.
-    - ${preserveExistingStructure ? 'Preserve the session identity and structure unless the workout clearly requires change.' : 'Build the full session from scratch.'}
-
-    SPORT RULES:
-    ${sportSpecificInstructions}
-
-    OUTPUT JSON matching the compact draft schema.`
+    let promptForAttempt = generatorMode === 'draft_json_v1' ? draftPrompt : legacyPrompt
     logStage('prompt-built', {
-      promptChars: generatorMode === 'draft_json_v1' ? draftPrompt.length : prompt.length,
-      targetDurationMinutes: Math.round((workout.durationSec || 3600) / 60)
+      promptChars: promptForAttempt.length,
+      generatorMode,
+      targetDurationMinutes: durationMinutes
     })
 
     let structure: any
-    let promptToUse = prompt
+    let lastAiOutputForRetry: any = null
     let totals: { distance: number; duration: number; tss: number } | null = null
     let actualModelUsed = 'flash'
     for (let attempt = 1; attempt <= 2; attempt++) {
@@ -1272,24 +1077,22 @@ export const generateStructuredWorkoutTask = task({
         const aiStartedAt = Date.now()
         const isRetry = attempt > 1
         if (isRetry) actualModelUsed = 'pro'
+        const aiOptions = buildStructureAiCallOptions({
+          attempt,
+          userId: workout.userId,
+          operation: 'generate_structured_workout',
+          entityType,
+          entityId: entityId!,
+          timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS
+        })
         if (generatorMode === 'draft_json_v1') {
           const draft = await generateStructuredAnalysis(
-            isRetry
-              ? `${draftPrompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous draft was rejected or incomplete.\n- Keep the same compact schema.\n- Stay inside duration tolerance and include a complete main set.`
-              : draftPrompt,
+            promptForAttempt,
             workoutPlanDraftSchema,
             'flash',
-            {
-              userId: workout.userId,
-              operation: 'generate_structured_workout',
-              entityType,
-              entityId: entityId!,
-              maxRetries: 0,
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
-              modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
-              thinkingLevelOverride: isRetry ? 'high' : undefined
-            }
+            aiOptions
           )
+          lastAiOutputForRetry = draft
           console.log('[GenerateStructuredWorkout] Compact draft generated', {
             entityId,
             attempt,
@@ -1305,25 +1108,18 @@ export const generateStructuredWorkoutTask = task({
           })
         } else {
           structure = await generateStructuredAnalysis(
-            promptToUse,
+            promptForAttempt,
             workoutStructureSchema,
             'flash',
-            {
-              userId: workout.userId,
-              operation: 'generate_structured_workout',
-              entityType,
-              entityId: entityId!,
-              maxRetries: 0, // We handle retries manually here to change models
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
-              modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
-              thinkingLevelOverride: isRetry ? 'high' : undefined
-            }
+            aiOptions
           )
+          lastAiOutputForRetry = structure
         }
         const aiDurationMs = Date.now() - aiStartedAt
         logStage('ai-structure-generated', {
           aiDurationMs,
           attempt,
+          promptChars: promptForAttempt.length,
           model: isRetry ? 'gemini-3-pro-preview' : 'default',
           hasSteps: Array.isArray(structure?.steps),
           stepsCount: Array.isArray(structure?.steps) ? structure.steps.length : 0,
@@ -1335,7 +1131,12 @@ export const generateStructuredWorkoutTask = task({
           attempt
         })
         if (attempt === 1) {
-          promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous generation attempt failed (possibly due to complexity or timeout).\n- I am retrying with a more capable model and more thinking budget.\n- Please ensure a complete and valid structure now.`
+          promptForAttempt = buildCorrectiveStructureRetryPrompt({
+            workout,
+            reason: aiError.message,
+            previousDraft: lastAiOutputForRetry,
+            generatorMode
+          })
           continue
         }
         throw aiError
@@ -1384,7 +1185,14 @@ export const generateStructuredWorkoutTask = task({
             )
           }
 
-          promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous strength structure was rejected because ${strengthValidation.reason}.\n- Return native strength 'blocks' with exercise 'steps' and per-set 'setRows'.\n- Loaded lifts must use real sets/reps/load, not one long duration block.\n- Retry with a complete and realistic strength prescription now.`
+          promptForAttempt = buildCorrectiveStructureRetryPrompt({
+            workout,
+            reason: strengthValidation.reason,
+            previousDraft: lastAiOutputForRetry,
+            generatorMode,
+            extraInstructions:
+              "Return native strength 'blocks' with exercise 'steps' and per-set 'setRows'. Loaded lifts must use real sets/reps/load."
+          })
           logStage('strength-validation-retry-requested', {
             attempt,
             reason: strengthValidation.reason
@@ -1439,9 +1247,15 @@ export const generateStructuredWorkoutTask = task({
 
       const swimCoverageFeedback =
         workout.type === 'Swim'
-          ? '\n- For swim workouts, explicitly account for pool time using total volume plus sendoffSeconds/restSeconds and targetSplit when appropriate.\n- If the previous swim plan was too short, add enough distance, repeats, or explicit recovery to reach the planned session time.\n- Do not leave repeated swim set recovery implied if it affects total duration.'
-          : ''
-      promptToUse = `${prompt}\n\nCORRECTIVE FEEDBACK FROM PREVIOUS ATTEMPT:\n- The previous structure was rejected because ${coverageValidation.reason}.\n- You MUST keep the workout within the allowed duration tolerance and include a complete main set matching the workout objective.${swimCoverageFeedback}\n- I am retrying with a more capable model and more thinking budget.\n- Retry with a complete structure now.`
+          ? 'For swim workouts, account for sendoffSeconds/restSeconds and targetSplit so total pool time matches the planned duration.'
+          : undefined
+      promptForAttempt = buildCorrectiveStructureRetryPrompt({
+        workout,
+        reason: coverageValidation.reason,
+        previousDraft: lastAiOutputForRetry,
+        generatorMode,
+        extraInstructions: swimCoverageFeedback
+      })
       logStage('ai-structure-retry-requested', {
         attempt,
         reason: coverageValidation.reason
@@ -1582,9 +1396,9 @@ export const generateStructuredWorkoutTask = task({
         normalizeCooldownRampDirection(step)
 
         // 4. Recurse and Calculate
-        let stepDistance = 0
-        let stepDuration = 0
-        let stepTSS = 0
+        let stepDistance: number
+        let stepDuration: number
+        let stepTSS: number
 
         if (step.steps && Array.isArray(step.steps) && step.steps.length > 0) {
           const nested = normalizeAndCalculate(step.steps, depth + 1, step)
@@ -1667,7 +1481,7 @@ export const generateStructuredWorkoutTask = task({
     if (structure.exercises && Array.isArray(structure.exercises)) {
       let gymDuration = 0
       structure.exercises.forEach((ex: any) => {
-        let exDuration = 0
+        let exDuration: number
         if (ex.duration) exDuration = ex.duration
         else {
           const sets = ex.sets || 1

--- a/trigger/utils/structure-generation-prompt.ts
+++ b/trigger/utils/structure-generation-prompt.ts
@@ -7,10 +7,98 @@ const AI_CONTEXT_MAX_CHARS = 500
 const AI_CONTEXT_SKIP_IF_DESCRIPTION_CHARS = 120
 const CORRECTIVE_DRAFT_JSON_MAX_CHARS = 12_000
 
+export type StructureContextProfile = 'minimal' | 'standard' | 'rich'
+
+export function looksLikeIntervalWorkout(workout: {
+  title?: string | null
+  description?: string | null
+}): boolean {
+  const text = `${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
+  return /\b(vo2|threshold|tempo|interval|repeats?|x\d+|\d+x)\b/.test(text)
+}
+
+export function looksLikeSteadyStateWorkout(workout: {
+  title?: string | null
+  description?: string | null
+  workIntensity?: number | null
+}): boolean {
+  if (looksLikeIntervalWorkout(workout)) return false
+  const text = `${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
+  return /\b(zone\s*2|z2|endurance|aerobic|easy|recovery|rest|steady)\b/.test(text)
+}
+
+export function resolveStructureContextProfile(params: {
+  workout: {
+    title?: string | null
+    description?: string | null
+    workIntensity?: number | null
+    trainingWeek?: unknown
+  }
+  preserveExistingStructure?: boolean
+}): StructureContextProfile {
+  if (params.preserveExistingStructure) return 'rich'
+  if (looksLikeIntervalWorkout(params.workout)) return 'standard'
+  if (looksLikeSteadyStateWorkout(params.workout)) return 'minimal'
+  if (params.workout.trainingWeek) return 'standard'
+  return 'minimal'
+}
+
+function zoneNameMatchesPatterns(zoneName: string, patterns: string[]): boolean {
+  const normalized = zoneName.toLowerCase()
+  return patterns.some((pattern) => normalized.includes(pattern))
+}
+
+export function filterZonesForWorkout(
+  zones: unknown,
+  workout: { title?: string | null; description?: string | null },
+  limit: number
+): any[] {
+  if (!Array.isArray(zones) || zones.length === 0) return []
+
+  const text = `${workout.title || ''} ${workout.description || ''}`.toLowerCase()
+  let patterns: string[] | null = null
+
+  if (/\b(zone\s*2|z2|endurance|aerobic|easy|recovery|rest|steady)\b/.test(text)) {
+    patterns = ['z1', 'z2', 'z3', 'zone 1', 'zone 2', 'zone 3', 'endurance', 'aerobic', 'easy']
+  } else if (/\b(tempo|sweet\s*spot|threshold|ftp)\b/.test(text)) {
+    patterns = ['tempo', 'threshold', 'sweet', 'z3', 'z4', 'zone 3', 'zone 4', 'ftp']
+  } else if (/\b(vo2|v02|anaerobic|sprint)\b/.test(text)) {
+    patterns = ['vo2', 'anaerobic', 'sprint', 'z5', 'zone 5']
+  }
+
+  if (!patterns) return zones.slice(0, limit)
+
+  const filtered = zones.filter((zone: any) =>
+    zoneNameMatchesPatterns(String(zone?.name || ''), patterns!)
+  )
+  return (filtered.length > 0 ? filtered : zones).slice(0, limit)
+}
+
+export function buildStructureGoalContextBlock(params: {
+  profile: StructureContextProfile
+  goal: string
+  phase: string
+  focus: string
+  persona: string
+}): string {
+  if (params.profile === 'minimal') {
+    return `- Coach Persona: ${params.persona}`
+  }
+
+  return `CONTEXT:
+- Goal: ${params.goal}
+- Phase: ${params.phase}
+- Focus: ${params.focus}
+- Coach Persona: ${params.persona}`
+}
+
 export function formatAiContextForStructureGen(params: {
   aiContext?: string | null
   workoutDescription?: string | null
+  profile?: StructureContextProfile
 }): string {
+  if (params.profile === 'minimal') return ''
+
   const raw = String(params.aiContext || '').trim()
   if (!raw) return ''
 
@@ -19,7 +107,9 @@ export function formatAiContextForStructureGen(params: {
     return ''
   }
 
-  const capped = raw.length <= AI_CONTEXT_MAX_CHARS ? raw : `${raw.slice(0, AI_CONTEXT_MAX_CHARS)}…`
+  const maxChars =
+    params.profile === 'rich' ? AI_CONTEXT_MAX_CHARS : Math.min(300, AI_CONTEXT_MAX_CHARS)
+  const capped = raw.length <= maxChars ? raw : `${raw.slice(0, maxChars)}…`
   return `- User Preferences/Context: ${capped}`
 }
 
@@ -30,45 +120,59 @@ export function buildCompactZoneDefinitions(params: {
   loadPreference: string
   ftp: number
   lthr: number
+  workout?: { title?: string | null; description?: string | null }
+  contextProfile?: StructureContextProfile
 }) {
-  const { workoutType, sportSettings, primaryMetric, loadPreference, ftp, lthr } = params
+  const {
+    workoutType,
+    sportSettings,
+    primaryMetric,
+    loadPreference,
+    ftp,
+    lthr,
+    workout,
+    contextProfile = 'standard'
+  } = params
   const parts: string[] = []
-  const addZones = (label: string, zones: any[], unit: string, limit = 5) => {
+  const primaryLimit = contextProfile === 'minimal' ? 3 : 5
+  const secondaryLimit = contextProfile === 'minimal' ? 2 : 3
+
+  const addZones = (label: string, zones: any[], unit: string, limit: number) => {
     if (!Array.isArray(zones) || zones.length === 0) return
-    const compact = zones
-      .slice(0, limit)
-      .map((z: any) => `${z.name}: ${z.min}-${z.max}${unit}`)
-      .join(' | ')
+    const scopedZones = workout
+      ? filterZonesForWorkout(zones, workout, limit)
+      : zones.slice(0, limit)
+    const compact = scopedZones.map((z: any) => `${z.name}: ${z.min}-${z.max}${unit}`).join(' | ')
     if (compact) parts.push(`${label}: ${compact}`)
   }
 
   if (primaryMetric === 'heartRate')
-    addZones(`${workoutType} HR Zones`, sportSettings?.hrZones, ' bpm')
+    addZones(`${workoutType} HR Zones`, sportSettings?.hrZones, ' bpm', primaryLimit)
   if (primaryMetric === 'power')
-    addZones(`${workoutType} Power Zones`, sportSettings?.powerZones, ' W')
+    addZones(`${workoutType} Power Zones`, sportSettings?.powerZones, ' W', primaryLimit)
   if (primaryMetric === 'pace')
-    addZones(`${workoutType} Pace Zones`, sportSettings?.paceZones, ' m/s')
+    addZones(`${workoutType} Pace Zones`, sportSettings?.paceZones, ' m/s', primaryLimit)
 
   if (
     primaryMetric !== 'heartRate' &&
     Array.isArray(sportSettings?.hrZones) &&
     sportSettings.hrZones.length > 0
   ) {
-    addZones(`${workoutType} HR Zones`, sportSettings.hrZones, ' bpm', 3)
+    addZones(`${workoutType} HR Zones`, sportSettings.hrZones, ' bpm', secondaryLimit)
   }
   if (
     primaryMetric !== 'power' &&
     Array.isArray(sportSettings?.powerZones) &&
     sportSettings.powerZones.length > 0
   ) {
-    addZones(`${workoutType} Power Zones`, sportSettings.powerZones, ' W', 3)
+    addZones(`${workoutType} Power Zones`, sportSettings.powerZones, ' W', secondaryLimit)
   }
   if (
     primaryMetric !== 'pace' &&
     Array.isArray(sportSettings?.paceZones) &&
     sportSettings.paceZones.length > 0
   ) {
-    addZones(`${workoutType} Pace Zones`, sportSettings.paceZones, ' m/s', 3)
+    addZones(`${workoutType} Pace Zones`, sportSettings.paceZones, ' m/s', secondaryLimit)
   }
 
   if (lthr) parts.push(`Reference LTHR: ${lthr} bpm`)

--- a/trigger/utils/structure-generation-prompt.ts
+++ b/trigger/utils/structure-generation-prompt.ts
@@ -1,0 +1,217 @@
+import type { LlmTrackingContext } from '../../server/utils/gemini'
+import type { TargetFormatPolicy } from '../../server/utils/workout-target-format-policy'
+import type { TargetPolicy } from '../../server/utils/workout-target-policy'
+import { formatCompactTargetingBlock } from './workout-targeting'
+
+const AI_CONTEXT_MAX_CHARS = 500
+const AI_CONTEXT_SKIP_IF_DESCRIPTION_CHARS = 120
+const CORRECTIVE_DRAFT_JSON_MAX_CHARS = 12_000
+
+export function formatAiContextForStructureGen(params: {
+  aiContext?: string | null
+  workoutDescription?: string | null
+}): string {
+  const raw = String(params.aiContext || '').trim()
+  if (!raw) return ''
+
+  const description = String(params.workoutDescription || '').trim()
+  if (description.length >= AI_CONTEXT_SKIP_IF_DESCRIPTION_CHARS) {
+    return ''
+  }
+
+  const capped = raw.length <= AI_CONTEXT_MAX_CHARS ? raw : `${raw.slice(0, AI_CONTEXT_MAX_CHARS)}…`
+  return `- User Preferences/Context: ${capped}`
+}
+
+export function buildCompactZoneDefinitions(params: {
+  workoutType: string
+  sportSettings: any
+  primaryMetric: string
+  loadPreference: string
+  ftp: number
+  lthr: number
+}) {
+  const { workoutType, sportSettings, primaryMetric, loadPreference, ftp, lthr } = params
+  const parts: string[] = []
+  const addZones = (label: string, zones: any[], unit: string, limit = 5) => {
+    if (!Array.isArray(zones) || zones.length === 0) return
+    const compact = zones
+      .slice(0, limit)
+      .map((z: any) => `${z.name}: ${z.min}-${z.max}${unit}`)
+      .join(' | ')
+    if (compact) parts.push(`${label}: ${compact}`)
+  }
+
+  if (primaryMetric === 'heartRate')
+    addZones(`${workoutType} HR Zones`, sportSettings?.hrZones, ' bpm')
+  if (primaryMetric === 'power')
+    addZones(`${workoutType} Power Zones`, sportSettings?.powerZones, ' W')
+  if (primaryMetric === 'pace')
+    addZones(`${workoutType} Pace Zones`, sportSettings?.paceZones, ' m/s')
+
+  if (
+    primaryMetric !== 'heartRate' &&
+    Array.isArray(sportSettings?.hrZones) &&
+    sportSettings.hrZones.length > 0
+  ) {
+    addZones(`${workoutType} HR Zones`, sportSettings.hrZones, ' bpm', 3)
+  }
+  if (
+    primaryMetric !== 'power' &&
+    Array.isArray(sportSettings?.powerZones) &&
+    sportSettings.powerZones.length > 0
+  ) {
+    addZones(`${workoutType} Power Zones`, sportSettings.powerZones, ' W', 3)
+  }
+  if (
+    primaryMetric !== 'pace' &&
+    Array.isArray(sportSettings?.paceZones) &&
+    sportSettings.paceZones.length > 0
+  ) {
+    addZones(`${workoutType} Pace Zones`, sportSettings.paceZones, ' m/s', 3)
+  }
+
+  if (lthr) parts.push(`Reference LTHR: ${lthr} bpm`)
+  if (ftp) parts.push(`Reference FTP: ${ftp} W`)
+  if (sportSettings?.thresholdPace) {
+    const metersPerSecond = Number(sportSettings.thresholdPace)
+    if (metersPerSecond > 0) {
+      const secondsPerKm = 1000 / metersPerSecond
+      const minutes = Math.floor(secondsPerKm / 60)
+      const seconds = Math.round(secondsPerKm % 60)
+      parts.push(
+        `Reference Threshold Pace: ${metersPerSecond} m/s (${minutes}:${seconds
+          .toString()
+          .padStart(2, '0')}/km)`
+      )
+    }
+  }
+  parts.push(`Preferred Load Metric: ${loadPreference}`)
+  if (sportSettings?.warmupTime) parts.push(`Default Warmup: ${sportSettings.warmupTime} min`)
+  if (sportSettings?.cooldownTime) parts.push(`Default Cooldown: ${sportSettings.cooldownTime} min`)
+
+  return parts.join('\n')
+}
+
+export function buildRunPaceUnitInstruction(targetFormatPolicy: TargetFormatPolicy): string {
+  return targetFormatPolicy.pace.mode === 'absolutePace'
+    ? 'Use pace.units="/km" with decimal minute values (5.33-5.67 for 5:20-5:40/km) when absolute pace is requested.'
+    : 'Use heartRate.units="LTHR" and pace.units="Pace" for percentage targets.'
+}
+
+export function buildSportSpecificInstructions(params: {
+  workoutType: string
+  targetFormatPolicy: TargetFormatPolicy
+  steadyTargetStyleRule: string
+}): string {
+  const workoutType = String(params.workoutType || '').toLowerCase()
+  const isCycling = workoutType.includes('ride')
+  const isRun = workoutType.includes('run')
+  const isSwim = workoutType.includes('swim')
+  const isStrength = workoutType.includes('gym') || workoutType.includes('weight')
+  const runPaceUnitInstruction = buildRunPaceUnitInstruction(params.targetFormatPolicy)
+
+  if (isCycling) {
+    return `FOR CYCLING:
+- Use % FTP for power (0.95 = 95%), power.units="%".
+- Include cadence (RPM) on every step; vary cadence on focus steps.
+- Use power ramps (start/end) for warmup/cooldown when appropriate.
+- Avoid repeated identical 20+ minute blocks unless repeats are requested.`
+  }
+
+  if (isRun) {
+    return `FOR RUNNING:
+- Include distance (meters) on every step; estimate from pace when duration-based.
+- ${runPaceUnitInstruction}
+- ${params.steadyTargetStyleRule}
+- In-session segments only; no static stretching as steps.
+- Respect quality spacing between hard efforts.`
+  }
+
+  if (isSwim) {
+    return `FOR SWIMMING:
+- Prefer distanceMeters; use stroke, equipment, sendoffSeconds, restSeconds, targetSplit, cssPercent when relevant.
+- One intensity cue per step when possible; drills may omit targets if send-off/rest defines the task.
+- Total session time must land near planned duration; sanity-check before returning.`
+  }
+
+  if (isStrength) {
+    return `FOR STRENGTH:
+- Return native 'blocks' with steps and setRows; not flat interval-style top-level steps.
+- Loaded lifts use real sets/reps/load, not one long duration row.
+- Block types: warmup, single_exercise, superset, circuit, cooldown.`
+  }
+
+  return `FOR THIS SPORT: use sport-relevant fields with clear work/recovery structure.`
+}
+
+export function buildStructureAiCallOptions(params: {
+  attempt: number
+  userId: string
+  operation: string
+  entityType: string
+  entityId: string
+  timeoutMs: number
+}): LlmTrackingContext {
+  const base: LlmTrackingContext = {
+    userId: params.userId,
+    operation: params.operation,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    maxRetries: 0,
+    timeoutMs: params.timeoutMs
+  }
+
+  if (params.attempt === 1) {
+    return { ...base, disableThinking: true }
+  }
+
+  return {
+    ...base,
+    modelOverride: 'gemini-3-pro-preview',
+    thinkingLevelOverride: 'low'
+  }
+}
+
+export function buildCorrectiveStructureRetryPrompt(params: {
+  workout: { title?: string | null; type?: string | null; durationSec?: number | null }
+  reason: string
+  previousDraft?: unknown
+  generatorMode: 'draft_json_v1' | 'legacy_json'
+  extraInstructions?: string
+}): string {
+  const durationMinutes = Math.round(Number(params.workout.durationSec || 3600) / 60)
+  const draftJson = params.previousDraft
+    ? JSON.stringify(params.previousDraft, null, 2).slice(0, CORRECTIVE_DRAFT_JSON_MAX_CHARS)
+    : null
+
+  const schemaHint =
+    params.generatorMode === 'draft_json_v1'
+      ? 'Return compact JSON matching the draft schema (single target object per step).'
+      : 'Return valid JSON matching the full structure schema.'
+
+  return `Fix this ${params.workout.type || 'workout'} structure.
+
+WORKOUT: ${params.workout.title || 'Untitled'} | ${durationMinutes} min
+
+FAILURE: ${params.reason}
+${params.extraInstructions ? `\n${params.extraInstructions}` : ''}
+${draftJson ? `\nPREVIOUS DRAFT:\n${draftJson}\n` : ''}
+Preserve valid steps where possible. ${schemaHint}`
+}
+
+export function buildDraftOutputRules(params: { preserveExistingStructure: boolean }): string {
+  return `- Return compact JSON only.
+- Use ONE \`target\` object per step, never multiple metric objects.
+- \`target.metric\` must be one of: power, heartRate, pace, rpe.
+- Use \`target.units\` from: %, w, bpm, LTHR, Pace, /km.
+- Percentages use decimal fractions (0.80 LTHR, 0.95 FTP).
+- Use \`durationSeconds\` for timed steps; \`distanceMeters\` when distance is central.
+- Use nested \`steps\` plus \`reps\` for repeats.
+- Every step needs a clear purpose and \`intent\`.
+- In-session steps only; no stretching/mobility as steps.
+- Put recovery guidance in \`coachInstructions\`, not \`steps\`.
+- ${params.preserveExistingStructure ? 'Preserve session identity unless the workout clearly requires change.' : 'Build the full session from scratch.'}`
+}
+
+export { formatCompactTargetingBlock }

--- a/trigger/utils/workout-targeting.ts
+++ b/trigger/utils/workout-targeting.ts
@@ -949,6 +949,7 @@ export function buildPlannedWorkoutGenerationContext(input: {
   phase?: string
   focus?: string
   persona?: string
+  contextProfile?: string
   adjustments?: any
 }) {
   return {
@@ -971,7 +972,8 @@ export function buildPlannedWorkoutGenerationContext(input: {
       phase: input.phase || null,
       focus: input.focus || null,
       persona: input.persona || null,
-      recentWorkoutsCount: input.recentWorkoutsCount
+      recentWorkoutsCount: input.recentWorkoutsCount,
+      contextProfile: input.contextProfile || null
     },
     targeting: {
       loadPreference: input.loadPreference,

--- a/trigger/utils/workout-targeting.ts
+++ b/trigger/utils/workout-targeting.ts
@@ -418,6 +418,29 @@ export function resolveWorkoutTargeting(
   return { targetPolicy, targetFormatPolicy, loadPreference, loadOrderTokens, priorityText }
 }
 
+export function formatCompactTargetingBlock(
+  targetPolicy: TargetPolicy,
+  targetFormatPolicy: TargetFormatPolicy,
+  priorityText: string
+): string {
+  const primaryMetric = metricLabel(targetPolicy.primaryMetric)
+  const fallbackOrder = targetPolicy.fallbackOrder.map(metricLabel).join(' > ')
+  const steadyRangeRule = formatSteadyTargetStyleInstruction(targetPolicy)
+  const hrFormat = targetFormatPolicy.heartRate.preferRange ? 'prefer range' : 'single value'
+  const powerFormat = targetFormatPolicy.power.preferRange ? 'prefer range' : 'single value'
+  const paceFormat =
+    targetFormatPolicy.pace.mode === 'absolutePace'
+      ? 'absolute /km'
+      : targetFormatPolicy.pace.preferRange
+        ? 'prefer range'
+        : 'single value'
+
+  return `- **TARGETING**: primary=${primaryMetric}, order=${priorityText}, fallback=${fallbackOrder}, strict=${targetPolicy.strictPrimary ? 'yes' : 'no'}, mixed=${targetPolicy.allowMixedTargetsPerStep ? 'allowed' : 'not allowed'}.
+- **FORMAT**: HR=${targetFormatPolicy.heartRate.mode} (${hrFormat}), power=${targetFormatPolicy.power.mode} (${powerFormat}), pace=${paceFormat}.
+- **UNITS**: HR=LTHR fractions (0.80), power=% FTP (0.95), pace per format above. ${steadyRangeRule}
+- Use one primary metric per step unless mixed targets are allowed.`
+}
+
 export function formatTargetPolicyPrompt(targetPolicy: TargetPolicy, loadPreference: string) {
   const fallbackOrder = targetPolicy.fallbackOrder.map(metricLabel).join(' > ')
   const primaryMetric = metricLabel(targetPolicy.primaryMetric)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements structure-generation speed/prompt improvements (issues **033–038**) plus follow-ups.

## Issues addressed

| Issue | Change |
|-------|--------|
| **033** | Ride/run/swim always use `draft_json_v1`; legacy only for strength |
| **034** | Single `formatCompactTargetingBlock()` replaces triple-stated targeting rules |
| **035** | Removed unused `streams` include from recent-workout fetch |
| **036** | `formatAiContextForStructureGen()` caps at 500 chars; skips when description ≥120 chars |
| **037** | Corrective retries send previous draft JSON + failure reason; Pro uses **low** thinking |
| **038** | Attempt 1 Flash calls use `disableThinking: true` |
| **001** | `assertRenderableStructure()` rejects empty steps/blocks before DB persist |
| *(follow-up)* | Tiered **context profiles** (minimal/standard/rich) + **zone band filtering** |

## Key files

- `trigger/utils/structure-generation-prompt.ts` — shared prompt/AI/context helpers
- `server/utils/structured-workout-validation.ts` — pre-persist renderable gate
- `trigger/generate-structured-workout.ts` / `trigger/adjust-structured-workout.ts`

## Behavior notes

- **Minimal profile** (Z2/easy/recovery): skips recent workouts, goal/phase/focus, aiContext; smaller zone lists
- **Rich profile** (regeneration): includes recent workouts + full context
- `contextProfile` logged at `prompt-built` and stored in `lastGenerationContext`
- Removed `generatorOverride` payload field

## Testing

- `tests/unit/trigger/structure-generation-prompt.test.ts`
- `tests/unit/server/utils/structured-workout-generator.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

