### PR TITLE
fix(quota): chat TTS/transcribe/retry, recommendations, plan adherence

### DIFF
--- a/docs/issues/163-chat-tts-transcribe-no-quota.md
+++ b/docs/issues/163-chat-tts-transcribe-no-quota.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ai,backend`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/docs/issues/164-chat-turn-retry-no-quota.md
+++ b/docs/issues/164-chat-turn-retry-no-quota.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ai,backend`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/docs/issues/176-recommend-today-inline-wellness-no-quota.md
+++ b/docs/issues/176-recommend-today-inline-wellness-no-quota.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** High  
 **Area:** `ai, planning`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/docs/issues/179-generate-recommendations-no-quota.md
+++ b/docs/issues/179-generate-recommendations-no-quota.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ai, planning`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/docs/issues/180-generate-recommendations-double-ai-call.md
+++ b/docs/issues/180-generate-recommendations-double-ai-call.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ai, planning`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/docs/issues/181-analyze-plan-adherence-no-quota-timeout.md
+++ b/docs/issues/181-analyze-plan-adherence-no-quota-timeout.md
@@ -3,7 +3,7 @@
 **Type:** Bug  
 **Priority:** Medium  
 **Area:** `ai, planning`  
-**Status:** Open
+**Status:** Fixed
 
 ## Description
 

--- a/server/api/chat/transcribe.post.ts
+++ b/server/api/chat/transcribe.post.ts
@@ -3,6 +3,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { generateText } from 'ai'
 import { prisma } from '../../utils/db'
 import { calculateLlmCost } from '../../utils/ai-config'
