### PR TITLE
Fix test failures and resolve planning.ts merge artifact

### DIFF
--- a/server/utils/ai-tools/planning.ts
+++ b/server/utils/ai-tools/planning.ts
@@ -983,7 +983,7 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
       }
 
       const shouldGenerate = args.generate_structure !== false
-      let structureStatus: StructureGenerationStatus = 'skipped'
+      const structureStatus: StructureGenerationStatus = 'skipped'
       let runId: string | undefined
       if (args.generate_structure !== false) {
         try {
@@ -1080,10 +1080,10 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
 
       const workout = await plannedWorkoutRepository.update(args.workout_id, userId, data)
 
-      const shouldRegenerateStructure = args.generate_structure !== false
       let structureStatus: StructureGenerationStatus = 'skipped'
+      let structureError: string | undefined
       let runId: string | undefined
-      if (args.generate_structure !== false) {
+      if (shouldRegenerateStructure) {
         try {
           const handle = await generateStructuredWorkoutTask.trigger(
             {
@@ -1099,9 +1099,12 @@ export const planningTools = (userId: string, timezone: string, aiSettings: AiSe
           await publishTaskRunStartedEvent(userId, 'generate-structured-workout', handle, {
             tags: [`user:${userId}`, `planned-workout:${workout.id}`]
           })
+          structureStatus = 'queued'
           runId = handle.id
         } catch (e) {
           console.error('Failed to trigger structured workout regeneration:', e)
+          structureStatus = 'failed'
+          structureError = e instanceof Error ? e.message : String(e)
         }
       }
 

--- a/tests/unit/app/utils/user-runs-client.test.ts
+++ b/tests/unit/app/utils/user-runs-client.test.ts
@@ -5,7 +5,7 @@ import {
   pruneRunsForCurrentUser,
   runBelongsToUser,
   type TriggerRun
-} from '../../../app/utils/user-runs-client'
+} from '../../../../app/utils/user-runs-client'
 
 describe('user-runs-client', () => {
   it('matches runs to the current user tag', () => {

--- a/tests/unit/server/api/admin/user-deactivate.test.ts
+++ b/tests/unit/server/api/admin/user-deactivate.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getServerSession } from '../../../../../server/utils/session'
 import { deactivateAccount } from '../../../../../server/utils/services/accountDeactivationService'
 
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+
 vi.mock('h3', () => ({
   defineEventHandler: (fn: any) => fn,
   getRouterParam: (event: any, key: string) => event.context?.params?.[key],

--- a/tests/unit/server/api/admin/user-reactivate.test.ts
+++ b/tests/unit/server/api/admin/user-reactivate.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getServerSession } from '../../../../../server/utils/session'
 import { reactivateAccount } from '../../../../../server/utils/services/accountDeactivationService'
 
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+
 vi.mock('h3', () => ({
   defineEventHandler: (fn: any) => fn,
   getRouterParam: (event: any, key: string) => event.context?.params?.[key],

--- a/tests/unit/server/api/calendar/index.get.test.ts
+++ b/tests/unit/server/api/calendar/index.get.test.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getServerSession } from '../../../../../server/utils/session'
 import { prisma } from '../../../../../server/utils/db'
 import {
+  formatDateUTC,
   getEndOfDayUTC,
+  getEndOfLocalDateUTC,
   getStartOfDayUTC,
+  getStartOfLocalDateUTC,
   getTimestampDateKey,
   getUserLocalDate
 } from '../../../../../server/utils/date'
@@ -50,10 +53,13 @@ vi.mock('../../../../../server/utils/db', () => ({
 }))
 
 vi.mock('../../../../../server/utils/date', () => ({
+  formatDateUTC: vi.fn((date: Date, _format?: string) => date.toISOString().split('T')[0]),
   getUserLocalDate: vi.fn(),
   getTimestampDateKey: vi.fn(),
   getStartOfDayUTC: vi.fn(),
-  getEndOfDayUTC: vi.fn()
+  getEndOfDayUTC: vi.fn(),
+  getStartOfLocalDateUTC: vi.fn(),
+  getEndOfLocalDateUTC: vi.fn()
 }))
 
 vi.mock('../../../../../server/utils/repositories/nutritionRepository', () => ({
@@ -119,6 +125,12 @@ describe('GET /api/calendar threshold milestones', () => {
     vi.mocked(getUserLocalDate).mockReturnValue(new Date('2026-03-12T00:00:00Z'))
     vi.mocked(getStartOfDayUTC).mockImplementation((_tz: string, date: Date) => date)
     vi.mocked(getEndOfDayUTC).mockImplementation((_tz: string, date: Date) => date)
+    vi.mocked(getStartOfLocalDateUTC).mockImplementation((_tz: string, dateStr: string) => {
+      return new Date(`${dateStr}T00:00:00.000Z`)
+    })
+    vi.mocked(getEndOfLocalDateUTC).mockImplementation((_tz: string, dateStr: string) => {
+      return new Date(`${dateStr}T23:59:59.999Z`)
+    })
     vi.mocked(getTimestampDateKey).mockImplementation(
       (date: Date) => date.toISOString().split('T')[0]
     )

--- a/tests/unit/server/api/join-code.test.ts
+++ b/tests/unit/server/api/join-code.test.ts
@@ -41,7 +41,7 @@ describe('join code endpoint', () => {
       coachId: 'coach-1',
       code: 'ABC12345',
       status: 'PENDING',
-      expiresAt: new Date('2026-04-20T00:00:00Z'),
+      expiresAt: new Date('2026-12-31T00:00:00Z'),
       email: null,
       coach: {
         id: 'coach-1',

--- a/tests/unit/server/api/workouts/link.post.test.ts
+++ b/tests/unit/server/api/workouts/link.post.test.ts
@@ -23,10 +23,10 @@ vi.mock('../../../../../server/utils/session', () => ({
 vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
     workout: {
-      findUnique: vi.fn()
+      findFirst: vi.fn()
     },
     plannedWorkout: {
-      findUnique: vi.fn()
+      findFirst: vi.fn()
     },
     $transaction: vi.fn()
   }
@@ -64,12 +64,12 @@ describe('POST /api/workouts/[id]/link', () => {
   it('rejects linking workouts from different local days', async () => {
     const handler = await getHandler()
 
-    vi.mocked(prisma.workout.findUnique).mockResolvedValue({
+    vi.mocked(prisma.workout.findFirst).mockResolvedValue({
       id: 'workout-1',
       userId: 'user-1',
       date: new Date('2026-03-28T18:22:47Z')
     } as any)
-    vi.mocked(prisma.plannedWorkout.findUnique).mockResolvedValue({
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue({
       id: 'planned-1',
       userId: 'user-1',
       date: new Date('2026-03-29T00:00:00Z')

--- a/tests/unit/server/utils/intervals-sync.test.ts
+++ b/tests/unit/server/utils/intervals-sync.test.ts
@@ -34,6 +34,12 @@ vi.mock('../../../../server/utils/intervals', () => ({
   isIntervalsEventId: vi.fn((value: string | null | undefined) => /^\d+$/.test(value || ''))
 }))
 
+vi.mock('../../../../server/utils/repositories/plannedWorkoutPublishRepository', () => ({
+  plannedWorkoutPublishRepository: {
+    upsert: vi.fn().mockResolvedValue(undefined)
+  }
+}))
+
 describe('intervals-sync helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/tests/unit/server/utils/services/intervalsService.test.ts
+++ b/tests/unit/server/utils/services/intervalsService.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { prisma } from '../../../../../server/utils/db'
 import {
   normalizeIntervalsWorkout,
+  fetchIntervalsActivity,
   fetchIntervalsWorkouts
 } from '../../../../../server/utils/intervals'
 import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
@@ -19,7 +20,13 @@ vi.mock('../../../../../server/utils/db', () => ({
       upsert: vi.fn()
     },
     user: { findUnique: vi.fn(), update: vi.fn() },
-    workout: { findUnique: vi.fn(), update: vi.fn(), findFirst: vi.fn(), delete: vi.fn() },
+    workout: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      delete: vi.fn()
+    },
     workoutStream: { upsert: vi.fn() }
   }
 }))
@@ -200,6 +207,14 @@ describe('IntervalsService syncActivities batch filtering', () => {
     vi.clearAllMocks()
     vi.mocked(prisma.workout.findMany).mockResolvedValue([])
     vi.mocked(prisma.integration.findUnique).mockResolvedValue(null as any)
+    vi.mocked(fetchIntervalsActivity).mockImplementation(async (_integration, id) => ({
+      id,
+      start_date: '2026-04-27T17:41:56Z',
+      name: 'Recovered Ride',
+      type: 'Ride',
+      moving_time: 3600,
+      source: 'STRAVA'
+    }))
     vi.mocked(workoutRepository.upsert).mockResolvedValue({
       record: { id: 'w-sync' } as any,
       isNew: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes 13 failing tests on `develop` by resolving a merge artifact in `planning.ts` and aligning unit test mocks with current handler behavior.

## Code fix

- **`update_planned_workout`**: Removed duplicate `shouldRegenerateStructure` declaration (compile error blocking 3 test suites). Structure regeneration now consistently uses opt-in `generate_structure === true` behavior and sets `structureStatus` / `structureError` on trigger success/failure.

## Test alignment

- Admin deactivate/reactivate: stub `defineEventHandler` globally
- Calendar API: mock `getStartOfLocalDateUTC`, `getEndOfLocalDateUTC`, and `formatDateUTC`
- Workout link API: mock `findFirst` instead of `findUnique`
- IntervalsService: add `findMany` to Prisma mock and stub `fetchIntervalsActivity`
- Intervals sync: mock `plannedWorkoutPublishRepository.upsert`
- Join code: use a non-expired invite date (April 2026 had passed)
- User runs client: fix import path depth

## Test plan

- [x] `pnpm test run` — **861/861 tests passing**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f41c7-2963-7622-9bd6-e7bef9f11517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f41c7-2963-7622-9bd6-e7bef9f11517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

