### PR TITLE
Fix RevenueCat $fetch prerender crash in Docker build

### DIFF
--- a/server/utils/revenuecat.ts
+++ b/server/utils/revenuecat.ts
@@ -34,11 +34,11 @@ type RevenueCatRequestOptions = {
   body?: Record<string, string>
 }
 
-// Bypass Nitro internal-route inference for dynamic external RevenueCat URLs.
-const revenueCatFetch = $fetch as unknown as <T = unknown>(
-  url: string,
-  options: RevenueCatRequestOptions
-) => Promise<T>
+// Lazy $fetch access (top-level $fetch breaks Nitro prerender) + cast to bypass
+// Nitro internal-route inference for dynamic external RevenueCat URLs.
+function revenueCatFetch<T = unknown>(url: string, options: RevenueCatRequestOptions): Promise<T> {
+  return ($fetch as any)(url, options)
+}
 
 function requiredRevenueCatKey(): string {
   const key = useRuntimeConfig().revenueCatSecretApiKey


### PR DESCRIPTION
## Summary
- Deploy failed with `$fetch is not defined` during Nitro prerender
- Root cause: top-level `$fetch` cast in `server/utils/revenuecat.ts` evaluated at module load
- Fix: call `$fetch` lazily inside a helper (same pattern as Telegram utils)

## Test plan
- [ ] CI typecheck passes
- [ ] Build and Deploy Docker build completes past prerender