### PR TITLE
Fix chat approval deduplication and structure tool approval (015, 018)

### DIFF
--- a/app/components/chat/ChatToolApproval.vue
+++ b/app/components/chat/ChatToolApproval.vue
@@ -65,6 +65,7 @@
   )
 
   const handleApprove = async () => {
+    if (submitting.value || resultText.value) return
     submitting.value = true
     emit('approve', { approvalId: props.approvalId, result: 'User confirmed action.' })
   }
@@ -79,6 +80,7 @@
   }
 
   const handleDeny = async () => {
+    if (submitting.value || resultText.value) return
     submitting.value = true
     const trimmedReason = denyReason.value.trim()
     const result = isSupportTicketTool.value
@@ -195,6 +197,7 @@
             variant="solid"
             icon="i-heroicons-check"
             :loading="submitting"
+            :disabled="submitting || Boolean(resultText)"
             @click="handleApprove"
           >
             Approve

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -773,11 +773,16 @@
     input.value = ''
   }
 
+  const pendingApprovalSubmissions = new Set<string>()
+
   const onToolApproval = async (approval: {
     approvalId: string
     approved: boolean
     result?: string
   }) => {
+    if (pendingApprovalSubmissions.has(approval.approvalId)) return
+    pendingApprovalSubmissions.add(approval.approvalId)
+
     // Append a tool message with a tool-approval-response part directly to chat.messages.
     // addToolApprovalResponse only works with messages that came through the SDK's own
     // streaming transport, not with messages synthesized from WebSocket-delivered state.
@@ -800,7 +805,12 @@
       createdAt: new Date()
     }
     chat.messages = [...(chat.messages as any[]), approvalToolMsg] as any
