### PR TITLE
Standardize Trigger.dev run tags for structure jobs (002, 029, 032)

### DIFF
--- a/docs/04-guides/background-task-monitoring.md
+++ b/docs/04-guides/background-task-monitoring.md
@@ -114,6 +114,19 @@ Cross-instance task monitor updates depend on `REDIS_URL`.
 - With `REDIS_URL`, task-start and other bus messages can reach browser sockets connected to other app instances.
 - Without `REDIS_URL`, the monitor still works through local delivery and polling, but you should not expect full cross-instance realtime behavior.
 
+### Run Tags
+
+Every user-scoped Trigger.dev run should include a `user:{userId}` tag so `/api/runs/active`, ownership checks, and the trigger monitor can filter correctly.
+
+Use the shared helpers in `server/utils/trigger-run-tags.ts`:
+
+- `buildUserRunTags(userId, extraTags?)` — base tag for any user-initiated job
+- `structureGenerationRunTags({ userId, plannedWorkoutId?, workoutTemplateId?, source? })` — structure generation and related tasks
+
+Structure jobs should always include either `planned-workout:{id}` or `workout-template:{id}` so the Planned Workout Details page and Trigger Monitor can correlate runs to a specific entity.
+
+Pass the same tags to both `tasks.trigger(...)` and `publishTaskRunStartedEvent(...)` when the route publishes a run-start event.
+
 ### Troubleshooting
 
 - **Task not appearing immediately?** Confirm the route publishes a task-start event after `tasks.trigger(...)`. If not, add `publishTaskRunStartedEvent(...)`.

--- a/server/api/chat/rooms/[id]/summarize.post.ts
+++ b/server/api/chat/rooms/[id]/summarize.post.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from '../../../../utils/session'
 import { prisma } from '../../../../utils/db'
 import { summarizeChatTask } from '../../../../../trigger/summarize-chat'
