### PR TITLE
Fix Trigger deploy: remove h3 import from garmin-push

### DIFF
--- a/server/api/workouts/planned/[id]/publish-garmin.post.ts
+++ b/server/api/workouts/planned/[id]/publish-garmin.post.ts
@@ -266,7 +266,7 @@ export default defineEventHandler(async (event) => {
     })
 
     throw createError({
-      statusCode: 500,
+      statusCode: Number(error?.statusCode) || 500,
       message: error?.message || 'Failed to publish to Garmin'
     })
   }

--- a/server/utils/garmin-push.ts
+++ b/server/utils/garmin-push.ts
@@ -1,5 +1,4 @@
 import type { Integration } from '@prisma/client'
-import { createError } from 'h3'
 import { refreshGarminToken } from './garmin'
 
 /**
@@ -356,10 +355,12 @@ export function buildGarminTrainingPayload(
   const garminSteps = buildGarminSteps(workout?.steps || [], sport, thresholds)
   const stepCount = countGarminWorkoutSteps(garminSteps)
   if (stepCount > 100) {
-    throw createError({
-      statusCode: 422,
-      message: `Garmin workouts are limited to 100 steps (this workout has ${stepCount}).`
-    })
+    // Avoid importing h3 here — this module is pulled into Trigger.dev builds.
+    const error = new Error(
+      `Garmin workouts are limited to 100 steps (this workout has ${stepCount}).`
+    ) as Error & { statusCode: number }
+    error.statusCode = 422
+    throw error
   }
 
   const ownerIdRaw = options.ownerId


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Master deploy failed during `npx trigger.dev deploy` with:

```text
server/utils/garmin-push.ts:2:28: ERROR: Could not resolve "h3"
```

## Fix
- Remove the `h3`/`createError` import from `server/utils/garmin-push.ts`
- Throw a plain `Error` with `statusCode: 422` for the 100-step limit
- Preserve that status code in the publish-garmin API catch path

## Why
Trigger.dev bundles this server util and cannot resolve Nuxt/`h3` there. The module should stay framework-agnostic.

## Test
- `pnpm exec vitest run tests/unit/server/utils/garmin-push.test.ts` — passing
- Re-run Trigger deploy after merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

