### PR TITLE
Fix typecheck failures blocking master builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 ENV CHAT_TURN_RUNNER_ENABLED=false
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN pnpm typecheck
+RUN NODE_OPTIONS=--max-old-space-size=16384 pnpm typecheck
 RUN NODE_OPTIONS=--max-old-space-size=16384 pnpm build
 
 # Stage 3: Production image

--- a/server/api/nutrition/estimate-photo.post.ts
+++ b/server/api/nutrition/estimate-photo.post.ts
@@ -43,6 +43,13 @@ export default defineEventHandler(async (event) => {
     // Strip data URI prefix if present
     const base64Data = imageBase64.includes(',') ? imageBase64.split(',')[1] : imageBase64
 
+    if (!base64Data) {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid imageBase64 payload.'
+      })
+    }
+
     const modelId = resolveModelId('gemini-3.1-flash-lite')
     const result = await generateObject({
       model: google(modelId),
@@ -58,7 +65,7 @@ export default defineEventHandler(async (event) => {
             {
               type: 'image',
               image: Buffer.from(base64Data, 'base64'),
-              mimeType
+              mediaType: mimeType
             }
           ]
         }

--- a/server/api/webhooks/revenuecat.post.ts
+++ b/server/api/webhooks/revenuecat.post.ts
@@ -42,7 +42,7 @@ function eventStatus(event: RevenueCatEvent): ProviderSubscriptionStatus {
   })
 }
 
-async function rejectWebhook(action: string, metadata: Prisma.InputJsonValue) {
+async function rejectWebhook(action: string, metadata: Record<string, unknown>) {
   await auditLogRepository.log({ action, resourceType: 'SUBSCRIPTION', metadata })
 }
 

--- a/server/utils/revenuecat.ts
+++ b/server/utils/revenuecat.ts
@@ -28,6 +28,18 @@ type RevenueCatSubscriberResponse = {
   }
 }
 
+type RevenueCatRequestOptions = {
+  method?: 'POST'
+  headers: Record<string, string>
+  body?: Record<string, string>
+}
+
+// Bypass Nitro internal-route inference for dynamic external RevenueCat URLs.
+const revenueCatFetch = $fetch as unknown as <T = unknown>(
+  url: string,
+  options: RevenueCatRequestOptions
+) => Promise<T>
+
 function requiredRevenueCatKey(): string {
   const key = useRuntimeConfig().revenueCatSecretApiKey
   if (!key)
@@ -37,7 +49,7 @@ function requiredRevenueCatKey(): string {
 
 export async function fetchRevenueCatSubscriber(userId: string) {
   const config = useRuntimeConfig()
-  return await $fetch<RevenueCatSubscriberResponse>(
+  return await revenueCatFetch<RevenueCatSubscriberResponse>(
     `${config.revenueCatApiBaseUrl || 'https://api.revenuecat.com/v1'}/subscribers/${encodeURIComponent(userId)}`,
     { headers: { Authorization: `Bearer ${requiredRevenueCatKey()}`, Accept: 'application/json' } }
   )
@@ -150,14 +162,17 @@ export async function trackStripeInRevenueCat(userId: string, subscriptionId: st
   const config = useRuntimeConfig()
   if (!config.revenueCatStripePublicApiKey) return
   try {
-    await $fetch(`${config.revenueCatApiBaseUrl || 'https://api.revenuecat.com/v1'}/receipts`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${config.revenueCatStripePublicApiKey}`,
-        'X-Platform': 'stripe'
-      },
-      body: { app_user_id: userId, fetch_token: subscriptionId }
-    })
+    await revenueCatFetch(
+      `${config.revenueCatApiBaseUrl || 'https://api.revenuecat.com/v1'}/receipts`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${config.revenueCatStripePublicApiKey}`,
+          'X-Platform': 'stripe'
+        },
+        body: { app_user_id: userId, fetch_token: subscriptionId }
+      }
+    )
   } catch (error) {
     console.error('RevenueCat Stripe tracking failed; Stripe remains canonical until retry', error)
   }


### PR DESCRIPTION
## Summary
- Fix meal photo estimate API type errors (`mediaType` + defined base64 payload)
- Fix RevenueCat webhook metadata typing and `$fetch` infinite type instantiation
- Raise Docker typecheck heap limit to match the build step (prevents OOM)

## Test plan
- [x] `pnpm typecheck` passes locally
- [ ] CI typecheck job passes
- [ ] Build and Deploy typecheck step passes