+import { buildUserRunTags } from '../../../../utils/trigger-run-tags'
 
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
@@ -33,7 +34,12 @@ export default defineEventHandler(async (event) => {
   const forceRename = !!body?.forceRename
 
   // Trigger task
-  const result = await summarizeChatTask.trigger({ roomId, userId, forceRename })
+  const result = await summarizeChatTask.trigger(
+    { roomId, userId, forceRename },
+    {
+      tags: buildUserRunTags(userId, [`chat-room:${roomId}`])
+    }
+  )
 
   return {
     success: true,

--- a/server/api/library/workouts/[id]/adjust.post.ts
+++ b/server/api/library/workouts/[id]/adjust.post.ts
@@ -7,6 +7,7 @@ import {
   getReadableLibraryOwnerIds,
   parseLibraryScope
 } from '../../../../utils/library-access'
+import { structureGenerationRunTags } from '../../../../utils/trigger-run-tags'
 
 const adjustSchema = z.object({
   durationMinutes: z.number().optional(),
@@ -41,6 +42,11 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'Workout template not found' })
   }
 
+  const tags = structureGenerationRunTags({
+    userId: template.userId,
+    workoutTemplateId: template.id,
+    source: 'library'
+  })
   const handle = await tasks.trigger(
     'adjust-structured-workout',
     {
@@ -49,7 +55,7 @@ export default defineEventHandler(async (event) => {
     },
     {
       concurrencyKey: template.userId,
-      tags: [`user:${template.userId}`, `workout-template:${template.id}`]
+      tags
     }
   )
 

--- a/server/api/library/workouts/[id]/generate-structure.post.ts
+++ b/server/api/library/workouts/[id]/generate-structure.post.ts
@@ -6,6 +6,7 @@ import {
   getReadableLibraryOwnerIds,
   parseLibraryScope
 } from '../../../../utils/library-access'
+import { structureGenerationRunTags } from '../../../../utils/trigger-run-tags'
 
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
@@ -32,13 +33,18 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'Workout template not found' })
   }
 
+  const tags = structureGenerationRunTags({
+    userId: template.userId,
+    workoutTemplateId: id,
+    source: 'library'
+  })
   const handle = await tasks.trigger(
     'generate-structured-workout',
     {
       workoutTemplateId: id
     },
     {
-      tags: [`user:${template.userId}`, `workout-template:${id}`],
+      tags,
       concurrencyKey: template.userId
     }
   )

--- a/server/api/nutrition/analyze-all.post.ts
+++ b/server/api/nutrition/analyze-all.post.ts
@@ -2,6 +2,7 @@ import { requireAuth } from '../../utils/auth-guard'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { nutritionRepository } from '../../utils/repositories/nutritionRepository'
 import { getUserTimezone, getUserLocalDate } from '../../utils/date'
+import { buildUserRunTags } from '../../utils/trigger-run-tags'
 
 const MAX_MANUAL_NUTRITION_ANALYSES = 10
 
@@ -77,7 +78,8 @@ export default defineEventHandler(async (event) => {
             nutritionId: nutrition.id
           },
           {
-            concurrencyKey: userId
+            concurrencyKey: userId,
+            tags: buildUserRunTags(userId)
           }
         )
         return { success: true, nutritionId: nutrition.id, jobId: handle.id }

--- a/server/api/recommendations/[id]/accept.post.ts
+++ b/server/api/recommendations/[id]/accept.post.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../utils/intervals-sync'
 import { isIntervalsEventId } from '../../../utils/intervals'
 import { validateRecommendationAcceptanceTarget } from '../../../utils/recommendation-guardrails'
+import { structureGenerationRunTags } from '../../../utils/trigger-run-tags'
 
 defineRouteMeta({
   openAPI: {
@@ -182,6 +183,11 @@ export default defineEventHandler(async (event) => {
   // Trigger regeneration of structured workout based on the new description/title/params.
   // The generation task is responsible for syncing the final structure to Intervals.
   if (requiresStructure) {
+    const tags = structureGenerationRunTags({
+      userId,
+      plannedWorkoutId: targetPlannedWorkoutId,
+      source: 'recommendation'
+    })
     await tasks.trigger(
       'generate-structured-workout',
       {
@@ -189,7 +195,7 @@ export default defineEventHandler(async (event) => {
       },
       {
         concurrencyKey: userId,
-        tags: [`user:${userId}`]
+        tags
       }
     )
   } else if (!isLocal) {

--- a/server/api/workouts/planned/[id]/adjust.post.ts
+++ b/server/api/workouts/planned/[id]/adjust.post.ts
@@ -3,6 +3,7 @@ import { tasks } from '@trigger.dev/sdk/v3'
 import { z } from 'zod'
 import { getServerSession } from '../../../../utils/session'
 import { publishTaskRunStartedEvent } from '../../../../utils/task-run-events'
+import { structureGenerationRunTags } from '../../../../utils/trigger-run-tags'
 
 const adjustSchema = z.object({
   durationMinutes: z.number().optional(),
@@ -31,6 +32,12 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'Workout not found' })
   }
 
+  const userId = (session.user as any).id
+  const tags = structureGenerationRunTags({
+    userId,
+    plannedWorkoutId: workout.id,
+    source: 'api'
+  })
   const handle = await tasks.trigger(
     'adjust-structured-workout',
     {
@@ -38,12 +45,12 @@ export default defineEventHandler(async (event) => {
       adjustments
     },
     {
-      concurrencyKey: (session.user as any).id,
-      tags: [`user:${(session.user as any).id}`]
+      concurrencyKey: userId,
+      tags
     }
   )
 
-  await publishTaskRunStartedEvent((session.user as any).id, 'adjust-structured-workout', handle)
+  await publishTaskRunStartedEvent(userId, 'adjust-structured-workout', handle, { tags })
 
   return { success: true, jobId: handle.id }
 })

--- a/server/api/workouts/planned/[id]/generate-structure.post.ts
+++ b/server/api/workouts/planned/[id]/generate-structure.post.ts
@@ -3,6 +3,7 @@ import { prisma } from '../../../../utils/db'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { checkQuota } from '../../../../utils/quotas/engine'
 import { publishTaskRunStartedEvent } from '../../../../utils/task-run-events'
+import { structureGenerationRunTags } from '../../../../utils/trigger-run-tags'
 
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
@@ -75,6 +76,11 @@ export default defineEventHandler(async (event) => {
 
   // Trigger the generation task
   try {
+    const tags = structureGenerationRunTags({
+      userId,
+      plannedWorkoutId: id,
+      source: 'api'
+    })
     const handle = await tasks.trigger(
       'generate-structured-workout',
       {
@@ -82,11 +88,11 @@ export default defineEventHandler(async (event) => {
       },
       {
         concurrencyKey: userId,
-        tags: [`user:${userId}`]
+        tags
       }
     )
 
-    await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle)
+    await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, { tags })
 
     return {
       success: true,

--- a/server/api/workouts/planned/[id]/messages.post.ts
+++ b/server/api/workouts/planned/[id]/messages.post.ts
@@ -3,6 +3,7 @@ import { tasks } from '@trigger.dev/sdk/v3'
 import { z } from 'zod'
 import { getServerSession } from '../../../../utils/session'
 import { publishTaskRunStartedEvent } from '../../../../utils/task-run-events'
+import { structureGenerationRunTags } from '../../../../utils/trigger-run-tags'
 
 const messageRequestSchema = z.object({
   tone: z.string().optional(),
@@ -30,6 +31,12 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'Workout not found' })
   }
 
+  const userId = (session.user as any).id
+  const tags = structureGenerationRunTags({
+    userId,
+    plannedWorkoutId: workout.id,
+    source: 'api'
+  })
   const handle = await tasks.trigger(
     'generate-workout-messages',
     {
@@ -38,11 +45,11 @@ export default defineEventHandler(async (event) => {
       context
     },
     {
-      tags: [`user:${(session.user as any).id}`]
+      tags
     }
   )
 
-  await publishTaskRunStartedEvent((session.user as any).id, 'generate-workout-messages', handle)
+  await publishTaskRunStartedEvent(userId, 'generate-workout-messages', handle, { tags })
 
   return { success: true, jobId: handle.id }
 })

--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -14,7 +14,6 @@ import {
   updateIntervalsPlannedWorkout,
   isIntervalsEventId
 } from '../../utils/intervals'
-import { tags } from '@trigger.dev/sdk/v3'
 import { plannedWorkoutRepository } from '../repositories/plannedWorkoutRepository'
 import { workoutRepository } from '../repositories/workoutRepository'
 import { sportSettingsRepository } from '../repositories/sportSettingsRepository'
@@ -45,6 +44,7 @@ import {
   getPendingSyncStatus
 } from '../structured-workout-persistence'
 import { publishTaskRunStartedEvent } from '../task-run-events'
+import { structureGenerationRunTags } from '../trigger-run-tags'
 
 const STEP_INTENT_VALUES = [
   'warmup',
@@ -908,18 +908,23 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       let runId: string | undefined
       if (args.generate_structure !== false) {
         try {
+          const tags = structureGenerationRunTags({
+            userId,
+            plannedWorkoutId: workout.id,
+            source: 'chat'
+          })
           const handle = await generateStructuredWorkoutTask.trigger(
             {
               plannedWorkoutId: workout.id, // Pass plannedWorkoutId
               targetingOverride: args.targeting_override || null
             },
             {
-              tags: [`user:${userId}`, `planned-workout:${workout.id}`],
+              tags,
               concurrencyKey: userId
             }
           )
           await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
-            tags: [`user:${userId}`, `planned-workout:${workout.id}`]
+            tags
           })
           runId = handle.id
         } catch (e) {
@@ -998,18 +1003,23 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       let runId: string | undefined
       if (args.generate_structure !== false) {
         try {
+          const tags = structureGenerationRunTags({
+            userId,
+            plannedWorkoutId: workout.id,
+            source: 'chat'
+          })
           const handle = await generateStructuredWorkoutTask.trigger(
             {
               plannedWorkoutId: workout.id,
               targetingOverride: args.targeting_override || null
             },
             {
-              tags: [`user:${userId}`, `planned-workout:${workout.id}`],
+              tags,
               concurrencyKey: userId
             }
           )
           await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
-            tags: [`user:${userId}`, `planned-workout:${workout.id}`]
+            tags
           })
           runId = handle.id
         } catch (e) {
@@ -1168,6 +1178,11 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
       // Trigger adjustment task
       try {
+        const tags = structureGenerationRunTags({
+          userId,
+          plannedWorkoutId: workout_id,
+          source: 'chat'
+        })
         const handle = await adjustStructuredWorkoutTask.trigger(
           {
             plannedWorkoutId: workout_id,
@@ -1179,12 +1194,12 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
             targetingOverride: targeting_override || null
           },
           {
-            tags: [`user:${userId}`, `planned-workout:${workout_id}`],
+            tags,
             concurrencyKey: userId
           }
         )
         await publishTaskRunStartedEvent(userId, 'adjust-structured-workout', handle, {
-          tags: [`user:${userId}`, `planned-workout:${workout_id}`]
+          tags
         })
         return {
           success: true,
@@ -1213,15 +1228,20 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       await checkQuota(userId, 'generate_structured_workout')
 
       try {
+        const tags = structureGenerationRunTags({
+          userId,
+          plannedWorkoutId: workout_id,
+          source: 'chat'
+        })
         const handle = await generateStructuredWorkoutTask.trigger(
           { plannedWorkoutId: workout_id, targetingOverride: targeting_override || null },
           {
-            tags: [`user:${userId}`, `planned-workout:${workout_id}`],
+            tags,
             concurrencyKey: userId
           }
         )
         await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
-          tags: [`user:${userId}`, `planned-workout:${workout_id}`]
+          tags
         })
         return {
           success: true,
@@ -1434,7 +1454,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const existingWorkout = await workoutRepository.getById(args.workout_id, userId, {
             select: { id: true, date: true }
           })
-          if (!existingWorkout) throw new Error('Workout not found')
+          if (!existingWorkout) throw new Error('Workout not found', { cause: e })
 
           await workoutRepository.delete(args.workout_id, userId)
 

--- a/server/utils/email-service.ts
+++ b/server/utils/email-service.ts
@@ -1,6 +1,7 @@
 import { tasks } from '@trigger.dev/sdk/v3'
 import type { EmailAudience } from '@prisma/client'
 import { getEmailTemplateDefinition } from './email-template-registry'
+import { buildUserRunTags } from './trigger-run-tags'
 
 /**
  * Triggers the background email task through a single service-layer entrypoint.
@@ -32,13 +33,19 @@ export async function queueEmail(options: {
     throw new Error(`Unknown template '${templateKey}'. Provide explicit audience and subject.`)
   }
 
-  return await tasks.trigger('send-email', {
-    userId,
-    templateKey,
-    eventKey,
-    audience: audience || template!.audience,
-    subject: subject || template!.defaultSubject,
-    props,
-    idempotencyKey
-  })
+  return await tasks.trigger(
+    'send-email',
+    {
+      userId,
+      templateKey,
+      eventKey,
+      audience: audience || template!.audience,
+      subject: subject || template!.defaultSubject,
+      props,
+      idempotencyKey
+    },
+    {
+      tags: buildUserRunTags(userId)
+    }
+  )
 }

--- a/server/utils/trigger-run-tags.ts
+++ b/server/utils/trigger-run-tags.ts
@@ -1,0 +1,30 @@
+export function buildUserRunTags(userId: string, extraTags: string[] = []): string[] {
+  const tags = [`user:${userId}`]
+  for (const tag of extraTags) {
+    if (tag && !tags.includes(tag)) {
+      tags.push(tag)
+    }
+  }
+  return tags
+}
+
+export type StructureRunSource = 'chat' | 'api' | 'block' | 'recommendation' | 'ad-hoc' | 'library'
+
+export function structureGenerationRunTags(opts: {
+  userId: string
+  plannedWorkoutId?: string
+  workoutTemplateId?: string
+  source?: StructureRunSource
+}): string[] {
+  const extraTags: string[] = []
+  if (opts.plannedWorkoutId) {
+    extraTags.push(`planned-workout:${opts.plannedWorkoutId}`)
+  }
+  if (opts.workoutTemplateId) {
+    extraTags.push(`workout-template:${opts.workoutTemplateId}`)
+  }
+  if (opts.source) {
+    extraTags.push(`source:${opts.source}`)
+  }
+  return buildUserRunTags(opts.userId, extraTags)
+}

--- a/tests/unit/server/utils/trigger-run-tags.test.ts
+++ b/tests/unit/server/utils/trigger-run-tags.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildUserRunTags,
+  structureGenerationRunTags
+} from '../../../../server/utils/trigger-run-tags'
+
+describe('trigger-run-tags', () => {
+  it('buildUserRunTags always includes user tag first', () => {
+    expect(buildUserRunTags('user-1')).toEqual(['user:user-1'])
+  })
+
+  it('buildUserRunTags deduplicates extra tags', () => {
+    expect(buildUserRunTags('user-1', ['planned-workout:pw-1', 'planned-workout:pw-1'])).toEqual([
+      'user:user-1',
+      'planned-workout:pw-1'
+    ])
+  })
+
+  it('structureGenerationRunTags includes planned workout and source tags', () => {
+    expect(
+      structureGenerationRunTags({
+        userId: 'user-1',
+        plannedWorkoutId: 'pw-1',
+        source: 'api'
+      })
+    ).toEqual(['user:user-1', 'planned-workout:pw-1', 'source:api'])
+  })
+
+  it('structureGenerationRunTags supports workout templates', () => {
+    expect(
+      structureGenerationRunTags({
+        userId: 'user-1',
+        workoutTemplateId: 'tpl-1',
+        source: 'library'
+      })
+    ).toEqual(['user:user-1', 'workout-template:tpl-1', 'source:library'])
+  })
+})

--- a/trigger/generate-ad-hoc-workout.ts
+++ b/trigger/generate-ad-hoc-workout.ts
@@ -7,6 +7,7 @@ import { wellnessRepository } from '../server/utils/repositories/wellnessReposit
 import { sportSettingsRepository } from '../server/utils/repositories/sportSettingsRepository'
 import { getUserTimezone, getStartOfDaysAgoUTC, formatUserDate } from '../server/utils/date'
 import { filterGoalsForContext } from '../server/utils/goal-context'
+import { structureGenerationRunTags } from '../server/utils/trigger-run-tags'
 import { autoUploadPlannedWorkoutToIntervalsIfEnabled } from '../server/utils/intervals-sync'
 
 const adHocWorkoutSchema = {
@@ -221,6 +222,11 @@ export const generateAdHocWorkoutTask = task({
     })
 
     // Trigger Structure Generation
+    const tags = structureGenerationRunTags({
+      userId,
+      plannedWorkoutId: plannedWorkout.id,
+      source: 'ad-hoc'
+    })
     await tasks.trigger(
       'generate-structured-workout',
       {
@@ -228,7 +234,7 @@ export const generateAdHocWorkoutTask = task({
       },
       {
         concurrencyKey: userId,
-        tags: [`user:${userId}`]
+        tags
       }
     )
 

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -16,6 +16,7 @@ import { getCurrentFitnessSummary } from '../server/utils/training-stress'
 import { getUserAiSettings } from '../server/utils/ai-user-settings'
 import { TRAINING_BLOCK_TYPES, TRAINING_BLOCK_FOCUSES } from '../app/utils/training-constants'
 import { availabilityRepository } from '../server/utils/repositories/availabilityRepository'
+import { structureGenerationRunTags } from '../server/utils/trigger-run-tags'
 
 const trainingBlockSchema = {
   type: 'object',
@@ -636,10 +637,15 @@ Return valid JSON matching the schema provided.`
           }
         )
         for (const workoutId of workoutIdsToStructure) {
+          const tags = structureGenerationRunTags({
+            userId,
+            plannedWorkoutId: workoutId,
+            source: 'block'
+          })
           await tasks.trigger(
             'generate-structured-workout',
             { plannedWorkoutId: workoutId },
-            { tags: [`user:${userId}`], concurrencyKey: userId }
+            { tags, concurrencyKey: userId }
           )
         }
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds shared run-tag helpers and applies them consistently so structure generation jobs are tagged with both `user:{userId}` and `planned-workout:{id}` (or `workout-template:{id}`), fixing UI run tracking on the Planned Workout Details page and improving Trigger Monitor filtering.

Also fixes missing `user:{userId}` tags on nutrition bulk analyze, chat room summarize, and queued emails.

## Changes

- **`server/utils/trigger-run-tags.ts`** — `buildUserRunTags()` and `structureGenerationRunTags()` helpers
- **Structure entry points** — API generate/adjust/messages, recommendations accept, training block batch, ad-hoc workout chain, library template APIs, chat planning tools
- **Missing user tags (029)** — `analyze-all.post.ts`, `summarize.post.ts`, `email-service.ts`
- **Docs** — tag conventions in `docs/04-guides/background-task-monitoring.md`
- **Tests** — unit tests for tag helpers

## Issues addressed

- [002](docs/issues/002-missing-planned-workout-run-tags.md) — manual/API triggers missing `planned-workout:` tag
- [029](docs/issues/029-triggers-missing-user-tags.md) — some triggers missing `user:{userId}` tag
- [032](docs/issues/032-trigger-tag-taxonomy-inconsistent.md) — inconsistent secondary entity tags

## Testing

- Added `tests/unit/server/utils/trigger-run-tags.test.ts`
- Full vitest suite requires `nuxt prepare` in CI (not run in cloud pod due to env deps)

**Do not merge** — part of ongoing workout generation fix cluster.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

