### PR TITLE
Fix open workout generation issues batch (003–031)

### DIFF
--- a/app/components/chat/ChatMessageContent.vue
+++ b/app/components/chat/ChatMessageContent.vue
@@ -6,6 +6,7 @@
   import ChatDomainToolCard from '~/components/chat/ChatDomainToolCard.vue'
   import ChatPlannedWorkoutCard from '~/components/chat/ChatPlannedWorkoutCard.vue'
   import ChatTicketToolCard from '~/components/chat/ChatTicketToolCard.vue'
+  import { hasStructuredWorkoutPreviewData } from '~/utils/structuredWorkout'
 
   const props = withDefaults(
     defineProps<{
@@ -123,11 +124,7 @@
   const hasPlannedWorkoutStructure = (response: any) => {
     if (!response || typeof response !== 'object') return false
     const structure = response.structuredWorkout || response.structured_workout
-    if (!structure || typeof structure !== 'object') return false
-    return (
-      (Array.isArray(structure.steps) && structure.steps.length > 0) ||
-      (Array.isArray(structure.exercises) && structure.exercises.length > 0)
-    )
+    return hasStructuredWorkoutPreviewData(structure)
   }
 
   const shouldRenderPlannedWorkoutCard = (part: any) => {

--- a/app/components/chat/ChatPlannedWorkoutCard.vue
+++ b/app/components/chat/ChatPlannedWorkoutCard.vue
@@ -2,6 +2,7 @@
   import { computed, onUnmounted, ref, watch } from 'vue'
   import MiniWorkoutChart from '~/components/workouts/MiniWorkoutChart.vue'
   import WorkoutMessagesTimeline from '~/components/workouts/WorkoutMessagesTimeline.vue'
+  import { hasStructuredWorkoutPreviewData } from '~/utils/structuredWorkout'
 
   const props = defineProps<{
     toolName: string
@@ -49,14 +50,13 @@
   const runError = ref<string | null>(null)
   const pollError = ref<string | null>(null)
   const isPolling = ref(false)
-  const fallbackWorkoutId = ref<string | null>(null)
 
   const directWorkoutId = computed(() => {
     const response = props.response || {}
     return response.workout_id || props.args?.workout_id
   })
 
-  const workoutId = computed(() => directWorkoutId.value || fallbackWorkoutId.value)
+  const workoutId = computed(() => directWorkoutId.value)
 
   const runId = computed(() => {
     const response = props.response || {}
@@ -144,12 +144,7 @@
   })
 
   const hasVisualization = computed(() => {
-    const structured = plannedWorkout.value?.structuredWorkout
-    if (!structured || typeof structured !== 'object') return false
-    return (
-      (Array.isArray(structured.steps) && structured.steps.length > 0) ||
-      (Array.isArray(structured.exercises) && structured.exercises.length > 0)
-    )
+    return hasStructuredWorkoutPreviewData(plannedWorkout.value)
   })
 
   const chartPreference = computed<'power' | 'hr' | 'pace'>(() => {
@@ -384,70 +379,6 @@
     }
   }
 
-  const resolveWorkoutIdFromCreateArgs = async () => {
-    if (directWorkoutId.value || fallbackWorkoutId.value) return
-    if (props.toolName !== 'create_planned_workout') return
-    const date = String(props.args?.date || '').slice(0, 10)
-    if (!date) return
-
-    try {
-      const data = (await ($fetch as any)(
-        `/api/workouts/planned/range?start=${date}&end=${date}`
-      )) as { workouts?: any[] }
-      const workouts = Array.isArray(data?.workouts) ? data.workouts : []
-      if (!workouts.length) return
-
-      const title = String(props.args?.title || '')
-        .trim()
-        .toLowerCase()
-      const type = String(props.args?.type || '')
-        .trim()
-        .toLowerCase()
-      const durationMinutes =
-        typeof props.args?.duration_minutes === 'number' ? props.args.duration_minutes : null
-
-      const byScore = [...workouts]
-        .map((w) => {
-          let score = 0
-          if (
-            title &&
-            String(w.title || '')
-              .trim()
-              .toLowerCase() === title
-          )
-            score += 4
-          else if (
-            title &&
-            String(w.title || '')
-              .trim()
-              .toLowerCase()
-              .includes(title)
-          )
-            score += 2
-          if (
-            type &&
-            String(w.type || '')
-              .trim()
-              .toLowerCase() === type
-          )
-            score += 2
-          if (durationMinutes && typeof w.durationSec === 'number') {
-            const minutes = Math.round(w.durationSec / 60)
-            if (minutes === durationMinutes) score += 2
-          }
-          return { workout: w, score }
-        })
-        .sort((a, b) => b.score - a.score)
-
-      const best = byScore[0]?.workout
-      if (best?.id) {
-        fallbackWorkoutId.value = best.id
-      }
-    } catch {
-      // Ignore and keep generic card state.
-    }
-  }
-
   const fetchRunStatus = async () => {
     if (!runId.value) return
 
@@ -468,7 +399,11 @@
   const startPolling = async () => {
     clearPolling()
 
-    await resolveWorkoutIdFromCreateArgs()
+    if (props.toolName === 'create_planned_workout' && !workoutId.value) {
+      pollError.value =
+        'Workout ID was not returned from create_planned_workout. Refresh the chat or open the calendar to find the workout.'
+      return
+    }
 
     const hasRun = Boolean(runId.value)
     const hasWorkout = Boolean(workoutId.value)

--- a/app/components/plans/PlanDashboard.vue
+++ b/app/components/plans/PlanDashboard.vue
@@ -1009,6 +1009,7 @@
   const generatingBlockId = ref<string | null>(null)
   const generatingStructureForWorkoutId = ref<string | null>(null)
   const generatingAllStructures = ref(false)
+  const pendingBatchStructureWorkoutIds = ref<Set<string>>(new Set())
   const adapting = ref<string | null>(null)
   const draggingId = ref<string | null>(null)
   const mobileDropTargetId = ref<string | null>(null)
@@ -1200,7 +1201,22 @@
 
   const { refresh: refreshRuns } = useUserRuns()
 
-  const { onTaskCompleted } = useUserRunsState()
+  const { onTaskCompleted, onTaskFailed } = useUserRunsState()
+
+  const plannedWorkoutIdFromRun = (run: { tags?: string[] }) => {
+    const tag = run.tags?.find((entry) => entry.startsWith('planned-workout:'))
+    return tag ? tag.slice('planned-workout:'.length) : null
+  }
+
+  const finishBatchStructureWorkout = (workoutId: string | null) => {
+    if (!workoutId || !pendingBatchStructureWorkoutIds.value.has(workoutId)) return
+    const next = new Set(pendingBatchStructureWorkoutIds.value)
+    next.delete(workoutId)
+    pendingBatchStructureWorkoutIds.value = next
+    if (next.size === 0) {
+      generatingAllStructures.value = false
+    }
+  }
 
   // Listeners
 
@@ -1218,6 +1234,14 @@
     emit('refresh')
 
     generatingStructureForWorkoutId.value = null
+    finishBatchStructureWorkout(plannedWorkoutIdFromRun(run))
+  })
+
+  onTaskFailed('generate-structured-workout', async (run) => {
+    emit('refresh')
+
+    generatingStructureForWorkoutId.value = null
+    finishBatchStructureWorkout(plannedWorkoutIdFromRun(run))
   })
 
   onTaskCompleted('adapt-training-plan', async (run) => {
@@ -1588,6 +1612,9 @@
     if (pendingWorkouts.length === 0) return
 
     generatingAllStructures.value = true
+    pendingBatchStructureWorkoutIds.value = new Set(
+      pendingWorkouts.map((w: { id: string }) => w.id)
+    )
     toast.add({
       title: 'Batch Generation Started',
       description: `Designing ${pendingWorkouts.length} workouts. This will take a minute...`,
@@ -1615,6 +1642,8 @@
               'You have reached your daily limit for generating AI-structured workouts.'
             )
           ) {
+            pendingBatchStructureWorkoutIds.value = new Set()
+            generatingAllStructures.value = false
             return // Stop completely on quota error
           }
           // For other errors, we might want to log and continue or stop.
@@ -1631,6 +1660,8 @@
       })
     } catch (error: any) {
       console.error('Batch generation failed', error)
+      pendingBatchStructureWorkoutIds.value = new Set()
+      generatingAllStructures.value = false
       if (
         !handleQuotaError(
           error,
@@ -1644,8 +1675,6 @@
           color: 'error'
         })
       }
-    } finally {
-      generatingAllStructures.value = false
     }
   }
 

--- a/app/composables/useUserRuns.ts
+++ b/app/composables/useUserRuns.ts
@@ -295,19 +295,18 @@ export function useUserRuns() {
   if (import.meta.client) {
     watch(
       () => (session.value?.user as any)?.id,
-      (newId) => {
-        if (newId) {
+      (newId, oldId) => {
+        if (newId && newId !== oldId) {
+          cleanupUserRunsConnection()
+          runs.value = []
+          initPromise = null
+          init()
+        } else if (newId) {
           init()
         } else {
-          if (ws) {
-            ws.close()
-            ws = null
-          }
-          isConnected.value = false
-          initPromise = null
-          stopPolling()
-          stopPing()
+          cleanupUserRunsConnection()
           runs.value = []
+          initPromise = null
         }
       }
     )

--- a/app/pages/workouts/planned/[id]/index.vue
+++ b/app/pages/workouts/planned/[id]/index.vue
@@ -625,8 +625,7 @@
           <pre
             v-else
             class="text-xs whitespace-pre-wrap break-words max-h-[60vh] overflow-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3 text-gray-800 dark:text-gray-100"
-            >{{ intervalsPreviewText || 'No Intervals.icu description available.' }}</pre
-          >
+            >{{ intervalsPreviewText || 'No Intervals.icu description available.' }}</pre>
           <div class="flex justify-end">
             <UButton
               size="xs"
@@ -644,8 +643,7 @@
         <div v-else class="space-y-3">
           <pre
             class="text-xs whitespace-pre-wrap break-words max-h-[60vh] overflow-auto rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 p-3 text-gray-800 dark:text-gray-100"
-            >{{ plannedWorkoutRawJson }}</pre
-          >
+            >{{ plannedWorkoutRawJson }}</pre>
           <div class="flex justify-end">
             <UButton
               size="xs"
@@ -1381,6 +1379,17 @@
     generating.value = false
 
     const output = run.output as any
+    if (output?.skipped || output?.reason === 'FREE_TIER_LIMIT') {
+      toast.add({
+        title: 'Generation Skipped',
+        description:
+          output?.message ||
+          'Structured workout generation is limited to 4 weeks in advance on the free plan.',
+        color: 'warning',
+        icon: 'i-heroicons-exclamation-triangle'
+      })
+      return
+    }
     if (output?.success === false) {
       if (output.reason === 'QUOTA_EXCEEDED') {
         handleQuotaError(
@@ -2335,7 +2344,7 @@
 
       toast.add({
         title: 'Generation Started',
-        description: 'AI is generating the workout structure. This may take up to 30 seconds.',
+        description: 'AI is generating the workout structure. This may take up to 2 minutes.',
         color: 'success'
       })
     } catch (error: any) {

--- a/server/api/library/workouts/[id]/generate-structure.post.ts
+++ b/server/api/library/workouts/[id]/generate-structure.post.ts
@@ -6,6 +6,7 @@ import {
   getReadableLibraryOwnerIds,
   parseLibraryScope
 } from '../../../../utils/library-access'
+import { publishTaskRunStartedEvent } from '../../../../utils/task-run-events'
 
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
@@ -13,6 +14,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 401, message: 'Unauthorized' })
   }
 
+  const sessionUserId = session.user.id
   const id = getRouterParam(event, 'id')
   if (!id) {
     throw createError({ statusCode: 400, message: 'Missing workout template ID' })
@@ -32,16 +34,26 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, message: 'Workout template not found' })
   }
 
+  const runTags = [
+    `user:${sessionUserId}`,
+    `workout-template:${id}`,
+    `template-owner:${template.userId}`
+  ]
+
   const handle = await tasks.trigger(
     'generate-structured-workout',
     {
       workoutTemplateId: id
     },
     {
-      tags: [`user:${template.userId}`, `workout-template:${id}`],
+      tags: runTags,
       concurrencyKey: template.userId
     }
   )
+
+  await publishTaskRunStartedEvent(sessionUserId, 'generate-structured-workout', handle, {
+    tags: runTags
+  })
 
   return {
     success: true,

--- a/server/api/workouts/planned/[id]/generate-structure.post.ts
+++ b/server/api/workouts/planned/[id]/generate-structure.post.ts
@@ -78,7 +78,8 @@ export default defineEventHandler(async (event) => {
     const handle = await tasks.trigger(
       'generate-structured-workout',
       {
-        plannedWorkoutId: id
+        plannedWorkoutId: id,
+        quotaCheckedAtEnqueue: true
       },
       {
         concurrencyKey: userId,

--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -42,9 +42,11 @@ import {
 import {
   normalizeStructuredWorkoutForPersistence,
   computeStructuredWorkoutMetrics,
-  getPendingSyncStatus
+  getPendingSyncStatus,
+  hasRenderableStructure
 } from '../structured-workout-persistence'
 import { publishTaskRunStartedEvent } from '../task-run-events'
+import { isPlannedWorkoutStructureJobInFlight } from '../trigger-check'
 
 const STEP_INTENT_VALUES = [
   'warmup',
@@ -619,9 +621,30 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
       if (!workout) return { error: 'Planned workout not found' }
 
+      const week = workout.trainingWeek
       return {
-        ...workout,
-        date: formatDateUTC(workout.date)
+        success: true,
+        workout_id: workout.id,
+        title: workout.title,
+        date: formatDateUTC(workout.date),
+        start_time: workout.startTime,
+        type: workout.type,
+        duration_minutes: workout.durationSec ? Math.round(workout.durationSec / 60) : undefined,
+        tss: workout.tss,
+        description: workout.description,
+        sync_status: workout.syncStatus,
+        completion_status: workout.completionStatus,
+        has_structure: hasRenderableStructure(workout.structuredWorkout),
+        training_context: week
+          ? {
+              plan_name: week.block?.plan?.name,
+              block_name: week.block?.name,
+              week_number: week.weekNumber,
+              focus: week.focus || week.block?.primaryFocus
+            }
+          : undefined,
+        message:
+          'Summary only. Use get_planned_workout_structure for full interval steps or exercises.'
       }
     }
   }),
@@ -680,6 +703,14 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       })) as any
 
       if (!existing) return { error: 'Planned workout not found' }
+      if (await isPlannedWorkoutStructureJobInFlight(userId, workout_id)) {
+        return {
+          success: false,
+          structure_job_in_flight: true,
+          error:
+            'Structure generation or adjustment is already running for this workout. Wait for it to finish before replacing the structure directly.'
+        }
+      }
       const sportSettings = await sportSettingsRepository.getForActivityType(
         userId,
         existing.type || ''
@@ -745,6 +776,14 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       })) as any
 
       if (!existing) return { error: 'Planned workout not found' }
+      if (await isPlannedWorkoutStructureJobInFlight(userId, workout_id)) {
+        return {
+          success: false,
+          structure_job_in_flight: true,
+          error:
+            'Structure generation or adjustment is already running for this workout. Wait for it to finish before patching structure directly.'
+        }
+      }
       if (!existing.structuredWorkout || typeof existing.structuredWorkout !== 'object') {
         return {
           success: false,
@@ -890,19 +929,21 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         completionStatus: 'PENDING'
       })
 
-      await autoUploadPlannedWorkoutToIntervalsIfEnabled({
-        id: workout.id,
-        userId,
-        externalId: workout.externalId,
-        date: workout.date,
-        startTime: workout.startTime,
-        title: workout.title,
-        description: workout.description,
-        type: workout.type,
-        durationSec: workout.durationSec,
-        tss: workout.tss,
-        managedBy: workout.managedBy
-      })
+      if (args.generate_structure === false) {
+        await autoUploadPlannedWorkoutToIntervalsIfEnabled({
+          id: workout.id,
+          userId,
+          externalId: workout.externalId,
+          date: workout.date,
+          startTime: workout.startTime,
+          title: workout.title,
+          description: workout.description,
+          type: workout.type,
+          durationSec: workout.durationSec,
+          tss: workout.tss,
+          managedBy: workout.managedBy
+        })
+      }
 
       // Trigger structured workout generation
       let runId: string | undefined
@@ -911,7 +952,8 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const handle = await generateStructuredWorkoutTask.trigger(
             {
               plannedWorkoutId: workout.id, // Pass plannedWorkoutId
-              targetingOverride: args.targeting_override || null
+              targetingOverride: args.targeting_override || null,
+              quotaCheckedAtEnqueue: true
             },
             {
               tags: [`user:${userId}`, `planned-workout:${workout.id}`],
@@ -1001,7 +1043,8 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const handle = await generateStructuredWorkoutTask.trigger(
             {
               plannedWorkoutId: workout.id,
-              targetingOverride: args.targeting_override || null
+              targetingOverride: args.targeting_override || null,
+              quotaCheckedAtEnqueue: true
             },
             {
               tags: [`user:${userId}`, `planned-workout:${workout.id}`],
@@ -1163,6 +1206,11 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       intensity,
       targeting_override
     }) => {
+      const existing = await plannedWorkoutRepository.getById(workout_id, userId, {
+        select: { id: true }
+      })
+      if (!existing) return { success: false, error: 'Planned workout not found' }
+
       // 0. Quota Check
       await checkQuota(userId, 'generate_structured_workout')
 
@@ -1176,7 +1224,8 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
               durationMinutes: duration_minutes,
               intensity: intensity
             },
-            targetingOverride: targeting_override || null
+            targetingOverride: targeting_override || null,
+            quotaCheckedAtEnqueue: true
           },
           {
             tags: [`user:${userId}`, `planned-workout:${workout_id}`],
@@ -1209,12 +1258,21 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       )
     }),
     execute: async ({ workout_id, targeting_override }) => {
+      const existing = await plannedWorkoutRepository.getById(workout_id, userId, {
+        select: { id: true }
+      })
+      if (!existing) return { success: false, error: 'Planned workout not found' }
+
       // 0. Quota Check
       await checkQuota(userId, 'generate_structured_workout')
 
       try {
         const handle = await generateStructuredWorkoutTask.trigger(
-          { plannedWorkoutId: workout_id, targetingOverride: targeting_override || null },
+          {
+            plannedWorkoutId: workout_id,
+            targetingOverride: targeting_override || null,
+            quotaCheckedAtEnqueue: true
+          },
           {
             tags: [`user:${userId}`, `planned-workout:${workout_id}`],
             concurrencyKey: userId
@@ -1247,7 +1305,15 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
         include: { user: { select: { ftp: true } } }
       })) as any // Cast because of complex include
 
-      if (!workout) return { error: 'Workout not found' }
+      if (!workout) return { error: 'Planned workout not found' }
+
+      if (!hasRenderableStructure(workout.structuredWorkout)) {
+        return {
+          success: false,
+          error:
+            'Workout structure is not ready yet. Wait for structure generation to finish or use Build Structure first.'
+        }
+      }
 
       // Logic copied from publish endpoint, simplified
       // Ideally this should be in a service but for now we implement directly using utils
@@ -1434,7 +1500,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           const existingWorkout = await workoutRepository.getById(args.workout_id, userId, {
             select: { id: true, date: true }
           })
-          if (!existingWorkout) throw new Error('Workout not found')
+          if (!existingWorkout) throw new Error('Workout not found', { cause: e })
 
           await workoutRepository.delete(args.workout_id, userId)
 

--- a/server/utils/ai-tools/recommendations.ts
+++ b/server/utils/ai-tools/recommendations.ts
@@ -1,6 +1,72 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 import { recommendationRepository } from '../repositories/recommendationRepository'
+import { activityRecommendationRepository } from '../repositories/activityRecommendationRepository'
+import { getUserLocalDate } from '../date'
+
+function formatActivityRecommendation(rec: {
+  id: string
+  recommendation: string
+  confidence: number
+  reasoning: string
+  analysisJson?: unknown
+  plannedWorkout?: {
+    id: string
+    title: string
+    type: string | null
+    durationSec: number | null
+    tss: number | null
+    description: string | null
+  } | null
+}) {
+  const analysis = (rec.analysisJson || {}) as Record<string, any>
+  const planned = rec.plannedWorkout
+  const modifications = analysis.suggested_modifications
+
+  if (planned) {
+    return {
+      source: 'activity_recommendation' as const,
+      recommendation_id: rec.id,
+      title: planned.title,
+      type: planned.type || 'Ride',
+      duration_minutes: planned.durationSec ? Math.round(planned.durationSec / 60) : undefined,
+      tss: planned.tss ?? undefined,
+      description: planned.description || rec.recommendation,
+      decision: rec.recommendation,
+      confidence: rec.confidence,
+      reasoning: rec.reasoning,
+      planned_workout_id: planned.id
+    }
+  }
+
+  if (modifications && typeof modifications === 'object') {
+    return {
+      source: 'activity_recommendation' as const,
+      recommendation_id: rec.id,
+      title: modifications.new_title || 'Suggested workout',
+      type: analysis.suggested_type || analysis.workout_type || undefined,
+      duration_minutes:
+        typeof modifications.new_duration_min === 'number'
+          ? modifications.new_duration_min
+          : undefined,
+      tss: typeof modifications.new_tss === 'number' ? modifications.new_tss : undefined,
+      description: modifications.description || rec.recommendation,
+      decision: rec.recommendation,
+      confidence: rec.confidence,
+      reasoning: rec.reasoning
+    }
+  }
+
+  return {
+    source: 'activity_recommendation' as const,
+    recommendation_id: rec.id,
+    title: rec.recommendation,
+    description: rec.reasoning,
+    decision: rec.recommendation,
+    confidence: rec.confidence,
+    reasoning: rec.reasoning
+  }
+}
 
 export const recommendationTools = (userId: string, timezone: string) => ({
   recommend_workout: tool({
@@ -17,18 +83,53 @@ export const recommendationTools = (userId: string, timezone: string) => ({
       notes: z.string().optional()
     }),
     execute: async (args) => {
-      // Logic to select a workout from a library or generate one
+      const today = getUserLocalDate(timezone)
+      const activityRec = await activityRecommendationRepository.findToday(userId, today)
+
+      if (activityRec && activityRec.status === 'COMPLETED') {
+        return {
+          created: false,
+          synced: false,
+          next_action:
+            'This is only a recommendation. To put it on the calendar or publish it to Intervals.icu, call create_planned_workout with these details.',
+          recommendation: formatActivityRecommendation(activityRec)
+        }
+      }
+
+      const recs = await recommendationRepository.list(userId, {
+        status: 'ACTIVE',
+        limit: 10
+      })
+
+      if (recs.length > 0) {
+        const pinned = recs.find((rec) => rec.isPinned)
+        const selected = pinned || recs[0]
+        return {
+          created: false,
+          synced: false,
+          next_action:
+            'This is only a recommendation. To put it on the calendar or publish it to Intervals.icu, call create_planned_workout with these details.',
+          recommendation: {
+            source: 'profile_recommendation' as const,
+            recommendation_id: selected.id,
+            title: selected.title,
+            description: selected.description,
+            category: selected.category,
+            metric: selected.metric,
+            priority: selected.priority,
+            notes: args.notes || undefined
+          }
+        }
+      }
+
       return {
         created: false,
         synced: false,
+        success: false,
+        error:
+          'No workout recommendation is available yet. Use list_pending_recommendations or wait for the daily readiness analysis to complete.',
         next_action:
-          'This is only a recommendation. To put it on the calendar or publish it to Intervals.icu, call create_planned_workout with these details.',
-        recommendation: {
-          title: 'Zone 2 Endurance Ride',
-          duration_minutes: 90,
-          description: 'Steady state ride at 65-75% FTP.',
-          tss: 60
-        }
+          'If the user wants a workout on the calendar, ask clarifying questions and use create_planned_workout once sport, duration, and date are clear.'
       }
     }
   }),

--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -180,6 +180,7 @@ const CHAT_SKILL_MANIFESTS: Record<ChatSkillId, ChatSkillManifest> = {
 - Never ask for approval in plain text without first invoking the relevant planning mutation tool.
 - If the user approves a prepared planning action, immediately execute that exact approved planning tool call.
 - After approval, do not just acknowledge the action in text. Execute the tool first, then report the result.
+- Do not call patch_planned_workout_structure or set_planned_workout_structure on the same workout in the same turn as generate_planned_workout_structure or adjust_planned_workout — async jobs overwrite direct edits.
 - Do not claim a workout was created, updated, moved, published, or deleted unless the planning tool actually ran successfully.`,
     contextFlags: ['planning', 'date_context', 'time'],
     approvalToolNames: [

--- a/server/utils/structured-workout-persistence.ts
+++ b/server/utils/structured-workout-persistence.ts
@@ -629,9 +629,9 @@ export function computeStructuredWorkoutMetrics(
 
     for (const step of steps || []) {
       const reps = toPositiveInt(step?.reps) || 1
-      let stepDuration = 0
-      let stepTss = 0
-      let stepDistance = 0
+      let stepDuration: number
+      let stepTss: number
+      let stepDistance: number
 
       if (Array.isArray(step?.steps) && step.steps.length > 0) {
         const nested = walk(step.steps)
@@ -682,4 +682,22 @@ export function computeStructuredWorkoutDurationSec(structuredWorkout: any) {
 
 export function getPendingSyncStatus(syncStatus: string | null | undefined) {
   return syncStatus === 'LOCAL_ONLY' ? 'LOCAL_ONLY' : 'PENDING'
+}
+
+export function hasRenderableStructure(structuredWorkout: unknown): boolean {
+  if (!structuredWorkout || typeof structuredWorkout !== 'object') return false
+
+  const structure = structuredWorkout as Record<string, unknown>
+  if (Array.isArray(structure.steps) && structure.steps.length > 0) return true
+  if (Array.isArray(structure.exercises) && structure.exercises.length > 0) return true
+
+  if (Array.isArray(structure.blocks) && structure.blocks.length > 0) {
+    return structure.blocks.some((block) => {
+      if (!block || typeof block !== 'object') return false
+      const steps = (block as Record<string, unknown>).steps
+      return Array.isArray(steps) && steps.length > 0
+    })
+  }
+
+  return false
 }

--- a/server/utils/trigger-check.ts
+++ b/server/utils/trigger-check.ts
@@ -19,6 +19,30 @@ export async function isTaskRunning(taskIdentifier: string, userId: string): Pro
   }
 }
 
+const STRUCTURE_TASK_IDENTIFIERS = ['generate-structured-workout', 'adjust-structured-workout']
+
+export async function isPlannedWorkoutStructureJobInFlight(
+  userId: string,
+  workoutId: string
+): Promise<boolean> {
+  try {
+    // @ts-expect-error - SDK v3 types mismatch for filter params
+    const activeRuns = await runs.list({
+      filter: {
+        taskIdentifier: STRUCTURE_TASK_IDENTIFIERS,
+        tags: [`user:${userId}`, `planned-workout:${workoutId}`],
+        status: ['EXECUTING', 'QUEUED', 'WAITING_FOR_DEPLOY', 'REATTEMPTING', 'FROZEN']
+      },
+      limit: 1
+    })
+
+    return activeRuns.data.length > 0
+  } catch (error) {
+    console.warn(`Failed to check structure job status for workout ${workoutId}:`, error)
+    return false
+  }
+}
+
 export async function isRunIdRunning(runId: string): Promise<boolean> {
   try {
     const run = await runs.retrieve(runId)

--- a/server/utils/workout-ai-timeouts.ts
+++ b/server/utils/workout-ai-timeouts.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared AI timeout policy for workout-related Trigger.dev tasks.
+ * Structure generation uses up to 2 attempts (Flash → Pro); each attempt is bounded here.
+ * Trigger task maxDuration remains 180s for generate/adjust structure tasks.
+ */
+export const WORKOUT_STRUCTURE_AI_TIMEOUT_MS = 45_000
+
+export const WORKOUT_STRUCTURE_AI_MAX_RETRIES = 0

--- a/tests/unit/server/utils/ai-tools/recommendations.test.ts
+++ b/tests/unit/server/utils/ai-tools/recommendations.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { recommendationTools } from '../../../../../server/utils/ai-tools/recommendations'
 import { recommendationRepository } from '../../../../../server/utils/repositories/recommendationRepository'
+import { activityRecommendationRepository } from '../../../../../server/utils/repositories/activityRecommendationRepository'
 
 vi.mock('../../../../../server/utils/repositories/recommendationRepository', () => ({
   recommendationRepository: {
     findById: vi.fn(),
     list: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/activityRecommendationRepository', () => ({
+  activityRecommendationRepository: {
+    findToday: vi.fn()
   }
 }))
 
@@ -16,6 +23,8 @@ describe('recommendationTools', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(activityRecommendationRepository.findToday).mockResolvedValue(null)
+    vi.mocked(recommendationRepository.list).mockResolvedValue([])
   })
 
   it('makes workout recommendations explicit that they are not scheduled or synced', async () => {
@@ -35,7 +44,41 @@ describe('recommendationTools', () => {
       expect.objectContaining({
         created: false,
         synced: false,
+        success: false,
         next_action: expect.stringContaining('create_planned_workout')
+      })
+    )
+  })
+
+  it('returns today activity recommendation when available', async () => {
+    vi.mocked(activityRecommendationRepository.findToday).mockResolvedValue({
+      id: 'act-rec-1',
+      recommendation: 'proceed',
+      confidence: 0.9,
+      reasoning: 'Readiness is good.',
+      status: 'COMPLETED',
+      analysisJson: null,
+      plannedWorkout: {
+        id: 'pw-1',
+        title: 'Easy Run',
+        type: 'Run',
+        durationSec: 3600,
+        tss: 45,
+        description: 'Zone 2 aerobic run.'
+      }
+    } as any)
+
+    const result = await tools.recommend_workout.execute(
+      { day_of_week: 2 },
+      { toolCallId: 'tool-1', messages: [] }
+    )
+
+    expect(result.recommendation).toEqual(
+      expect.objectContaining({
+        source: 'activity_recommendation',
+        title: 'Easy Run',
+        type: 'Run',
+        planned_workout_id: 'pw-1'
       })
     )
   })

--- a/tests/unit/server/utils/structured-workout-renderable.test.ts
+++ b/tests/unit/server/utils/structured-workout-renderable.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { hasRenderableStructure } from '../../../../server/utils/structured-workout-persistence'
+
+describe('hasRenderableStructure', () => {
+  it('detects blocks-only strength structures', () => {
+    expect(
+      hasRenderableStructure({
+        blocks: [{ name: 'Main', steps: [{ name: 'Squat' }] }]
+      })
+    ).toBe(true)
+  })
+
+  it('returns false for empty structures', () => {
+    expect(hasRenderableStructure(null)).toBe(false)
+    expect(hasRenderableStructure({ steps: [] })).toBe(false)
+  })
+})

--- a/trigger/adjust-structured-workout.ts
+++ b/trigger/adjust-structured-workout.ts
@@ -48,8 +48,13 @@ import {
   estimateStepDurationSeconds,
   normalizeStructuredWorkoutForPersistence,
   selectStepIntensity,
-  computeStrengthExerciseMetrics
+  computeStrengthExerciseMetrics,
+  hasRenderableStructure
 } from '../server/utils/structured-workout-persistence'
+import {
+  WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+  WORKOUT_STRUCTURE_AI_TIMEOUT_MS
+} from '../server/utils/workout-ai-timeouts'
 
 const workoutStructureSchema = {
   type: 'object',
@@ -693,6 +698,7 @@ export const adjustStructuredWorkoutTask = task({
     adjustments: any
     targetingOverride?: WorkoutTargetingOverride | null
     generatorOverride?: StructuredWorkoutGeneratorMode | null
+    quotaCheckedAtEnqueue?: boolean
   }) => {
     const { plannedWorkoutId, workoutTemplateId, adjustments } = payload
     const entityId = plannedWorkoutId || workoutTemplateId
@@ -700,7 +706,6 @@ export const adjustStructuredWorkoutTask = task({
     if (!entityId) throw new Error('Planned workout ID or workout template ID is required')
     const startedAtMs = Date.now()
     const MAX_DURATION_MS = 180_000
-    const STRUCTURED_WORKOUT_TIMEOUT_MS = 45_000
     const logStage = (stage: string, meta: Record<string, any> = {}) => {
       const elapsedMs = Date.now() - startedAtMs
       logger.log(`[AdjustStructuredWorkout] ${stage}`, {
@@ -1109,8 +1114,8 @@ export const adjustStructuredWorkoutTask = task({
               operation: 'adjust_structured_workout',
               entityType,
               entityId: entityId!,
-              maxRetries: 0,
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
+              maxRetries: WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+              timeoutMs: WORKOUT_STRUCTURE_AI_TIMEOUT_MS,
               modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
               thinkingLevelOverride: isRetry ? 'high' : undefined
             }
@@ -1138,8 +1143,8 @@ export const adjustStructuredWorkoutTask = task({
               operation: 'adjust_structured_workout',
               entityType,
               entityId: entityId!,
-              maxRetries: 0, // We handle retries manually here to change models
-              timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS,
+              maxRetries: WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+              timeoutMs: WORKOUT_STRUCTURE_AI_TIMEOUT_MS,
               modelOverride: isRetry ? 'gemini-3-pro-preview' : undefined,
               thinkingLevelOverride: isRetry ? 'high' : undefined
             }
@@ -1404,9 +1409,9 @@ export const adjustStructuredWorkoutTask = task({
         }
         normalizeCooldownRampDirection(step)
 
-        let stepDistance = 0
-        let stepDuration = 0
-        let stepTSS = 0
+        let stepDistance: number
+        let stepDuration: number
+        let stepTSS: number
 
         if (step.steps && Array.isArray(step.steps) && step.steps.length > 0) {
           const nested = normalizeAndCalculate(step.steps, depth + 1, step)
@@ -1485,19 +1490,34 @@ export const adjustStructuredWorkoutTask = task({
       totalDuration += strengthMetrics.durationSec
       totalTSS += strengthMetrics.tss
     }
+    if (Array.isArray(structure.blocks) && structure.blocks.length > 0) {
+      let blockDuration = 0
+      for (const block of structure.blocks) {
+        const blockSteps = Array.isArray(block?.steps) ? block.steps : []
+        for (const step of blockSteps) {
+          blockDuration += Number(step?.durationSeconds || step?.duration || 0)
+        }
+      }
+      totalDuration += blockDuration
+      if (blockDuration > 0 && totalTSS === 0) {
+        totalTSS += (blockDuration / 3600) * 40
+      }
+    }
     logStage('structure-normalized', {
       totalDistance,
       totalDuration,
       totalTSS: Math.round(totalTSS * 100) / 100
     })
 
-    const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
-    const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
-    if ((hasSteps || hasExercises) && totalDuration <= 0) {
+    const renderable = hasRenderableStructure(structure)
+    if (renderable && totalDuration <= 0) {
       throw new Error('Adjusted structured workout has zero total duration')
     }
-    if ((hasSteps || hasExercises) && totalTSS <= 0) {
+    if (renderable && totalTSS <= 0) {
       throw new Error('Adjusted structured workout has zero total TSS')
+    }
+    if (!renderable) {
+      throw new Error('Adjusted structured workout has no renderable steps, exercises, or blocks')
     }
 
     const settingsSnapshot = buildPlannedWorkoutSettingsSnapshot(

--- a/trigger/generate-ad-hoc-workout.ts
+++ b/trigger/generate-ad-hoc-workout.ts
@@ -1,6 +1,10 @@
 import './init'
 import { logger, task, tasks } from '@trigger.dev/sdk/v3'
 import { generateStructuredAnalysis, buildWorkoutSummary } from '../server/utils/gemini'
+import {
+  WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+  WORKOUT_STRUCTURE_AI_TIMEOUT_MS
+} from '../server/utils/workout-ai-timeouts'
 import { prisma } from '../server/utils/db'
 import { workoutRepository } from '../server/utils/repositories/workoutRepository'
 import { wellnessRepository } from '../server/utils/repositories/wellnessRepository'
@@ -181,7 +185,9 @@ export const generateAdHocWorkoutTask = task({
     const suggestion = await generateStructuredAnalysis(prompt, adHocWorkoutSchema, 'flash', {
       userId,
       operation: 'generate_ad_hoc_workout',
-      entityType: 'PlannedWorkout'
+      entityType: 'PlannedWorkout',
+      timeoutMs: WORKOUT_STRUCTURE_AI_TIMEOUT_MS,
+      maxRetries: WORKOUT_STRUCTURE_AI_MAX_RETRIES
     })
 
     // Create Planned Workout

--- a/trigger/generate-structured-workout.ts
+++ b/trigger/generate-structured-workout.ts
@@ -9,6 +9,18 @@ import { workoutRepository } from '../server/utils/repositories/workoutRepositor
 import { sportSettingsRepository } from '../server/utils/repositories/sportSettingsRepository'
 import { getUserTimezone, getUserLocalDate } from '../server/utils/date'
 import { checkQuota } from '../server/utils/quotas/engine'
+import {
+  hasRenderableStructure,
+  estimateStepDistanceMeters,
+  estimateStepDurationSeconds,
+  normalizeStructuredWorkoutForPersistence,
+  selectStepIntensity,
+  computeStrengthExerciseMetrics
+} from '../server/utils/structured-workout-persistence'
+import {
+  WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+  WORKOUT_STRUCTURE_AI_TIMEOUT_MS
+} from '../server/utils/workout-ai-timeouts'
 import { enforceCyclingCadenceVariation, resolveCyclingCadence } from './utils/cadence'
 import {
   resolveWorkoutTargeting,
@@ -43,13 +55,6 @@ import {
   isDraftStructuredWorkoutSupported,
   workoutPlanDraftSchema
 } from '../server/utils/structured-workout-draft'
-import {
-  estimateStepDistanceMeters,
-  estimateStepDurationSeconds,
-  normalizeStructuredWorkoutForPersistence,
-  selectStepIntensity,
-  computeStrengthExerciseMetrics
-} from '../server/utils/structured-workout-persistence'
 
 const workoutStructureSchema = {
   type: 'object',
@@ -827,6 +832,7 @@ export const generateStructuredWorkoutTask = task({
     workoutTemplateId?: string
     targetingOverride?: WorkoutTargetingOverride | null
     generatorOverride?: StructuredWorkoutGeneratorMode | null
+    quotaCheckedAtEnqueue?: boolean
   }) => {
     const { plannedWorkoutId, workoutTemplateId } = payload
     const entityId = plannedWorkoutId || workoutTemplateId
@@ -958,18 +964,20 @@ export const generateStructuredWorkoutTask = task({
       })
     }
 
-    // Check Quota
-    try {
-      await checkQuota(workout.userId, 'generate_structured_workout')
-    } catch (quotaError: any) {
-      if (quotaError.statusCode === 429) {
-        logger.warn('Structured workout generation quota exceeded', {
-          userId: workout.userId,
-          entityId
-        })
-        return { success: false, reason: 'QUOTA_EXCEEDED' }
+    // Check Quota (skip when already validated at enqueue time)
+    if (!payload.quotaCheckedAtEnqueue) {
+      try {
+        await checkQuota(workout.userId, 'generate_structured_workout')
+      } catch (quotaError: any) {
+        if (quotaError.statusCode === 429) {
+          logger.warn('Structured workout generation quota exceeded', {
+            userId: workout.userId,
+            entityId
+          })
+          return { success: false, reason: 'QUOTA_EXCEEDED' }
+        }
+        throw quotaError
       }
-      throw quotaError
     }
     logStage('quota-check-passed')
 
@@ -1039,8 +1047,9 @@ export const generateStructuredWorkoutTask = task({
           limitDate: fourWeeksFromNow
         })
         return {
-          success: true,
+          success: false,
           skipped: true,
+          reason: 'FREE_TIER_LIMIT',
           message: 'Structured workout generation is limited to 4 weeks in advance for free users.'
         }
       }
@@ -1582,9 +1591,9 @@ export const generateStructuredWorkoutTask = task({
         normalizeCooldownRampDirection(step)
 
         // 4. Recurse and Calculate
-        let stepDistance = 0
-        let stepDuration = 0
-        let stepTSS = 0
+        let stepDistance: number
+        let stepDuration: number
+        let stepTSS: number
 
         if (step.steps && Array.isArray(step.steps) && step.steps.length > 0) {
           const nested = normalizeAndCalculate(step.steps, depth + 1, step)
@@ -1667,7 +1676,7 @@ export const generateStructuredWorkoutTask = task({
     if (structure.exercises && Array.isArray(structure.exercises)) {
       let gymDuration = 0
       structure.exercises.forEach((ex: any) => {
-        let exDuration = 0
+        let exDuration: number
         if (ex.duration) exDuration = ex.duration
         else {
           const sets = ex.sets || 1
@@ -1699,19 +1708,35 @@ export const generateStructuredWorkoutTask = task({
         totalTSS += (gymDuration / 3600) * 40
       }
     }
+
+    if (Array.isArray(structure.blocks) && structure.blocks.length > 0) {
+      let blockDuration = 0
+      for (const block of structure.blocks) {
+        const blockSteps = Array.isArray(block?.steps) ? block.steps : []
+        for (const step of blockSteps) {
+          blockDuration += Number(step?.durationSeconds || step?.duration || 0)
+        }
+      }
+      totalDuration += blockDuration
+      if (blockDuration > 0 && totalTSS === 0) {
+        totalTSS += (blockDuration / 3600) * 40
+      }
+    }
     logStage('structure-normalized', {
       totalDistance,
       totalDuration,
       totalTSS: Math.round(totalTSS * 100) / 100
     })
 
-    const hasSteps = Array.isArray(structure.steps) && structure.steps.length > 0
-    const hasExercises = Array.isArray(structure.exercises) && structure.exercises.length > 0
-    if ((hasSteps || hasExercises) && totalDuration <= 0) {
+    const renderable = hasRenderableStructure(structure)
+    if (renderable && totalDuration <= 0) {
       throw new Error('Generated structured workout has zero total duration')
     }
-    if ((hasSteps || hasExercises) && totalTSS <= 0) {
+    if (renderable && totalTSS <= 0) {
       throw new Error('Generated structured workout has zero total TSS')
+    }
+    if (!renderable) {
+      throw new Error('Generated structured workout has no renderable steps, exercises, or blocks')
     }
 
     const settingsSnapshot = buildPlannedWorkoutSettingsSnapshot(

--- a/trigger/generate-workout-messages.ts
+++ b/trigger/generate-workout-messages.ts
@@ -1,6 +1,10 @@
 import './init'
 import { logger, task } from '@trigger.dev/sdk/v3'
 import { generateStructuredAnalysis } from '../server/utils/gemini'
+import {
+  WORKOUT_STRUCTURE_AI_MAX_RETRIES,
+  WORKOUT_STRUCTURE_AI_TIMEOUT_MS
+} from '../server/utils/workout-ai-timeouts'
 import { prisma } from '../server/utils/db'
 import { userReportsQueue } from './queues'
 import { publishActivityEvent } from '../server/utils/activity-realtime'
@@ -81,7 +85,9 @@ export const generateWorkoutMessagesTask = task({
         userId: workout.userId,
         operation: 'generate_workout_messages',
         entityType: 'PlannedWorkout',
-        entityId: plannedWorkoutId
+        entityId: plannedWorkoutId,
+        timeoutMs: WORKOUT_STRUCTURE_AI_TIMEOUT_MS,
+        maxRetries: WORKOUT_STRUCTURE_AI_MAX_RETRIES
       }
     )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the remaining **Open** issues from the workout structure generation review tracker (issues 003–031), building on prior draft PRs #214–#221.

## Changes

### UI / UX
- **003** — Free-tier skip shows warning toast; trigger returns `success: false` with `reason: FREE_TIER_LIMIT`
- **006** — Planned workout details toast copy updated to “up to 2 minutes”
- **010** — Plan dashboard batch generation keeps loading until all queued structure jobs complete or fail
- **019** — Chat cards use `hasStructuredWorkoutPreviewData()` (includes strength `blocks`)
- **024** — Removed fuzzy same-day workout ID fallback; shows error when `workout_id` missing

### Backend / triggers
- **007, 012 (partial)** — Shared `workout-ai-timeouts.ts` applied to structure, adjust, ad-hoc, and messages tasks
- **009** — Skip in-trigger quota re-check when `quotaCheckedAtEnqueue: true` (API/chat enqueue paths)
- **011** — `adjust-structured-workout` uses `hasRenderableStructure()` including blocks duration
- **020** — Defer Intervals auto-upload on create until structure exists (chat `create_planned_workout`)
- **025** — Slim `get_planned_workout_details` response (summary, not full structure dump)
- **026** — Preflight workout existence for generate/adjust structure tools
- **021** — `recommend_workout` reads today's activity recommendation or active profile recommendations (no stub)
- **022** — Reject patch/set while structure job in flight; planning skill warns against mixing sync + async edits

### Infra / monitor
- **030** — Library generate-structure tags session actor + template owner; publishes run-started event
- **031** — WebSocket reconnects and re-authenticates on session identity change

## Testing

- Added unit test for `hasRenderableStructure()`
- Updated `recommendations.test.ts` for real recommendation wiring
- Full vitest suite not run in cloud pod (`nuxt prepare` / missing `unstorage`)

## Related

- Docs tracker update on `cursor/workout-generation-issues-docs-7804`
- Draft — do not merge until reviewed alongside #214–#221 (several touch `planning.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3e09-962b-7524-bc45-6aee933e7804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

