### PR TITLE
Prevent duplicate chat structure generation triggers (013)

### DIFF
--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -955,7 +955,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         .boolean()
         .optional()
         .describe(
-          'Set to false to skip structured interval regeneration (e.g. for rest days, holidays, or minor updates)'
+          'Set to true to regenerate structured intervals after the update. Defaults to false — use only when duration, type, intensity, or structure changed, or the user asked to rebuild intervals.'
         ),
       targeting_override: targetingOverrideSchema.describe(
         'Optional per-workout targeting override for this regeneration only (does not change profile defaults).'
@@ -963,8 +963,10 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
     }),
     needsApproval: async () => aiSettings.aiRequireToolApproval,
     execute: async (args) => {
+      const shouldRegenerateStructure = args.generate_structure === true
+
       // 0. Quota Check
-      if (args.generate_structure !== false) {
+      if (shouldRegenerateStructure) {
         await checkQuota(userId, 'generate_structured_workout')
       }
 
@@ -996,7 +998,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
       // Trigger regeneration of structured intervals
       let runId: string | undefined
-      if (args.generate_structure !== false) {
+      if (shouldRegenerateStructure) {
         try {
           const handle = await generateStructuredWorkoutTask.trigger(
             {
@@ -1201,7 +1203,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
   generate_planned_workout_structure: tool({
     description:
-      'Generate or fully regenerate the structured intervals for a planned workout. Use this when no structure exists yet or when a full rebuild is desired. Do NOT use this for minor edits when patch_planned_workout_structure is sufficient.',
+      'Generate or fully regenerate the structured intervals for a planned workout. Use this when no structure exists yet or when a full rebuild is desired. Do NOT use this after create_planned_workout in the same turn — creation already starts structure generation. Do NOT use this for minor edits when patch_planned_workout_structure is sufficient.',
     inputSchema: z.object({
       workout_id: z.string(),
       targeting_override: targetingOverrideSchema.describe(
@@ -1434,7 +1436,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const existingWorkout = await workoutRepository.getById(args.workout_id, userId, {
             select: { id: true, date: true }
           })
-          if (!existingWorkout) throw new Error('Workout not found')
+          if (!existingWorkout) throw new Error('Workout not found', { cause: e })
 
           await workoutRepository.delete(args.workout_id, userId)
 

--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -180,7 +180,10 @@ const CHAT_SKILL_MANIFESTS: Record<ChatSkillId, ChatSkillManifest> = {
 - Never ask for approval in plain text without first invoking the relevant planning mutation tool.
 - If the user approves a prepared planning action, immediately execute that exact approved planning tool call.
 - After approval, do not just acknowledge the action in text. Execute the tool first, then report the result.
-- Do not claim a workout was created, updated, moved, published, or deleted unless the planning tool actually ran successfully.`,
+- Do not claim a workout was created, updated, moved, published, or deleted unless the planning tool actually ran successfully.
+- After \`create_planned_workout\` with default structure generation, do **not** call \`generate_planned_workout_structure\` for the same workout in the same turn — creation already enqueues one structure job.
+- On \`update_planned_workout\`, omit \`generate_structure\` or set it to \`false\` for metadata-only edits (title, description, reschedule). Set \`generate_structure: true\` only when duration, type, intensity, or structure must be rebuilt, or the user explicitly asked to regenerate intervals.
+- Do not chain \`create_planned_workout\` and \`update_planned_workout\` in one turn unless the user asked for separate follow-up edits; prefer passing complete details into a single create call.`,
     contextFlags: ['planning', 'date_context', 'time'],
     approvalToolNames: [
       'update_training_availability',

--- a/server/utils/chat/turns.ts
+++ b/server/utils/chat/turns.ts
@@ -115,6 +115,8 @@ export function isMutatingChatTool(toolName: string) {
     toolName === 'log_nutrition_meal' ||
     toolName === 'log_hydration_intake' ||
     toolName === 'lock_meal_to_plan' ||
+    toolName === 'generate_planned_workout_structure' ||
+    toolName === 'adjust_planned_workout' ||
     toolName.startsWith('create_') ||
     toolName.startsWith('update_') ||
     toolName.startsWith('delete_') ||

--- a/tests/unit/server/utils/chat-turns.test.ts
+++ b/tests/unit/server/utils/chat-turns.test.ts
@@ -37,6 +37,8 @@ describe('chat turn helpers', () => {
 
   it('detects mutating chat tools', () => {
     expect(isMutatingChatTool('create_planned_workout')).toBe(true)
+    expect(isMutatingChatTool('generate_planned_workout_structure')).toBe(true)
+    expect(isMutatingChatTool('adjust_planned_workout')).toBe(true)
     expect(isMutatingChatTool('log_nutrition_meal')).toBe(true)
     expect(isMutatingChatTool('log_hydration_intake')).toBe(true)
     expect(isMutatingChatTool('lock_meal_to_plan')).toBe(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces duplicate `generate-structured-workout` enqueues when chat creates or updates planned workouts in a single turn.

## Changes

- **`update_planned_workout`** — structure regeneration is now **opt-in** (`generate_structure: true`) instead of default-on when omitted
- **`planning_write` skill** — instructs the model not to call `generate_planned_workout_structure` after `create_planned_workout`, and to only set `generate_structure: true` on updates when structure must rebuild
- **`generate_planned_workout_structure` tool description** — warns against post-create redundant calls
- **`isMutatingChatTool`** — includes `generate_planned_workout_structure` and `adjust_planned_workout` so identical structure trigger calls dedupe within a chat turn

## Issue addressed

- [013](docs/issues/013-chat-duplicate-structure-generation-triggers.md) — chat enqueues multiple structure generations for one workout

## Testing

- Updated `tests/unit/server/utils/chat-turns.test.ts` for new mutating tool classification

**Do not merge** — part of ongoing workout generation fix cluster.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