+import { assertQuotaAllowed } from '../../utils/quotas/http'
 
 const VALID_AUDIO_TYPES = new Set([
   'audio/webm',
@@ -34,6 +35,12 @@ export default defineEventHandler(async (event) => {
   if (!userId) {
     throw createError({ statusCode: 401, message: 'User ID not found' })
   }
+
+  await assertQuotaAllowed(
+    userId,
+    'chat',
+    'Chat quota exceeded. Voice transcription is unavailable until your limit resets.'
+  )
 
   const formData = await readMultipartFormData(event)
   if (!formData?.length) {

--- a/server/api/chat/tts.post.ts
+++ b/server/api/chat/tts.post.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from '../../utils/session'
 import { prisma } from '../../utils/db'
 import { calculateLlmCost } from '../../utils/ai-config'
+import { assertQuotaAllowed } from '../../utils/quotas/http'
 
 const MODEL_NAME = 'gemini-2.5-flash-preview-tts'
 const SAMPLE_RATE = 24000
@@ -161,6 +162,12 @@ export default defineEventHandler(async (event) => {
   if (!userId) {
     throw createError({ statusCode: 401, message: 'User ID not found' })
   }
+
+  await assertQuotaAllowed(
+    userId,
+    'chat',
+    'Chat quota exceeded. Text-to-speech is unavailable until your limit resets.'
+  )
 
   if (!process.env.GEMINI_API_KEY) {
     throw createError({ statusCode: 500, message: 'Missing GEMINI_API_KEY' })

--- a/server/api/chat/turns/[id]/retry.post.ts
+++ b/server/api/chat/turns/[id]/retry.post.ts
@@ -3,6 +3,7 @@ import { prisma } from '../../../../utils/db'
 import { CHAT_TURN_STATUS } from '../../../../utils/chat/turns'
 import { chatService } from '../../../../utils/services/chatService'
 import { chatTurnService } from '../../../../utils/services/chatTurnService'
+import { assertQuotaAllowed } from '../../../../utils/quotas/http'
 
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
@@ -26,6 +27,12 @@ export default defineEventHandler(async (event) => {
   }
 
   await chatService.validateRoomAccess(userId, turn.roomId)
+
+  await assertQuotaAllowed(
+    userId,
+    'chat',
+    'Chat quota exceeded. Turn retry is unavailable until your limit resets.'
+  )
 
   const originalMessage = await prisma.chatMessage.findUnique({
     where: { id: turn.userMessageId }

--- a/server/api/recommendations/generate.post.ts
+++ b/server/api/recommendations/generate.post.ts
@@ -2,6 +2,7 @@ import { getServerSession } from '../../utils/session'
 import { prisma } from '../../utils/db'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { publishTaskRunStartedEvent } from '../../utils/task-run-events'
+import { assertQuotaAllowed } from '../../utils/quotas/http'
 
 defineRouteMeta({
   openAPI: {
@@ -50,6 +51,12 @@ export default defineEventHandler(async (event) => {
       message: 'User not found'
     })
   }
+
+  await assertQuotaAllowed(
+    user.id,
+    'unified_report_generation',
+    'Recommendation update quota exceeded. Please wait or upgrade your plan.'
+  )
 
   try {
     // Trigger the recommendation generation job

--- a/trigger/analyze-plan-adherence.ts
+++ b/trigger/analyze-plan-adherence.ts
@@ -6,6 +6,7 @@ import { userReportsQueue } from './queues'
 import { queueWorkoutInsightEmail } from '../server/utils/workout-insight-email'
 import { formatStructuredPlanForPrompt } from './utils/planned-workout-targets'
 import { sportSettingsRepository } from '../server/utils/repositories/sportSettingsRepository'
+import { checkQuota } from '../server/utils/quotas/engine'
 import {
   buildWorkoutAnalysisFactsV2,
   formatActualIntervalsForPrompt,
@@ -58,6 +59,8 @@ const adherenceSchema = {
   },
   required: ['overallScore', 'summary', 'deviations']
 }
+
+const PLAN_ADHERENCE_AI_TIMEOUT_MS = 60_000
 
 export function buildPlanAdherencePrompt(workout: any, plan: any, sportSettings?: any): string {
   const structuredPlan = formatStructuredPlanForPrompt(plan.structuredWorkout, {
@@ -198,6 +201,26 @@ export const analyzePlanAdherenceTask = task({
     })
 
     try {
+      try {
+        await checkQuota(workout.userId, 'workout_analysis')
+      } catch (quotaError: any) {
+        if (quotaError.statusCode === 429) {
+          logger.warn('Plan adherence analysis quota exceeded', {
+            userId: workout.userId,
+            workoutId
+          })
+          await prisma.planAdherence.update({
+            where: { workoutId },
+            data: {
+              analysisStatus: 'QUOTA_EXCEEDED',
+              summary: 'Workout analysis quota exceeded.'
+            }
+          })
+          return { success: false, reason: 'QUOTA_EXCEEDED' }
+        }
+        throw quotaError
+      }
+
       const prompt = buildPlanAdherencePrompt(workout, plan, sportSettings)
 
       const analysis = await generateStructuredAnalysis<AdherenceAnalysis>(
@@ -208,7 +231,8 @@ export const analyzePlanAdherenceTask = task({
           userId: workout.userId,
           operation: 'analyze_plan_adherence',
           entityType: 'PlanAdherence',
-          entityId: workoutId
+          entityId: workoutId,
+          timeoutMs: PLAN_ADHERENCE_AI_TIMEOUT_MS
         }
       )
 

--- a/trigger/generate-recommendations.ts
+++ b/trigger/generate-recommendations.ts
@@ -10,6 +10,7 @@ import { nutritionRepository } from '../server/utils/repositories/nutritionRepos
 import { getUserAiSettings } from '../server/utils/ai-user-settings'
 import { userReportsQueue } from './queues'
 import { filterGoalsForContext } from '../server/utils/goal-context'
+import { checkQuota } from '../server/utils/quotas/engine'
 
 interface RecommendationHistoryItem {
   date: string
@@ -50,6 +51,16 @@ export const generateRecommendationsTask = task({
     logger.log('🚀 GENERATING RECOMMENDATIONS')
     logger.log('='.repeat(60))
     logger.log(`User ID: ${userId}`)
+
+    try {
+      await checkQuota(userId, 'unified_report_generation')
+    } catch (quotaError: any) {
+      if (quotaError.statusCode === 429) {
+        logger.warn('Recommendation generation quota exceeded', { userId })
+        return { success: false, reason: 'QUOTA_EXCEEDED' }
+      }
+      throw quotaError
+    }
 
     const timezone = await getUserTimezone(userId)
     const aiSettings = await getUserAiSettings(userId)
@@ -423,8 +434,9 @@ JSON object with 'new_recommendations', 'updated_recommendations', 'completed_re
 
     // Fetch fresh active recommendations (including newly created ones)
     const freshActiveRecs = await recommendationRepository.getActive(userId)
+    const createdNewRecommendations = (new_recommendations?.length || 0) > 0
 
-    if (freshActiveRecs.length > 1) {
+    if (freshActiveRecs.length > 1 && createdNewRecommendations) {
       const dedupPrompt = `You are a data cleaner. Review the following list of active recommendations and identify DUPLICATES or CONFLICTING items.
 
 ACTIVE RECOMMENDATIONS:
@@ -477,6 +489,8 @@ JSON object with 'ids_to_dismiss' array (string IDs). If no duplicates or only p
       } else {
         logger.log('✨ No redundant items found (or all kept due to focus)')
       }
+    } else {
+      logger.log('Skipping deduplication sweep (no new recommendations created this run)')
     }
 
     return {

--- a/trigger/recommend-today-activity.ts
+++ b/trigger/recommend-today-activity.ts
@@ -459,6 +459,7 @@ export const recommendTodayActivityTask = task({
         wellnessId: todayMetric.id
       })
       try {
+        await checkQuota(userId, 'wellness_analysis')
         const result = await analyzeWellness(todayMetric.id, userId)
         if (result.success && result.analysis) {
           // Update our local object so the prompt gets the new data
@@ -469,8 +470,15 @@ export const recommendTodayActivityTask = task({
           }
           logger.log('Inline wellness analysis completed successfully')
         }
-      } catch (err) {
-        logger.error('Failed to run inline wellness analysis', { err })
+      } catch (err: any) {
+        if (err?.statusCode === 429) {
+          logger.warn('Inline wellness analysis skipped due to quota', {
+            userId,
+            wellnessId: todayMetric.id
+          })
+        } else {
+          logger.error('Failed to run inline wellness analysis', { err })
+        }
         // We continue without the analysis rather than failing the whole recommendation
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes quota and cost-control gaps from the app review:

- **163** — `chat/tts.post` and `chat/transcribe.post` enforce `chat` quota via `assertQuotaAllowed`
- **164** — `chat/turns/[id]/retry.post` checks `chat` quota before enqueueing a retry turn
- **176** — `recommend-today-activity` checks `wellness_analysis` quota before inline `analyzeWellness`; skips gracefully on 429
- **179** — `generate-recommendations` task and `/api/recommendations/generate` enforce `unified_report_generation` quota
- **180** — Deduplication sweep only runs when new recommendations were created this run (avoids unconditional second LLM call)
- **181** — `analyze-plan-adherence` checks `workout_analysis` quota and sets `timeoutMs: 60_000` on the AI call

## Issues

163, 164, 176, 179, 180, 181
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4391-10d8-7dc8-a0cd-ba5ec963b927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

