### PR TITLE
Default sport targeting to HR before pace and power

### DIFF
--- a/app/components/profile/SportSettings.vue
+++ b/app/components/profile/SportSettings.vue
@@ -1710,9 +1710,9 @@
     },
     warmupTime: 10,
     cooldownTime: 10,
-    loadPreference: 'POWER_HR_PACE',
+    loadPreference: 'HR_PACE_POWER',
     targetPolicy: {
-      primaryMetric: 'power',
+      primaryMetric: 'heartRate',
       strictPrimary: true,
       allowMixedTargetsPerStep: false,
       defaultTargetStyle: 'range',
@@ -1831,12 +1831,12 @@
   ]
 
   const LOAD_PREFERENCES = [
-    'POWER_HR_PACE',
-    'POWER_PACE_HR',
-    'HR_POWER_PACE',
     'HR_PACE_POWER',
+    'HR_POWER_PACE',
+    'PACE_HR_POWER',
     'PACE_POWER_HR',
-    'PACE_HR_POWER'
+    'POWER_HR_PACE',
+    'POWER_PACE_HR'
   ]
   const TARGET_METRICS = ['heartRate', 'power', 'pace', 'rpe']
   const TARGET_STYLES = ['range', 'value']
@@ -2308,9 +2308,9 @@
       },
       warmupTime: 10,
       cooldownTime: 10,
