### PR TITLE
Migrate Garmin Training publish to API V2

### DIFF
--- a/server/api/workouts/planned/[id]/publish-garmin.post.ts
+++ b/server/api/workouts/planned/[id]/publish-garmin.post.ts
@@ -150,7 +150,13 @@ export default defineEventHandler(async (event) => {
         try {
           await updateGarminWorkout(integration, workoutId, payload)
         } catch (e: any) {
-          if (String(e?.message || '').includes('(404)')) {
+          const message = String(e?.message || '')
+          // Stale Garmin ids or missing ownerId (Training API V2) → recreate.
+          if (
+            message.includes('(404)') ||
+            message.includes('requires ownerId') ||
+            e?.code === 'GARMIN_OWNER_ID_REQUIRED'
+          ) {
             workoutId = null
           } else {
             throw e

--- a/server/utils/garmin-push.ts
+++ b/server/utils/garmin-push.ts
@@ -299,8 +299,10 @@ function buildGarminSteps(
     if (nested.length > 0) {
       const repeatOrder = stepOrder++
       const childSteps = nested
-        .map((child) => convert(child))
-        .filter((child): child is Record<string, unknown> => child != null)
+        .map((child: any) => convert(child))
+        .filter(
+          (child: Record<string, unknown> | null): child is Record<string, unknown> => child != null
+        )
       return {
         type: 'WorkoutRepeatStep',
         stepOrder: repeatOrder,

--- a/server/utils/garmin-push.ts
+++ b/server/utils/garmin-push.ts
@@ -1,4 +1,5 @@
 import type { Integration } from '@prisma/client'
+import { createError } from 'h3'
 import { refreshGarminToken } from './garmin'
 
 /**
@@ -17,6 +18,32 @@ export type GarminTargetThresholds = {
   maxHr?: number
 }
 
+type GarminTargetFields = {
+  targetType: string
+  targetValue?: number
+  targetValueLow?: number
+  targetValueHigh?: number
+  targetValueType?: string
+  secondaryTargetType?: string
+  secondaryTargetValue?: number
+  secondaryTargetValueLow?: number
+  secondaryTargetValueHigh?: number
+  secondaryTargetValueType?: string
+}
+
+type GarminMetricCandidate = {
+  kind: 'POWER' | 'HEART_RATE' | 'PACE' | 'CADENCE'
+  targetValue?: number
+  targetValueLow?: number
+  targetValueHigh?: number
+  targetValueType?: string
+}
+
+const WORKOUT_PROVIDER = 'COACH_WATTZ'
+const GARMIN_TRAINING_WORKOUT_V2 = 'https://apis.garmin.com/training-api/workout/v2'
+const GARMIN_TRAINING_WORKOUT_CREATE_V2 = 'https://apis.garmin.com/workoutportal/workout/v2'
+const GARMIN_TRAINING_SCHEDULE = 'https://apis.garmin.com/training-api/schedule'
+
 function getGarminHeaders(accessToken: string) {
   return {
     'Content-Type': 'application/json',
@@ -28,7 +55,9 @@ function mapStepIntensity(stepType: string): string {
   const type = stepType?.toLowerCase?.() || ''
   if (type.includes('warm')) return 'WARMUP'
   if (type.includes('cool')) return 'COOLDOWN'
-  if (type.includes('rest') || type.includes('recover')) return 'REST'
+  if (type.includes('recover')) return 'RECOVERY'
+  if (type.includes('rest')) return 'REST'
+  if (type.includes('interval')) return 'INTERVAL'
   return 'ACTIVE'
 }
 
@@ -98,129 +127,303 @@ function toAbsoluteHeartRate(
   return Math.round(normalizeRelativeFraction(value) * basis)
 }
 
-function getTarget(
+function extractCadenceValue(cadence: unknown): number | null {
+  if (typeof cadence === 'number' && Number.isFinite(cadence)) return cadence
+  if (cadence && typeof cadence === 'object') {
+    const value = Number((cadence as any).value)
+    if (Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function collectMetricCandidates(
   step: any,
   thresholds: GarminTargetThresholds = {}
-): {
-  targetType: string
-  targetValue?: number
-  targetValueLow?: number
-  targetValueHigh?: number
-} {
+): GarminMetricCandidate[] {
+  const candidates: GarminMetricCandidate[] = []
   const power = step?.power
-  const hr = step?.heartRate
+  const hr = step?.heartRate || step?.hr
   const pace = step?.pace
-  const cadence = step?.cadence
+  const cadence = extractCadenceValue(step?.cadence)
 
   if (power?.range) {
-    return {
-      targetType: 'POWER',
+    candidates.push({
+      kind: 'POWER',
       targetValueLow: toAbsolutePower(Number(power.range.start) || 0, power.units, thresholds),
       targetValueHigh: toAbsolutePower(Number(power.range.end) || 0, power.units, thresholds)
-    }
-  }
-  if (typeof power?.value === 'number') {
-    return {
-      targetType: 'POWER',
+    })
+  } else if (typeof power?.value === 'number') {
+    candidates.push({
+      kind: 'POWER',
       targetValue: toAbsolutePower(power.value, power.units, thresholds)
-    }
+    })
   }
 
   if (hr?.range) {
-    return {
-      targetType: 'HEART_RATE',
+    candidates.push({
+      kind: 'HEART_RATE',
       targetValueLow: toAbsoluteHeartRate(Number(hr.range.start) || 0, hr.units, thresholds),
       targetValueHigh: toAbsoluteHeartRate(Number(hr.range.end) || 0, hr.units, thresholds)
-    }
-  }
-  if (typeof hr?.value === 'number') {
-    return {
-      targetType: 'HEART_RATE',
+    })
+  } else if (typeof hr?.value === 'number') {
+    candidates.push({
+      kind: 'HEART_RATE',
       targetValue: toAbsoluteHeartRate(hr.value, hr.units, thresholds)
-    }
+    })
   }
 
   if (pace?.range) {
-    return {
-      targetType: 'PACE',
+    candidates.push({
+      kind: 'PACE',
       targetValueLow: Number(pace.range.start) || 0,
       targetValueHigh: Number(pace.range.end) || 0
-    }
-  }
-  if (typeof pace?.value === 'number') {
-    return { targetType: 'PACE', targetValue: pace.value }
-  }
-
-  if (typeof cadence === 'number') {
-    return { targetType: 'CADENCE', targetValue: cadence }
+    })
+  } else if (typeof pace?.value === 'number') {
+    candidates.push({ kind: 'PACE', targetValue: pace.value })
   }
 
-  return { targetType: 'OPEN' }
+  if (cadence != null) {
+    candidates.push({ kind: 'CADENCE', targetValue: cadence })
+  }
+
+  return candidates
 }
 
-function explodeSteps(steps: any[]): any[] {
-  const out: any[] = []
-
-  const visit = (step: any) => {
-    if (!step) return
-    const repsRaw = Number(step.reps ?? step.repeat ?? step.intervals ?? 1)
-    const reps = Number.isFinite(repsRaw) && repsRaw > 0 ? Math.floor(repsRaw) : 1
-
-    if (Array.isArray(step.steps) && step.steps.length > 0) {
-      for (let i = 0; i < reps; i++) {
-        for (const nested of step.steps) visit(nested)
-      }
-      return
-    }
-
-    for (let i = 0; i < reps; i++) out.push(step)
-  }
-
-  for (const step of steps || []) visit(step)
-  return out
+/** Sport-aware metric priority for primary/secondary Garmin targets. */
+function metricPriorityForSport(sport: string): GarminMetricCandidate['kind'][] {
+  if (sport === 'RUNNING') return ['PACE', 'HEART_RATE', 'POWER', 'CADENCE']
+  if (sport === 'CYCLING') return ['POWER', 'HEART_RATE', 'CADENCE', 'PACE']
+  if (sport === 'LAP_SWIMMING') return ['PACE', 'HEART_RATE', 'CADENCE', 'POWER']
+  return ['POWER', 'HEART_RATE', 'PACE', 'CADENCE']
 }
 
-export function buildGarminTrainingPayload(workout: any, thresholds: GarminTargetThresholds = {}) {
-  const steps = explodeSteps(workout?.steps || [])
+function candidateToFields(
+  candidate: GarminMetricCandidate,
+  prefix: 'primary' | 'secondary'
+): Record<string, unknown> {
+  if (prefix === 'primary') {
+    return {
+      targetType: candidate.kind,
+      ...(candidate.targetValue != null ? { targetValue: candidate.targetValue } : {}),
+      ...(candidate.targetValueLow != null ? { targetValueLow: candidate.targetValueLow } : {}),
+      ...(candidate.targetValueHigh != null ? { targetValueHigh: candidate.targetValueHigh } : {}),
+      ...(candidate.targetValueType ? { targetValueType: candidate.targetValueType } : {})
+    }
+  }
+  return {
+    secondaryTargetType: candidate.kind,
+    ...(candidate.targetValue != null ? { secondaryTargetValue: candidate.targetValue } : {}),
+    ...(candidate.targetValueLow != null
+      ? { secondaryTargetValueLow: candidate.targetValueLow }
+      : {}),
+    ...(candidate.targetValueHigh != null
+      ? { secondaryTargetValueHigh: candidate.targetValueHigh }
+      : {}),
+    ...(candidate.targetValueType ? { secondaryTargetValueType: candidate.targetValueType } : {})
+  }
+}
+
+function supportsSecondaryTarget(sport: string): boolean {
+  // Training API V2 documents secondary targets for CYCLING (accessory) and swim.
+  return sport === 'CYCLING' || sport === 'LAP_SWIMMING'
+}
+
+function getTargets(
+  step: any,
+  sport: string,
+  thresholds: GarminTargetThresholds = {}
+): GarminTargetFields {
+  const candidates = collectMetricCandidates(step, thresholds)
+  const priority = metricPriorityForSport(sport)
+  const ranked = [...candidates].sort((a, b) => priority.indexOf(a.kind) - priority.indexOf(b.kind))
+
+  const primary = ranked[0]
+  if (!primary) return { targetType: 'OPEN' }
+
+  const fields: GarminTargetFields = {
+    ...(candidateToFields(primary, 'primary') as GarminTargetFields)
+  }
+
+  // V2: OPEN cannot be primary when a secondary target is present.
+  if (supportsSecondaryTarget(sport)) {
+    const secondary = ranked.find((candidate) => candidate.kind !== primary.kind)
+    if (secondary) Object.assign(fields, candidateToFields(secondary, 'secondary'))
+  }
+  return fields
+}
+
+function getRepeatCount(step: any): number {
+  const repsRaw = Number(step?.reps ?? step?.repeat ?? step?.intervals ?? 1)
+  return Number.isFinite(repsRaw) && repsRaw > 0 ? Math.floor(repsRaw) : 1
+}
+
+function buildWorkoutStep(
+  step: any,
+  stepOrder: number,
+  sport: string,
+  thresholds: GarminTargetThresholds
+): Record<string, unknown> {
+  const durationType = getDurationType(step)
+  const durationValue = getDurationValue(step)
+  const targets = getTargets(step, sport, thresholds)
 
   return {
-    workoutName: workout.title,
-    description: workout.description || '',
-    sport: mapSportToGarmin(workout.type),
-    estimatedDurationInSecs: Number(workout.durationSec) || undefined,
-    estimatedDistanceInMeters: Number(workout.distanceMeters) || undefined,
-    workoutProvider: 'COACH_WATTZ',
-    steps: steps.map((step: any, index: number) => {
-      const durationType = getDurationType(step)
-      const durationValue = getDurationValue(step)
-      const target = getTarget(step, thresholds)
+    type: 'WorkoutStep',
+    stepOrder,
+    intensity: mapStepIntensity(step.type || ''),
+    description: step.name || undefined,
+    durationType,
+    ...(durationValue > 0 ? { durationValue } : {}),
+    ...(durationType === 'DISTANCE' ? { durationValueType: 'METER' } : {}),
+    ...targets
+  }
+}
+
+/**
+ * Convert canonical nested steps into Garmin V2 steps, preserving
+ * WorkoutRepeatStep groups instead of unrolling them.
+ * stepOrder is assigned globally (parent repeat before its children), matching V2 examples.
+ */
+function buildGarminSteps(
+  steps: any[],
+  sport: string,
+  thresholds: GarminTargetThresholds
+): Record<string, unknown>[] {
+  let stepOrder = 1
+
+  const convert = (step: any): Record<string, unknown> | null => {
+    if (!step) return null
+    const nested = Array.isArray(step.steps) ? step.steps.filter(Boolean) : []
+    const reps = getRepeatCount(step)
+
+    if (nested.length > 0) {
+      const repeatOrder = stepOrder++
+      const childSteps = nested
+        .map((child) => convert(child))
+        .filter((child): child is Record<string, unknown> => child != null)
       return {
-        stepOrder: index + 1,
-        type: 'WorkoutStep',
-        intensity: mapStepIntensity(step.type || ''),
-        description: step.name || undefined,
-        durationType,
-        durationValue: durationValue > 0 ? durationValue : undefined,
-        ...target
+        type: 'WorkoutRepeatStep',
+        stepOrder: repeatOrder,
+        repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+        repeatValue: reps,
+        steps: childSteps
       }
+    }
+
+    if (reps > 1) {
+      const repeatOrder = stepOrder++
+      return {
+        type: 'WorkoutRepeatStep',
+        stepOrder: repeatOrder,
+        repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+        repeatValue: reps,
+        steps: [buildWorkoutStep(step, stepOrder++, sport, thresholds)]
+      }
+    }
+
+    return buildWorkoutStep(step, stepOrder++, sport, thresholds)
+  }
+
+  return (steps || [])
+    .map((step) => convert(step))
+    .filter((step): step is Record<string, unknown> => step != null)
+}
+
+/** Count leaf WorkoutSteps for the 100-step single-sport limit. */
+export function countGarminWorkoutSteps(steps: Record<string, unknown>[]): number {
+  let count = 0
+  const visit = (list: Record<string, unknown>[]) => {
+    for (const step of list || []) {
+      if (step?.type === 'WorkoutRepeatStep' && Array.isArray(step.steps)) {
+        visit(step.steps as Record<string, unknown>[])
+      } else {
+        count += 1
+      }
+    }
+  }
+  visit(steps)
+  return count
+}
+
+export function buildGarminTrainingPayload(
+  workout: any,
+  thresholds: GarminTargetThresholds = {},
+  options: { ownerId?: string | number | null } = {}
+) {
+  const sport = mapSportToGarmin(workout.type)
+  const garminSteps = buildGarminSteps(workout?.steps || [], sport, thresholds)
+  const stepCount = countGarminWorkoutSteps(garminSteps)
+  if (stepCount > 100) {
+    throw createError({
+      statusCode: 422,
+      message: `Garmin workouts are limited to 100 steps (this workout has ${stepCount}).`
     })
   }
+
+  const ownerIdRaw = options.ownerId
+  const ownerId =
+    ownerIdRaw != null && String(ownerIdRaw).trim() !== ''
+      ? Number.isFinite(Number(ownerIdRaw))
+        ? Number(ownerIdRaw)
+        : String(ownerIdRaw)
+      : undefined
+
+  return {
+    ...(ownerId != null ? { ownerId } : {}),
+    workoutName: workout.title,
+    description: workout.description || '',
+    sport,
+    estimatedDurationInSecs: Number(workout.durationSec) || undefined,
+    estimatedDistanceInMeters: Number(workout.distanceMeters) || undefined,
+    workoutProvider: WORKOUT_PROVIDER,
+    workoutSourceId: WORKOUT_PROVIDER,
+    isSessionTransitionEnabled: false,
+    segments: [
+      {
+        segmentOrder: 1,
+        sport,
+        steps: garminSteps
+      }
+    ]
+  }
+}
+
+function garminOwnerIdFromIntegration(integration: Integration): string | number | undefined {
+  const raw = integration.externalUserId
+  if (raw == null || String(raw).trim() === '') return undefined
+  const asNumber = Number(raw)
+  return Number.isFinite(asNumber) ? asNumber : raw
 }
 
 export async function createGarminWorkout(integration: Integration, payload: any) {
   const validIntegration = await ensureValidToken(integration)
-  const response = await fetch('https://apis.garmin.com/training-api/workout', {
-    method: 'POST',
-    headers: getGarminHeaders(validIntegration.accessToken),
-    body: JSON.stringify(payload)
-  })
+  const body = {
+    ...payload,
+    ...(payload?.ownerId == null && validIntegration.externalUserId
+      ? { ownerId: garminOwnerIdFromIntegration(validIntegration) }
+      : {})
+  }
+  const headers = getGarminHeaders(validIntegration.accessToken)
 
-  if (!response.ok) {
+  // Training API V2 docs list create on workoutportal; retrieve/update use training-api.
+  // Prefer the documented create URL, then fall back if that host rejects the route.
+  const createUrls = [GARMIN_TRAINING_WORKOUT_CREATE_V2, GARMIN_TRAINING_WORKOUT_V2]
+  let lastError = 'unknown error'
+  for (const url of createUrls) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    })
+    if (response.ok) return response.json()
     const error = await response.text().catch(() => response.statusText)
-    throw new Error(`Garmin create workout failed (${response.status}): ${error}`)
+    lastError = `(${response.status}): ${error}`
+    if (response.status !== 404 && response.status !== 405) {
+      throw new Error(`Garmin create workout failed ${lastError}`)
+    }
   }
 
-  return response.json()
+  throw new Error(`Garmin create workout failed ${lastError}`)
 }
 
 export async function updateGarminWorkout(
@@ -229,10 +432,19 @@ export async function updateGarminWorkout(
   payload: any
 ) {
   const validIntegration = await ensureValidToken(integration)
-  const response = await fetch(`https://apis.garmin.com/training-api/workout/${workoutId}`, {
+  const ownerId = payload?.ownerId ?? garminOwnerIdFromIntegration(validIntegration)
+  if (ownerId == null) {
+    const err = new Error(
+      'Garmin update workout requires ownerId (missing Garmin externalUserId)'
+    ) as Error & { code?: string }
+    err.code = 'GARMIN_OWNER_ID_REQUIRED'
+    throw err
+  }
+  const body = { ...payload, ownerId }
+  const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${workoutId}`, {
     method: 'PUT',
     headers: getGarminHeaders(validIntegration.accessToken),
-    body: JSON.stringify(payload)
+    body: JSON.stringify(body)
   })
 
   if (!response.ok) {
@@ -248,7 +460,7 @@ export async function createGarminWorkoutSchedule(
   payload: { workoutId: number | string; date: string }
 ) {
   const validIntegration = await ensureValidToken(integration)
-  const response = await fetch('https://apis.garmin.com/training-api/schedule', {
+  const response = await fetch(GARMIN_TRAINING_SCHEDULE, {
     method: 'POST',
     headers: getGarminHeaders(validIntegration.accessToken),
     body: JSON.stringify(payload)
@@ -279,7 +491,7 @@ export async function updateGarminWorkoutSchedule(
   payload: { workoutId: number | string; date: string }
 ) {
   const validIntegration = await ensureValidToken(integration)
-  const response = await fetch(`https://apis.garmin.com/training-api/schedule/${scheduleId}`, {
+  const response = await fetch(`${GARMIN_TRAINING_SCHEDULE}/${scheduleId}`, {
     method: 'PUT',
     headers: getGarminHeaders(validIntegration.accessToken),
     body: JSON.stringify(payload)
@@ -342,29 +554,38 @@ export async function createGarminCourse(integration: Integration, payload: any)
   return response.json()
 }
 
+/**
+ * Map Coach Watts sport types to Training API V2 sport enums.
+ * V2 single-segment sports: RUNNING, CYCLING, LAP_SWIMMING, STRENGTH_TRAINING,
+ * CARDIO_TRAINING, GENERIC, YOGA, PILATES.
+ */
 function mapSportToGarmin(type: string): string {
   const normalized = String(type || '').trim()
   const map: Record<string, string> = {
     Run: 'RUNNING',
-    TrailRun: 'TRAIL_RUNNING',
+    TrailRun: 'RUNNING',
     Ride: 'CYCLING',
     VirtualRide: 'CYCLING',
     GravelRide: 'CYCLING',
     MountainBikeRide: 'CYCLING',
     Swim: 'LAP_SWIMMING',
-    Walk: 'WALKING',
-    Hike: 'HIKING'
+    Strength: 'STRENGTH_TRAINING',
+    WeightTraining: 'STRENGTH_TRAINING',
+    Yoga: 'YOGA',
+    Pilates: 'PILATES',
+    Walk: 'GENERIC',
+    Hike: 'GENERIC'
   }
   if (map[normalized]) return map[normalized]!
 
   const lower = normalized.toLowerCase()
-  if (lower.includes('trail') && lower.includes('run')) return 'TRAIL_RUNNING'
-  if (lower.includes('run')) return 'RUNNING'
   if (lower.includes('swim')) return 'LAP_SWIMMING'
+  if (lower.includes('yoga')) return 'YOGA'
+  if (lower.includes('pilates')) return 'PILATES'
+  if (lower.includes('strength') || lower.includes('weight')) return 'STRENGTH_TRAINING'
+  if (lower.includes('run')) return 'RUNNING'
   if (lower.includes('virtual') || lower.includes('ride') || lower.includes('bike')) {
     return 'CYCLING'
   }
-  if (lower.includes('hike')) return 'HIKING'
-  if (lower.includes('walk')) return 'WALKING'
   return 'GENERIC'
 }

--- a/tests/unit/server/utils/garmin-push.test.ts
+++ b/tests/unit/server/utils/garmin-push.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildGarminTrainingPayload,
+  countGarminWorkoutSteps,
   extractGarminScheduleId
 } from '../../../../server/utils/garmin-push'
 
 describe('garmin push helpers', () => {
-  it('converts relative power and heart rate targets to absolute values', () => {
+  it('builds a V2 segmented payload with absolute power as primary target', () => {
     const payload = buildGarminTrainingPayload(
       {
         title: 'Test Ride',
@@ -22,9 +23,144 @@ describe('garmin push helpers', () => {
       { ftp: 200, lthr: 150 }
     )
 
-    const step = payload.steps[0] as Record<string, unknown>
+    expect(payload.sport).toBe('CYCLING')
+    expect(payload.workoutProvider).toBe('COACH_WATTZ')
+    expect(payload.workoutSourceId).toBe('COACH_WATTZ')
+    expect(payload.isSessionTransitionEnabled).toBe(false)
+    expect(payload.segments).toHaveLength(1)
+    expect(payload.segments[0]).toMatchObject({
+      segmentOrder: 1,
+      sport: 'CYCLING'
+    })
+
+    const step = payload.segments[0]!.steps[0] as Record<string, unknown>
+    expect(step.type).toBe('WorkoutStep')
     expect(step.targetType).toBe('POWER')
     expect(step.targetValue).toBe(190)
+    expect(step.secondaryTargetType).toBe('HEART_RATE')
+    expect(step.secondaryTargetValue).toBe(128)
+    expect(payload).not.toHaveProperty('steps')
+  })
+
+  it('prefers pace as primary for running and maps trail run to RUNNING', () => {
+    const payload = buildGarminTrainingPayload(
+      {
+        title: 'Tempo Run',
+        type: 'TrailRun',
+        steps: [
+          {
+            type: 'Active',
+            distance: 1600,
+            pace: { range: { start: 3.3, end: 3.5 }, units: 'm/s' },
+            heartRate: { range: { start: 0.85, end: 0.9 }, units: '%' },
+            cadence: 180
+          }
+        ]
+      },
+      { lthr: 160 }
+    )
+
+    expect(payload.sport).toBe('RUNNING')
+    const step = payload.segments[0]!.steps[0] as Record<string, unknown>
+    expect(step.durationType).toBe('DISTANCE')
+    expect(step.durationValue).toBe(1600)
+    expect(step.durationValueType).toBe('METER')
+    expect(step.targetType).toBe('PACE')
+    expect(step.targetValueLow).toBe(3.3)
+    expect(step.targetValueHigh).toBe(3.5)
+    // V2 docs only guarantee secondary targets for cycling/swim — omit for run.
+    expect(step.secondaryTargetType).toBeUndefined()
+  })
+
+  it('preserves WorkoutRepeatStep instead of unrolling repeats', () => {
+    const payload = buildGarminTrainingPayload(
+      {
+        title: 'Intervals',
+        type: 'Ride',
+        steps: [
+          { type: 'Warmup', durationSeconds: 600, power: { value: 0.55, units: '%' } },
+          {
+            type: 'Repeat',
+            reps: 4,
+            steps: [
+              {
+                type: 'Interval',
+                durationSeconds: 180,
+                power: { range: { start: 1.05, end: 1.1 }, units: '%' },
+                cadence: 95
+              },
+              { type: 'Recovery', durationSeconds: 120, power: { value: 0.5, units: '%' } }
+            ]
+          },
+          { type: 'Cooldown', durationSeconds: 300, power: { value: 0.5, units: '%' } }
+        ]
+      },
+      { ftp: 250 }
+    )
+
+    const steps = payload.segments[0]!.steps
+    expect(steps).toHaveLength(3)
+    expect(steps[0]).toMatchObject({
+      type: 'WorkoutStep',
+      stepOrder: 1,
+      intensity: 'WARMUP'
+    })
+    expect(steps[1]).toMatchObject({
+      type: 'WorkoutRepeatStep',
+      stepOrder: 2,
+      repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+      repeatValue: 4
+    })
+    const repeatChildren = (steps[1] as any).steps
+    expect(repeatChildren).toHaveLength(2)
+    expect(repeatChildren[0]).toMatchObject({
+      type: 'WorkoutStep',
+      stepOrder: 3,
+      intensity: 'INTERVAL',
+      targetType: 'POWER',
+      secondaryTargetType: 'CADENCE',
+      secondaryTargetValue: 95
+    })
+    expect(repeatChildren[1]).toMatchObject({
+      type: 'WorkoutStep',
+      stepOrder: 4,
+      intensity: 'RECOVERY'
+    })
+    expect(steps[2]).toMatchObject({
+      type: 'WorkoutStep',
+      stepOrder: 5,
+      intensity: 'COOLDOWN'
+    })
+    expect(countGarminWorkoutSteps(steps)).toBe(4)
+  })
+
+  it('wraps leaf steps with reps into WorkoutRepeatStep', () => {
+    const payload = buildGarminTrainingPayload({
+      title: 'Strides',
+      type: 'Run',
+      steps: [
+        {
+          type: 'Active',
+          reps: 6,
+          durationSeconds: 30,
+          pace: { value: 4.5, units: 'm/s' }
+        }
+      ]
+    })
+
+    const step = payload.segments[0]!.steps[0] as Record<string, unknown>
+    expect(step).toMatchObject({
+      type: 'WorkoutRepeatStep',
+      stepOrder: 1,
+      repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+      repeatValue: 6
+    })
+    expect((step.steps as any[])[0]).toMatchObject({
+      type: 'WorkoutStep',
+      stepOrder: 2,
+      targetType: 'PACE',
+      targetValue: 4.5
+    })
   })
 
   it('extracts schedule ids from Garmin API responses', () => {
@@ -34,7 +170,7 @@ describe('garmin push helpers', () => {
     expect(extractGarminScheduleId({})).toBe('')
   })
 
-  it('maps extended sport types', () => {
+  it('maps extended sport types to V2 enums', () => {
     const payload = buildGarminTrainingPayload({
       title: 'Virtual Ride',
       type: 'VirtualRide',
@@ -42,5 +178,19 @@ describe('garmin push helpers', () => {
     })
 
     expect(payload.sport).toBe('CYCLING')
+    expect(payload.segments[0]!.sport).toBe('CYCLING')
+  })
+
+  it('includes ownerId when provided', () => {
+    const payload = buildGarminTrainingPayload(
+      {
+        title: 'Owned',
+        type: 'Ride',
+        steps: [{ type: 'Active', durationSeconds: 60 }]
+      },
+      {},
+      { ownerId: '998877' }
+    )
+    expect(payload.ownerId).toBe(998877)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Migrates planned workout publish to Garmin Connect **Training API V2**, with correct handling for running and cycling workout steps.

## Changes
- **V2 payload shape**: workouts now use `segments[]` (single segment for run/ride) instead of a flat top-level `steps` array
- **Native repeats**: nested/repeated steps emit `WorkoutRepeatStep` + `REPEAT_UNTIL_STEPS_CMPLT` instead of unrolling into dozens of flat steps
- **Sport-aware targets**
  - **Running**: primary `PACE` (m/s) preferred over HR/power/cadence
  - **Cycling**: primary `POWER` preferred; secondary target supported (e.g. HR or cadence) per V2 docs
- **Endpoints**: create via `workoutportal/workout/v2` (with fallback to `training-api/workout/v2`); update via `training-api/workout/v2/{id}`
- **Update requirements**: include Garmin `ownerId` from `integration.externalUserId`; recreate if missing/404
- **Sport mapping**: Training API sports limited to V2 enums (`TrailRun` → `RUNNING`, walk/hike → `GENERIC`)
- Enforces the **100-step** single-sport limit before calling Garmin

## Tests
- Expanded `tests/unit/server/utils/garmin-push.test.ts` for V2 segments, run pace primary, cycling secondary targets, and repeat preservation
- `pnpm exec vitest run tests/unit/server/utils/garmin-push.test.ts` — passing

## Notes
Based on Garmin Training API V2 (2025-05-26). Courses API path is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