-    await (chat as any).sendMessage()
+    try {
+      await (chat as any).sendMessage()
+    } catch (error) {
+      pendingApprovalSubmissions.delete(approval.approvalId)
+      throw error
+    }
     awaitingTurnStart.value = true
     restartTurnPolling({ forceForMs: 15000 })
     if (currentRoomId.value) {

--- a/server/api/chat/messages.post.ts
+++ b/server/api/chat/messages.post.ts
@@ -4,6 +4,12 @@ import { prisma } from '../../utils/db'
 import { checkQuota } from '../../utils/quotas/engine'
 import { chatService } from '../../utils/services/chatService'
 import { chatTurnService } from '../../utils/services/chatTurnService'
+import {
+  extractApprovalIdFromToolMessage,
+  findExistingApprovalResponseMessage,
+  findTurnForApprovalResponseMessage,
+  resolveApprovalOriginLineageId
+} from '../../utils/chat/approval-continuation'
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event, ['chat:write'])
@@ -141,7 +147,37 @@ export default defineEventHandler(async (event) => {
   const shouldPersistIncomingMessage =
     !!lastMessage &&
     (lastMessage.role === 'user' || (lastMessage.role === 'tool' && isLastToolApprovalResponse))
+  const approvalIdForContinuation = isLastToolApprovalResponse
+    ? extractApprovalIdFromToolMessage(lastMessage)
+    : null
   let persistedMessage = existingMessage
+
+  if (approvalIdForContinuation) {
+    const existingApprovalResponse = await findExistingApprovalResponseMessage(
+      roomId,
+      approvalIdForContinuation
+    )
+
+    if (existingApprovalResponse && existingApprovalResponse.id !== incomingMessageId) {
+      const existingTurn = await findTurnForApprovalResponseMessage(existingApprovalResponse)
+      const stream = createUIMessageStream({
+        execute: ({ writer }) => {
+          if (existingTurn) {
+            writer.write({
+              type: 'data-chat-turn',
+              data: {
+                turnId: existingTurn.id,
+                status: existingTurn.status
+              },
+              transient: true
+            } as any)
+          }
+        }
+      })
+
+      return createUIMessageStreamResponse({ stream })
+    }
+  }
 
   if (shouldPersistIncomingMessage && !existingMessage) {
     const metadata: any = {}
@@ -180,10 +216,15 @@ export default defineEventHandler(async (event) => {
   let turn = await chatTurnService.findLatestTurnForMessage(triggerMessageId)
 
   if (!turn) {
+    const approvalLineageId = isToolContinuationTurn
+      ? await resolveApprovalOriginLineageId(roomId, truncatedMessages)
+      : null
+
     turn = await chatTurnService.createTurn({
       roomId,
       userId,
       userMessageId: triggerMessageId,
+      ...(approvalLineageId ? { lineageId: approvalLineageId } : {}),
       request: {
         messages: await chatTurnService.buildStableRequestMessages(roomId, triggerMessageId, 25),
         files: attachedFiles,

--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -1156,6 +1156,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         'Optional per-workout targeting override for this adjustment only (does not change profile defaults).'
       )
     }),
+    needsApproval: async () => aiSettings.aiRequireToolApproval,
     execute: async ({
       workout_id,
       instructions,
@@ -1208,6 +1209,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         'Optional per-workout targeting override for this generation only (does not change profile defaults).'
       )
     }),
+    needsApproval: async () => aiSettings.aiRequireToolApproval,
     execute: async ({ workout_id, targeting_override }) => {
       // 0. Quota Check
       await checkQuota(userId, 'generate_structured_workout')
@@ -1434,7 +1436,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const existingWorkout = await workoutRepository.getById(args.workout_id, userId, {
             select: { id: true, date: true }
           })
-          if (!existingWorkout) throw new Error('Workout not found')
+          if (!existingWorkout) throw new Error('Workout not found', { cause: e })
 
           await workoutRepository.delete(args.workout_id, userId)
 

--- a/server/utils/chat/approval-continuation.ts
+++ b/server/utils/chat/approval-continuation.ts
@@ -1,0 +1,120 @@
+import { prisma } from '../db'
+import { CHAT_TURN_STATUS } from './turns'
+
+function getMessageParts(message: any): any[] {
+  if (Array.isArray(message?.parts)) return message.parts
+  if (Array.isArray(message?.content)) return message.content
+  return []
+}
+
+export function extractApprovalIdFromToolMessage(message: any): string | null {
+  const approvalPart = getMessageParts(message).find(
+    (part) => part?.type === 'tool-approval-response'
+  )
+  if (!approvalPart) return null
+  return approvalPart.toolCallId || approvalPart.approvalId || null
+}
+
+function approvalResponseMatchesId(part: any, approvalId: string) {
+  if (part?.type !== 'tool-approval-response') return false
+  return part.toolCallId === approvalId || part.approvalId === approvalId
+}
+
+export async function findExistingApprovalResponseMessage(roomId: string, approvalId: string) {
+  const messages = await prisma.chatMessage.findMany({
+    where: {
+      roomId,
+      senderId: 'system_tool'
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 100,
+    select: {
+      id: true,
+      turnId: true,
+      metadata: true
+    }
+  })
+
+  for (const message of messages) {
+    const toolResponse = (message.metadata as any)?.toolResponse
+    if (!Array.isArray(toolResponse)) continue
+
+    if (toolResponse.some((part: any) => approvalResponseMatchesId(part, approvalId))) {
+      return message
+    }
+  }
+
+  return null
+}
+
+export async function resolveApprovalOriginLineageId(
+  roomId: string,
+  messages: any[]
+): Promise<string | null> {
+  const latestMessage = messages[messages.length - 1]
+  const approvalId = extractApprovalIdFromToolMessage(latestMessage)
+  if (!approvalId) return null
+
+  for (let index = messages.length - 2; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.role !== 'assistant') continue
+
+    const matchingPart = getMessageParts(message).find((part: any) => {
+      if (!part?.type?.startsWith('tool-')) return false
+      const partApprovalId = part?.approval?.id || part?.approvalId || part?.toolCallId
+      return partApprovalId === approvalId
+    })
+
+    if (!matchingPart || typeof message?.id !== 'string') continue
+
+    const assistantMessage = await prisma.chatMessage.findFirst({
+      where: {
+        id: message.id,
+        roomId
+      },
+      select: {
+        turnId: true
+      }
+    })
+
+    if (!assistantMessage?.turnId) continue
+
+    const originTurn = await prisma.chatTurn.findUnique({
+      where: { id: assistantMessage.turnId },
+      select: { lineageId: true }
+    })
+
+    if (originTurn?.lineageId) {
+      return originTurn.lineageId
+    }
+  }
+
+  const waitingTurn = await prisma.chatTurn.findFirst({
+    where: {
+      roomId,
+      status: CHAT_TURN_STATUS.WAITING_FOR_TOOLS
+    },
+    orderBy: { createdAt: 'desc' },
+    select: { lineageId: true }
+  })
+
+  return waitingTurn?.lineageId || null
+}
+
+export async function findTurnForApprovalResponseMessage(message: {
+  id: string
+  turnId?: string | null
+}) {
+  if (message.turnId) {
+    return await prisma.chatTurn.findUnique({
+      where: { id: message.turnId }
+    })
+  }
+
+  return await prisma.chatTurn.findFirst({
+    where: {
+      userMessageId: message.id
+    },
+    orderBy: { createdAt: 'desc' }
+  })
+}

--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -189,6 +189,8 @@ const CHAT_SKILL_MANIFESTS: Record<ChatSkillId, ChatSkillManifest> = {
       'create_planned_workout',
       'update_planned_workout',
       'reschedule_planned_workout',
+      'adjust_planned_workout',
+      'generate_planned_workout_structure',
       'publish_planned_workout',
       'delete_planned_workout',
       'delete_workout'

--- a/tests/unit/server/utils/chat/approval-continuation.test.ts
+++ b/tests/unit/server/utils/chat/approval-continuation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { extractApprovalIdFromToolMessage } from '../../../../server/utils/chat/approval-continuation'
+
+describe('approval continuation helpers', () => {
+  it('extracts approval id from tool approval response parts', () => {
+    expect(
+      extractApprovalIdFromToolMessage({
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'approval-123',
+            approved: true
+          }
+        ]
+      })
+    ).toBe('approval-123')
+  })
+
+  it('returns null when no approval response is present', () => {
+    expect(
+      extractApprovalIdFromToolMessage({
+        role: 'tool',
+        parts: [{ type: 'tool-result', toolCallId: 'call-1' }]
+      })
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents duplicate planned workouts from double approval submissions and ensures expensive structure mutation tools respect tool approval settings.

## Changes

### Approval deduplication (015)
- **`server/utils/chat/approval-continuation.ts`** — helpers to extract approval IDs, resolve origin `lineageId`, and detect duplicate responses
- **`server/api/chat/messages.post.ts`**
  - Approval continuation turns inherit the originating turn's `lineageId` (stable `externalId` / idempotency)
  - Duplicate approval for the same `approvalId` returns the existing turn instead of creating another
- **`app/components/chat/ChatToolApproval.vue`** — guard against double-click approve/deny
- **`app/pages/chat.vue`** — track in-flight approval submissions client-side

### Structure tool approval gates (018)
- **`adjust_planned_workout`** and **`generate_planned_workout_structure`** now use `needsApproval` when `aiRequireToolApproval` is enabled
- Added both tools to `planning_write.approvalToolNames` in `server/utils/chat/skills.ts`

## Issues addressed

- [015](docs/issues/015-approval-turn-duplicate-workouts.md)
- [018](docs/issues/018-structure-tools-bypass-approval.md)

## Testing

- Added `tests/unit/server/utils/chat/approval-continuation.test.ts`

**Do not merge** — part of ongoing workout generation fix cluster.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

