### PR TITLE
fix: clear trigger monitor runs on identity switch (027, 028)

### DIFF
--- a/app/composables/useUserRuns.ts
+++ b/app/composables/useUserRuns.ts
@@ -1,16 +1,13 @@
 import { ref, computed, watch, getCurrentScope, onScopeDispose } from 'vue'
+import {
+  ACTIVE_STATUSES,
+  mergeActiveRunsFromApi,
+  pruneRunsForCurrentUser,
+  type TriggerRun
+} from '../utils/user-runs-client'
 
-export interface TriggerRun {
-  id: string
-  taskIdentifier: string
-  status: string
-  startedAt: string
-  finishedAt?: string
-  output?: any
-  error?: any
-  isTest?: boolean
-  tags?: string[]
-}
+export type { TriggerRun } from '../utils/user-runs-client'
+export { ACTIVE_STATUSES } from '../utils/user-runs-client'
 
 export interface RealtimeDomainEvent {
   type: 'domain_event'
@@ -36,18 +33,21 @@ let pingInterval: NodeJS.Timeout | null = null
 const realtimeListeners = new Set<(event: RealtimeDomainEvent) => void>()
 let lastPollAt = 0
 
-export const ACTIVE_STATUSES = [
-  'EXECUTING',
-  'QUEUED',
-  'WAITING_FOR_DEPLOY',
-  'REATTEMPTING',
-  'FROZEN',
-  'PENDING_VERSION',
-  'DELAYED'
-]
-
 const FAST_POLL_INTERVAL_MS = 5000
 const IDLE_POLL_INTERVAL_MS = 15000
+
+let trackedUserId: string | null = null
+
+function getSessionUserId(session: { user?: { id?: string } } | null | undefined): string | null {
+  const id = session?.user?.id
+  return typeof id === 'string' && id.length > 0 ? id : null
+}
+
+function resetRunsForIdentityChange() {
+  runs.value = []
+  initPromise = null
+  cleanupUserRunsConnection()
+}
 
 function cleanupUserRunsConnection() {
   if (ws) {
@@ -86,41 +86,9 @@ export function useUserRuns() {
     lastPollAt = Date.now()
     try {
       const data = (await ($fetch as any)('/api/runs/active')) as TriggerRun[]
-
-      // Start with a map of existing runs to facilitate merging
-      const mergedRunsMap = new Map<string, TriggerRun>()
-      runs.value.forEach((r) => mergedRunsMap.set(r.id, r))
-
-      // Update/Add with new data from API
-      data.forEach((run: any) => {
-        const existing = mergedRunsMap.get(run.id)
-
-        if (existing) {
-          // Check existing runs for any local final states we want to preserve
-          // (e.g. if API is slightly behind and says EXECUTING but we know it's COMPLETED via WS)
-          const isLocalFinal = ['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'].includes(
-            existing.status
-          )
-          const isApiFinal = ['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'].includes(run.status)
-
-          if (isLocalFinal && !isApiFinal) {
-            // Overwrite API run status with local final status
-            mergedRunsMap.set(run.id, { ...run, ...existing, status: existing.status })
-          } else {
-            // Regular update
-            mergedRunsMap.set(run.id, { ...existing, ...run })
-          }
-        } else {
-          // New run found in API
-          mergedRunsMap.set(run.id, run)
-        }
-      })
-
-      const finalRuns = Array.from(mergedRunsMap.values())
-      finalRuns.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
-
-      // Keep only the last 50 runs to avoid memory bloat
-      runs.value = finalRuns.slice(0, 50)
+      const userId = getSessionUserId(session.value)
+      const mergedRuns = mergeActiveRunsFromApi(runs.value, data)
+      runs.value = pruneRunsForCurrentUser(mergedRuns, userId)
     } catch (e) {
       // Failed to fetch active runs
     } finally {
@@ -241,6 +209,12 @@ export function useUserRuns() {
   }
 
   const handleRunUpdate = (update: any) => {
+    const userId = getSessionUserId(session.value)
+    const updateTags = Array.isArray(update.tags) ? update.tags : undefined
+    if (updateTags && updateTags.length > 0 && userId && !updateTags.includes(`user:${userId}`)) {
+      return
+    }
+
     const existingIndex = runs.value.findIndex((r) => r.id === update.runId)
     const existing = existingIndex !== -1 ? runs.value[existingIndex] : null
 
@@ -268,10 +242,9 @@ export function useUserRuns() {
       newRuns[existingIndex] = updatedRun
     } else {
       newRuns.unshift(updatedRun)
-      // Re-sort if it's a new run to ensure correct order
-      newRuns.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
     }
-    runs.value = newRuns.slice(0, 50)
+
+    runs.value = pruneRunsForCurrentUser(newRuns, userId)
   }
 
   const cancelRun = async (runId: string) => {
@@ -294,20 +267,17 @@ export function useUserRuns() {
 
   if (import.meta.client) {
     watch(
-      () => (session.value?.user as any)?.id,
+      () => getSessionUserId(session.value),
       (newId) => {
         if (newId) {
-          init()
-        } else {
-          if (ws) {
-            ws.close()
-            ws = null
+          if (trackedUserId !== newId) {
+            trackedUserId = newId
+            resetRunsForIdentityChange()
+            void init()
           }
-          isConnected.value = false
-          initPromise = null
-          stopPolling()
-          stopPing()
-          runs.value = []
+        } else {
+          trackedUserId = null
+          resetRunsForIdentityChange()
         }
       }
     )

--- a/app/utils/user-runs-client.ts
+++ b/app/utils/user-runs-client.ts
@@ -1,0 +1,73 @@
+export interface TriggerRun {
+  id: string
+  taskIdentifier: string
+  status: string
+  startedAt: string
+  finishedAt?: string
+  output?: any
+  error?: any
+  isTest?: boolean
+  tags?: string[]
+}
+
+export const ACTIVE_STATUSES = [
+  'EXECUTING',
+  'QUEUED',
+  'WAITING_FOR_DEPLOY',
+  'REATTEMPTING',
+  'FROZEN',
+  'PENDING_VERSION',
+  'DELAYED'
+]
+
+export const COMPLETED_RUN_TTL_MS = 5 * 60 * 1000
+
+export function runBelongsToUser(run: TriggerRun, userId: string | null): boolean {
+  if (!userId) return false
+  if (!Array.isArray(run.tags) || run.tags.length === 0) return true
+  return run.tags.includes(`user:${userId}`)
+}
+
+export function pruneRunsForCurrentUser(
+  runsList: TriggerRun[],
+  userId: string | null,
+  now = Date.now()
+): TriggerRun[] {
+  return runsList
+    .filter((run) => {
+      if (!runBelongsToUser(run, userId)) return false
+      if (ACTIVE_STATUSES.includes(run.status)) return true
+      if (!run.finishedAt) return false
+      return now - new Date(run.finishedAt).getTime() < COMPLETED_RUN_TTL_MS
+    })
+    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
+    .slice(0, 50)
+}
+
+export function mergeActiveRunsFromApi(
+  existingRuns: TriggerRun[],
+  apiRuns: TriggerRun[]
+): TriggerRun[] {
+  const mergedRunsMap = new Map<string, TriggerRun>()
+
+  apiRuns.forEach((run) => {
+    const existing = existingRuns.find((item) => item.id === run.id)
+
+    if (existing) {
+      const isLocalFinal = ['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'].includes(
+        existing.status
+      )
+      const isApiFinal = ['COMPLETED', 'FAILED', 'CANCELED', 'TIMED_OUT'].includes(run.status)
+
+      if (isLocalFinal && !isApiFinal) {
+        mergedRunsMap.set(run.id, { ...run, ...existing, status: existing.status })
+      } else {
+        mergedRunsMap.set(run.id, { ...existing, ...run })
+      }
+    } else {
+      mergedRunsMap.set(run.id, run)
+    }
+  })
+
+  return Array.from(mergedRunsMap.values())
+}

--- a/tests/unit/app/utils/user-runs-client.test.ts
+++ b/tests/unit/app/utils/user-runs-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  mergeActiveRunsFromApi,
+  pruneRunsForCurrentUser,
+  runBelongsToUser,
+  type TriggerRun
+} from '../../../app/utils/user-runs-client'
+
+describe('user-runs-client', () => {
+  it('matches runs to the current user tag', () => {
+    const run: TriggerRun = {
+      id: 'run-1',
+      taskIdentifier: 'generate-structured-workout',
+      status: 'EXECUTING',
+      startedAt: new Date().toISOString(),
+      tags: ['user:user-a']
+    }
+
+    expect(runBelongsToUser(run, 'user-a')).toBe(true)
+    expect(runBelongsToUser(run, 'user-b')).toBe(false)
+  })
+
+  it('does not merge prior-user runs when API returns a fresh identity list', () => {
+    const existingRuns: TriggerRun[] = [
+      {
+        id: 'old-run',
+        taskIdentifier: 'generate-structured-workout',
+        status: 'COMPLETED',
+        startedAt: new Date().toISOString(),
+        tags: ['user:user-a']
+      }
+    ]
+
+    const apiRuns: TriggerRun[] = [
+      {
+        id: 'new-run',
+        taskIdentifier: 'generate-structured-workout',
+        status: 'EXECUTING',
+        startedAt: new Date().toISOString(),
+        tags: ['user:user-b']
+      }
+    ]
+
+    const merged = mergeActiveRunsFromApi(existingRuns, apiRuns)
+    const pruned = pruneRunsForCurrentUser(merged, 'user-b')
+
+    expect(pruned.map((run) => run.id)).toEqual(['new-run'])
+  })
+
+  it('drops completed runs after the client TTL', () => {
+    const now = Date.parse('2026-07-07T12:00:00.000Z')
+    const runs: TriggerRun[] = [
+      {
+        id: 'fresh-complete',
+        taskIdentifier: 'generate-structured-workout',
+        status: 'COMPLETED',
+        startedAt: '2026-07-07T11:58:00.000Z',
+        finishedAt: '2026-07-07T11:59:30.000Z',
+        tags: ['user:user-a']
+      },
+      {
+        id: 'stale-complete',
+        taskIdentifier: 'generate-structured-workout',
+        status: 'COMPLETED',
+        startedAt: '2026-07-07T11:00:00.000Z',
+        finishedAt: '2026-07-07T11:50:00.000Z',
+        tags: ['user:user-a']
+      }
+    ]
+
+    const pruned = pruneRunsForCurrentUser(runs, 'user-a', now)
+    expect(pruned.map((run) => run.id)).toEqual(['fresh-complete'])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes client-side Trigger Monitor state bugs that made it look like users could see other people's jobs after identity switches.

## Issues addressed

| Issue | Fix |
|-------|-----|
| **027** | Clear runs + reconnect WebSocket when `session.user.id` changes (act-as / impersonation) |
| **028** | Stop merge-retaining stale completed runs; prune completed runs after 5 minutes client-side |

## Changes

- Track `trackedUserId` and call `resetRunsForIdentityChange()` on identity switch
- `mergeActiveRunsFromApi()` only merges local state for runs returned by `/api/runs/active` (does not seed from entire prior list)
- `handleRunUpdate()` ignores WS events whose tags don't include `user:{currentUserId}`
- Extracted helpers to `app/utils/user-runs-client.ts` with unit tests

## Testing

- `tests/unit/app/utils/user-runs-client.test.ts`

Related: [031](./docs/issues/031-websocket-not-reauth-on-identity-switch.md) (full WS re-auth) remains open — this PR reconnects the socket on identity change via existing cleanup path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

