### PR TITLE
Fix chat structure enqueue failures and recovery (008, 014, 016)

### DIFF
--- a/app/components/chat/ChatPlannedWorkoutCard.vue
+++ b/app/components/chat/ChatPlannedWorkoutCard.vue
@@ -29,6 +29,7 @@
     'SYSTEM_FAILURE'
   ])
   const SYNC_PENDING_STATUSES = new Set(['PENDING', 'QUEUED_FOR_SYNC'])
+  const STRUCTURE_WAIT_TIMEOUT_MS = 120_000
   const EXPECTS_STRUCTURE_TOOL_NAMES = new Set([
     'create_planned_workout',
     'update_planned_workout',
@@ -50,6 +51,7 @@
   const pollError = ref<string | null>(null)
   const isPolling = ref(false)
   const fallbackWorkoutId = ref<string | null>(null)
+  const pollStartedAt = ref<number | null>(null)
 
   const directWorkoutId = computed(() => {
     const response = props.response || {}
@@ -63,8 +65,32 @@
     return response.run_id || response.taskId || null
   })
 
+  const structureEnqueueFailed = computed(() => {
+    return (
+      props.response?.structure_generation === 'failed' || Boolean(props.response?.structure_error)
+    )
+  })
+
   const expectsStructure = computed(() => {
-    return EXPECTS_STRUCTURE_TOOL_NAMES.has(props.toolName)
+    if (structureEnqueueFailed.value) return false
+    if (!EXPECTS_STRUCTURE_TOOL_NAMES.has(props.toolName)) return false
+
+    if (props.toolName === 'create_planned_workout') {
+      return (
+        props.args?.generate_structure !== false &&
+        props.response?.structure_generation !== 'exists' &&
+        props.response?.structure_generation !== 'skipped'
+      )
+    }
+
+    if (props.toolName === 'update_planned_workout') {
+      return (
+        props.args?.generate_structure !== false &&
+        props.response?.structure_generation !== 'skipped'
+      )
+    }
+
+    return true
   })
 
   const runStatusLabel = computed(() => {
@@ -148,7 +174,11 @@
     if (!structured || typeof structured !== 'object') return false
     return (
       (Array.isArray(structured.steps) && structured.steps.length > 0) ||
-      (Array.isArray(structured.exercises) && structured.exercises.length > 0)
+      (Array.isArray(structured.exercises) && structured.exercises.length > 0) ||
+      (Array.isArray(structured.blocks) &&
+        structured.blocks.some(
+          (block: any) => Array.isArray(block?.steps) && block.steps.length > 0
+        ))
     )
   })
 
@@ -224,6 +254,11 @@
       return props.response?.error || 'Operation failed'
     }
 
+    if (props.response?.structure_error) return props.response.structure_error
+    if (props.response?.structure_generation === 'failed') {
+      return 'Structure generation failed to start'
+    }
+
     if (runError.value) return runError.value
     if (pollError.value) return pollError.value
     if (syncStatusLabel.value === 'Structure generation running') return syncStatusLabel.value
@@ -241,6 +276,7 @@
 
   const isOperationComplete = computed(() => {
     if (props.response?.success === false) return false
+    if (structureEnqueueFailed.value) return true
     if (runError.value || pollError.value) return false
     if (runStatus.value && ACTIVE_RUN_STATUSES.has(runStatus.value)) return false
     if (SYNC_PENDING_STATUSES.has(currentSyncStatus.value)) return false
@@ -251,6 +287,7 @@
 
   const showStatusLine = computed(() => {
     if (props.response?.success === false) return true
+    if (structureEnqueueFailed.value) return true
     if (runError.value || pollError.value) return true
     if (runStatus.value && ACTIVE_RUN_STATUSES.has(runStatus.value)) return true
     if (SYNC_PENDING_STATUSES.has(currentSyncStatus.value)) return true
@@ -465,8 +502,23 @@
     }
   }
 
+  const checkStructureWaitTimeout = () => {
+    if (
+      runId.value ||
+      !expectsStructure.value ||
+      hasVisualization.value ||
+      structureEnqueueFailed.value ||
+      !pollStartedAt.value
+    ) {
+      return false
+    }
+
+    return Date.now() - pollStartedAt.value > STRUCTURE_WAIT_TIMEOUT_MS
+  }
+
   const startPolling = async () => {
     clearPolling()
+    pollStartedAt.value = Date.now()
 
     await resolveWorkoutIdFromCreateArgs()
 
@@ -479,6 +531,13 @@
     if (hasWorkout) {
       await fetchWorkout()
       workoutPollTimer = setInterval(async () => {
+        if (checkStructureWaitTimeout()) {
+          pollError.value =
+            'Structure generation did not start. Open the workout page and use Build Structure to retry.'
+          clearPolling()
+          return
+        }
+
         await fetchWorkout()
 
         const syncStatus = String(liveWorkout.value?.syncStatus || '').toUpperCase()
@@ -622,7 +681,7 @@
           v-if="showStatusLine && (operationStatusText || isPolling)"
           class="text-xs mt-1"
           :class="
-            props.response?.success === false
+            props.response?.success === false || structureEnqueueFailed
               ? 'text-red-500'
               : 'text-emerald-600 dark:text-emerald-400'
           "

--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -42,9 +42,15 @@ import {
 import {
   normalizeStructuredWorkoutForPersistence,
   computeStructuredWorkoutMetrics,
-  getPendingSyncStatus
+  getPendingSyncStatus,
+  hasRenderableStructure
 } from '../structured-workout-persistence'
 import { publishTaskRunStartedEvent } from '../task-run-events'
+import {
+  buildStructureGenerationMessage,
+  enqueuePlannedWorkoutStructureGeneration,
+  type StructureGenerationStatus
+} from '../planned-workout-structure-trigger'
 
 const STEP_INTENT_VALUES = [
   'warmup',
@@ -865,13 +871,50 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       })
 
       if (existingByExternalId) {
+        const shouldGenerate = args.generate_structure !== false
+        let structureStatus: StructureGenerationStatus = 'skipped'
+        let runId: string | undefined
+        let structureError: string | undefined
+
+        if (shouldGenerate) {
+          const existingWorkout = await plannedWorkoutRepository.getById(
+            existingByExternalId.id,
+            userId,
+            {
+              select: { id: true, structuredWorkout: true }
+            }
+          )
+
+          if (existingWorkout && hasRenderableStructure(existingWorkout.structuredWorkout)) {
+            structureStatus = 'exists'
+          } else {
+            const enqueue = await enqueuePlannedWorkoutStructureGeneration({
+              userId,
+              plannedWorkoutId: existingByExternalId.id,
+              targetingOverride: args.targeting_override || null
+            })
+            if (enqueue.status === 'queued') {
+              structureStatus = 'queued'
+              runId = enqueue.runId
+            } else {
+              structureStatus = 'failed'
+              structureError = enqueue.error
+            }
+          }
+        }
+
         return {
           success: true,
           workout_id: existingByExternalId.id,
-          message:
-            args.generate_structure !== false
-              ? 'Planned workout already exists for this chat turn.'
-              : 'Planned workout already exists.'
+          outcome: 'already_exists',
+          ...(shouldGenerate ? { structure_generation: structureStatus } : {}),
+          ...(runId ? { run_id: runId } : {}),
+          ...(structureError ? { structure_error: structureError } : {}),
+          message: buildStructureGenerationMessage({
+            outcome: 'already_exists',
+            requested: shouldGenerate,
+            status: structureStatus
+          })
         }
       }
 
@@ -904,37 +947,38 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         managedBy: workout.managedBy
       })
 
-      // Trigger structured workout generation
+      const shouldGenerate = args.generate_structure !== false
+      let structureStatus: StructureGenerationStatus = 'skipped'
       let runId: string | undefined
-      if (args.generate_structure !== false) {
-        try {
-          const handle = await generateStructuredWorkoutTask.trigger(
-            {
-              plannedWorkoutId: workout.id, // Pass plannedWorkoutId
-              targetingOverride: args.targeting_override || null
-            },
-            {
-              tags: [`user:${userId}`, `planned-workout:${workout.id}`],
-              concurrencyKey: userId
-            }
-          )
-          await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
-            tags: [`user:${userId}`, `planned-workout:${workout.id}`]
-          })
-          runId = handle.id
-        } catch (e) {
-          console.error('Failed to trigger structured workout generation:', e)
+      let structureError: string | undefined
+
+      if (shouldGenerate) {
+        const enqueue = await enqueuePlannedWorkoutStructureGeneration({
+          userId,
+          plannedWorkoutId: workout.id,
+          targetingOverride: args.targeting_override || null
+        })
+        if (enqueue.status === 'queued') {
+          structureStatus = 'queued'
+          runId = enqueue.runId
+        } else {
+          structureStatus = 'failed'
+          structureError = enqueue.error
         }
       }
 
       return {
         success: true,
         workout_id: workout.id,
+        outcome: 'created',
+        ...(shouldGenerate ? { structure_generation: structureStatus } : {}),
         ...(runId ? { run_id: runId } : {}),
-        message:
-          args.generate_structure !== false
-            ? 'Planned workout created and structured generation started.'
-            : 'Planned workout created.'
+        ...(structureError ? { structure_error: structureError } : {}),
+        message: buildStructureGenerationMessage({
+          outcome: 'created',
+          requested: shouldGenerate,
+          status: structureStatus
+        })
       }
     }
   }),
@@ -994,33 +1038,32 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
       const workout = await plannedWorkoutRepository.update(args.workout_id, userId, data)
 
-      // Trigger regeneration of structured intervals
+      const shouldRegenerateStructure = args.generate_structure !== false
+      let structureStatus: StructureGenerationStatus = 'skipped'
       let runId: string | undefined
-      if (args.generate_structure !== false) {
-        try {
-          const handle = await generateStructuredWorkoutTask.trigger(
-            {
-              plannedWorkoutId: workout.id,
-              targetingOverride: args.targeting_override || null
-            },
-            {
-              tags: [`user:${userId}`, `planned-workout:${workout.id}`],
-              concurrencyKey: userId
-            }
-          )
-          await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
-            tags: [`user:${userId}`, `planned-workout:${workout.id}`]
-          })
-          runId = handle.id
-        } catch (e) {
-          console.error('Failed to trigger structured workout regeneration:', e)
+      let structureError: string | undefined
+
+      if (shouldRegenerateStructure) {
+        const enqueue = await enqueuePlannedWorkoutStructureGeneration({
+          userId,
+          plannedWorkoutId: workout.id,
+          targetingOverride: args.targeting_override || null
+        })
+        if (enqueue.status === 'queued') {
+          structureStatus = 'queued'
+          runId = enqueue.runId
+        } else {
+          structureStatus = 'failed'
+          structureError = enqueue.error
         }
       }
 
       return {
         success: true,
         workout_id: workout.id,
+        ...(shouldRegenerateStructure ? { structure_generation: structureStatus } : {}),
         ...(runId ? { run_id: runId } : {}),
+        ...(structureError ? { structure_error: structureError } : {}),
         status: nextSyncStatus === 'LOCAL_ONLY' ? 'LOCAL_ONLY' : 'QUEUED_FOR_SYNC'
       }
     }
@@ -1434,7 +1477,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const existingWorkout = await workoutRepository.getById(args.workout_id, userId, {
             select: { id: true, date: true }
           })
-          if (!existingWorkout) throw new Error('Workout not found')
+          if (!existingWorkout) throw new Error('Workout not found', { cause: e })
 
           await workoutRepository.delete(args.workout_id, userId)
 

--- a/server/utils/planned-workout-structure-trigger.ts
+++ b/server/utils/planned-workout-structure-trigger.ts
@@ -1,0 +1,72 @@
+import { generateStructuredWorkoutTask } from '../../trigger/generate-structured-workout'
+import { publishTaskRunStartedEvent } from './task-run-events'
+import type { WorkoutTargetingOverride } from '../../trigger/utils/workout-targeting'
+
+export type StructureGenerationStatus = 'queued' | 'skipped' | 'failed' | 'exists'
+
+export type StructureEnqueueResult =
+  { status: 'queued'; runId: string } | { status: 'failed'; error: string }
+
+function formatTriggerError(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return 'Failed to start structure generation'
+}
+
+export async function enqueuePlannedWorkoutStructureGeneration(options: {
+  userId: string
+  plannedWorkoutId: string
+  targetingOverride?: WorkoutTargetingOverride | null
+}): Promise<StructureEnqueueResult> {
+  const { userId, plannedWorkoutId, targetingOverride = null } = options
+
+  try {
+    const tags = [`user:${userId}`, `planned-workout:${plannedWorkoutId}`]
+    const handle = await generateStructuredWorkoutTask.trigger(
+      {
+        plannedWorkoutId,
+        targetingOverride
+      },
+      {
+        tags,
+        concurrencyKey: userId
+      }
+    )
+    await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, { tags })
+    return { status: 'queued', runId: handle.id }
+  } catch (error) {
+    console.error('Failed to trigger structured workout generation:', error)
+    return { status: 'failed', error: formatTriggerError(error) }
+  }
+}
+
+export function buildStructureGenerationMessage(options: {
+  outcome: 'created' | 'already_exists'
+  requested: boolean
+  status: StructureGenerationStatus
+}): string {
+  const { outcome, requested, status } = options
+
+  if (!requested) {
+    return outcome === 'created' ? 'Planned workout created.' : 'Planned workout already exists.'
+  }
+
+  if (status === 'queued') {
+    return outcome === 'created'
+      ? 'Planned workout created and structured generation started.'
+      : 'Planned workout already exists; structure generation started.'
+  }
+
+  if (status === 'exists') {
+    return outcome === 'created'
+      ? 'Planned workout created with existing structure.'
+      : 'Planned workout already exists with structure.'
+  }
+
+  if (status === 'failed') {
+    return outcome === 'created'
+      ? 'Planned workout created, but structure generation failed to start.'
+      : 'Planned workout already exists, but structure generation failed to start.'
+  }
+
+  return outcome === 'created' ? 'Planned workout created.' : 'Planned workout already exists.'
+}

