### PR TITLE
Fix Garmin publish: ownerId must be numeric Long, not wellness UUID

### DIFF
--- a/server/api/workouts/planned/[id]/publish-garmin.post.ts
+++ b/server/api/workouts/planned/[id]/publish-garmin.post.ts
@@ -151,10 +151,11 @@ export default defineEventHandler(async (event) => {
           await updateGarminWorkout(integration, workoutId, payload)
         } catch (e: any) {
           const message = String(e?.message || '')
-          // Stale Garmin ids or missing ownerId (Training API V2) → recreate.
+          // Stale Garmin ids, missing/invalid ownerId, or bad Long deserialize → recreate.
           if (
             message.includes('(404)') ||
-            message.includes('requires ownerId') ||
+            (message.includes('requires') && message.includes('ownerId')) ||
+            message.includes('not a valid `java.lang.Long`') ||
             e?.code === 'GARMIN_OWNER_ID_REQUIRED'
           ) {
             workoutId = null

--- a/server/utils/garmin-push.ts
+++ b/server/utils/garmin-push.ts
@@ -363,13 +363,7 @@ export function buildGarminTrainingPayload(
     throw error
   }
 
-  const ownerIdRaw = options.ownerId
-  const ownerId =
-    ownerIdRaw != null && String(ownerIdRaw).trim() !== ''
-      ? Number.isFinite(Number(ownerIdRaw))
-        ? Number(ownerIdRaw)
-        : String(ownerIdRaw)
-      : undefined
+  const ownerId = toGarminOwnerId(options.ownerId)
 
   return {
     ...(ownerId != null ? { ownerId } : {}),
@@ -391,21 +385,48 @@ export function buildGarminTrainingPayload(
   }
 }
 
-function garminOwnerIdFromIntegration(integration: Integration): string | number | undefined {
-  const raw = integration.externalUserId
-  if (raw == null || String(raw).trim() === '') return undefined
+/**
+ * Training API V2 `ownerId` is a Java Long (Garmin Connect numeric id).
+ * Wellness `/user/id` returns a UUID — that must never be sent as ownerId.
+ */
+export function toGarminOwnerId(value: unknown): number | undefined {
+  if (value == null) return undefined
+  const raw = String(value).trim()
+  if (!raw || !/^\d+$/.test(raw)) return undefined
   const asNumber = Number(raw)
-  return Number.isFinite(asNumber) ? asNumber : raw
+  if (!Number.isSafeInteger(asNumber) || asNumber <= 0) return undefined
+  return asNumber
+}
+
+function stripInvalidOwnerId(payload: Record<string, unknown>): Record<string, unknown> {
+  const body = { ...payload }
+  const ownerId = toGarminOwnerId(body.ownerId)
+  if (ownerId != null) body.ownerId = ownerId
+  else delete body.ownerId
+  return body
+}
+
+async function fetchGarminWorkoutOwnerId(
+  integration: Integration,
+  workoutId: string
+): Promise<number | undefined> {
+  const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${workoutId}`, {
+    method: 'GET',
+    headers: getGarminHeaders(integration.accessToken)
+  })
+  if (!response.ok) return undefined
+  const workout = (await response.json().catch(() => null)) as { ownerId?: unknown } | null
+  return toGarminOwnerId(workout?.ownerId)
 }
 
 export async function createGarminWorkout(integration: Integration, payload: any) {
   const validIntegration = await ensureValidToken(integration)
-  const body = {
-    ...payload,
-    ...(payload?.ownerId == null && validIntegration.externalUserId
-      ? { ownerId: garminOwnerIdFromIntegration(validIntegration) }
-      : {})
-  }
+  // Create does not require ownerId. Never inject the wellness UUID.
+  const numericExternalOwnerId = toGarminOwnerId(validIntegration.externalUserId)
+  const body = stripInvalidOwnerId({
+    ...(payload || {}),
+    ...(numericExternalOwnerId != null ? { ownerId: numericExternalOwnerId } : {})
+  })
   const headers = getGarminHeaders(validIntegration.accessToken)
 
   // Training API V2 docs list create on workoutportal; retrieve/update use training-api.
@@ -435,15 +456,23 @@ export async function updateGarminWorkout(
   payload: any
 ) {
   const validIntegration = await ensureValidToken(integration)
-  const ownerId = payload?.ownerId ?? garminOwnerIdFromIntegration(validIntegration)
+  let ownerId =
+    toGarminOwnerId(payload?.ownerId) ?? toGarminOwnerId(validIntegration.externalUserId)
+
+  // Wellness externalUserId is a UUID; resolve numeric ownerId from the existing workout.
+  if (ownerId == null) {
+    ownerId = await fetchGarminWorkoutOwnerId(validIntegration, workoutId)
+  }
+
   if (ownerId == null) {
     const err = new Error(
-      'Garmin update workout requires ownerId (missing Garmin externalUserId)'
+      'Garmin update workout requires numeric ownerId (wellness UUID cannot be used)'
     ) as Error & { code?: string }
     err.code = 'GARMIN_OWNER_ID_REQUIRED'
     throw err
   }
-  const body = { ...payload, ownerId }
+
+  const body = stripInvalidOwnerId({ ...(payload || {}), ownerId })
   const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${workoutId}`, {
     method: 'PUT',
     headers: getGarminHeaders(validIntegration.accessToken),

--- a/tests/unit/server/utils/garmin-push.test.ts
+++ b/tests/unit/server/utils/garmin-push.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildGarminTrainingPayload,
   countGarminWorkoutSteps,
-  extractGarminScheduleId
+  extractGarminScheduleId,
+  toGarminOwnerId
 } from '../../../../server/utils/garmin-push'
 
 describe('garmin push helpers', () => {
@@ -181,8 +182,8 @@ describe('garmin push helpers', () => {
     expect(payload.segments[0]!.sport).toBe('CYCLING')
   })
 
-  it('includes ownerId when provided', () => {
-    const payload = buildGarminTrainingPayload(
+  it('includes numeric ownerId and rejects wellness UUID ownerIds', () => {
+    const withNumeric = buildGarminTrainingPayload(
       {
         title: 'Owned',
         type: 'Ride',
@@ -191,6 +192,19 @@ describe('garmin push helpers', () => {
       {},
       { ownerId: '998877' }
     )
-    expect(payload.ownerId).toBe(998877)
+    expect(withNumeric.ownerId).toBe(998877)
+
+    const withUuid = buildGarminTrainingPayload(
+      {
+        title: 'Owned',
+        type: 'Ride',
+        steps: [{ type: 'Active', durationSeconds: 60 }]
+      },
+      {},
+      { ownerId: '0db20509-029f-4a45-ada0-fc230913f3b3' }
+    )
+    expect(withUuid.ownerId).toBeUndefined()
+    expect(toGarminOwnerId('0db20509-029f-4a45-ada0-fc230913f3b3')).toBeUndefined()
+    expect(toGarminOwnerId('12345')).toBe(12345)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Publishing to Garmin failed with:

```text
Cannot deserialize value of type `java.lang.Long` from String "0db20509-..."
```

We were sending Garmin wellness `/user/id` (UUID) as Training API V2 `ownerId`, which must be a numeric Long.

## Fix
- Only accept digit-only positive integers as `ownerId`
- Never inject the wellness UUID on create/update
- On update, resolve numeric `ownerId` by GETting the existing workout when needed
- Recreate the workout if ownerId still can’t be resolved or Garmin returns the Long deserialize error

## Test
- Unit tests cover UUID rejection + numeric acceptance
- `pnpm exec vitest run tests/unit/server/utils/garmin-push.test.ts` — passing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

