### PR TITLE
fix(ingest): date windows, quota checks, sync guards, stuck PROCESSING (171, 172, 175, 177, 108, 106, 060)

### DIFF
--- a/docs/issues/060-integration-syncstatus-stuck.md
+++ b/docs/issues/060-integration-syncstatus-stuck.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `integrations`, `backend`, `data`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `ingest-strava` and `ingest-intervals` use `finally` blocks to always clear `SYNCING` to a terminal `SUCCESS` or `FAILED` status.
 
 ## Description
 
@@ -48,5 +50,5 @@ Use `finally` block to set terminal status; add stale-SYNCING recovery job or ti
 
 ## Acceptance Criteria
 
-- [ ] Normal and abnormal task exit clears SYNCING state
-- [ ] UI reflects accurate sync status after task ends
+- [x] Normal and abnormal task exit clears SYNCING state
+- [x] UI reflects accurate sync status after task ends

--- a/docs/issues/106-sync-queue-duplicate-processing.md
+++ b/docs/issues/106-sync-queue-duplicate-processing.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `integrations, data`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `process-sync-queue` atomically claims `PENDING` items with `updateMany` (`PENDING` → `PROCESSING`) before processing.
 
 ## Description
 
@@ -31,5 +33,5 @@ Add claim step or SELECT FOR UPDATE.
 
 ## Acceptance Criteria
 
-- [ ] Bug no longer reproducible via steps above
-- [ ] Appropriate error handling or auth in place
+- [x] Bug no longer reproducible via steps above
+- [x] Appropriate error handling or auth in place

--- a/docs/issues/108-integration-sync-no-inflight-guard.md
+++ b/docs/issues/108-integration-sync-no-inflight-guard.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `integrations, ui/ux`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `POST /api/integrations/sync` returns 409 when the target integration (or any integration for `all`) has `syncStatus === 'SYNCING'`.
 
 ## Description
 
@@ -31,5 +33,5 @@ Check running ingest tasks; return 409 if sync in progress.
 
 ## Acceptance Criteria
 
-- [ ] Bug no longer reproducible via steps above
-- [ ] Appropriate error handling or auth in place
+- [x] Bug no longer reproducible via steps above
+- [x] Appropriate error handling or auth in place

--- a/docs/issues/171-ingest-hevy-no-date-window.md
+++ b/docs/issues/171-ingest-hevy-no-date-window.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `integrations, data`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `ingest-hevy` accepts `startDate`/`endDate` from ingest-all and stops pagination once workouts fall outside the requested window.
 
 ## Description
 
@@ -20,5 +22,5 @@ Run ingest-all with Hevy connected; entire history pulled not 7-day window.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
-- [ ] Appropriate fix verified
+- [x] Issue no longer reproducible
+- [x] Appropriate fix verified

--- a/docs/issues/172-garmin-ingest-clamps-24h-window.md
+++ b/docs/issues/172-garmin-ingest-clamps-24h-window.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `integrations, data`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `ingest-garmin` chunks multi-day windows into consecutive 24-hour slices via `buildGarminTimeSlices` instead of clamping to the last day.
 
 ## Description
 
@@ -20,5 +22,5 @@ Sync all with Garmin; only last day ingested despite 7-day batch window.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
-- [ ] Appropriate fix verified
+- [x] Issue no longer reproducible
+- [x] Appropriate fix verified

--- a/docs/issues/175-wellness-analysis-no-quota-check.md
+++ b/docs/issues/175-wellness-analysis-no-quota-check.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `ai, wellness`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `analyzeWellness` calls `checkQuota(userId, 'wellness_analysis')` before `generateStructuredAnalysis` and marks records `QUOTA_EXCEEDED` on 429.
 
 ## Description
 
@@ -20,5 +22,5 @@ Trigger analyze-wellness directly beyond free-tier wellness quota.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
-- [ ] Appropriate fix verified
+- [x] Issue no longer reproducible
+- [x] Appropriate fix verified

--- a/docs/issues/177-recommend-today-processing-stuck-on-failure.md
+++ b/docs/issues/177-recommend-today-processing-stuck-on-failure.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `planning, ai`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `recommend-today-activity` wraps generation in try/catch and sets `ActivityRecommendation.status = FAILED` on any uncaught error.
 
 ## Description
 
@@ -20,5 +22,5 @@ Fail recommend-today task; recommendation row stuck PROCESSING.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
-- [ ] Appropriate fix verified
+- [x] Issue no longer reproducible
+- [x] Appropriate fix verified

--- a/server/api/integrations/sync.post.ts
+++ b/server/api/integrations/sync.post.ts
@@ -207,6 +207,28 @@ export default defineEventHandler(async (event) => {
         message: `${provider} integration not found. Please connect your account first.`
       })
     }
+
+    if (integration.syncStatus === 'SYNCING') {
+      throw createError({
+        statusCode: 409,
+        message: `${provider} sync is already in progress. Please wait for it to finish.`
+      })
+    }
+  } else {
+    const syncingIntegration = await prisma.integration.findFirst({
+      where: {
+        userId,
+        syncStatus: 'SYNCING'
+      },
+      select: { provider: true }
+    })
+
+    if (syncingIntegration) {
+      throw createError({
+        statusCode: 409,
+        message: `Sync already in progress for ${syncingIntegration.provider}. Please wait for it to finish.`
+      })
+    }
   }
 
   // Trigger the appropriate job

--- a/server/utils/garmin.ts
+++ b/server/utils/garmin.ts
@@ -28,6 +28,23 @@ export function parseGarminScope(scope: string | null | undefined): Set<string> 
   )
 }
 
+export function buildGarminTimeSlices(
+  startTimestamp: number,
+  endTimestamp: number,
+  maxSliceSeconds = 86400
+): Array<{ startTimestamp: number; endTimestamp: number }> {
+  const slices: Array<{ startTimestamp: number; endTimestamp: number }> = []
+  let sliceStart = startTimestamp
+
+  while (sliceStart < endTimestamp) {
+    const sliceEnd = Math.min(sliceStart + maxSliceSeconds, endTimestamp)
+    slices.push({ startTimestamp: sliceStart, endTimestamp: sliceEnd })
+    sliceStart = sliceEnd
+  }
+
+  return slices
+}
+
 export function mergeGarminScopes(
   ...sources: Array<string | string[] | Set<string> | null | undefined>
 ): Set<string> {

--- a/server/utils/hevy.ts
+++ b/server/utils/hevy.ts
@@ -43,6 +43,30 @@ export interface HevyWorkoutsResponse {
   workouts: HevyWorkout[]
 }
 
+export function isHevyWorkoutInDateWindow(
+  workout: HevyWorkout,
+  startDate?: string,
+  endDate?: string
+): { inWindow: boolean; beforeWindow: boolean } {
+  if (!startDate && !endDate) {
+    return { inWindow: true, beforeWindow: false }
+  }
+
+  const workoutDate = new Date(workout.start_time)
+  const start = startDate ? new Date(startDate) : null
+  const end = endDate ? new Date(endDate) : null
+
+  if (start && workoutDate < start) {
+    return { inWindow: false, beforeWindow: true }
+  }
+
+  if (end && workoutDate > end) {
+    return { inWindow: false, beforeWindow: false }
+  }
+
+  return { inWindow: true, beforeWindow: false }
+}
+
 /**
  * Fetch workouts from Hevy API
  */

--- a/server/utils/services/wellness-analysis.ts
+++ b/server/utils/services/wellness-analysis.ts
@@ -5,6 +5,7 @@ import { getUserAiSettings } from '../ai-user-settings'
 import { auditLogRepository } from '../repositories/auditLogRepository'
 import { getUserLocalDate, getUserTimezone } from '../date'
 import { triggerDailyCheckinIfNeeded } from './checkin-service'
+import { checkQuota } from '../quotas/engine'
 import {
   getMoodLabel,
   getStressLabel,
@@ -147,6 +148,20 @@ export async function analyzeWellness(wellnessId: string, userId: string) {
         endDate
       })
     ])
+
+    try {
+      await checkQuota(userId, 'wellness_analysis')
+    } catch (quotaError: any) {
+      if (quotaError.statusCode === 429) {
+        console.log(`[WellnessAnalysis] Quota exceeded for user ${userId}`)
+        await prisma.wellness.update({
+          where: { id: wellnessId },
+          data: { aiAnalysisStatus: 'QUOTA_EXCEEDED' }
+        })
+        return { success: false, reason: 'QUOTA_EXCEEDED' }
+      }
+      throw quotaError
+    }
 
     const activeWellnessEvents = getActiveWellnessEventsForDate(wellnessEvents, wellness.date)
     const activeWellnessEventsContext =

