### PR TITLE
fix(onboarding): join callback whitelist, auto-accept, consent validation (152, 153, 154, 097, 124)

### DIFF
--- a/app/middleware/onboarding.global.ts
+++ b/app/middleware/onboarding.global.ts
@@ -21,6 +21,9 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     // Allow access to public legal pages
     if (to.path === '/terms' || to.path === '/privacy') return
 
+    // Allow join invite flow (OAuth callback after signup)
+    if (to.path === '/join' || to.path.startsWith('/join/')) return
+
     // Allow sign out flow (if it uses a specific route, though usually it's a function call)
     // We'll allow anything under /auth just in case
     if (to.path.startsWith('/api/auth')) return

--- a/app/pages/join/[code].vue
+++ b/app/pages/join/[code].vue
@@ -75,8 +75,9 @@
     if (
       import.meta.client &&
       session.value &&
+      invite.value &&
+      !loading.value &&
       route.query.accept === '1' &&
-      brandedJoin.value &&
       !joining.value &&
       !autoAccepting.value
     ) {

--- a/app/pages/onboarding.vue
+++ b/app/pages/onboarding.vue
@@ -115,6 +115,7 @@
   })
 
   const { data: session, refresh } = useAuth()
+  const toast = useToast()
   const acceptedTerms = ref(false)
   const acceptedHealth = ref(false)
   const loading = ref(false)
@@ -134,7 +135,8 @@
         method: 'POST',
         body: {
           termsVersion: TOS_VERSION,
-          privacyPolicyVersion: PRIVACY_VERSION
+          privacyPolicyVersion: PRIVACY_VERSION,
+          healthConsentAccepted: true
         }
       })
 
@@ -149,9 +151,13 @@
       await refresh()
 
       navigateTo('/dashboard')
-    } catch (error) {
+    } catch (error: any) {
       console.error('Failed to save consent:', error)
-      // You might want to show a toast notification here
+      toast.add({
+        title: 'Failed to save consent',
+        description: error?.data?.message || 'Please try again.',
+        color: 'error'
+      })
     } finally {
       loading.value = false
     }

