### PR TITLE
fix(events): Bearer auth via goal:read for mobile

### DIFF
--- a/server/api/events/[id].get.ts
+++ b/server/api/events/[id].get.ts
@@ -1,11 +1,11 @@
-import { getServerSession } from '../../utils/session'
+import { requireAuth } from '../../utils/auth-guard'
 import { prisma } from '../../utils/db'
 
 defineRouteMeta({
   openAPI: {
     tags: ['Events'],
     summary: 'Get event details',
-    description: 'Returns a single event by ID.',
+    description: 'Returns a single event by ID (session or Bearer with goal:read).',
     inputSchema: [
       {
         in: 'path',
@@ -18,19 +18,15 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
-  if (!session?.user) {
-    throw createError({ statusCode: 401, message: 'Unauthorized' })
-  }
+  const user = await requireAuth(event, ['goal:read'])
 
   const id = getRouterParam(event, 'id')
-  const userId = (session.user as any).id
 
   try {
     const eventData = await prisma.event.findFirst({
       where: {
         id,
-        userId
+        userId: user.id
       },
       include: {
         goals: true

--- a/server/api/events/index.get.ts
+++ b/server/api/events/index.get.ts
@@ -1,11 +1,12 @@
-import { getServerSession } from '../../utils/session'
+import { requireAuth } from '../../utils/auth-guard'
 import { prisma } from '../../utils/db'
 
 defineRouteMeta({
   openAPI: {
     tags: ['Events'],
     summary: 'List events',
-    description: 'Returns a list of racing events for the authenticated user.',
+    description:
+      'Returns a list of racing/life events for the authenticated user (session or Bearer with goal:read).',
     responses: {
       200: {
         description: 'Success',
@@ -38,20 +39,11 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
-
-  if (!session?.user) {
-    throw createError({
-      statusCode: 401,
-      message: 'Unauthorized'
-    })
-  }
-
-  const userId = (session.user as any).id
+  const user = await requireAuth(event, ['goal:read'])
 
   try {
     const events = await prisma.event.findMany({
-      where: { userId },
+      where: { userId: user.id },
       orderBy: { date: 'asc' },
       include: { goals: true }
     })


### PR DESCRIPTION
## Summary
- Migrate `GET /api/events` and `GET /api/events/:id` from session-only to `requireAuth(..., ['goal:read'])`
- Unblocks watts-mobile issue 026 (race/event countdown chip) after Official Mobile App requests `goal:read`

## Test plan
- [ ] Session cookie: list/get events still works on web
- [ ] Bearer with `goal:read`: `GET /api/events` returns 200
- [ ] Bearer without scope: 403