--- a/server/utils/structured-workout-persistence.ts
+++ b/server/utils/structured-workout-persistence.ts
@@ -629,9 +629,9 @@ export function computeStructuredWorkoutMetrics(
 
     for (const step of steps || []) {
       const reps = toPositiveInt(step?.reps) || 1
-      let stepDuration = 0
-      let stepTss = 0
-      let stepDistance = 0
+      let stepDuration: number
+      let stepTss: number
+      let stepDistance: number
 
       if (Array.isArray(step?.steps) && step.steps.length > 0) {
         const nested = walk(step.steps)
@@ -643,9 +643,7 @@ export function computeStructuredWorkoutMetrics(
         stepDistance = estimateStepDistanceMeters(step, context)
 
         const intensity = selectStepIntensity(step, context.refs, context.fallbackOrder)
-        if (stepDuration > 0) {
-          stepTss = ((stepDuration * intensity * intensity) / 3600) * 100
-        }
+        stepTss = stepDuration > 0 ? ((stepDuration * intensity * intensity) / 3600) * 100 : 0
       }
 
       duration += stepDuration * reps
@@ -682,4 +680,22 @@ export function computeStructuredWorkoutDurationSec(structuredWorkout: any) {
 
 export function getPendingSyncStatus(syncStatus: string | null | undefined) {
   return syncStatus === 'LOCAL_ONLY' ? 'LOCAL_ONLY' : 'PENDING'
+}
+
+export function hasRenderableStructure(structuredWorkout: unknown): boolean {
+  if (!structuredWorkout || typeof structuredWorkout !== 'object') return false
+
+  const structure = structuredWorkout as Record<string, unknown>
+  if (Array.isArray(structure.steps) && structure.steps.length > 0) return true
+  if (Array.isArray(structure.exercises) && structure.exercises.length > 0) return true
+
+  if (Array.isArray(structure.blocks) && structure.blocks.length > 0) {
+    return structure.blocks.some((block) => {
+      if (!block || typeof block !== 'object') return false
+      const steps = (block as Record<string, unknown>).steps
+      return Array.isArray(steps) && steps.length > 0
+    })
+  }
+
+  return false
 }

--- a/tests/unit/server/utils/planned-workout-structure-trigger.test.ts
+++ b/tests/unit/server/utils/planned-workout-structure-trigger.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { hasRenderableStructure } from '../../../../server/utils/structured-workout-persistence'
+import { buildStructureGenerationMessage } from '../../../../server/utils/planned-workout-structure-trigger'
+
+describe('hasRenderableStructure', () => {
+  it('returns false for empty or missing structure', () => {
+    expect(hasRenderableStructure(null)).toBe(false)
+    expect(hasRenderableStructure({})).toBe(false)
+    expect(hasRenderableStructure({ steps: [] })).toBe(false)
+  })
+
+  it('detects endurance steps and strength exercises', () => {
+    expect(hasRenderableStructure({ steps: [{ durationSeconds: 600 }] })).toBe(true)
+    expect(hasRenderableStructure({ exercises: [{ name: 'Squat' }] })).toBe(true)
+  })
+
+  it('detects blocks-only strength structures', () => {
+    expect(
+      hasRenderableStructure({
+        blocks: [{ name: 'Main', steps: [{ name: 'Squat' }] }]
+      })
+    ).toBe(true)
+  })
+})
+
+describe('buildStructureGenerationMessage', () => {
+  it('describes failed enqueue on create', () => {
+    expect(
+      buildStructureGenerationMessage({
+        outcome: 'created',
+        requested: true,
+        status: 'failed'
+      })
+    ).toContain('failed to start')
+  })
+
+  it('describes idempotent recovery enqueue', () => {
+    expect(
+      buildStructureGenerationMessage({
+        outcome: 'already_exists',
+        requested: true,
+        status: 'queued'
+      })
+    ).toContain('structure generation started')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the chat structure enqueue failure chain: silent trigger errors, idempotent create replay that never re-queues structure, and infinite chat card polling when no `run_id` is returned.

## Changes

### Server (`008`, `014`)
- **`server/utils/planned-workout-structure-trigger.ts`** — shared enqueue helper with explicit `queued` / `failed` results
- **`server/utils/structured-workout-persistence.ts`** — `hasRenderableStructure()` helper (includes blocks-only strength)
- **`server/utils/ai-tools/planning.ts`**
  - `create_planned_workout` / `update_planned_workout` return `structure_generation`, `structure_error`, and accurate messages on enqueue failure
  - Idempotent create replay re-enqueues structure when workout exists but has no renderable structure

### UI (`016`)
- **`app/components/chat/ChatPlannedWorkoutCard.vue`**
  - Surfaces `structure_error` / `structure_generation: failed` as terminal red status
  - Stops polling after 120s when structure is expected but no `run_id` and no structure appears
  - Recognizes blocks-only strength structures in visualization check

## Issues addressed

- [008](docs/issues/008-chat-silent-trigger-failures.md)
- [014](docs/issues/014-idempotent-create-skips-structure-retrigger.md)
- [016](docs/issues/016-chat-card-infinite-poll-without-run-id.md)

## Testing

- Added `tests/unit/server/utils/planned-workout-structure-trigger.test.ts`

**Do not merge** — part of ongoing workout generation fix cluster.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