--- a/tests/unit/server/api/integrations/sync.post.test.ts
+++ b/tests/unit/server/api/integrations/sync.post.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { tasks } from '@trigger.dev/sdk/v3'
+
+const prismaMock = vi.hoisted(() => ({
+  integration: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn()
+  }
+}))
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('prisma', prismaMock)
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+  getUserLocalDate: vi.fn(() => new Date('2026-03-10T00:00:00.000Z'))
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  tasks: {
+    trigger: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../server/utils/task-run-events', () => ({
+  publishTaskRunStartedEvent: vi.fn()
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/integrations/sync.post')
+  return mod.default
+}
+
+describe('POST /api/integrations/sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(tasks.trigger).mockResolvedValue({ id: 'job-1' } as any)
+  })
+
+  it('returns 409 when the provider integration is already syncing', async () => {
+    const handler = await getHandler()
+
+    prismaMock.integration.findUnique.mockResolvedValue({
+      id: 'integration-1',
+      provider: 'strava',
+      syncStatus: 'SYNCING'
+    })
+
+    await expect(
+      handler({
+        body: { provider: 'strava' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: 'strava sync is already in progress. Please wait for it to finish.'
+    })
+
+    expect(tasks.trigger).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 for sync-all when any integration is syncing', async () => {
+    const handler = await getHandler()
+
+    prismaMock.integration.findFirst.mockResolvedValue({
+      provider: 'garmin'
+    })
+
+    await expect(
+      handler({
+        body: { provider: 'all' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: 'Sync already in progress for garmin. Please wait for it to finish.'
+    })
+
+    expect(tasks.trigger).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/server/utils/garmin.test.ts
+++ b/tests/unit/server/utils/garmin.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchGarminActivityFile,
   fetchGarminData,
+  buildGarminTimeSlices,
   hasGarminPermission,
   mergeGarminScopes,
   parseGarminScope
@@ -28,6 +29,22 @@ beforeEach(() => {
   vi.restoreAllMocks()
   process.env.GARMIN_CLIENT_ID = 'test-client-id'
   process.env.GARMIN_CLIENT_SECRET = 'test-client-secret'
+})
+
+describe('buildGarminTimeSlices', () => {
+  it('returns a single slice for ranges within 24 hours', () => {
+    expect(buildGarminTimeSlices(1_000, 10_000)).toEqual([
+      { startTimestamp: 1_000, endTimestamp: 10_000 }
+    ])
+  })
+
+  it('chunks multi-day ranges into consecutive 24-hour slices', () => {
+    expect(buildGarminTimeSlices(0, 200_000)).toEqual([
+      { startTimestamp: 0, endTimestamp: 86_400 },
+      { startTimestamp: 86_400, endTimestamp: 172_800 },
+      { startTimestamp: 172_800, endTimestamp: 200_000 }
+    ])
+  })
 })
 
 describe('Garmin permission helpers', () => {

--- a/tests/unit/server/utils/hevy.test.ts
+++ b/tests/unit/server/utils/hevy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { isHevyWorkoutInDateWindow } from '../../../../server/utils/hevy'
+
+describe('isHevyWorkoutInDateWindow', () => {
+  const workout = {
+    id: 'workout-1',
+    title: 'Leg Day',
+    description: '',
+    start_time: '2026-03-05T10:00:00.000Z',
+    end_time: '2026-03-05T11:00:00.000Z',
+    exercises: []
+  }
+
+  it('treats workouts without a date window as in range', () => {
+    expect(isHevyWorkoutInDateWindow(workout)).toEqual({
+      inWindow: true,
+      beforeWindow: false
+    })
+  })
+
+  it('flags workouts older than the start date', () => {
+    expect(
+      isHevyWorkoutInDateWindow(workout, '2026-03-06T00:00:00.000Z', '2026-03-12T00:00:00.000Z')
+    ).toEqual({
+      inWindow: false,
+      beforeWindow: true
+    })
+  })
+
+  it('skips workouts newer than the end date without stopping pagination', () => {
+    expect(
+      isHevyWorkoutInDateWindow(workout, '2026-03-01T00:00:00.000Z', '2026-03-04T00:00:00.000Z')
+    ).toEqual({
+      inWindow: false,
+      beforeWindow: false
+    })
+  })
+
+  it('accepts workouts inside the requested window', () => {
+    expect(
+      isHevyWorkoutInDateWindow(workout, '2026-03-01T00:00:00.000Z', '2026-03-10T00:00:00.000Z')
+    ).toEqual({
+      inWindow: true,
+      beforeWindow: false
+    })
+  })
+})

--- a/tests/unit/server/utils/services/wellness-analysis.test.ts
+++ b/tests/unit/server/utils/services/wellness-analysis.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { prismaWellnessFindUnique, prismaWellnessUpdate, prismaUserFindUnique, checkQuotaMock } =
+  vi.hoisted(() => ({
+    prismaWellnessFindUnique: vi.fn(),
+    prismaWellnessUpdate: vi.fn(),
+    prismaUserFindUnique: vi.fn(),
+    checkQuotaMock: vi.fn()
+  }))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    wellness: {
+      findUnique: prismaWellnessFindUnique,
+      update: prismaWellnessUpdate
+    },
+    user: {
+      findUnique: prismaUserFindUnique
+    }
+  }
+}))
+
+vi.mock('../../../../server/utils/quotas/engine', () => ({
+  checkQuota: checkQuotaMock
+}))
+
+vi.mock('../../../../server/utils/ai-user-settings', () => ({
+  getUserAiSettings: vi.fn().mockResolvedValue({
+    aiPersona: 'Supportive',
+    aiModelPreference: 'gemini-2.0-flash-exp'
+  })
+}))
+
+vi.mock('../../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+  getUserLocalDate: vi.fn(() => new Date('2026-03-10T00:00:00.000Z'))
+}))
+
+vi.mock('../../../../server/utils/repositories/wellnessRepository', () => ({
+  wellnessRepository: {
+    getForUser: vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../../../../server/utils/services/wellnessEventService', () => ({
+  getWellnessEventOverlaysForUser: vi.fn().mockResolvedValue([]),
+  getActiveWellnessEventsForDate: vi.fn(() => []),
+  formatWellnessEventsForPrompt: vi.fn(() => '')
+}))
+
+vi.mock('../../../../server/utils/services/checkin-service', () => ({
+  triggerDailyCheckinIfNeeded: vi.fn()
+}))
+
+vi.mock('../../../../server/utils/gemini', () => ({
+  generateStructuredAnalysis: vi.fn()
+}))
+
+describe('analyzeWellness quota enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    prismaWellnessFindUnique.mockResolvedValue({
+      id: 'wellness-1',
+      date: new Date('2026-03-09T00:00:00.000Z'),
+      hrv: 55,
+      restingHr: 50,
+      sleepHours: 7.5,
+      recoveryScore: 80,
+      readiness: 8,
+      rawJson: {}
+    })
+    prismaUserFindUnique.mockResolvedValue({ language: 'English' })
+  })
+
+  it('marks wellness analysis as QUOTA_EXCEEDED when quota is exceeded', async () => {
+    const { analyzeWellness } = await import('../../../../server/utils/services/wellness-analysis')
+
+    const quotaError = Object.assign(new Error('Quota exceeded for wellness_analysis'), {
+      statusCode: 429
+    })
+    checkQuotaMock.mockRejectedValue(quotaError)
+
+    const result = await analyzeWellness('wellness-1', 'user-1')
+
+    expect(checkQuotaMock).toHaveBeenCalledWith('user-1', 'wellness_analysis')
+    expect(prismaWellnessUpdate).toHaveBeenCalledWith({
+      where: { id: 'wellness-1' },
+      data: { aiAnalysisStatus: 'QUOTA_EXCEEDED' }
+    })
+    expect(result).toEqual({ success: false, reason: 'QUOTA_EXCEEDED' })
+  })
+})

