### PR TITLE
fix(sync): recover stale Sync All locks and clarify in-progress toasts

### DIFF
--- a/app/pages/settings/apps.vue
+++ b/app/pages/settings/apps.vue
@@ -728,10 +728,20 @@
         refreshIntegrations()
       }, 2000)
     } catch (error: any) {
+      const statusCode = error.statusCode || error.status || error.data?.statusCode
+      const conflict =
+        statusCode === 409 ||
+        error.data?.data?.code === 'SYNC_IN_PROGRESS' ||
+        error.data?.code === 'SYNC_IN_PROGRESS'
+
       toast.add({
-        title: 'Sync Failed',
-        description: error.data?.message || `Failed to sync ${provider}`,
-        color: 'error'
+        title: conflict ? 'Sync already in progress' : 'Sync Failed',
+        description:
+          error.data?.message ||
+          (conflict
+            ? `${getProviderName(provider)} is already syncing. Please wait for it to finish.`
+            : `Failed to sync ${provider}`),
+        color: conflict ? 'warning' : 'error'
       })
     } finally {
       syncingProviders.value.delete(provider)

--- a/app/stores/integrations.ts
+++ b/app/stores/integrations.ts
@@ -109,13 +109,42 @@ export const useIntegrationStore = defineStore('integration', () => {
       )
     } catch (error: any) {
       console.error('Error syncing data:', error)
-      syncingData.value = false
 
+      const statusCode = error.statusCode || error.status || error.data?.statusCode
+      const conflict =
+        statusCode === 409 ||
+        error.data?.data?.code === 'SYNC_IN_PROGRESS' ||
+        error.data?.code === 'SYNC_IN_PROGRESS'
+      const reason = error.data?.data?.reason || error.data?.reason
+      const message =
+        error.data?.message ||
+        (conflict
+          ? 'A sync is already in progress. You can monitor it in the activity monitor.'
+          : 'Failed to sync data. Please try again.')
+
+      if (conflict) {
+        // Adopt in-progress UI when the batch sync itself is already running.
+        syncingData.value = reason === 'ingest-all'
+        showDashboardProgressToast(
+          toast,
+          {
+            title: 'Sync already in progress',
+            description: message,
+            color: 'warning',
+            icon: 'i-heroicons-arrow-path',
+            duration: 5000
+          },
+          'integration.sync.in_progress'
+        )
+        return
+      }
+
+      syncingData.value = false
       showDashboardProgressToast(
         toast,
         {
           title: 'Sync Failed',
-          description: error.data?.message || 'Failed to sync data. Please try again.',
+          description: message,
           color: 'error',
           icon: 'i-heroicons-exclamation-circle',
           duration: 3000

--- a/server/api/integrations/sync.post.ts
+++ b/server/api/integrations/sync.post.ts
@@ -2,7 +2,11 @@ import { getServerSession } from '../../utils/session'
 import { tasks } from '@trigger.dev/sdk/v3'
 import { getUserTimezone, getUserLocalDate } from '../../utils/date'
 import { publishTaskRunStartedEvent } from '../../utils/task-run-events'
-import { resolveProviderSyncBlock, resolveSyncAllBlock } from '../../utils/integration-sync-guard'
+import {
+  formatSyncInProgressMessage,
+  resolveProviderSyncBlock,
+  resolveSyncAllBlock
+} from '../../utils/integration-sync-guard'
 
 defineRouteMeta({
   openAPI: {
@@ -213,7 +217,12 @@ export default defineEventHandler(async (event) => {
     if (providerSyncBlock.blocked) {
       throw createError({
         statusCode: 409,
-        message: `${provider} sync is already in progress. Please wait for it to finish.`
+        message: formatSyncInProgressMessage(providerSyncBlock),
+        data: {
+          code: 'SYNC_IN_PROGRESS',
+          provider: providerSyncBlock.provider,
+          reason: providerSyncBlock.reason
+        }
       })
     }
   } else {
@@ -221,7 +230,12 @@ export default defineEventHandler(async (event) => {
     if (syncAllBlock.blocked) {
       throw createError({
         statusCode: 409,
-        message: `Sync already in progress for ${syncAllBlock.provider}. Please wait for it to finish.`
+        message: formatSyncInProgressMessage(syncAllBlock),
+        data: {
+          code: 'SYNC_IN_PROGRESS',
+          provider: syncAllBlock.provider,
+          reason: syncAllBlock.reason
+        }
       })
     }
   }

--- a/server/utils/integration-sync-guard.ts
+++ b/server/utils/integration-sync-guard.ts
@@ -19,6 +19,11 @@ export const PROVIDER_INGEST_TASKS: Record<string, string> = {
 
 const STALE_SYNC_MESSAGE = 'Previous sync did not complete'
 
+export type SyncBlockReason = 'ingest-all' | 'provider'
+
+export type SyncBlockResult =
+  { blocked: false } | { blocked: true; provider: string; reason: SyncBlockReason }
+
 export async function clearStaleSyncStatus(integrationId: string, provider: string) {
   await prisma.integration.update({
     where: { id: integrationId },
@@ -56,7 +61,7 @@ export async function isProviderActivelySyncing(
 export async function resolveProviderSyncBlock(
   userId: string,
   integration: { id: string; provider: string; syncStatus: string | null | undefined }
-): Promise<{ blocked: boolean; provider?: string }> {
+): Promise<SyncBlockResult> {
   if (integration.syncStatus !== 'SYNCING') {
     return { blocked: false }
   }
@@ -68,16 +73,14 @@ export async function resolveProviderSyncBlock(
   )
 
   if (activelySyncing) {
-    return { blocked: true, provider: integration.provider }
+    return { blocked: true, provider: integration.provider, reason: 'provider' }
   }
 
   await clearStaleSyncStatus(integration.id, integration.provider)
   return { blocked: false }
 }
 
-export async function resolveSyncAllBlock(
-  userId: string
-): Promise<{ blocked: boolean; provider?: string }> {
+export async function resolveSyncAllBlock(userId: string): Promise<SyncBlockResult> {
   const batchRunning = await isTaskRunning('ingest-all', userId)
   if (batchRunning) {
     const syncingIntegration = await prisma.integration.findFirst({
@@ -87,7 +90,8 @@ export async function resolveSyncAllBlock(
 
     return {
       blocked: true,
-      provider: syncingIntegration?.provider || 'all'
+      provider: syncingIntegration?.provider || 'all',
+      reason: 'ingest-all'
     }
   }
 
@@ -107,4 +111,17 @@ export async function resolveSyncAllBlock(
   }
 
   return { blocked: false }
+}
+
+export function formatSyncInProgressMessage(block: {
+  provider: string
+  reason: SyncBlockReason
+}): string {
+  if (block.reason === 'ingest-all') {
+    return block.provider === 'all'
+      ? 'A sync of all connected apps is already in progress. You can monitor it in the activity monitor.'
+      : `A sync of all connected apps is already in progress (currently syncing ${block.provider}). You can monitor it in the activity monitor.`
+  }
+
+  return `${block.provider} sync is already in progress. Sync All will be available when it finishes, or sync other apps individually from Settings.`
 }

--- a/server/utils/trigger-check.ts
+++ b/server/utils/trigger-check.ts
@@ -8,6 +8,26 @@ const RUNNING_STATUSES = new Set([
   'FROZEN'
 ])
 
+/** Trigger runs older than this are treated as stale and ignored for sync guards. */
+export const STALE_TRIGGER_RUN_MS = 2 * 60 * 60 * 1000
+
+function getRunTimestamp(run: {
+  startedAt?: string | Date | null
+  createdAt?: string | Date | null
+}) {
+  return run.startedAt || run.createdAt || null
+}
+
+export function isRunFresh(
+  run: { startedAt?: string | Date | null; createdAt?: string | Date | null },
+  nowMs = Date.now(),
+  maxAgeMs = STALE_TRIGGER_RUN_MS
+): boolean {
+  const timestamp = getRunTimestamp(run)
+  if (!timestamp) return true
+  return nowMs - new Date(timestamp).getTime() <= maxAgeMs
+}
+
 export async function isTaskRunning(taskIdentifier: string, userId: string): Promise<boolean> {
   try {
     // @ts-expect-error - SDK v3 types mismatch for filter params
@@ -20,8 +40,19 @@ export async function isTaskRunning(taskIdentifier: string, userId: string): Pro
       limit: 10
     })
 
-    // Trigger API may ignore status filters; verify client-side.
-    return activeRuns.data.some((run) => RUNNING_STATUSES.has(run.status))
+    const nowMs = Date.now()
+
+    // Trigger API may ignore status filters; verify client-side and skip stale runs.
+    return activeRuns.data.some((run) => {
+      if (!RUNNING_STATUSES.has(run.status)) return false
+      if (!isRunFresh(run, nowMs)) {
+        console.warn(
+          `[Sync] Ignoring stale Trigger run ${run.id} for ${taskIdentifier} (status=${run.status})`
+        )
+        return false
+      }
+      return true
+    })
   } catch (error) {
     console.warn(`Failed to check running status for task ${taskIdentifier}:`, error)
     return false // Fail open to allow retry if check fails
@@ -32,7 +63,12 @@ export async function isRunIdRunning(runId: string): Promise<boolean> {
   try {
     const run = await runs.retrieve(runId)
     const runningStatuses = ['EXECUTING', 'QUEUED', 'WAITING_FOR_DEPLOY', 'REATTEMPTING', 'FROZEN']
-    return runningStatuses.includes(run.status)
+    if (!runningStatuses.includes(run.status)) return false
+    if (!isRunFresh(run)) {
+      console.warn(`[Sync] Ignoring stale Trigger run ${runId} (status=${run.status})`)
+      return false
+    }
+    return true
   } catch (error) {
     console.warn(`Failed to check running status for run ${runId}:`, error)
     return false

--- a/tests/unit/server/api/integrations/sync.post.test.ts
+++ b/tests/unit/server/api/integrations/sync.post.test.ts
@@ -19,6 +19,7 @@ vi.stubGlobal('readBody', async (event: any) => event.body)
 vi.stubGlobal('createError', (err: any) => {
   const error = new Error(err.message)
   ;(error as any).statusCode = err.statusCode
+  ;(error as any).data = err.data
   return error
 })
 vi.stubGlobal('prisma', prismaMock)
@@ -42,10 +43,15 @@ vi.mock('../../../../../server/utils/task-run-events', () => ({
   publishTaskRunStartedEvent: vi.fn()
 }))
 
-vi.mock('../../../../../server/utils/integration-sync-guard', () => ({
-  resolveProviderSyncBlock: resolveProviderSyncBlockMock,
-  resolveSyncAllBlock: resolveSyncAllBlockMock
-}))
+vi.mock('../../../../../server/utils/integration-sync-guard', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../server/utils/integration-sync-guard')>()
+  return {
+    ...actual,
+    resolveProviderSyncBlock: resolveProviderSyncBlockMock,
+    resolveSyncAllBlock: resolveSyncAllBlockMock
+  }
+})
 
 const getHandler = async () => {
   const mod = await import('../../../../../server/api/integrations/sync.post')
@@ -69,7 +75,11 @@ describe('POST /api/integrations/sync', () => {
       provider: 'strava',
       syncStatus: 'SYNCING'
     })
-    resolveProviderSyncBlockMock.mockResolvedValue({ blocked: true, provider: 'strava' })
+    resolveProviderSyncBlockMock.mockResolvedValue({
+      blocked: true,
+      provider: 'strava',
+      reason: 'provider'
+    })
 
     await expect(
       handler({
@@ -77,7 +87,12 @@ describe('POST /api/integrations/sync', () => {
       } as any)
     ).rejects.toMatchObject({
       statusCode: 409,
-      message: 'strava sync is already in progress. Please wait for it to finish.'
+      message: expect.stringContaining('strava sync is already in progress'),
+      data: {
+        code: 'SYNC_IN_PROGRESS',
+        provider: 'strava',
+        reason: 'provider'
+      }
     })
 
     expect(tasks.trigger).not.toHaveBeenCalled()
@@ -86,7 +101,11 @@ describe('POST /api/integrations/sync', () => {
   it('returns 409 for sync-all when any integration is actively syncing', async () => {
     const handler = await getHandler()
 
-    resolveSyncAllBlockMock.mockResolvedValue({ blocked: true, provider: 'oura' })
+    resolveSyncAllBlockMock.mockResolvedValue({
+      blocked: true,
+      provider: 'oura',
+      reason: 'provider'
+    })
 
     await expect(
       handler({
@@ -94,7 +113,38 @@ describe('POST /api/integrations/sync', () => {
       } as any)
     ).rejects.toMatchObject({
       statusCode: 409,
-      message: 'Sync already in progress for oura. Please wait for it to finish.'
+      message: expect.stringContaining('oura sync is already in progress'),
+      data: {
+        code: 'SYNC_IN_PROGRESS',
+        provider: 'oura',
+        reason: 'provider'
+      }
+    })
+
+    expect(tasks.trigger).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 for sync-all when ingest-all is already running', async () => {
+    const handler = await getHandler()
+
+    resolveSyncAllBlockMock.mockResolvedValue({
+      blocked: true,
+      provider: 'oura',
+      reason: 'ingest-all'
+    })
+
+    await expect(
+      handler({
+        body: { provider: 'all' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: expect.stringContaining('all connected apps'),
+      data: {
+        code: 'SYNC_IN_PROGRESS',
+        provider: 'oura',
+        reason: 'ingest-all'
+      }
     })
 
     expect(tasks.trigger).not.toHaveBeenCalled()

--- a/tests/unit/server/utils/integration-sync-guard.test.ts
+++ b/tests/unit/server/utils/integration-sync-guard.test.ts
@@ -60,7 +60,7 @@ describe('integration-sync-guard', () => {
       syncStatus: 'SYNCING'
     })
 
-    expect(result).toEqual({ blocked: true, provider: 'oura' })
+    expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'provider' })
     expect(prismaMock.integration.update).not.toHaveBeenCalled()
   })
 
@@ -86,7 +86,35 @@ describe('integration-sync-guard', () => {
 
     const result = await resolveSyncAllBlock('user-1')
 
-    expect(result).toEqual({ blocked: true, provider: 'oura' })
+    expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'ingest-all' })
     expect(prismaMock.integration.update).not.toHaveBeenCalled()
+  })
+
+  it('blocks sync-all when a provider ingest task is actively running', async () => {
+    isTaskRunningMock.mockImplementation(async (taskId: string) => taskId === 'ingest-oura')
+    prismaMock.integration.findMany.mockResolvedValue([
+      { id: 'integration-oura', provider: 'oura', syncStatus: 'SYNCING' }
+    ])
+
+    const { resolveSyncAllBlock } = await import('../../../../server/utils/integration-sync-guard')
+
+    const result = await resolveSyncAllBlock('user-1')
+
+    expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'provider' })
+  })
+
+  it('formats sync-in-progress messages for batch and provider blocks', async () => {
+    const { formatSyncInProgressMessage } =
+      await import('../../../../server/utils/integration-sync-guard')
+
+    expect(formatSyncInProgressMessage({ provider: 'all', reason: 'ingest-all' })).toContain(
+      'all connected apps'
+    )
+    expect(formatSyncInProgressMessage({ provider: 'oura', reason: 'ingest-all' })).toContain(
+      'oura'
+    )
+    expect(formatSyncInProgressMessage({ provider: 'oura', reason: 'provider' })).toContain(
+      'Sync All will be available'
+    )
   })
 })

--- a/tests/unit/server/utils/trigger-check.test.ts
+++ b/tests/unit/server/utils/trigger-check.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { STALE_TRIGGER_RUN_MS, isRunFresh } from '../../../../server/utils/trigger-check'
+
+describe('trigger-check isRunFresh', () => {
+  it('treats runs without timestamps as fresh', () => {
+    expect(isRunFresh({})).toBe(true)
+  })
+
+  it('treats recent runs as fresh', () => {
+    const now = Date.now()
+    expect(isRunFresh({ startedAt: new Date(now - 5 * 60 * 1000).toISOString() }, now)).toBe(true)
+  })
+
+  it('treats runs older than the stale threshold as not fresh', () => {
+    const now = Date.now()
+    expect(
+      isRunFresh({ createdAt: new Date(now - STALE_TRIGGER_RUN_MS - 1000).toISOString() }, now)
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dashboard **Sync All** and per-app sync share `POST /api/integrations/sync`, but use different guards:

- **Sync All** blocks if `ingest-all` is running **or any** provider is actively syncing
- **Per-app sync** only blocks that provider (and only when its DB status is `SYNCING`)

That is why a user can still sync apps individually while Sync All shows an “already syncing” toast — and why the toast was easy to misread as a hard failure when a background sync was running (or a Trigger run looked stuck).

### Changes

1. **Stale Trigger run recovery** — `isTaskRunning` ignores runs older than 2 hours, so Sync All can proceed when a lock is effectively dead (DB stale `SYNCING` was already cleared when no live task exists).
2. **Clearer 409 response** — returns `SYNC_IN_PROGRESS` with `provider` + `reason` (`ingest-all` | `provider`) and a message that explains what is running.
3. **Toast UX** — Sync All / Settings no longer show **“Sync Failed”** for 409; they show a warning **“Sync already in progress”**. If the batch (`ingest-all`) itself is running, the dashboard adopts the in-progress sync UI instead of looking idle.

## Test plan

- [x] Unit tests for sync guard, trigger freshness, and sync API 409 payloads
- [ ] Manually: start Sync All twice quickly → second click shows warning toast (not Sync Failed)
- [ ] Manually: while one app is syncing from Settings, Sync All names that app and explains Sync All waits
- [ ] Manually: with a stuck/old Trigger run (>2h), Sync All should clear the path and start a new sync

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b69-f35a-7b8a-b7d0-b67cafecd977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b69-f35a-7b8a-b7d0-b67cafecd977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

