### PR TITLE
Fix Garmin republish workoutId mismatch and empty steps

### DIFF
--- a/server/api/workouts/planned/[id]/publish-garmin.post.ts
+++ b/server/api/workouts/planned/[id]/publish-garmin.post.ts
@@ -151,12 +151,16 @@ export default defineEventHandler(async (event) => {
           await updateGarminWorkout(integration, workoutId, payload)
         } catch (e: any) {
           const message = String(e?.message || '')
-          // Stale Garmin ids, missing/invalid ownerId, or bad Long deserialize → recreate.
+          // Stale/partial Garmin workouts or invalid update identity → recreate.
           if (
             message.includes('(404)') ||
             (message.includes('requires') && message.includes('ownerId')) ||
+            message.includes('requires numeric workoutId') ||
             message.includes('not a valid `java.lang.Long`') ||
-            e?.code === 'GARMIN_OWNER_ID_REQUIRED'
+            message.includes("doesn't match with null") ||
+            message.includes('has no steps') ||
+            e?.code === 'GARMIN_OWNER_ID_REQUIRED' ||
+            e?.code === 'GARMIN_WORKOUT_ID_INVALID'
           ) {
             workoutId = null
           } else {

--- a/server/utils/garmin-push.ts
+++ b/server/utils/garmin-push.ts
@@ -398,6 +398,10 @@ export function toGarminOwnerId(value: unknown): number | undefined {
   return asNumber
 }
 
+export function toGarminWorkoutId(value: unknown): number | undefined {
+  return toGarminOwnerId(value)
+}
+
 function stripInvalidOwnerId(payload: Record<string, unknown>): Record<string, unknown> {
   const body = { ...payload }
   const ownerId = toGarminOwnerId(body.ownerId)
@@ -406,17 +410,32 @@ function stripInvalidOwnerId(payload: Record<string, unknown>): Record<string, u
   return body
 }
 
-async function fetchGarminWorkoutOwnerId(
+/** Count leaf steps from a Garmin create/retrieve response (segments or legacy top-level). */
+export function countStepsInGarminWorkoutResponse(workout: unknown): number {
+  if (!workout || typeof workout !== 'object') return 0
+  const value = workout as Record<string, unknown>
+  const segments = Array.isArray(value.segments) ? value.segments : []
+  let count = 0
+  for (const segment of segments) {
+    const steps = Array.isArray((segment as any)?.steps) ? (segment as any).steps : []
+    count += countGarminWorkoutSteps(steps)
+  }
+  if (count > 0) return count
+  if (Array.isArray(value.steps)) return countGarminWorkoutSteps(value.steps as any[])
+  return 0
+}
+
+async function fetchGarminWorkout(
   integration: Integration,
   workoutId: string
-): Promise<number | undefined> {
+): Promise<Record<string, unknown> | null> {
   const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${workoutId}`, {
     method: 'GET',
     headers: getGarminHeaders(integration.accessToken)
   })
-  if (!response.ok) return undefined
-  const workout = (await response.json().catch(() => null)) as { ownerId?: unknown } | null
-  return toGarminOwnerId(workout?.ownerId)
+  if (!response.ok) return null
+  const workout = (await response.json().catch(() => null)) as Record<string, unknown> | null
+  return workout
 }
 
 export async function createGarminWorkout(integration: Integration, payload: any) {
@@ -427,11 +446,12 @@ export async function createGarminWorkout(integration: Integration, payload: any
     ...(payload || {}),
     ...(numericExternalOwnerId != null ? { ownerId: numericExternalOwnerId } : {})
   })
+  // Create must not send workoutId (server assigns it).
+  delete body.workoutId
   const headers = getGarminHeaders(validIntegration.accessToken)
 
-  // Training API V2 docs list create on workoutportal; retrieve/update use training-api.
-  // Prefer the documented create URL, then fall back if that host rejects the route.
-  const createUrls = [GARMIN_TRAINING_WORKOUT_CREATE_V2, GARMIN_TRAINING_WORKOUT_V2]
+  // Prefer training-api (same host as retrieve/update). Fall back to workoutportal from the docs.
+  const createUrls = [GARMIN_TRAINING_WORKOUT_V2, GARMIN_TRAINING_WORKOUT_CREATE_V2]
   let lastError = 'unknown error'
   for (const url of createUrls) {
     const response = await fetch(url, {
@@ -439,12 +459,29 @@ export async function createGarminWorkout(integration: Integration, payload: any
       headers,
       body: JSON.stringify(body)
     })
-    if (response.ok) return response.json()
-    const error = await response.text().catch(() => response.statusText)
-    lastError = `(${response.status}): ${error}`
-    if (response.status !== 404 && response.status !== 405) {
-      throw new Error(`Garmin create workout failed ${lastError}`)
+    if (!response.ok) {
+      const error = await response.text().catch(() => response.statusText)
+      lastError = `(${response.status}): ${error}`
+      if (response.status !== 404 && response.status !== 405) {
+        throw new Error(`Garmin create workout failed ${lastError}`)
+      }
+      continue
     }
+
+    const created = await response.json()
+    const createdId = toGarminWorkoutId(created?.workoutId ?? created?.id)
+    // Some create responses omit segments; verify via retrieve when we have an id.
+    let stepCount = countStepsInGarminWorkoutResponse(created)
+    if (stepCount === 0 && createdId != null) {
+      const retrieved = await fetchGarminWorkout(validIntegration, String(createdId))
+      stepCount = countStepsInGarminWorkoutResponse(retrieved)
+    }
+    if (stepCount === 0) {
+      lastError = `(200): created workout ${createdId ?? 'unknown'} has no steps`
+      // Try the alternate create URL before giving up.
+      continue
+    }
+    return created
   }
 
   throw new Error(`Garmin create workout failed ${lastError}`)
@@ -456,12 +493,22 @@ export async function updateGarminWorkout(
   payload: any
 ) {
   const validIntegration = await ensureValidToken(integration)
+  const numericWorkoutId = toGarminWorkoutId(workoutId)
+  if (numericWorkoutId == null) {
+    const err = new Error(
+      `Garmin update workout requires numeric workoutId (got ${String(workoutId)})`
+    ) as Error & { code?: string }
+    err.code = 'GARMIN_WORKOUT_ID_INVALID'
+    throw err
+  }
+
   let ownerId =
     toGarminOwnerId(payload?.ownerId) ?? toGarminOwnerId(validIntegration.externalUserId)
 
   // Wellness externalUserId is a UUID; resolve numeric ownerId from the existing workout.
   if (ownerId == null) {
-    ownerId = await fetchGarminWorkoutOwnerId(validIntegration, workoutId)
+    const existing = await fetchGarminWorkout(validIntegration, String(numericWorkoutId))
+    ownerId = toGarminOwnerId(existing?.ownerId)
   }
 
   if (ownerId == null) {
@@ -472,8 +519,13 @@ export async function updateGarminWorkout(
     throw err
   }
 
-  const body = stripInvalidOwnerId({ ...(payload || {}), ownerId })
-  const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${workoutId}`, {
+  // V2 rejects updates when path workoutId does not match body.workoutId (null → this error).
+  const body = stripInvalidOwnerId({
+    ...(payload || {}),
+    workoutId: numericWorkoutId,
+    ownerId
+  })
+  const response = await fetch(`${GARMIN_TRAINING_WORKOUT_V2}/${numericWorkoutId}`, {
     method: 'PUT',
     headers: getGarminHeaders(validIntegration.accessToken),
     body: JSON.stringify(body)

--- a/tests/unit/server/utils/garmin-push.test.ts
+++ b/tests/unit/server/utils/garmin-push.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   buildGarminTrainingPayload,
   countGarminWorkoutSteps,
+  countStepsInGarminWorkoutResponse,
   extractGarminScheduleId,
-  toGarminOwnerId
+  toGarminOwnerId,
+  toGarminWorkoutId
 } from '../../../../server/utils/garmin-push'
 
 describe('garmin push helpers', () => {
@@ -206,5 +208,89 @@ describe('garmin push helpers', () => {
     expect(withUuid.ownerId).toBeUndefined()
     expect(toGarminOwnerId('0db20509-029f-4a45-ada0-fc230913f3b3')).toBeUndefined()
     expect(toGarminOwnerId('12345')).toBe(12345)
+    expect(toGarminWorkoutId('1633580475')).toBe(1633580475)
+  })
+
+  it('builds Tempo Power Builder ride steps with repeat + power targets', () => {
+    const payload = buildGarminTrainingPayload(
+      {
+        title: 'Tempo Power Builder',
+        type: 'Ride',
+        durationSec: 5400,
+        steps: [
+          {
+            name: 'Progressive Warmup',
+            type: 'Warmup',
+            power: { range: { end: 0.6, start: 0.5 }, units: '%ftp' },
+            cadence: 85,
+            durationSeconds: 1200
+          },
+          {
+            name: '3x',
+            reps: 3,
+            type: 'Active',
+            distance: 0,
+            steps: [
+              {
+                name: 'Tempo Effort',
+                type: 'Active',
+                power: { range: { end: 0.88, start: 0.8 }, units: '%ftp' },
+                cadence: 90,
+                durationSeconds: 900
+              }
+            ]
+          },
+          {
+            name: 'Sweet Spot Interval',
+            type: 'Active',
+            power: { range: { end: 0.94, start: 0.9 }, units: '%ftp' },
+            cadence: 85,
+            durationSeconds: 900
+          },
+          {
+            name: 'Cooldown',
+            type: 'Cooldown',
+            power: { range: { end: 0.4, start: 0.5 }, units: '%ftp' },
+            cadence: 80,
+            durationSeconds: 600
+          }
+        ]
+      },
+      { ftp: 229 }
+    )
+
+    const steps = payload.segments[0]!.steps
+    expect(steps).toHaveLength(4)
+    expect(steps[0]).toMatchObject({
+      type: 'WorkoutStep',
+      intensity: 'WARMUP',
+      durationType: 'TIME',
+      durationValue: 1200,
+      targetType: 'POWER',
+      targetValueLow: 115,
+      targetValueHigh: 137,
+      secondaryTargetType: 'CADENCE',
+      secondaryTargetValue: 85
+    })
+    expect(steps[1]).toMatchObject({
+      type: 'WorkoutRepeatStep',
+      repeatType: 'REPEAT_UNTIL_STEPS_CMPLT',
+      repeatValue: 3
+    })
+    expect((steps[1] as any).steps[0]).toMatchObject({
+      type: 'WorkoutStep',
+      targetType: 'POWER',
+      targetValueLow: 183,
+      targetValueHigh: 202,
+      secondaryTargetType: 'CADENCE',
+      secondaryTargetValue: 90
+    })
+    expect(countGarminWorkoutSteps(steps)).toBe(4)
+    expect(
+      countStepsInGarminWorkoutResponse({
+        workoutId: 1633580475,
+        segments: payload.segments
+      })
+    ).toBe(4)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Republishing failed with:

```text
workoutId 1633580475 doesn't match with null
```

And the previously created Garmin workout showed no steps.

## Root cause
1. Training API V2 update requires `workoutId` in the JSON body to match the path id; we omitted it (`null`).
2. Create preferred `workoutportal`, which can accept a workout without persisting usable step structure; we now prefer `training-api/workout/v2` and verify steps after create.

## Fix
- Always send numeric `workoutId` + `ownerId` on update
- Prefer `training-api/workout/v2` for create (fallback to workoutportal)
- Verify created workouts actually contain steps (retrieve if needed)
- Recreate on `doesn't match with null` / empty-step / invalid id errors
- Unit test for the Tempo Power Builder ride payload (warmup, 3x repeat, sweet spot, cooldown)

## Test plan
- [ ] After deploy, republish Tempo Power Builder to Garmin Training
- [ ] Confirm no workoutId mismatch toast
- [ ] Confirm intervals/steps appear in Garmin Connect
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6b53-f948-7db4-b0dc-1ba58340c202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