--- a/tests/unit/trigger/process-sync-queue.test.ts
+++ b/tests/unit/trigger/process-sync-queue.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { syncQueueFindMany, syncQueueUpdateMany, syncQueueUpdate, processSyncQueueItem } =
+  vi.hoisted(() => ({
+    syncQueueFindMany: vi.fn(),
+    syncQueueUpdateMany: vi.fn(),
+    syncQueueUpdate: vi.fn(),
+    processSyncQueueItem: vi.fn()
+  }))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    syncQueue: {
+      findMany: syncQueueFindMany,
+      updateMany: syncQueueUpdateMany,
+      update: syncQueueUpdate
+    }
+  }
+}))
+
+vi.mock('../../../server/utils/intervals-sync', () => ({
+  processSyncQueueItem
+}))
+
+vi.mock('../../../trigger/init', () => ({}))
+
+vi.mock('@trigger.dev/sdk/v3', async () => {
+  const actual = await vi.importActual('@trigger.dev/sdk/v3')
+  return {
+    ...actual,
+    logger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    task: vi.fn().mockImplementation((config) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+})
+
+describe('processSyncQueueTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('atomically claims pending items before processing them', async () => {
+    syncQueueFindMany.mockResolvedValue([
+      {
+        id: 'queue-1',
+        entityType: 'plannedWorkout',
+        entityId: 'planned-1',
+        operation: 'UPDATE',
+        attempts: 0
+      }
+    ])
+    syncQueueUpdateMany.mockResolvedValue({ count: 1 })
+    processSyncQueueItem.mockResolvedValue(true)
+    syncQueueUpdate.mockResolvedValue({})
+
+    const { processSyncQueueTask } = await import('../../../trigger/process-sync-queue')
+    await processSyncQueueTask.run({})
+
+    expect(syncQueueUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'queue-1',
+        status: 'PENDING'
+      },
+      data: {
+        status: 'PROCESSING',
+        lastAttempt: expect.any(Date)
+      }
+    })
+    expect(processSyncQueueItem).toHaveBeenCalled()
+  })
+
+  it('skips items that were already claimed by another worker', async () => {
+    syncQueueFindMany.mockResolvedValue([
+      {
+        id: 'queue-1',
+        entityType: 'plannedWorkout',
+        entityId: 'planned-1',
+        operation: 'UPDATE',
+        attempts: 0
+      }
+    ])
+    syncQueueUpdateMany.mockResolvedValue({ count: 0 })
+
+    const { processSyncQueueTask } = await import('../../../trigger/process-sync-queue')
+    await processSyncQueueTask.run({})
+
+    expect(processSyncQueueItem).not.toHaveBeenCalled()
+    expect(syncQueueUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/trigger/recommend-today-activity.test.ts
+++ b/tests/unit/trigger/recommend-today-activity.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { activityRecommendationUpdate, generateStructuredAnalysis } = vi.hoisted(() => ({
+  activityRecommendationUpdate: vi.fn(),
+  generateStructuredAnalysis: vi.fn()
+}))
+
+vi.mock('../../../trigger/init', () => ({}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    emailPreference: { findUnique: vi.fn() },
+    plannedWorkout: { findMany: vi.fn() },
+    report: { findFirst: vi.fn() },
+    goal: { findMany: vi.fn() },
+    weeklyTrainingPlan: { findFirst: vi.fn() },
+    event: { findMany: vi.fn() },
+    activityRecommendation: { update: vi.fn() }
+  }
+}))
+
+vi.mock('../../../server/utils/repositories/activityRecommendationRepository', () => ({
+  activityRecommendationRepository: {
+    update: activityRecommendationUpdate,
+    findById: vi.fn()
+  }
+}))
+
+vi.mock('../../../server/utils/quotas/engine', () => ({
+  checkQuota: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../../server/utils/ai-user-settings', () => ({
+  getUserAiSettings: vi.fn().mockResolvedValue({
+    aiPersona: 'Supportive',
+    aiModelPreference: 'gemini-2.0-flash-exp'
+  })
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  formatUserDate: vi.fn(() => 'March 10, 2026'),
+  getUserLocalDate: vi.fn(() => new Date('2026-03-10T00:00:00.000Z')),
+  formatDateUTC: vi.fn(() => '2026-03-10'),
+  calculateAge: vi.fn(() => 30),
+  getEndOfDayUTC: vi.fn(() => new Date('2026-03-10T23:59:59.999Z')),
+  getStartOfDaysAgoUTC: vi.fn(() => new Date('2026-03-04T00:00:00.000Z')),
+  getTimestampDateKey: vi.fn(() => '2026-03-10')
+}))
+
+vi.mock('../../../server/utils/repositories/workoutRepository', () => ({
+  workoutRepository: { getForUser: vi.fn().mockResolvedValue([]) }
+}))
+
+vi.mock('../../../server/utils/repositories/wellnessRepository', () => ({
+  wellnessRepository: {
+    getByDate: vi.fn().mockResolvedValue(null),
+    getForUser: vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../../../server/utils/repositories/recommendationRepository', () => ({
+  recommendationRepository: { list: vi.fn().mockResolvedValue([]) }
+}))
+
+vi.mock('../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: { getByUserId: vi.fn().mockResolvedValue([]) }
+}))
+
+vi.mock('../../../server/utils/repositories/availabilityRepository', () => ({
+  availabilityRepository: {
+    getForDay: vi.fn().mockResolvedValue(null),
+    getFullSchedule: vi.fn().mockResolvedValue([]),
+    formatForPrompt: vi.fn(() => '')
+  }
+}))
+
+vi.mock('../../../server/utils/training-stress', () => ({
+  calculateProjectedPMC: vi.fn(() => []),
+  getCurrentFitnessSummary: vi.fn().mockResolvedValue({
+    ctl: 50,
+    atl: 40,
+    tsb: 10,
+    formStatus: { status: 'Fresh', description: 'Ready' },
+    lastUpdated: new Date('2026-03-10T00:00:00.000Z')
+  })
+}))
+
+vi.mock('../../../server/utils/services/wellness-analysis', () => ({
+  analyzeWellness: vi.fn()
+}))
+
+vi.mock('../../../server/utils/services/checkin-service', () => ({
+  getCheckinHistoryContext: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('../../../server/utils/services/metabolicService', () => ({
+  metabolicService: { getMealTargetContext: vi.fn().mockResolvedValue(null) }
+}))
+
+vi.mock('../../../server/utils/services/bodyMetricResolver', () => ({
+  bodyMetricResolver: {
+    resolveEffectiveWeight: vi.fn().mockResolvedValue({ value: 70 })
+  }
+}))
+
+vi.mock('../../../server/utils/services/wellnessEventService', () => ({
+  getWellnessEventOverlaysForUser: vi.fn().mockResolvedValue([]),
+  getActiveWellnessEventsForDate: vi.fn(() => []),
+  formatWellnessEventsForPrompt: vi.fn(() => '')
+}))
+
+vi.mock('../../../server/utils/gemini', () => ({
+  generateStructuredAnalysis,
+  buildWorkoutSummary: vi.fn(() => '')
+}))
+
+vi.mock('@trigger.dev/sdk/v3', async () => {
+  const actual = await vi.importActual('@trigger.dev/sdk/v3')
+  return {
+    ...actual,
+    logger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    tasks: { trigger: vi.fn(), onFailure: vi.fn() },
+    task: vi.fn().mockImplementation((config) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+})
+
+describe('recommendTodayActivityTask', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    const { prisma } = await import('../../../server/utils/db')
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      timezone: 'UTC',
+      nutritionTrackingEnabled: false,
+      aiAutoAnalyzeReadiness: true,
+      language: 'English'
+    } as any)
+    vi.mocked(prisma.emailPreference.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([])
+    vi.mocked(prisma.report.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.goal.findMany).mockResolvedValue([])
+    vi.mocked(prisma.weeklyTrainingPlan.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.event.findMany).mockResolvedValue([])
+
+    generateStructuredAnalysis.mockRejectedValue(new Error('Gemini unavailable'))
+  })
+
+  it('marks the recommendation FAILED when generation fails outside the quota handler', async () => {
+    const { recommendTodayActivityTask } = await import('../../../trigger/recommend-today-activity')
+
+    await expect(
+      recommendTodayActivityTask.run({
+        userId: 'user-1',
+        date: new Date('2026-03-10T00:00:00.000Z'),
+        recommendationId: 'rec-1'
+      })
+    ).rejects.toThrow('Gemini unavailable')
+
+    expect(activityRecommendationUpdate).toHaveBeenCalledWith('rec-1', 'user-1', {
+      status: 'FAILED',
+      reasoning: 'Gemini unavailable'
+    })
+  })
+})

--- a/trigger/ingest-all.ts
+++ b/trigger/ingest-all.ts
@@ -131,7 +131,7 @@ export const ingestAllTask = task({
         case 'hevy':
           tasksTrigger.push({
             task: ingestHevyTask,
-            payload: { userId, fullSync: false }
+            payload: { userId, startDate, endDate, fullSync: false }
           })
           break
         case 'polar':

--- a/trigger/ingest-garmin.ts
+++ b/trigger/ingest-garmin.ts
@@ -6,7 +6,8 @@ import {
   fetchGarminDailies,
   fetchGarminSleeps,
   fetchGarminHRV,
-  fetchGarminActivities
+  fetchGarminActivities,
+  buildGarminTimeSlices
 } from '../server/utils/garmin'
 import { userIngestionQueue } from './queues'
 
@@ -67,18 +68,12 @@ export const ingestGarminTask = task({
       isEndNan: isNaN(endTimestamp!)
     })
 
-    // Garmin Pull API enforces a strict 24-hour (86400s) maximum range.
-    // If the requested range is larger, we clamp it to the last 24 hours of the range.
-    if (endTimestamp - startTimestamp > 86400) {
-      logger.warn(
-        `Garmin requested range too large (${endTimestamp - startTimestamp}s). Clamping to 24 hours.`,
-        {
-          originalStart: startTimestamp,
-          clampedStart: endTimestamp - 86400,
-          end: endTimestamp
-        }
+    const timeSlices = buildGarminTimeSlices(startTimestamp!, endTimestamp)
+    if (timeSlices.length > 1) {
+      logger.log(
+        `Garmin requested range spans ${endTimestamp - startTimestamp!}s. Processing ${timeSlices.length} 24h slices.`,
+        { sliceCount: timeSlices.length, startTimestamp, endTimestamp }
       )
-      startTimestamp = endTimestamp - 86400
     }
 
     logger.log(`Starting Garmin ingestion for user ${userId}`, { startTimestamp, endTimestamp })
@@ -93,23 +88,40 @@ export const ingestGarminTask = task({
       const wellnessEnabled = shouldIngestWellness(settings)
       const workoutsEnabled = shouldIngestActivities('garmin', integration.ingestWorkouts, settings)
 
-      const results = await Promise.allSettled([
-        wellnessEnabled ? fetchGarminDailies(integration, startTimestamp, endTimestamp) : [],
-        wellnessEnabled ? fetchGarminSleeps(integration, startTimestamp, endTimestamp) : [],
-        wellnessEnabled ? fetchGarminHRV(integration, startTimestamp, endTimestamp) : [],
-        workoutsEnabled ? fetchGarminActivities(integration, startTimestamp, endTimestamp) : []
-      ])
+      const dailies: Awaited<ReturnType<typeof fetchGarminDailies>> = []
+      const sleeps: Awaited<ReturnType<typeof fetchGarminSleeps>> = []
+      const hrv: Awaited<ReturnType<typeof fetchGarminHRV>> = []
+      const activities: Awaited<ReturnType<typeof fetchGarminActivities>> = []
+      const results: PromiseSettledResult<unknown>[] = []
 
-      const dailies = results[0].status === 'fulfilled' ? results[0].value : []
-      const sleeps = results[1].status === 'fulfilled' ? results[1].value : []
-      const hrv = results[2].status === 'fulfilled' ? results[2].value : []
-      const activities = results[3].status === 'fulfilled' ? results[3].value : []
+      for (const slice of timeSlices) {
+        const sliceResults = await Promise.allSettled([
+          wellnessEnabled
+            ? fetchGarminDailies(integration, slice.startTimestamp, slice.endTimestamp)
+            : [],
+          wellnessEnabled
+            ? fetchGarminSleeps(integration, slice.startTimestamp, slice.endTimestamp)
+            : [],
+          wellnessEnabled
+            ? fetchGarminHRV(integration, slice.startTimestamp, slice.endTimestamp)
+            : [],
+          workoutsEnabled
+            ? fetchGarminActivities(integration, slice.startTimestamp, slice.endTimestamp)
+            : []
+        ])
 
-      // Log errors for failed requests
+        results.push(...sliceResults)
+
+        if (sliceResults[0].status === 'fulfilled') dailies.push(...sliceResults[0].value)
+        if (sliceResults[1].status === 'fulfilled') sleeps.push(...sliceResults[1].value)
+        if (sliceResults[2].status === 'fulfilled') hrv.push(...sliceResults[2].value)
+        if (sliceResults[3].status === 'fulfilled') activities.push(...sliceResults[3].value)
+      }
+
+      const types = ['dailies', 'sleeps', 'hrv', 'activities']
       results.forEach((result, index) => {
         if (result.status === 'rejected') {
-          const types = ['dailies', 'sleeps', 'hrv', 'activities']
-          const type = types[index]
+          const type = types[index % types.length]
           const error = result.reason
 
           console.error(`[DEBUG] Garmin fetch failed for ${type}:`, error)

--- a/trigger/ingest-hevy.ts
+++ b/trigger/ingest-hevy.ts
@@ -6,7 +6,8 @@ import { shouldIngestActivities } from '../server/utils/integration-settings'
 import {
   fetchHevyWorkouts,
   fetchHevyExerciseTemplate,
-  normalizeHevyWorkout
+  normalizeHevyWorkout,
+  isHevyWorkoutInDateWindow
 } from '../server/utils/hevy'
 import { roundToTwoDecimals } from '../server/utils/number'
 import type { IngestionResult } from './types'
@@ -15,8 +16,13 @@ export const ingestHevyTask = task({
   id: 'ingest-hevy',
   queue: userIngestionQueue,
   maxDuration: 900, // 15 minutes
-  run: async (payload: { userId: string; fullSync?: boolean }): Promise<IngestionResult> => {
-    const { userId, fullSync } = payload
+  run: async (payload: {
+    userId: string
+    startDate?: string
+    endDate?: string
+    fullSync?: boolean
+  }): Promise<IngestionResult> => {
+    const { userId, startDate, endDate, fullSync } = payload
 
     // 1. Get Integration
     const integration = await prisma.integration.findUnique({
@@ -80,6 +86,21 @@ export const ingestHevyTask = task({
         }
 
         for (const hevyWorkout of workouts) {
+          const { inWindow, beforeWindow } = isHevyWorkoutInDateWindow(
+            hevyWorkout,
+            startDate,
+            endDate
+          )
+
+          if (beforeWindow) {
+            keepFetching = false
+            break
+          }
+
+          if (!inWindow) {
+            continue
+          }
+
           // Check if workout exists to optimize "incremental" sync
           const existingWorkout = await prisma.workout.findUnique({
             where: {

--- a/trigger/ingest-intervals.ts
+++ b/trigger/ingest-intervals.ts
@@ -43,6 +43,9 @@ export const ingestIntervalsTask = task({
       data: { syncStatus: 'SYNCING' }
     })
 
+    let syncSucceeded = false
+    let syncErrorMessage: string | null = null
+
     try {
       const timezone = await getUserTimezone(userId)
       const start = new Date(startDate)
@@ -105,16 +108,7 @@ export const ingestIntervalsTask = task({
         logger.log('Wellness ingestion disabled for Intervals.icu, skipping')
       }
 
-      // Update sync status
-      await prisma.integration.update({
-        where: { id: integration.id },
-        data: {
-          syncStatus: 'SUCCESS',
-          lastSyncAt: new Date(),
-          errorMessage: null,
-          initialSyncCompleted: true // Mark initial sync as done
-        }
-      })
+      syncSucceeded = true
 
       // REACTIVE: Trigger fueling plan update for today
       // This ensures that newly synced workouts/events are immediately reflected.
@@ -142,16 +136,19 @@ export const ingestIntervalsTask = task({
     } catch (error) {
       logger.error('Error ingesting Intervals data', { error })
 
-      // Update error status
+      syncErrorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+      throw error
+    } finally {
       await prisma.integration.update({
         where: { id: integration.id },
         data: {
-          syncStatus: 'FAILED',
-          errorMessage: error instanceof Error ? error.message : 'Unknown error'
+          syncStatus: syncSucceeded ? 'SUCCESS' : 'FAILED',
+          lastSyncAt: syncSucceeded ? new Date() : undefined,
+          errorMessage: syncSucceeded ? null : syncErrorMessage,
+          ...(syncSucceeded ? { initialSyncCompleted: true } : {})
         }
       })
-
-      throw error
     }
   }
 })

--- a/trigger/ingest-strava.ts
+++ b/trigger/ingest-strava.ts
@@ -73,18 +73,14 @@ export const ingestStravaTask = task({
       data: { syncStatus: 'SYNCING' }
     })
 
+    let syncSucceeded = false
+    let syncErrorMessage: string | null = null
+
     try {
       const settings = (integration.settings as Record<string, any> | null) || {}
       if (!shouldIngestActivities('strava', integration.ingestWorkouts, settings)) {
         logger.log('Strava activity ingestion disabled - skipping')
-        await prisma.integration.update({
-          where: { id: integration.id },
-          data: {
-            syncStatus: 'SUCCESS',
-            lastSyncAt: new Date(),
-            errorMessage: null
-          }
-        })
+        syncSucceeded = true
 
         return {
           success: true,
@@ -287,14 +283,7 @@ export const ingestStravaTask = task({
 
       logger.log(`Upserted ${workoutsUpserted} workouts from Strava`)
 
-      await prisma.integration.update({
-        where: { id: integration.id },
-        data: {
-          syncStatus: 'SUCCESS',
-          lastSyncAt: new Date(),
-          errorMessage: null
-        }
-      })
+      syncSucceeded = true
 
       return {
         success: true,
@@ -309,15 +298,18 @@ export const ingestStravaTask = task({
     } catch (error) {
       logger.error('Error ingesting Strava data', { error })
 
+      syncErrorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+      throw error
+    } finally {
       await prisma.integration.update({
         where: { id: integration.id },
         data: {
-          syncStatus: 'FAILED',
-          errorMessage: error instanceof Error ? error.message : 'Unknown error'
+          syncStatus: syncSucceeded ? 'SUCCESS' : 'FAILED',
+          lastSyncAt: syncSucceeded ? new Date() : undefined,
+          errorMessage: syncSucceeded ? null : syncErrorMessage
         }
       })
-
-      throw error
     }
   }
 })

--- a/trigger/process-sync-queue.ts
+++ b/trigger/process-sync-queue.ts
@@ -51,6 +51,22 @@ export const processSyncQueueTask = task({
 
       // Process each item
       for (const item of pendingItems) {
+        const claimed = await prisma.syncQueue.updateMany({
+          where: {
+            id: item.id,
+            status: 'PENDING'
+          },
+          data: {
+            status: 'PROCESSING',
+            lastAttempt: new Date()
+          }
+        })
+
+        if (claimed.count === 0) {
+          logger.log(`Skipping sync item ${item.id} - already claimed by another worker`)
+          continue
+        }
+
         logger.log(`Processing sync item`, {
           id: item.id,
           entityType: item.entityType,

--- a/trigger/recommend-today-activity.ts
+++ b/trigger/recommend-today-activity.ts
@@ -162,385 +162,388 @@ export const recommendTodayActivityTask = task({
 
     logger.log("Starting today's activity recommendation", { userId, payloadDate, source })
 
-    const aiSettings = await getUserAiSettings(userId)
-
-    // Check Quota
     try {
-      await checkQuota(userId, 'activity_recommendation')
-    } catch (quotaError: any) {
-      if (quotaError.statusCode === 429) {
-        logger.warn('Activity recommendation quota exceeded', { userId, recommendationId })
-        if (recommendationId) {
-          await activityRecommendationRepository.update(recommendationId, userId, {
-            status: 'FAILED',
-            reasoning: 'Quota exceeded. Upgrade your plan for higher limits.'
-          })
-        }
-        return { success: false, reason: 'QUOTA_EXCEEDED' }
-      }
-      throw quotaError
-    }
+      const aiSettings = await getUserAiSettings(userId)
 
-    // 1. Fetch User Profile & Timezone FIRST to establish "Today" correctly
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        ftp: true,
-        weight: true,
-        weightUnits: true,
-        weightSourceMode: true,
-        height: true,
-        heightUnits: true,
-        maxHr: true,
-        timezone: true,
-        lthr: true,
-        dob: true,
-        sex: true,
-        language: true,
-        nutritionTrackingEnabled: true,
-        aiAutoAnalyzeReadiness: true
-      }
-    })
-
-    const userTimezone = user?.timezone || 'UTC'
-    const nutritionEnabled = user?.nutritionTrackingEnabled ?? true
-    const userAge = calculateAge(user?.dob)
-    const effectiveWeight = await bodyMetricResolver.resolveEffectiveWeight(userId, {
-      weight: user?.weight,
-      weightSourceMode: user?.weightSourceMode,
-      weightUnits: user?.weightUnits
-    })
-
-    // Fetch Email Preferences
-    const emailPrefs = await prisma.emailPreference.findUnique({
-      where: { userId_channel: { userId, channel: 'EMAIL' } }
-    })
-
-    logger.log('Proceeding with recommendation using latest available context.')
-
-    // Logic Check: If AUTOMATIC, ensure aiAutoAnalyzeReadiness is enabled
-    if (source === 'AUTOMATIC' && !user?.aiAutoAnalyzeReadiness) {
-      logger.log('EXIT: Auto-analyze readiness disabled for user.')
-      return { success: true, skipped: true, reason: 'AUTO_ANALYZE_DISABLED' }
-    }
-
-    // 3. Calculate Effective Today based on User's Timezone
-    // This fixes issues where server time (UTC) might be ahead/behind user's local "Today"
-    const effectiveDate = getUserLocalDate(userTimezone)
-    const payloadDateObj = new Date(payloadDate)
-
-    logger.log('Timezone Context', {
-      userTimezone,
-      effectiveDate: effectiveDate.toISOString(),
-      payloadDate: payloadDateObj.toISOString()
-    })
-
-    // 3. Update Recommendation Date if needed
-    // If the payload date (likely server UTC) differs from user's local date, sync them.
-    if (recommendationId && effectiveDate.getTime() !== payloadDateObj.getTime()) {
-      logger.log('Date mismatch detected. Updating recommendation date to match user local date.', {
-        oldDate: payloadDateObj,
-        newDate: effectiveDate
-      })
-      await prisma.activityRecommendation.update({
-        where: { id: recommendationId },
-        data: { date: effectiveDate }
-      })
-    }
-
-    // Use effectiveDate for all subsequent queries
-    const today = effectiveDate
-
-    const recentWorkoutsStartDate = getStartOfDaysAgoUTC(userTimezone, 6, today)
-    const recentWorkoutsEndDate = getEndOfDayUTC(userTimezone, today)
-
-    // Fetch remaining data
-    const [
-      plannedWorkouts,
-      todayMetric,
-      recentWorkouts,
-      athleteProfile,
-      rawActiveGoals,
-      futureWorkouts,
-      currentPlan,
-      upcomingEvents,
-      currentFitness,
-      focusedRecommendations,
-      sportSettings,
-      todayAvailability,
-      weeklyAvailability,
-      recentWellness,
-      mealTargetContext,
-      wellnessEvents
-    ] = await Promise.all([
-      // Today's planned workouts (Fetch ALL to handle multi-session days)
-      prisma.plannedWorkout.findMany({
-        where: {
-          userId,
-          date: today,
-          completed: {
-            not: true
-          },
-          completedWorkouts: {
-            none: {}
+      // Check Quota
+      try {
+        await checkQuota(userId, 'activity_recommendation')
+      } catch (quotaError: any) {
+        if (quotaError.statusCode === 429) {
+          logger.warn('Activity recommendation quota exceeded', { userId, recommendationId })
+          if (recommendationId) {
+            await activityRecommendationRepository.update(recommendationId, userId, {
+              status: 'FAILED',
+              reasoning: 'Quota exceeded. Upgrade your plan for higher limits.'
+            })
           }
-        },
-        orderBy: { tss: 'desc' } // Prioritize hardest workout
-      }),
+          return { success: false, reason: 'QUOTA_EXCEEDED' }
+        }
+        throw quotaError
+      }
 
-      // Today's recovery metrics from Wellness table (WHOOP, Intervals.icu, etc.)
-      wellnessRepository.getByDate(userId, today),
+      // 1. Fetch User Profile & Timezone FIRST to establish "Today" correctly
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          ftp: true,
+          weight: true,
+          weightUnits: true,
+          weightSourceMode: true,
+          height: true,
+          heightUnits: true,
+          maxHr: true,
+          timezone: true,
+          lthr: true,
+          dob: true,
+          sex: true,
+          language: true,
+          nutritionTrackingEnabled: true,
+          aiAutoAnalyzeReadiness: true
+        }
+      })
 
-      // Last 7 days of workouts for context
-      workoutRepository.getForUser(userId, {
-        startDate: recentWorkoutsStartDate,
-        endDate: recentWorkoutsEndDate,
-        orderBy: { date: 'desc' },
-        includeDuplicates: false,
-        include: {
-          streams: {
-            select: {
-              hrZoneTimes: true,
-              powerZoneTimes: true
+      const userTimezone = user?.timezone || 'UTC'
+      const nutritionEnabled = user?.nutritionTrackingEnabled ?? true
+      const userAge = calculateAge(user?.dob)
+      const effectiveWeight = await bodyMetricResolver.resolveEffectiveWeight(userId, {
+        weight: user?.weight,
+        weightSourceMode: user?.weightSourceMode,
+        weightUnits: user?.weightUnits
+      })
+
+      // Fetch Email Preferences
+      const emailPrefs = await prisma.emailPreference.findUnique({
+        where: { userId_channel: { userId, channel: 'EMAIL' } }
+      })
+
+      logger.log('Proceeding with recommendation using latest available context.')
+
+      // Logic Check: If AUTOMATIC, ensure aiAutoAnalyzeReadiness is enabled
+      if (source === 'AUTOMATIC' && !user?.aiAutoAnalyzeReadiness) {
+        logger.log('EXIT: Auto-analyze readiness disabled for user.')
+        return { success: true, skipped: true, reason: 'AUTO_ANALYZE_DISABLED' }
+      }
+
+      // 3. Calculate Effective Today based on User's Timezone
+      // This fixes issues where server time (UTC) might be ahead/behind user's local "Today"
+      const effectiveDate = getUserLocalDate(userTimezone)
+      const payloadDateObj = new Date(payloadDate)
+
+      logger.log('Timezone Context', {
+        userTimezone,
+        effectiveDate: effectiveDate.toISOString(),
+        payloadDate: payloadDateObj.toISOString()
+      })
+
+      // 3. Update Recommendation Date if needed
+      // If the payload date (likely server UTC) differs from user's local date, sync them.
+      if (recommendationId && effectiveDate.getTime() !== payloadDateObj.getTime()) {
+        logger.log(
+          'Date mismatch detected. Updating recommendation date to match user local date.',
+          {
+            oldDate: payloadDateObj,
+            newDate: effectiveDate
+          }
+        )
+        await prisma.activityRecommendation.update({
+          where: { id: recommendationId },
+          data: { date: effectiveDate }
+        })
+      }
+
+      // Use effectiveDate for all subsequent queries
+      const today = effectiveDate
+
+      const recentWorkoutsStartDate = getStartOfDaysAgoUTC(userTimezone, 6, today)
+      const recentWorkoutsEndDate = getEndOfDayUTC(userTimezone, today)
+
+      // Fetch remaining data
+      const [
+        plannedWorkouts,
+        todayMetric,
+        recentWorkouts,
+        athleteProfile,
+        rawActiveGoals,
+        futureWorkouts,
+        currentPlan,
+        upcomingEvents,
+        currentFitness,
+        focusedRecommendations,
+        sportSettings,
+        todayAvailability,
+        weeklyAvailability,
+        recentWellness,
+        mealTargetContext,
+        wellnessEvents
+      ] = await Promise.all([
+        // Today's planned workouts (Fetch ALL to handle multi-session days)
+        prisma.plannedWorkout.findMany({
+          where: {
+            userId,
+            date: today,
+            completed: {
+              not: true
+            },
+            completedWorkouts: {
+              none: {}
             }
           },
-          plannedWorkout: true
-        }
-      }),
+          orderBy: { tss: 'desc' } // Prioritize hardest workout
+        }),
 
-      // Latest athlete profile
-      prisma.report.findFirst({
-        where: {
-          userId,
-          type: 'ATHLETE_PROFILE',
-          status: 'COMPLETED'
-        },
-        orderBy: { createdAt: 'desc' },
-        select: { analysisJson: true, createdAt: true }
-      }),
+        // Today's recovery metrics from Wellness table (WHOOP, Intervals.icu, etc.)
+        wellnessRepository.getByDate(userId, today),
 
-      // Active goals
-      prisma.goal.findMany({
-        where: {
-          userId,
-          status: 'ACTIVE'
-        },
-        orderBy: { priority: 'desc' },
-        select: {
-          title: true,
-          type: true,
-          eventType: true,
-          description: true,
-          targetDate: true,
-          eventDate: true,
-          priority: true
-        }
-      }),
-
-      // Future planned workouts (next 14 days)
-      prisma.plannedWorkout.findMany({
-        where: {
-          userId,
-          completed: {
-            not: true
-          },
-          completedWorkouts: {
-            none: {}
-          },
-          date: {
-            gt: today,
-            lte: new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000)
+        // Last 7 days of workouts for context
+        workoutRepository.getForUser(userId, {
+          startDate: recentWorkoutsStartDate,
+          endDate: recentWorkoutsEndDate,
+          orderBy: { date: 'desc' },
+          includeDuplicates: false,
+          include: {
+            streams: {
+              select: {
+                hrZoneTimes: true,
+                powerZoneTimes: true
+              }
+            },
+            plannedWorkout: true
           }
-        },
-        orderBy: { date: 'asc' },
-        select: {
-          date: true,
-          title: true,
-          type: true,
-          tss: true,
-          description: true
-        }
-      }),
+        }),
 
-      // Current active training plan
-      prisma.weeklyTrainingPlan.findFirst({
-        where: {
-          userId,
-          status: 'ACTIVE',
-          weekStartDate: {
-            lte: today
-          },
-          weekEndDate: {
-            gte: today
-          }
-        },
-        select: {
-          planJson: true
-        }
-      }),
-
-      // Upcoming Events (next 14 days)
-      prisma.event.findMany({
-        where: {
-          userId,
-          date: {
-            gte: today,
-            lte: new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000)
-          }
-        },
-        orderBy: { date: 'asc' }
-      }),
-
-      // Keep prompt metrics aligned with the dashboard/source-of-truth widget values.
-      getCurrentFitnessSummary(userId, undefined, {
-        adjustForTodayUncompletedPlannedTSS: true,
-        timezone: userTimezone
-      }),
-
-      // Pinned/Focused recommendations
-      recommendationRepository.list(userId, { isPinned: true, status: 'ACTIVE' }),
-
-      // Sport Settings (New centralized system)
-      sportSettingsRepository.getByUserId(userId),
-
-      // Today's Training Availability
-      availabilityRepository.getForDay(userId, today.getDay()),
-
-      // Full weekly training availability (for forward-looking guidance)
-      availabilityRepository.getFullSchedule(userId),
-
-      wellnessRepository.getForUser(userId, {
-        startDate: new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000),
-        endDate: today,
-        where: {
-          lastSource: 'fitbit'
-        },
-        select: {
-          date: true,
-          hrv: true
-        },
-        orderBy: { date: 'desc' }
-      }),
-
-      // Canonical metabolic meal target context (same engine as nutrition charts)
-      nutritionEnabled
-        ? metabolicService.getMealTargetContext(userId, today, new Date())
-        : Promise.resolve(null),
-
-      getWellnessEventOverlaysForUser(userId, {
-        startDate: new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000),
-        endDate: today
-      })
-    ])
-    const activeGoals = filterGoalsForContext(rawActiveGoals, userTimezone, today)
-
-    // Identify primary workout for linking (DB only allows 1:1) and logic fallback
-    const primaryPlannedWorkout = plannedWorkouts[0] || null
-
-    // Build today's availability summary
-    const availabilityContext = todayAvailability
-      ? `\nTODAY'S TRAINING AVAILABILITY:\n${availabilityRepository.formatForPrompt(todayAvailability)}\n`
-      : ''
-    const weeklyAvailabilityContext =
-      weeklyAvailability.length > 0
-        ? `\nWEEKLY TRAINING AVAILABILITY:\n${availabilityRepository.formatForPrompt(weeklyAvailability)}\n`
-        : ''
-
-    // --- CHECK FOR AND RUN WELLNESS ANALYSIS IF MISSING ---
-    // If we have a wellness record (todayMetric) but no AI analysis, run it now.
-    // This ensures we always have the AI context for the recommendation.
-    let enrichedTodayMetric = todayMetric
-
-    if (
-      todayMetric &&
-      (!todayMetric.aiAnalysisJson || todayMetric.aiAnalysisStatus !== 'COMPLETED')
-    ) {
-      logger.log('Wellness analysis missing for today, running inline...', {
-        wellnessId: todayMetric.id
-      })
-      try {
-        await checkQuota(userId, 'wellness_analysis')
-        const result = await analyzeWellness(todayMetric.id, userId)
-        if (result.success && result.analysis) {
-          // Update our local object so the prompt gets the new data
-          enrichedTodayMetric = {
-            ...todayMetric,
-            aiAnalysisJson: result.analysis as any,
-            aiAnalysisStatus: 'COMPLETED'
-          }
-          logger.log('Inline wellness analysis completed successfully')
-        }
-      } catch (err: any) {
-        if (err?.statusCode === 429) {
-          logger.warn('Inline wellness analysis skipped due to quota', {
+        // Latest athlete profile
+        prisma.report.findFirst({
+          where: {
             userId,
-            wellnessId: todayMetric.id
-          })
-        } else {
-          logger.error('Failed to run inline wellness analysis', { err })
+            type: 'ATHLETE_PROFILE',
+            status: 'COMPLETED'
+          },
+          orderBy: { createdAt: 'desc' },
+          select: { analysisJson: true, createdAt: true }
+        }),
+
+        // Active goals
+        prisma.goal.findMany({
+          where: {
+            userId,
+            status: 'ACTIVE'
+          },
+          orderBy: { priority: 'desc' },
+          select: {
+            title: true,
+            type: true,
+            eventType: true,
+            description: true,
+            targetDate: true,
+            eventDate: true,
+            priority: true
+          }
+        }),
+
+        // Future planned workouts (next 14 days)
+        prisma.plannedWorkout.findMany({
+          where: {
+            userId,
+            completed: {
+              not: true
+            },
+            completedWorkouts: {
+              none: {}
+            },
+            date: {
+              gt: today,
+              lte: new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000)
+            }
+          },
+          orderBy: { date: 'asc' },
+          select: {
+            date: true,
+            title: true,
+            type: true,
+            tss: true,
+            description: true
+          }
+        }),
+
+        // Current active training plan
+        prisma.weeklyTrainingPlan.findFirst({
+          where: {
+            userId,
+            status: 'ACTIVE',
+            weekStartDate: {
+              lte: today
+            },
+            weekEndDate: {
+              gte: today
+            }
+          },
+          select: {
+            planJson: true
+          }
+        }),
+
+        // Upcoming Events (next 14 days)
+        prisma.event.findMany({
+          where: {
+            userId,
+            date: {
+              gte: today,
+              lte: new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000)
+            }
+          },
+          orderBy: { date: 'asc' }
+        }),
+
+        // Keep prompt metrics aligned with the dashboard/source-of-truth widget values.
+        getCurrentFitnessSummary(userId, undefined, {
+          adjustForTodayUncompletedPlannedTSS: true,
+          timezone: userTimezone
+        }),
+
+        // Pinned/Focused recommendations
+        recommendationRepository.list(userId, { isPinned: true, status: 'ACTIVE' }),
+
+        // Sport Settings (New centralized system)
+        sportSettingsRepository.getByUserId(userId),
+
+        // Today's Training Availability
+        availabilityRepository.getForDay(userId, today.getDay()),
+
+        // Full weekly training availability (for forward-looking guidance)
+        availabilityRepository.getFullSchedule(userId),
+
+        wellnessRepository.getForUser(userId, {
+          startDate: new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000),
+          endDate: today,
+          where: {
+            lastSource: 'fitbit'
+          },
+          select: {
+            date: true,
+            hrv: true
+          },
+          orderBy: { date: 'desc' }
+        }),
+
+        // Canonical metabolic meal target context (same engine as nutrition charts)
+        nutritionEnabled
+          ? metabolicService.getMealTargetContext(userId, today, new Date())
+          : Promise.resolve(null),
+
+        getWellnessEventOverlaysForUser(userId, {
+          startDate: new Date(today.getTime() - 14 * 24 * 60 * 60 * 1000),
+          endDate: today
+        })
+      ])
+      const activeGoals = filterGoalsForContext(rawActiveGoals, userTimezone, today)
+
+      // Identify primary workout for linking (DB only allows 1:1) and logic fallback
+      const primaryPlannedWorkout = plannedWorkouts[0] || null
+
+      // Build today's availability summary
+      const availabilityContext = todayAvailability
+        ? `\nTODAY'S TRAINING AVAILABILITY:\n${availabilityRepository.formatForPrompt(todayAvailability)}\n`
+        : ''
+      const weeklyAvailabilityContext =
+        weeklyAvailability.length > 0
+          ? `\nWEEKLY TRAINING AVAILABILITY:\n${availabilityRepository.formatForPrompt(weeklyAvailability)}\n`
+          : ''
+
+      // --- CHECK FOR AND RUN WELLNESS ANALYSIS IF MISSING ---
+      // If we have a wellness record (todayMetric) but no AI analysis, run it now.
+      // This ensures we always have the AI context for the recommendation.
+      let enrichedTodayMetric = todayMetric
+
+      if (
+        todayMetric &&
+        (!todayMetric.aiAnalysisJson || todayMetric.aiAnalysisStatus !== 'COMPLETED')
+      ) {
+        logger.log('Wellness analysis missing for today, running inline...', {
+          wellnessId: todayMetric.id
+        })
+        try {
+          await checkQuota(userId, 'wellness_analysis')
+          const result = await analyzeWellness(todayMetric.id, userId)
+          if (result.success && result.analysis) {
+            enrichedTodayMetric = {
+              ...todayMetric,
+              aiAnalysisJson: result.analysis as any,
+              aiAnalysisStatus: 'COMPLETED'
+            }
+            logger.log('Inline wellness analysis completed successfully')
+          }
+        } catch (err: any) {
+          if (err?.statusCode === 429) {
+            logger.warn('Inline wellness analysis skipped due to quota', {
+              userId,
+              wellnessId: todayMetric.id
+            })
+          } else {
+            logger.error('Failed to run inline wellness analysis', { err })
+          }
+          // We continue without the analysis rather than failing the whole recommendation
         }
-        // We continue without the analysis rather than failing the whole recommendation
       }
-    }
 
-    if (enrichedTodayMetric) {
-      enrichedTodayMetric = {
-        ...enrichedTodayMetric,
-        stress: getCanonicalWellnessStress(enrichedTodayMetric)
+      if (enrichedTodayMetric) {
+        enrichedTodayMetric = {
+          ...enrichedTodayMetric,
+          stress: getCanonicalWellnessStress(enrichedTodayMetric)
+        }
       }
-    }
 
-    logger.log('Data fetched', {
-      plannedWorkoutsCount: plannedWorkouts.length,
-      hasTodayMetric: !!enrichedTodayMetric,
-      recentWorkoutsCount: recentWorkouts.length,
-      hasAthleteProfile: !!athleteProfile,
-      activeGoalsCount: activeGoals.length,
-      futureWorkoutsCount: futureWorkouts.length,
-      upcomingEventsCount: upcomingEvents.length,
-      currentFitness
-    })
+      logger.log('Data fetched', {
+        plannedWorkoutsCount: plannedWorkouts.length,
+        hasTodayMetric: !!enrichedTodayMetric,
+        recentWorkoutsCount: recentWorkouts.length,
+        hasAthleteProfile: !!athleteProfile,
+        activeGoalsCount: activeGoals.length,
+        futureWorkoutsCount: futureWorkouts.length,
+        upcomingEventsCount: upcomingEvents.length,
+        currentFitness
+      })
 
-    // Calculate Projected PMC Trends
-    const projectedMetrics = calculateProjectedPMC(
-      today,
-      new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000),
-      currentFitness.ctl,
-      currentFitness.atl,
-      futureWorkouts
-    )
+      // Calculate Projected PMC Trends
+      const projectedMetrics = calculateProjectedPMC(
+        today,
+        new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000),
+        currentFitness.ctl,
+        currentFitness.atl,
+        futureWorkouts
+      )
 
-    // Calculate local time context
-    const now = new Date()
-    const localTime = now.toLocaleTimeString('en-US', {
-      timeZone: userTimezone,
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false
-    })
+      // Calculate local time context
+      const now = new Date()
+      const localTime = now.toLocaleTimeString('en-US', {
+        timeZone: userTimezone,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      })
 
-    // Use target date string for the prompt to ensure alignment with "Today"
-    // Since 'today' is now strictly User Local Date @ UTC Midnight,
-    // toISOString().split('T')[0] will give the correct YYYY-MM-DD
-    const targetDateStr = formatDateUTC(today, 'yyyy-MM-dd')
+      // Use target date string for the prompt to ensure alignment with "Today"
+      // Since 'today' is now strictly User Local Date @ UTC Midnight,
+      // toISOString().split('T')[0] will give the correct YYYY-MM-DD
+      const targetDateStr = formatDateUTC(today, 'yyyy-MM-dd')
 
-    // `today` is a date-only value stored at UTC midnight, so keep display formatting
-    // anchored to its calendar date instead of re-zoning it like a timestamp.
-    const localDate = formatDateUTC(today, 'EEEE, MMMM d, yyyy')
+      // `today` is a date-only value stored at UTC midnight, so keep display formatting
+      // anchored to its calendar date instead of re-zoning it like a timestamp.
+      const localDate = formatDateUTC(today, 'EEEE, MMMM d, yyyy')
 
-    // Split workouts into "Today's" and "Past"
-    const todaysWorkouts = recentWorkouts.filter(
-      (w) => getTimestampDateKey(w.date, userTimezone) === targetDateStr
-    )
-    const pastWorkouts = recentWorkouts.filter(
-      (w) => getTimestampDateKey(w.date, userTimezone) !== targetDateStr
-    )
+      // Split workouts into "Today's" and "Past"
+      const todaysWorkouts = recentWorkouts.filter(
+        (w) => getTimestampDateKey(w.date, userTimezone) === targetDateStr
+      )
+      const pastWorkouts = recentWorkouts.filter(
+        (w) => getTimestampDateKey(w.date, userTimezone) !== targetDateStr
+      )
 
-    // Build athlete profile context
-    let athleteContext = ''
-    if (athleteProfile?.analysisJson) {
-      const profile = athleteProfile.analysisJson as any
-      athleteContext = `
+      // Build athlete profile context
+      let athleteContext = ''
+      if (athleteProfile?.analysisJson) {
+        const profile = athleteProfile.analysisJson as any
+        athleteContext = `
 ATHLETE PROFILE (Generated ${formatUserDate(athleteProfile.createdAt, userTimezone)}):
 ${profile.executive_summary ? `Summary: ${profile.executive_summary}` : ''}
 
@@ -562,8 +565,8 @@ ${profile.planning_context?.current_focus ? `Current Focus: ${profile.planning_c
 ${profile.planning_context?.limitations?.length ? `Limitations: ${profile.planning_context.limitations.join(', ')}` : ''}
 ${profile.planning_context?.opportunities?.length ? `Opportunities: ${profile.planning_context.opportunities.join(', ')}` : ''}
 `
-    } else {
-      athleteContext = `
+      } else {
+        athleteContext = `
 ATHLETE BASIC INFO:
 - Age: ${userAge || 'Unknown'}
 - Sex: ${user?.sex || 'Unknown'}
@@ -575,20 +578,20 @@ ATHLETE BASIC INFO:
 - Max HR: ${user?.maxHr || 'Unknown'} bpm
 Note: No structured athlete profile available yet. Generate one for better recommendations.
 `
-    }
-
-    // Add Sport Specific Profiles to context
-    if (sportSettings.length > 0) {
-      athleteContext += `\nSPORT SPECIFIC SETTINGS:\n`
-      for (const s of sportSettings) {
-        const types = s.isDefault ? 'Fallback/Generic' : s.types.join(', ')
-        athleteContext += `- **${s.name || (s.isDefault ? 'Default' : 'Profile')}** (${types}): FTP=${s.ftp || 'N/A'}W, LTHR=${s.lthr || 'N/A'}bpm, MaxHR=${s.maxHr || 'N/A'}bpm\n`
       }
-    }
 
-    // Add goals context
-    if (activeGoals.length > 0) {
-      athleteContext += `
+      // Add Sport Specific Profiles to context
+      if (sportSettings.length > 0) {
+        athleteContext += `\nSPORT SPECIFIC SETTINGS:\n`
+        for (const s of sportSettings) {
+          const types = s.isDefault ? 'Fallback/Generic' : s.types.join(', ')
+          athleteContext += `- **${s.name || (s.isDefault ? 'Default' : 'Profile')}** (${types}): FTP=${s.ftp || 'N/A'}W, LTHR=${s.lthr || 'N/A'}bpm, MaxHR=${s.maxHr || 'N/A'}bpm\n`
+        }
+      }
+
+      // Add goals context
+      if (activeGoals.length > 0) {
+        athleteContext += `
       
 CURRENT GOALS:
 ${activeGoals
@@ -609,23 +612,23 @@ ${activeGoals
   })
   .join('\n')}
 `
-    }
+      }
 
-    // Build plan context
-    let planContext = ''
-    if (currentPlan) {
-      const plan = currentPlan.planJson as any
-      planContext = `
+      // Build plan context
+      let planContext = ''
+      if (currentPlan) {
+        const plan = currentPlan.planJson as any
+        planContext = `
 CURRENT TRAINING PLAN:
 - Weekly Focus: ${plan.weekSummary || 'Not specified'}
 - Planned TSS: ${plan.totalTSS || 'Unknown'}
 `
-    }
+      }
 
-    // Build upcoming events summary
-    let eventsContext = ''
-    if (upcomingEvents.length > 0) {
-      eventsContext = `
+      // Build upcoming events summary
+      let eventsContext = ''
+      if (upcomingEvents.length > 0) {
+        eventsContext = `
 UPCOMING EVENTS (Next 14 Days):
 ${upcomingEvents
   .map(
@@ -634,23 +637,23 @@ ${upcomingEvents
   )
   .join('\n')}
 `
-    }
+      }
 
-    // Build upcoming workouts summary (Next 14 Days)
-    let upcomingContext = ''
-    if (futureWorkouts.length > 0) {
-      upcomingContext = `
+      // Build upcoming workouts summary (Next 14 Days)
+      let upcomingContext = ''
+      if (futureWorkouts.length > 0) {
+        upcomingContext = `
 UPCOMING PLANNED WORKOUTS (Next 14 Days):
 ${futureWorkouts
   .map((w) => `- ${formatDateUTC(w.date, 'EEE dd')}: ${w.title} (TSS: ${w.tss || 'N/A'})`)
   .join('\n')}
 `
-    }
+      }
 
-    // Build Projected Metrics Context
-    let metricsContext = ''
-    if (projectedMetrics.length > 0) {
-      metricsContext = `
+      // Build Projected Metrics Context
+      let metricsContext = ''
+      if (projectedMetrics.length > 0) {
+        metricsContext = `
 PROJECTED FITNESS TRENDS (Next 14 Days based on plan):
 ${projectedMetrics
   .map(
@@ -659,112 +662,112 @@ ${projectedMetrics
   )
   .join('\n')}
 `
-    }
-
-    // Build zone definitions based on today's activity type
-    let zoneDefinitions = ''
-    let activeProfile = sportSettings.find((s: any) => s.isDefault)
-    if (primaryPlannedWorkout?.type) {
-      const match = sportSettings.find(
-        (s: any) => !s.isDefault && s.types.includes(primaryPlannedWorkout.type!)
-      )
-      if (match) activeProfile = match
-    }
-
-    if (activeProfile) {
-      zoneDefinitions += `**Applicable Zones for ${primaryPlannedWorkout?.type || 'Today'} (Profile: ${activeProfile.name}):**\n`
-
-      if (activeProfile.hrZones && Array.isArray(activeProfile.hrZones)) {
-        zoneDefinitions += '*Heart Rate Zones:*\n'
-        activeProfile.hrZones.forEach((z: any) => {
-          zoneDefinitions += `- ${z.name}: ${z.min}-${z.max} bpm\n`
-        })
       }
 
-      if (activeProfile.powerZones && Array.isArray(activeProfile.powerZones)) {
-        zoneDefinitions += '*Power Zones:*\n'
-        activeProfile.powerZones.forEach((z: any) => {
-          zoneDefinitions += `- ${z.name}: ${z.min}-${z.max} Watts\n`
-        })
+      // Build zone definitions based on today's activity type
+      let zoneDefinitions = ''
+      let activeProfile = sportSettings.find((s: any) => s.isDefault)
+      if (primaryPlannedWorkout?.type) {
+        const match = sportSettings.find(
+          (s: any) => !s.isDefault && s.types.includes(primaryPlannedWorkout.type!)
+        )
+        if (match) activeProfile = match
       }
 
-      if (activeProfile.lthr) {
-        zoneDefinitions += `\n**Reference LTHR:** ${activeProfile.lthr} bpm\n`
-      }
-      if (activeProfile.ftp) {
-        zoneDefinitions += `**Reference FTP:** ${activeProfile.ftp} Watts\n`
-      }
-    }
+      if (activeProfile) {
+        zoneDefinitions += `**Applicable Zones for ${primaryPlannedWorkout?.type || 'Today'} (Profile: ${activeProfile.name}):**\n`
 
-    // Build Wellness Analysis Context
-    let wellnessAnalysisContext = ''
-    if (enrichedTodayMetric?.aiAnalysisJson) {
-      const analysis = enrichedTodayMetric.aiAnalysisJson as any
-      wellnessAnalysisContext = `
+        if (activeProfile.hrZones && Array.isArray(activeProfile.hrZones)) {
+          zoneDefinitions += '*Heart Rate Zones:*\n'
+          activeProfile.hrZones.forEach((z: any) => {
+            zoneDefinitions += `- ${z.name}: ${z.min}-${z.max} bpm\n`
+          })
+        }
+
+        if (activeProfile.powerZones && Array.isArray(activeProfile.powerZones)) {
+          zoneDefinitions += '*Power Zones:*\n'
+          activeProfile.powerZones.forEach((z: any) => {
+            zoneDefinitions += `- ${z.name}: ${z.min}-${z.max} Watts\n`
+          })
+        }
+
+        if (activeProfile.lthr) {
+          zoneDefinitions += `\n**Reference LTHR:** ${activeProfile.lthr} bpm\n`
+        }
+        if (activeProfile.ftp) {
+          zoneDefinitions += `**Reference FTP:** ${activeProfile.ftp} Watts\n`
+        }
+      }
+
+      // Build Wellness Analysis Context
+      let wellnessAnalysisContext = ''
+      if (enrichedTodayMetric?.aiAnalysisJson) {
+        const analysis = enrichedTodayMetric.aiAnalysisJson as any
+        wellnessAnalysisContext = `
 TODAY'S WELLNESS ANALYSIS (AI Generated):
 - Status: ${analysis.status ? analysis.status.toUpperCase() : 'Unknown'}
 - Summary: ${analysis.executive_summary || 'N/A'}
 ${analysis.recommendations ? 'Recommendations:\n' + analysis.recommendations.map((r: any) => `  * ${r.title}: ${r.description} (${r.priority})`).join('\n') : ''}
 `
-    }
+      }
 
-    const priorHrvValues = recentWellness
-      .filter((metric) => metric.date.getTime() < today.getTime())
-      .map((metric) => metric.hrv)
+      const priorHrvValues = recentWellness
+        .filter((metric) => metric.date.getTime() < today.getTime())
+        .map((metric) => metric.hrv)
 
-    const fitbitRecoveryAlert = evaluateFitbitRecoveryAlert({
-      lastSource: enrichedTodayMetric?.lastSource,
-      hrv: enrichedTodayMetric?.hrv,
-      sleepHours: enrichedTodayMetric?.sleepHours,
-      sleepQuality: enrichedTodayMetric?.sleepQuality,
-      sleepScore: enrichedTodayMetric?.sleepScore,
-      atl: currentFitness?.atl,
-      recentHrvValues: priorHrvValues
-    })
+      const fitbitRecoveryAlert = evaluateFitbitRecoveryAlert({
+        lastSource: enrichedTodayMetric?.lastSource,
+        hrv: enrichedTodayMetric?.hrv,
+        sleepHours: enrichedTodayMetric?.sleepHours,
+        sleepQuality: enrichedTodayMetric?.sleepQuality,
+        sleepScore: enrichedTodayMetric?.sleepScore,
+        atl: currentFitness?.atl,
+        recentHrvValues: priorHrvValues
+      })
 
-    const fitbitRecoveryAlertContext = `
+      const fitbitRecoveryAlertContext = `
 FITBIT RECOVERY ALERT CHECK:
 - ${fitbitRecoveryAlert.summary}
 `
 
-    const activeWellnessEvents = getActiveWellnessEventsForDate(wellnessEvents, today)
-    const activeWellnessEventsContext =
-      activeWellnessEvents.length > 0
-        ? activeWellnessEvents
-            .map((event) => `${event.label}${event.description ? ` (${event.description})` : ''}`)
-            .join(', ')
-        : 'None'
-    const wellnessEventsContext = formatWellnessEventsForPrompt(
-      wellnessEvents,
-      userTimezone,
-      'WELLNESS EVENT CONTEXT (Last 14 Days)'
-    )
+      const activeWellnessEvents = getActiveWellnessEventsForDate(wellnessEvents, today)
+      const activeWellnessEventsContext =
+        activeWellnessEvents.length > 0
+          ? activeWellnessEvents
+              .map((event) => `${event.label}${event.description ? ` (${event.description})` : ''}`)
+              .join(', ')
+          : 'None'
+      const wellnessEventsContext = formatWellnessEventsForPrompt(
+        wellnessEvents,
+        userTimezone,
+        'WELLNESS EVENT CONTEXT (Last 14 Days)'
+      )
 
-    const missingSubjectiveMetrics = enrichedTodayMetric
-      ? [
-          enrichedTodayMetric.stress == null ? 'stress' : null,
-          enrichedTodayMetric.fatigue == null ? 'fatigue' : null,
-          enrichedTodayMetric.soreness == null ? 'soreness' : null,
-          enrichedTodayMetric.mood == null ? 'mood' : null,
-          enrichedTodayMetric.motivation == null ? 'motivation' : null
-        ].filter((metric): metric is string => Boolean(metric))
-      : ['stress', 'fatigue', 'soreness', 'mood', 'motivation']
+      const missingSubjectiveMetrics = enrichedTodayMetric
+        ? [
+            enrichedTodayMetric.stress == null ? 'stress' : null,
+            enrichedTodayMetric.fatigue == null ? 'fatigue' : null,
+            enrichedTodayMetric.soreness == null ? 'soreness' : null,
+            enrichedTodayMetric.mood == null ? 'mood' : null,
+            enrichedTodayMetric.motivation == null ? 'motivation' : null
+          ].filter((metric): metric is string => Boolean(metric))
+        : ['stress', 'fatigue', 'soreness', 'mood', 'motivation']
 
-    const subjectiveDataIntegrityContext = missingSubjectiveMetrics.length
-      ? `
+      const subjectiveDataIntegrityContext = missingSubjectiveMetrics.length
+        ? `
 SUBJECTIVE DATA INTEGRITY:
 - Missing subjective metrics today: ${missingSubjectiveMetrics.join(', ')}.
 - Treat missing subjective metrics as "not reported today".
 - Do NOT infer, estimate, or mention a numeric value for any missing subjective metric.
 `
-      : `
+        : `
 SUBJECTIVE DATA INTEGRITY:
 - All core subjective metrics are present today.
 `
 
-    // Build canonical metabolic meal-target context
-    const mealTargetContextText = mealTargetContext
-      ? `
+      // Build canonical metabolic meal-target context
+      const mealTargetContextText = mealTargetContext
+        ? `
 CANONICAL METABOLIC MEAL TARGET CONTEXT (Use this as nutrition source of truth):
 - Tank Now: ${mealTargetContext.currentTank.percentage}% (State ${mealTargetContext.currentTank.state})
 - Tank Advice: ${mealTargetContext.currentTank.advice}
@@ -779,35 +782,35 @@ ${
     : '- Suggested Intake Now: none needed'
 }
 `
-      : ''
+        : ''
 
-    // Build focused recommendations context
-    let focusedRecsContext = ''
-    if (focusedRecommendations && focusedRecommendations.length > 0) {
-      focusedRecsContext = `
+      // Build focused recommendations context
+      let focusedRecsContext = ''
+      if (focusedRecommendations && focusedRecommendations.length > 0) {
+        focusedRecsContext = `
 CURRENT FOCUS AREAS (Pinned Recommendations):
 ${focusedRecommendations.map((r) => `- [${r.priority.toUpperCase()}] ${r.title}: ${r.description}`).join('\n')}
 `
-    }
+      }
 
-    // Build Daily Check-in Summary
-    const checkinHistory = await getCheckinHistoryContext(
-      userId,
-      new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000),
-      today,
-      userTimezone
-    )
+      // Build Daily Check-in Summary
+      const checkinHistory = await getCheckinHistoryContext(
+        userId,
+        new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000),
+        today,
+        userTimezone
+      )
 
-    const checkinsSummary = checkinHistory
-      ? `\nDAILY CHECK-INS (Subjective Feedback - Last 7 Days):\n${checkinHistory}`
-      : ''
+      const checkinsSummary = checkinHistory
+        ? `\nDAILY CHECK-INS (Subjective Feedback - Last 7 Days):\n${checkinHistory}`
+        : ''
 
-    if (checkinHistory) {
-      logger.log('Check-ins Summary for Prompt', { checkinHistory })
-    }
+      if (checkinHistory) {
+        logger.log('Check-ins Summary for Prompt', { checkinHistory })
+      }
 
-    // Build current fitness context
-    const currentStatusContext = `
+      // Build current fitness context
+      const currentStatusContext = `
 CURRENT ATHLETE STATUS (Source of Truth):
 - Chronic Training Load (CTL/Fitness): ${currentFitness.ctl.toFixed(1)}
 - Acute Training Load (ATL/Fatigue): ${currentFitness.atl.toFixed(1)}
@@ -816,8 +819,8 @@ CURRENT ATHLETE STATUS (Source of Truth):
 - Metrics Last Updated: ${currentFitness.lastUpdated ? formatUserDate(currentFitness.lastUpdated, userTimezone, 'MMM dd, HH:mm') : 'Unknown'}
 `
 
-    // Build comprehensive prompt
-    const prompt = `You are a **${aiSettings.aiPersona}** expert cycling coach analyzing today's training for your athlete.
+      // Build comprehensive prompt
+      const prompt = `You are a **${aiSettings.aiPersona}** expert cycling coach analyzing today's training for your athlete.
 Adapt your analysis tone and recommendation style to match your **${aiSettings.aiPersona}** persona.
 
 CURRENT CONTEXT:
@@ -971,184 +974,209 @@ Absorption Profile Matrix for your guidance:
 - HYPER_LOAD: Large Meal, Start 60m, Peak 180m.
 
 Include this advice in your reasoning.${
-      upcomingEvents.some((e) => e.subType === 'Social Ride') ||
-      plannedWorkouts.some((w) => w.title?.toLowerCase().includes('social ride')) ||
-      activeGoals.some((g) => g.eventType === 'Social Ride')
-        ? '\n\n**Social Ride**: Prioritize "Mental Freshness" and "Aerobic Base" over "Intensity". Recommend low-intensity, community-focused rides.'
-        : ''
-    }${
-      upcomingEvents.some((e) => e.subType === 'Cyclotour') ||
-      plannedWorkouts.some(
-        (w) =>
-          w.title?.toLowerCase().includes('cyclotour') ||
-          w.title?.toLowerCase().includes('toertocht')
-      ) ||
-      activeGoals.some((g) => g.eventType === 'Cyclotour')
-        ? '\n\n**Cyclotour (Toertocht)**: Treat these as "Priority B or C" events. They require a mini-taper (2-3 days leading up) and a focused fueling plan due to their long duration, even if they aren\'t competitive races.'
-        : ''
-    }${
-      upcomingEvents.some((e) => e.subType === 'Criterium') ||
-      plannedWorkouts.some((w) => w.title?.toLowerCase().includes('criterium')) ||
-      activeGoals.some((g) => g.eventType === 'Criterium')
-        ? '\n\n**Criterium**: Prioritize anaerobic capacity, high-intensity intervals (VO2 Max), and repeated sprint efforts. Focus on repeatability.'
-        : ''
-    }${
-      upcomingEvents.some((e) => e.subType === 'Time Trial') ||
-      plannedWorkouts.some((w) => w.title?.toLowerCase().includes('time trial')) ||
-      activeGoals.some((g) => g.eventType === 'Time Trial')
-        ? '\n\n**Time Trial**: Focus on sustained threshold power (FTP), steady-state intervals, and pacing discipline.'
-        : ''
-    }${
-      upcomingEvents.some((e) => e.subType === 'Road Race') ||
-      plannedWorkouts.some((w) => w.title?.toLowerCase().includes('road race')) ||
-      activeGoals.some((g) => g.eventType === 'Road Race')
-        ? '\n\n**Road Race**: Emphasize aerobic volume, sweet spot endurance, and the ability to handle repeatable surges.'
-        : ''
-    }${
-      upcomingEvents.some((e) => e.subType === 'Gran Fondo') ||
-      plannedWorkouts.some((w) => w.title?.toLowerCase().includes('gran fondo')) ||
-      activeGoals.some((g) => g.eventType === 'Gran Fondo')
-        ? '\n\n**Gran Fondo**: Prioritize muscular endurance (low cadence work), long climbs, and overall aerobic durability.'
-        : ''
-    }
+        upcomingEvents.some((e) => e.subType === 'Social Ride') ||
+        plannedWorkouts.some((w) => w.title?.toLowerCase().includes('social ride')) ||
+        activeGoals.some((g) => g.eventType === 'Social Ride')
+          ? '\n\n**Social Ride**: Prioritize "Mental Freshness" and "Aerobic Base" over "Intensity". Recommend low-intensity, community-focused rides.'
+          : ''
+      }${
+        upcomingEvents.some((e) => e.subType === 'Cyclotour') ||
+        plannedWorkouts.some(
+          (w) =>
+            w.title?.toLowerCase().includes('cyclotour') ||
+            w.title?.toLowerCase().includes('toertocht')
+        ) ||
+        activeGoals.some((g) => g.eventType === 'Cyclotour')
+          ? '\n\n**Cyclotour (Toertocht)**: Treat these as "Priority B or C" events. They require a mini-taper (2-3 days leading up) and a focused fueling plan due to their long duration, even if they aren\'t competitive races.'
+          : ''
+      }${
+        upcomingEvents.some((e) => e.subType === 'Criterium') ||
+        plannedWorkouts.some((w) => w.title?.toLowerCase().includes('criterium')) ||
+        activeGoals.some((g) => g.eventType === 'Criterium')
+          ? '\n\n**Criterium**: Prioritize anaerobic capacity, high-intensity intervals (VO2 Max), and repeated sprint efforts. Focus on repeatability.'
+          : ''
+      }${
+        upcomingEvents.some((e) => e.subType === 'Time Trial') ||
+        plannedWorkouts.some((w) => w.title?.toLowerCase().includes('time trial')) ||
+        activeGoals.some((g) => g.eventType === 'Time Trial')
+          ? '\n\n**Time Trial**: Focus on sustained threshold power (FTP), steady-state intervals, and pacing discipline.'
+          : ''
+      }${
+        upcomingEvents.some((e) => e.subType === 'Road Race') ||
+        plannedWorkouts.some((w) => w.title?.toLowerCase().includes('road race')) ||
+        activeGoals.some((g) => g.eventType === 'Road Race')
+          ? '\n\n**Road Race**: Emphasize aerobic volume, sweet spot endurance, and the ability to handle repeatable surges.'
+          : ''
+      }${
+        upcomingEvents.some((e) => e.subType === 'Gran Fondo') ||
+        plannedWorkouts.some((w) => w.title?.toLowerCase().includes('gran fondo')) ||
+        activeGoals.some((g) => g.eventType === 'Gran Fondo')
+          ? '\n\n**Gran Fondo**: Prioritize muscular endurance (low cadence work), long climbs, and overall aerobic durability.'
+          : ''
+      }
 
 Provide specific, actionable recommendations with clear reasoning.
 Maintain your **${aiSettings.aiPersona}** persona throughout.`
 
-    logger.log(`Generating recommendation with Gemini (${aiSettings.aiModelPreference})`)
+      logger.log(`Generating recommendation with Gemini (${aiSettings.aiModelPreference})`)
 
-    // Generate recommendation
-    const analysis = await generateStructuredAnalysis<RecommendationAnalysis>(
-      prompt,
-      recommendationSchema,
-      aiSettings.aiModelPreference, // Use user preference
-      {
-        userId,
-        operation: 'activity_recommendation',
-        entityType: 'ActivityRecommendation',
-        entityId: recommendationId
-      }
-    )
+      // Generate recommendation
+      const analysis = await generateStructuredAnalysis<RecommendationAnalysis>(
+        prompt,
+        recommendationSchema,
+        aiSettings.aiModelPreference, // Use user preference
+        {
+          userId,
+          operation: 'activity_recommendation',
+          entityType: 'ActivityRecommendation',
+          entityId: recommendationId
+        }
+      )
 
-    logger.log('Analysis generated', { recommendation: analysis.recommendation })
+      logger.log('Analysis generated', { recommendation: analysis.recommendation })
 
-    // Update or create the recommendation
-    let recommendation
-    if (recommendationId) {
-      // Check if recommendation still exists
-      const exists = await activityRecommendationRepository.findById(recommendationId, userId)
-      if (!exists) {
-        logger.warn('Recommendation was deleted during generation, skipping update', {
-          recommendationId
-        })
-        return { success: true, skipped: true, reason: 'RECOMMENDATION_DELETED' }
-      }
-
-      // Update the existing pending recommendation
-      recommendation = await activityRecommendationRepository.update(recommendationId, userId, {
-        recommendation: analysis.recommendation,
-        confidence: analysis.confidence,
-        reasoning: analysis.reasoning,
-        analysisJson: attachRecommendationGuardrails(
-          analysis as any,
-          primaryPlannedWorkout,
-          plannedWorkouts
-        ) as any,
-        plannedWorkout: primaryPlannedWorkout?.id
-          ? { connect: { id: primaryPlannedWorkout.id } }
-          : undefined,
-        status: 'COMPLETED',
-        modelVersion: 'gemini-2.0-flash-exp'
-      })
-    } else {
-      // Fallback: create new recommendation if no ID provided
-      recommendation = await activityRecommendationRepository.create({
-        user: { connect: { id: userId } },
-        date: today,
-        recommendation: analysis.recommendation,
-        confidence: analysis.confidence,
-        reasoning: analysis.reasoning,
-        analysisJson: attachRecommendationGuardrails(
-          analysis as any,
-          primaryPlannedWorkout,
-          plannedWorkouts
-        ) as any,
-        plannedWorkout: primaryPlannedWorkout?.id
-          ? { connect: { id: primaryPlannedWorkout.id } }
-          : undefined,
-        status: 'COMPLETED',
-        modelVersion: 'gemini-2.0-flash-exp'
-      })
-    }
-
-    logger.log('Recommendation saved', {
-      recommendationId: recommendation.id,
-      decision: analysis.recommendation
-    })
-
-    // TRIGGER EMAIL (Only if AUTOMATIC and preferences allow)
-    if (
-      source === 'AUTOMATIC' &&
-      emailPrefs &&
-      emailPrefs.dailyCoach &&
-      !emailPrefs.globalUnsubscribe
-    ) {
-      const todayDayName = formatUserDate(today, userTimezone, 'EEEE').toUpperCase()
-      const isScheduledDay = emailPrefs.dailyCoachDays.includes(todayDayName)
-      const isWithinPreferredTime = isWithinPreferredEmailTime({
-        timezone: userTimezone,
-        preferredTime: emailPrefs.dailyCoachTime
-      })
-
-      if (isScheduledDay && isWithinPreferredTime) {
-        logger.log(`Triggering daily recommendation email for ${todayDayName}`)
-        try {
-          const fullUser = await prisma.user.findUnique({
-            where: { id: userId },
-            select: { name: true, email: true }
+      // Update or create the recommendation
+      let recommendation
+      if (recommendationId) {
+        // Check if recommendation still exists
+        const exists = await activityRecommendationRepository.findById(recommendationId, userId)
+        if (!exists) {
+          logger.warn('Recommendation was deleted during generation, skipping update', {
+            recommendationId
           })
-          if (fullUser) {
-            const recommendationDateKey = today.toISOString().slice(0, 10)
-            await tasks.trigger('send-email', {
-              userId,
-              templateKey: 'DailyRecommendation',
-              eventKey: `DAILY_RECOMMENDATION_${recommendation.id}`,
-              idempotencyKey: `daily-recommendation:${userId}:${recommendationDateKey}`,
-              audience: 'ENGAGEMENT',
-              subject: `Today's Training: ${analysis.recommendation.toUpperCase().replace('_', ' ')}`,
-              props: {
-                name: fullUser.name || 'Athlete',
-                date: formatUserDate(today, userTimezone, 'EEEE, MMM d'),
-                recommendation: analysis.recommendation.toUpperCase().replace('_', ' '),
-                reasoning: analysis.reasoning,
-                unsubscribeUrl: `${process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'}/profile/settings?tab=communication`
-              }
+          return { success: true, skipped: true, reason: 'RECOMMENDATION_DELETED' }
+        }
+
+        // Update the existing pending recommendation
+        recommendation = await activityRecommendationRepository.update(recommendationId, userId, {
+          recommendation: analysis.recommendation,
+          confidence: analysis.confidence,
+          reasoning: analysis.reasoning,
+          analysisJson: attachRecommendationGuardrails(
+            analysis as any,
+            primaryPlannedWorkout,
+            plannedWorkouts
+          ) as any,
+          plannedWorkout: primaryPlannedWorkout?.id
+            ? { connect: { id: primaryPlannedWorkout.id } }
+            : undefined,
+          status: 'COMPLETED',
+          modelVersion: 'gemini-2.0-flash-exp'
+        })
+      } else {
+        // Fallback: create new recommendation if no ID provided
+        recommendation = await activityRecommendationRepository.create({
+          user: { connect: { id: userId } },
+          date: today,
+          recommendation: analysis.recommendation,
+          confidence: analysis.confidence,
+          reasoning: analysis.reasoning,
+          analysisJson: attachRecommendationGuardrails(
+            analysis as any,
+            primaryPlannedWorkout,
+            plannedWorkouts
+          ) as any,
+          plannedWorkout: primaryPlannedWorkout?.id
+            ? { connect: { id: primaryPlannedWorkout.id } }
+            : undefined,
+          status: 'COMPLETED',
+          modelVersion: 'gemini-2.0-flash-exp'
+        })
+      }
+
+      logger.log('Recommendation saved', {
+        recommendationId: recommendation.id,
+        decision: analysis.recommendation
+      })
+
+      // TRIGGER EMAIL (Only if AUTOMATIC and preferences allow)
+      if (
+        source === 'AUTOMATIC' &&
+        emailPrefs &&
+        emailPrefs.dailyCoach &&
+        !emailPrefs.globalUnsubscribe
+      ) {
+        const todayDayName = formatUserDate(today, userTimezone, 'EEEE').toUpperCase()
+        const isScheduledDay = emailPrefs.dailyCoachDays.includes(todayDayName)
+        const isWithinPreferredTime = isWithinPreferredEmailTime({
+          timezone: userTimezone,
+          preferredTime: emailPrefs.dailyCoachTime
+        })
+
+        if (isScheduledDay && isWithinPreferredTime) {
+          logger.log(`Triggering daily recommendation email for ${todayDayName}`)
+          try {
+            const fullUser = await prisma.user.findUnique({
+              where: { id: userId },
+              select: { name: true, email: true }
+            })
+            if (fullUser) {
+              const recommendationDateKey = today.toISOString().slice(0, 10)
+              await tasks.trigger('send-email', {
+                userId,
+                templateKey: 'DailyRecommendation',
+                eventKey: `DAILY_RECOMMENDATION_${recommendation.id}`,
+                idempotencyKey: `daily-recommendation:${userId}:${recommendationDateKey}`,
+                audience: 'ENGAGEMENT',
+                subject: `Today's Training: ${analysis.recommendation.toUpperCase().replace('_', ' ')}`,
+                props: {
+                  name: fullUser.name || 'Athlete',
+                  date: formatUserDate(today, userTimezone, 'EEEE, MMM d'),
+                  recommendation: analysis.recommendation.toUpperCase().replace('_', ' '),
+                  reasoning: analysis.reasoning,
+                  unsubscribeUrl: `${process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'}/profile/settings?tab=communication`
+                }
+              })
+            }
+          } catch (emailError) {
+            logger.warn('Failed to trigger daily recommendation email', {
+              recommendationId: recommendation.id,
+              error: emailError
             })
           }
-        } catch (emailError) {
-          logger.warn('Failed to trigger daily recommendation email', {
-            recommendationId: recommendation.id,
-            error: emailError
+        } else {
+          logger.log('Skipping email: not in scheduled day/time window.', {
+            todayDayName,
+            scheduledDays: emailPrefs.dailyCoachDays,
+            preferredTime: emailPrefs.dailyCoachTime
           })
         }
       } else {
-        logger.log('Skipping email: not in scheduled day/time window.', {
-          todayDayName,
-          scheduledDays: emailPrefs.dailyCoachDays,
-          preferredTime: emailPrefs.dailyCoachTime
+        logger.log('Skipping email trigger: Source is MANUAL or preferences disabled.', {
+          source,
+          dailyCoachEnabled: emailPrefs?.dailyCoach
         })
       }
-    } else {
-      logger.log('Skipping email trigger: Source is MANUAL or preferences disabled.', {
-        source,
-        dailyCoachEnabled: emailPrefs?.dailyCoach
-      })
-    }
 
-    return {
-      success: true,
-      recommendationId: recommendation.id,
-      recommendation: analysis.recommendation
+      return {
+        success: true,
+        recommendationId: recommendation.id,
+        recommendation: analysis.recommendation
+      }
+    } catch (error: any) {
+      logger.error("Today's activity recommendation failed", {
+        userId,
+        recommendationId,
+        error
+      })
+
+      if (recommendationId) {
+        const failureMessage =
+          error instanceof Error ? error.message : 'Recommendation generation failed'
+        try {
+          await activityRecommendationRepository.update(recommendationId, userId, {
+            status: 'FAILED',
+            reasoning: failureMessage
+          })
+        } catch (updateError) {
+          logger.error('Failed to mark recommendation as FAILED', {
+            recommendationId,
+            updateError
+          })
+        }
+      }
+
+      throw error
     }
   }
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issues closed

- **171** — Hevy ingest ignored date window from ingest-all
- **172** — Garmin ingest clamped multi-day sync to last 24h only
- **175** — Wellness analysis skipped quota check
- **177** — Recommend-today stuck in PROCESSING on task failure
- **108** — Integration sync allowed duplicate in-flight jobs
- **106** — Sync queue double-processed PENDING items concurrently
- **060** — Integration syncStatus stuck on SYNCING after abnormal exit (Strava + Intervals)

## Root cause / pattern

Ingest date windows not propagated, Garmin API 24h limit not chunked, missing quota guards, missing try/finally on async tasks, and no inflight/atomic-claim guards on sync endpoints.

## Files changed

Trigger tasks (ingest-hevy, ingest-garmin, ingest-all, ingest-strava, ingest-intervals, process-sync-queue, recommend-today-activity), server utils (hevy, garmin, wellness-analysis), `integrations/sync.post.ts`, tests, issue docs.

## Test plan

- [x] Unit tests for hevy window, garmin slices, wellness quota, sync 409, queue claim, recommend-today failure
- [ ] Manual: 7-day ingest-all includes all Hevy/Garmin days; concurrent sync returns 409

## Postponed issues NOT touched

058, 059, 063, 069, 071, 072, 093, 094, 098, 099, 100, 101, 102, 105, 110, 111, 125, 126, 129, 070, 158
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