--- a/docs/issues/097-onboarding-consent-api-bypass.md
+++ b/docs/issues/097-onboarding-consent-api-bypass.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ui/ux, backend`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** `POST /api/user/consent` requires `healthConsentAccepted: true` in the request body; onboarding sends the flag explicitly.
 
 ## Description
 
@@ -31,5 +33,5 @@ Require explicit healthConsentAccepted in request body.
 
 ## Acceptance Criteria
 
-- [ ] Bug no longer reproducible via steps above
-- [ ] Appropriate error handling or auth in place
+- [x] Bug no longer reproducible via steps above
+- [x] Appropriate error handling or auth in place

--- a/docs/issues/124-onboarding-consent-save-silent-fail.md
+++ b/docs/issues/124-onboarding-consent-save-silent-fail.md
@@ -3,7 +3,9 @@
 **Type:** UI  
 **Priority:** Medium  
 **Area:** `ui/ux, backend`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** Onboarding consent submit shows an error toast on API failure and keeps the user on the consent step.
 
 ## Description
 
@@ -31,5 +33,5 @@ Show error toast; keep user on consent step.
 
 ## Acceptance Criteria
 
-- [ ] Bug no longer reproducible via steps above
-- [ ] Appropriate error handling or auth in place
+- [x] Bug no longer reproducible via steps above
+- [x] Appropriate error handling or auth in place

--- a/docs/issues/152-onboarding-blocks-join-callback.md
+++ b/docs/issues/152-onboarding-blocks-join-callback.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `onboarding, coaching`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** Whitelisted `/join` and `/join/*` routes in onboarding middleware so OAuth signup callbacks can complete invite acceptance.
 
 ## Description
 
@@ -19,4 +21,4 @@ Invite lost after OAuth signup.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
+- [x] Issue no longer reproducible

--- a/docs/issues/153-join-auto-accept-branded-only.md
+++ b/docs/issues/153-join-auto-accept-branded-only.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `coaching, ui/ux`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** Auto-accept with `?accept=1` now runs for all invite types once the invite is loaded, not only branded athlete invites.
 
 ## Description
 
@@ -19,4 +21,4 @@ Team invite needs manual accept.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
+- [x] Issue no longer reproducible

--- a/docs/issues/154-join-accept-errors-return-500.md
+++ b/docs/issues/154-join-accept-errors-return-500.md
@@ -3,7 +3,9 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `coaching, backend`  
-**Status:** Open
+**Status:** Fixed
+
+> **Fixed (2026-07-08):** Join accept handler maps repository validation errors (wrong email, self-invite, expired code) to 4xx responses instead of HTTP 500.
 
 ## Description
 
@@ -19,4 +21,4 @@ Wrong email gives 500.
 
 ## Acceptance Criteria
 
-- [ ] Issue no longer reproducible
+- [x] Issue no longer reproducible

--- a/docs/issues/app-review-issues.md
+++ b/docs/issues/app-review-issues.md
@@ -163,7 +163,7 @@ Documents **180 app-wide issues** (039–218) from systematic codebase review. C
 | [094](./094-share-generate-workout-read-all-types.md)     | Share generate scope escalation   | Medium   |
 | [095](./095-plan-share-auto-creates-permanent-tokens.md)  | Plan share auto-creates tokens    | Medium   |
 | [096](./096-join-invite-preview-exposes-pii.md)           | Join preview exposes PII          | Medium   |
-| [097](./097-onboarding-consent-api-bypass.md)             | Onboarding consent bypass         | Medium   |
+| ~~[097](./097-onboarding-consent-api-bypass.md)~~         | Onboarding consent bypass (fixed) | Medium   |
 | [098](./098-polar-webhook-missing-userid.md)              | Polar webhook missing userId      | High     |
 | [099](./099-oauth-generic-webhook-ignores-secret.md)      | OAuth webhook ignores secret      | High     |
 | [100](./100-strava-webhook-post-unauthenticated.md)       | Strava POST unauthenticated       | High     |
@@ -225,28 +225,28 @@ Documents **180 app-wide issues** (039–218) from systematic codebase review. C
 
 ## Issues 151–170 (join, share, developer, triggers)
 
-| ID                                                     | Title                          | Priority |
-| ------------------------------------------------------ | ------------------------------ | -------- |
-| [151](./151-user-profile-stale-on-error.md)            | User profile stale on error    | Medium   |
-| [152](./152-onboarding-blocks-join-callback.md)        | Onboarding blocks join         | High     |
-| [153](./153-join-auto-accept-branded-only.md)          | Join auto-accept branded only  | Medium   |
-| [154](./154-join-accept-errors-return-500.md)          | Join accept returns 500        | Medium   |
-| [155](./155-workout-share-leaks-zone-profiles.md)      | Share leaks zone profiles      | High     |
-| [156](./156-nutrition-share-url-404.md)                | Nutrition share URL 404        | Medium   |
-| [157](./157-nutrition-share-unsanitized-payload.md)    | Nutrition share unsanitized    | High     |
-| [158](./158-developer-get-leaks-webhook-secret.md)     | Developer GET leaks secret     | High     |
-| [159](./159-planned-workout-share-ignores-preview.md)  | Planned share ignores preview  | Medium   |
-| [160](./160-wellness-share-og-leaks-biometrics.md)     | Wellness OG leaks biometrics   | Medium   |
-| [161](./161-connect-yazio-no-auth-middleware.md)       | Connect Yazio no auth          | High     |
-| [162](./162-fit-ingest-no-file-ownership-check.md)     | FIT ingest no ownership check  | High     |
-| [163](./163-chat-tts-transcribe-no-quota.md)           | Chat TTS/transcribe no quota   | Medium   |
-| [164](./164-chat-turn-retry-no-quota.md)               | Chat retry no quota            | Medium   |
-| [165](./165-chat-queued-messages-lost-on-error.md)     | Queued messages lost on error  | Medium   |
-| [166](./166-chat-message-queue-in-memory-only.md)      | Chat queue in-memory only      | Medium   |
-| [167](./167-admin-impersonate-self-allowed.md)         | Admin impersonate self         | Medium   |
-| [168](./168-admin-user-detail-no-error-state.md)       | Admin user detail no error     | Medium   |
-| [169](./169-admin-webhook-stats-wrong-progress-max.md) | Admin webhook stats wrong max  | Low      |
-| [170](./170-deduplicate-auto-analyzes-all-recent.md)   | Dedup auto-analyzes all recent | Medium   |
+| ID                                                     | Title                                 | Priority |
+| ------------------------------------------------------ | ------------------------------------- | -------- |
+| [151](./151-user-profile-stale-on-error.md)            | User profile stale on error           | Medium   |
+| ~~[152](./152-onboarding-blocks-join-callback.md)~~    | Onboarding blocks join (fixed)        | High     |
+| ~~[153](./153-join-auto-accept-branded-only.md)~~      | Join auto-accept branded only (fixed) | Medium   |
+| ~~[154](./154-join-accept-errors-return-500.md)~~      | Join accept returns 500 (fixed)       | Medium   |
+| [155](./155-workout-share-leaks-zone-profiles.md)      | Share leaks zone profiles             | High     |
+| [156](./156-nutrition-share-url-404.md)                | Nutrition share URL 404               | Medium   |
+| [157](./157-nutrition-share-unsanitized-payload.md)    | Nutrition share unsanitized           | High     |
+| [158](./158-developer-get-leaks-webhook-secret.md)     | Developer GET leaks secret            | High     |
+| [159](./159-planned-workout-share-ignores-preview.md)  | Planned share ignores preview         | Medium   |
+| [160](./160-wellness-share-og-leaks-biometrics.md)     | Wellness OG leaks biometrics          | Medium   |
+| [161](./161-connect-yazio-no-auth-middleware.md)       | Connect Yazio no auth                 | High     |
+| [162](./162-fit-ingest-no-file-ownership-check.md)     | FIT ingest no ownership check         | High     |
+| [163](./163-chat-tts-transcribe-no-quota.md)           | Chat TTS/transcribe no quota          | Medium   |
+| [164](./164-chat-turn-retry-no-quota.md)               | Chat retry no quota                   | Medium   |
+| [165](./165-chat-queued-messages-lost-on-error.md)     | Queued messages lost on error         | Medium   |
+| [166](./166-chat-message-queue-in-memory-only.md)      | Chat queue in-memory only             | Medium   |
+| [167](./167-admin-impersonate-self-allowed.md)         | Admin impersonate self                | Medium   |
+| [168](./168-admin-user-detail-no-error-state.md)       | Admin user detail no error            | Medium   |
+| [169](./169-admin-webhook-stats-wrong-progress-max.md) | Admin webhook stats wrong max         | Low      |
+| [170](./170-deduplicate-auto-analyzes-all-recent.md)   | Dedup auto-analyzes all recent        | Medium   |
 
 ## Issues 171–185 (trigger tasks deep pass)
 
@@ -323,7 +323,7 @@ Documents **180 app-wide issues** (039–218) from systematic codebase review. C
 6. ~~**171–172, 175–177**~~ — Trigger ingest/quota/stuck PROCESSING **Fixed** (PR 6)
 7. ~~**066, 155–160, 157**~~ — Share/privacy hardening **Fixed** (PR 7; 158 postponed — OAuth developer)
 8. ~~Webhook/OAuth auth (057–129 subset)~~ — **Postponed** until third-party coordination
-9. **152–154** — Join/onboarding flow
+9. ~~**152–154** — Join/onboarding flow~~ **Fixed** (PR 8)
 10. **199–215** — i18n/a11y (incremental, low risk)
 11. Remaining active medium/low
 

--- a/server/api/join/[code].post.ts
+++ b/server/api/join/[code].post.ts
@@ -3,6 +3,22 @@ import { teamRepository } from '../../utils/repositories/teamRepository'
 import { coachingRepository } from '../../utils/repositories/coachingRepository'
 import { prisma } from '../../utils/db'
 
+function mapJoinAcceptError(error: unknown): never {
+  const message = error instanceof Error ? error.message : 'Failed to accept invitation'
+
+  const statusByMessage: Record<string, number> = {
+    'Invalid or expired invite code': 404,
+    'Athlete account not found': 404,
+    'This invite is restricted to another email address': 403,
+    'You cannot invite yourself': 400,
+    'You cannot coach yourself': 400
+  }
+
+  const statusCode = statusByMessage[message] ?? 500
+
+  throw createError({ statusCode, message })
+}
+
 defineRouteMeta({
   openAPI: {
     tags: ['Coaching', 'Invites'],
@@ -37,11 +53,15 @@ export default defineEventHandler(async (event) => {
   })
 
   if (teamInvite && teamInvite.status === 'PENDING' && teamInvite.expiresAt > new Date()) {
-    const membership = await teamRepository.acceptInvite(user.id, code)
-    return {
-      success: true,
-      type: 'TEAM',
-      teamId: membership.teamId
+    try {
+      const membership = await teamRepository.acceptInvite(user.id, code)
+      return {
+        success: true,
+        type: 'TEAM',
+        teamId: membership.teamId
+      }
+    } catch (error) {
+      mapJoinAcceptError(error)
     }
   }
 
@@ -55,10 +75,14 @@ export default defineEventHandler(async (event) => {
     coachingInvite.status === 'PENDING' &&
     coachingInvite.expiresAt > new Date()
   ) {
-    await coachingRepository.connectAthleteWithCode(user.id, code)
-    return {
-      success: true,
-      type: 'COACHING'
+    try {
+      await coachingRepository.connectAthleteWithCode(user.id, code)
+      return {
+        success: true,
+        type: 'COACHING'
+      }
+    } catch (error) {
+      mapJoinAcceptError(error)
     }
   }
 
@@ -70,11 +94,15 @@ export default defineEventHandler(async (event) => {
     coachAthleteInvite.status === 'PENDING' &&
     coachAthleteInvite.expiresAt > new Date()
   ) {
-    const relationship = await coachingRepository.acceptAthleteInviteForCoach(user.id, code)
-    return {
-      success: true,
-      type: 'ATHLETE_INVITE',
-      coachId: relationship.coachId
+    try {
+      const relationship = await coachingRepository.acceptAthleteInviteForCoach(user.id, code)
+      return {
+        success: true,
+        type: 'ATHLETE_INVITE',
+        coachId: relationship.coachId
+      }
+    } catch (error) {
+      mapJoinAcceptError(error)
     }
   }
 

--- a/server/api/user/consent.post.ts
+++ b/server/api/user/consent.post.ts
@@ -8,10 +8,14 @@ export default defineEventHandler(async (event) => {
   }
 
   const body = await readBody(event)
-  const { termsVersion, privacyPolicyVersion } = body
+  const { termsVersion, privacyPolicyVersion, healthConsentAccepted } = body
 
   if (!termsVersion || !privacyPolicyVersion) {
     throw createError({ statusCode: 400, message: 'Missing version information' })
+  }
+
+  if (healthConsentAccepted !== true) {
+    throw createError({ statusCode: 400, message: 'Health consent is required' })
   }
 
   const user = await prisma.user.update({

--- a/tests/unit/server/api/join-code-post.test.ts
+++ b/tests/unit/server/api/join-code-post.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const teamInviteFindUnique = vi.fn()
+const coachingInviteFindUnique = vi.fn()
+const acceptInvite = vi.fn()
+const connectAthleteWithCode = vi.fn()
+const acceptAthleteInviteForCoach = vi.fn()
+const getCoachAthleteInviteByCode = vi.fn()
+
+vi.mock('../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ id: 'user-1', email: 'wrong@example.com' })
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    teamInvite: { findUnique: teamInviteFindUnique },
+    coachingInvite: { findUnique: coachingInviteFindUnique }
+  }
+}))
+
+vi.mock('../../../../server/utils/repositories/teamRepository', () => ({
+  teamRepository: { acceptInvite }
+}))
+
+vi.mock('../../../../server/utils/repositories/coachingRepository', () => ({
+  coachingRepository: {
+    connectAthleteWithCode,
+    acceptAthleteInviteForCoach,
+    getCoachAthleteInviteByCode
+  }
+}))
+
+const futureDate = new Date('2026-12-31T00:00:00Z')
+
+describe('POST /api/join/[code]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    teamInviteFindUnique.mockResolvedValue(null)
+    coachingInviteFindUnique.mockResolvedValue(null)
+    getCoachAthleteInviteByCode.mockResolvedValue(null)
+  })
+
+  it('maps team invite email mismatch to 403', async () => {
+    teamInviteFindUnique.mockResolvedValue({
+      code: 'TEAM1234',
+      status: 'PENDING',
+      expiresAt: futureDate
+    })
+    acceptInvite.mockRejectedValue(new Error('This invite is restricted to another email address'))
+
+    const mod = await import('../../../../server/api/join/[code].post')
+    const handler = mod.default
+
+    await expect(
+      handler({ context: { params: { code: 'team1234' } } } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'This invite is restricted to another email address'
+    })
+  })
+
+  it('maps athlete invite validation errors to 4xx', async () => {
+    getCoachAthleteInviteByCode.mockResolvedValue({
+      status: 'PENDING',
+      expiresAt: futureDate
+    })
+    acceptAthleteInviteForCoach.mockRejectedValue(new Error('You cannot invite yourself'))
+
+    const mod = await import('../../../../server/api/join/[code].post')
+    const handler = mod.default
+
+    await expect(
+      handler({ context: { params: { code: 'athlete1' } } } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'You cannot invite yourself'
+    })
+  })
+})

--- a/tests/unit/server/api/user/consent.post.test.ts
+++ b/tests/unit/server/api/user/consent.post.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+const readBody = vi.fn()
+vi.stubGlobal('readBody', readBody)
+
+const getServerSession = vi.fn()
+const userUpdate = vi.fn()
+
+vi.mock('#auth', () => ({
+  getServerSession
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    user: { update: userUpdate }
+  }
+}))
+
+describe('POST /api/user/consent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    getServerSession.mockResolvedValue({ user: { id: 'user-1' } })
+    userUpdate.mockResolvedValue({
+      termsAcceptedAt: new Date('2026-07-08T00:00:00Z')
+    })
+  })
+
+  it('rejects requests without explicit health consent', async () => {
+    readBody.mockResolvedValue({
+      termsVersion: '1.0',
+      privacyPolicyVersion: '1.0'
+    })
+
+    const mod = await import('../../../../../server/api/user/consent.post')
+    const handler = mod.default
+
+    await expect(handler({} as any)).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Health consent is required'
+    })
+    expect(userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('accepts consent when healthConsentAccepted is true', async () => {
+    readBody.mockResolvedValue({
+      termsVersion: '1.0',
+      privacyPolicyVersion: '1.0',
+      healthConsentAccepted: true
+    })
+
+    const mod = await import('../../../../../server/api/user/consent.post')
+    const handler = mod.default
+    const result = await handler({} as any)
+
+    expect(userUpdate).toHaveBeenCalled()
+    expect(result).toMatchObject({ success: true })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issues closed

- **152** — Onboarding middleware blocked post-signup join callback
- **153** — Join auto-accept only worked for branded athlete invites
- **154** — Join accept validation errors returned 500
- **097** — Consent API allowed bypassing health consent checkbox
- **124** — Onboarding consent save failed silently

## Root cause / pattern

Onboarding middleware was too broad, auto-accept logic was invite-type-specific, repository errors weren't mapped to HTTP 4xx, and consent/onboarding UX lacked validation and error feedback.

## Files changed

`app/middleware/onboarding.global.ts`, `app/pages/join/[code].vue`, `app/pages/onboarding.vue`, `server/api/join/[code].post.ts`, `server/api/user/consent.post.ts`, unit tests, issue docs.

## Test plan

- [x] Unit tests for join POST 4xx mapping and consent healthConsentAccepted requirement
- [ ] Manual: OAuth signup via invite link completes join; wrong-email invite returns 4xx; consent failure shows toast

## Postponed issues NOT touched

058, 059, 063, 069, 071, 072, 093, 094, 098, 099, 100, 101, 102, 105, 110, 111, 125, 126, 129, 070, 158
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