-      loadPreference: 'POWER_HR_PACE',
+      loadPreference: 'HR_PACE_POWER',
       targetPolicy: {
-        primaryMetric: 'power',
+        primaryMetric: 'heartRate',
         strictPrimary: true,
         allowMixedTargetsPerStep: false,
         defaultTargetStyle: 'range',
@@ -2339,12 +2339,13 @@
   }
 
   function derivePrimaryMetric(loadPreference?: string): string {
-    if (!loadPreference) return 'power'
+    if (!loadPreference) return 'heartRate'
     const first = loadPreference.split('_')[0]?.toUpperCase()
     if (first === 'HR') return 'heartRate'
     if (first === 'PACE') return 'pace'
     if (first === 'RPE') return 'rpe'
-    return 'power'
+    if (first === 'POWER') return 'power'
+    return 'heartRate'
   }
 
   function metricToLoadPreferenceToken(metric?: string): string {
@@ -2359,7 +2360,7 @@
     primaryMetric?: string
   ): string {
     const preferred = metricToLoadPreferenceToken(primaryMetric)
-    const tokens = String(loadPreference || 'POWER_HR_PACE')
+    const tokens = String(loadPreference || 'HR_PACE_POWER')
       .split('_')
       .map((token) => token.trim().toUpperCase())
       .filter((token) => ['POWER', 'HR', 'PACE', 'RPE'].includes(token))
@@ -2368,7 +2369,7 @@
     for (const token of tokens) {
       if (!ordered.includes(token)) ordered.push(token)
     }
-    for (const token of ['POWER', 'HR', 'PACE']) {
+    for (const token of ['HR', 'PACE', 'POWER']) {
       if (!ordered.includes(token)) ordered.push(token)
     }
 

--- a/app/utils/sportSettings.ts
+++ b/app/utils/sportSettings.ts
@@ -62,7 +62,7 @@ export function getPreferredMetric(
   }
 
   if (order.length === 0) {
-    const legacy = String(settings?.loadPreference || 'POWER_HR_PACE')
+    const legacy = String(settings?.loadPreference || 'HR_PACE_POWER')
       .split('_')
       .map((token) => token.trim().toUpperCase())
     for (const token of legacy) {
@@ -78,7 +78,7 @@ export function getPreferredMetric(
     order.splice(0, order.length, primaryMetric, ...rest)
   }
 
-  for (const metric of ['POWER', 'HR', 'PACE'] as const) {
+  for (const metric of ['HR', 'PACE', 'POWER'] as const) {
     if (!order.includes(metric)) order.push(metric)
   }
 

--- a/server/utils/repositories/sportSettingsRepository.ts
+++ b/server/utils/repositories/sportSettingsRepository.ts
@@ -96,7 +96,8 @@ export const sportSettingsRepository = {
     const prisma = prismaOverride || globalPrisma
     const { targetPolicy, loadPreference, targetFormatPolicy } =
       resolveTargetPolicyAndLoadPreference({
-        loadPreference: 'POWER_HR_PACE'
+        // HR-first: works across sports and for athletes without a power meter.
+        loadPreference: 'HR_PACE_POWER'
       })
     return await prisma.sportSettings
       .create({

--- a/server/utils/workout-converter.ts
+++ b/server/utils/workout-converter.ts
@@ -660,7 +660,8 @@ export const WorkoutConverter = {
     const sportType = workout.type?.toLowerCase() || ''
     const isSwim = sportType.includes('swim')
     const isRun = !isSwim && sportType.includes('run')
-    const fallbackLoadPreference = isRun || isSwim ? 'HR_PACE_POWER' : 'POWER_HR_PACE'
+    // HR-first matches the system Default profile for athletes without power meters.
+    const fallbackLoadPreference = 'HR_PACE_POWER'
     const currentPolicySource = workout.sportSettings || null
     const snapshotPolicySource = workout.generationSettingsSnapshot || null
     const hasExplicitTargetPolicy = Boolean(

--- a/server/utils/workout-target-policy.test.ts
+++ b/server/utils/workout-target-policy.test.ts
@@ -3,9 +3,23 @@ import { normalizeTargetPolicy } from './workout-target-policy'
 
 describe('normalizeTargetPolicy', () => {
   it('defaults strictPrimary to true when not provided', () => {
-    const policy = normalizeTargetPolicy({}, 'POWER_HR_PACE')
+    const policy = normalizeTargetPolicy({}, 'HR_PACE_POWER')
 
     expect(policy.strictPrimary).toBe(true)
+    expect(policy.primaryMetric).toBe('heartRate')
+    expect(policy.fallbackOrder[0]).toBe('heartRate')
+  })
+
+  it('defaults to HR-first when load preference is missing', () => {
+    const policy = normalizeTargetPolicy({}, null)
+
+    expect(policy.primaryMetric).toBe('heartRate')
+    expect(policy.fallbackOrder.slice(0, 3)).toEqual(['heartRate', 'pace', 'power'])
+  })
+
+  it('still honors an explicit power-first load preference', () => {
+    const policy = normalizeTargetPolicy({}, 'POWER_HR_PACE')
+
     expect(policy.primaryMetric).toBe('power')
     expect(policy.fallbackOrder[0]).toBe('power')
   })
@@ -17,7 +31,7 @@ describe('normalizeTargetPolicy', () => {
         primaryMetric: 'heartRate',
         fallbackOrder: ['heartRate', 'pace', 'power']
       },
-      'POWER_HR_PACE'
+      'HR_PACE_POWER'
     )
 
     expect(policy.strictPrimary).toBe(false)
@@ -25,4 +39,3 @@ describe('normalizeTargetPolicy', () => {
     expect(policy.fallbackOrder[0]).toBe('heartRate')
   })
 })
-

--- a/server/utils/workout-target-policy.ts
+++ b/server/utils/workout-target-policy.ts
@@ -9,7 +9,7 @@ export interface TargetPolicy {
   preferRangesForSteady: boolean
 }
 
-const METRIC_ORDER: MetricTarget[] = ['power', 'heartRate', 'pace', 'rpe']
+const METRIC_ORDER: MetricTarget[] = ['heartRate', 'pace', 'power', 'rpe']
 
 function normalizeMetricToken(token: unknown): MetricTarget | null {
   if (typeof token !== 'string') return null
@@ -59,7 +59,7 @@ export function normalizeTargetPolicy(
     const withoutPrimary = fallbackOrder.filter((metric) => metric !== explicitPrimary)
     fallbackOrder.splice(0, fallbackOrder.length, explicitPrimary, ...withoutPrimary)
   }
-  const primaryMetric = explicitPrimary || fallbackOrder[0] || 'power'
+  const primaryMetric = explicitPrimary || fallbackOrder[0] || 'heartRate'
 
   const result: TargetPolicy = {
     primaryMetric,

--- a/tests/unit/server/utils/repositories/sportSettingsRepository.test.ts
+++ b/tests/unit/server/utils/repositories/sportSettingsRepository.test.ts
@@ -37,7 +37,7 @@ describe('sportSettingsRepository', () => {
         isDefault: true,
         id: 's-1',
         ftp: 250,
-        loadPreference: 'POWER_HR_PACE'
+        loadPreference: 'HR_PACE_POWER'
       })
       expect(prisma.user.findUnique).not.toHaveBeenCalled()
     })
@@ -63,7 +63,8 @@ describe('sportSettingsRepository', () => {
           data: expect.objectContaining({
             userId,
             isDefault: true,
-            ftp: 200
+            ftp: 200,
+            loadPreference: 'HR_PACE_POWER'
           })
         })
       )

--- a/tests/unit/trigger/workout-metric-priority.test.ts
+++ b/tests/unit/trigger/workout-metric-priority.test.ts
@@ -12,8 +12,8 @@ describe('workout metric priority', () => {
     expect(parseLoadPreference('PACE_HR_POWER')).toEqual(['PACE', 'HR', 'POWER'])
   })
 
-  it('defaults to HR > POWER > PACE when preference is missing', () => {
-    expect(parseLoadPreference(undefined)).toEqual(['HR', 'POWER', 'PACE'])
+  it('defaults to HR > PACE > POWER when preference is missing', () => {
+    expect(parseLoadPreference(undefined)).toEqual(['HR', 'PACE', 'POWER'])
   })
 
   it('marks pace as primary and condenses HR when pace data is available', () => {

--- a/trigger/utils/workout-metric-priority.ts
+++ b/trigger/utils/workout-metric-priority.ts
@@ -1,6 +1,6 @@
 type MetricKey = 'PACE' | 'HR' | 'POWER'
 
-const DEFAULT_PRIORITY: MetricKey[] = ['HR', 'POWER', 'PACE']
+const DEFAULT_PRIORITY: MetricKey[] = ['HR', 'PACE', 'POWER']
 const VALID_METRICS = new Set<MetricKey>(['PACE', 'HR', 'POWER'])
 
 function isMetricKey(value: string): value is MetricKey {
@@ -78,7 +78,7 @@ export function resolveMetricPriorityContext(
   const secondaryMetric = priority[1] || null
 
   return {
-    loadPreference: loadPreference || 'HR_POWER_PACE',
+    loadPreference: loadPreference || 'HR_PACE_POWER',
     priority,
     primaryMetric,
     primaryMetricAvailable: isAvailable(primaryMetric),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New users (and newly added sport profiles) default to **`HR_PACE_POWER`** instead of `POWER_HR_PACE`.

Heart rate is the metric most athletes already understand and can use across sports, including cyclists without a power meter and runners who do not want watt-based workouts.

## What changed

- System **Default** profile creation uses `HR_PACE_POWER` (primary = heartRate)
- **Add Sport** form defaults match that order
- Missing/null load preference normalizes to HR → pace → power
- Export + analysis metric fallbacks align with the same HR-first order
- Explicit `POWER_*` preferences and Intervals `load_order` still override

## What did not change

- Existing saved sport profiles keep their stored preference
- Power remains available as a Load Priority option in Settings
- No auto-created Run/Ride/Swim profiles

## Test plan

- [x] Unit tests for target policy, sport settings repository, metric priority, workout converter
- [ ] New user / fresh Default profile generates HR-based run and ride structures
- [ ] Athlete with Intervals power-first `load_order` still gets power targets after sync
- [ ] Manually selecting `POWER_HR_PACE` in Sport Settings still produces watt targets

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b6b-21c9-78df-a546-f24a3b5c5a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b6b-21c9-78df-a546-f24a3b5c5a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

