### PR TITLE
Report partial syncs and refresh dashboard data

### DIFF
--- a/app/components/dashboard/PerformanceScoresCard.vue
+++ b/app/components/dashboard/PerformanceScoresCard.vue
@@ -193,15 +193,17 @@
 
   const emit = defineEmits(['open-score-modal', 'open-training-load'])
 
-  // Fetch athlete profile scores
-  const { data: scoresData, pending: loadingScores } = (useFetch as any)(
-    '/api/scores/athlete-profile',
-    {
-      lazy: true,
-      server: false,
-      watch: [() => integrationStore.intervalsConnected]
-    }
-  )
+  // Scores exist for any onboarded athlete, regardless of integration provider.
+  const {
+    data: scoresData,
+    pending: loadingScores,
+    refresh: refreshScores
+  } = (useFetch as any)('/api/scores/athlete-profile', {
+    lazy: true,
+    server: false,
+    immediate: true,
+    watch: [isOnboarded]
+  })
 
   const profileScores = computed(() => scoresData.value?.scores || null)
   const scoresHistory = computed(() => scoresData.value?.history || [])
@@ -210,7 +212,11 @@
   )
 
   // Fetch PMC data for TL/ATL/TSB if enabled
-  const { data: pmcData, pending: loadingPMC } = (useFetch as any)('/api/performance/pmc', {
+  const {
+    data: pmcData,
+    pending: loadingPMC,
+    refresh: refreshPmc
+  } = (useFetch as any)('/api/performance/pmc', {
     lazy: true,
     server: false,
     query: computed(() => ({
@@ -218,7 +224,11 @@
       displayMode: trainingLoadDisplayMode.value
     })),
     immediate: true,
-    watch: [() => integrationStore.intervalsConnected, trainingLoadDisplayMode]
+    watch: [isOnboarded, trainingLoadDisplayMode]
+  })
+
+  defineExpose({
+    refresh: () => Promise.all([refreshScores(), refreshPmc()])
   })
 
   const pmcSummary = computed(() => pmcData.value?.summary || null)

--- a/app/components/profile/BasicSettings.vue
+++ b/app/components/profile/BasicSettings.vue
@@ -412,17 +412,9 @@
                     on {{ formatDateUTC(method.linkedAt, 'PPP') }}
                   </span>
                 </p>
-                <p v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5">
-                  ID: {{ method.profileId }}
-                </p>
               </div>
-              <p v-else-if="method.isIntegrated" class="flex flex-col">
-                <span class="text-xs text-amber-500 font-medium">{{
-                  t('basic_login_methods_linked')
-                }}</span>
-                <span v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5"
-                  >ID: {{ method.profileId }}</span
-                >
+              <p v-else-if="method.isIntegrated" class="text-xs text-amber-500 font-medium">
+                {{ t('basic_login_methods_linked') }}
               </p>
               <p v-else class="text-xs text-gray-500 dark:text-gray-400">
                 {{ t('basic_login_methods_not_connected') }}
@@ -563,6 +555,7 @@
     loading?: boolean
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:modelValue', 'autodetect', 'navigate'])
@@ -583,8 +576,7 @@
         iconClass: 'text-gray-900 dark:text-white',
         isConnected: accounts.some((a: any) => a.provider === 'google'),
         isIntegrated: false, // Google is login-only for now
-        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt,
-        profileId: accounts.find((a: any) => a.provider === 'google')?.providerAccountId
+        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt
       },
       {
         id: 'strava',
@@ -593,10 +585,7 @@
         iconClass: 'text-[#FC4C02]',
         isConnected: accounts.some((a: any) => a.provider === 'strava'),
         isIntegrated: integrations.some((i: any) => i.provider === 'strava'),
-        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'strava')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'strava')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt
       },
       {
         id: 'intervals',
@@ -605,10 +594,7 @@
         iconClass: 'text-primary',
         isConnected: accounts.some((a: any) => a.provider === 'intervals'),
         isIntegrated: integrations.some((i: any) => i.provider === 'intervals'),
-        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'intervals')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'intervals')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt
       }
     ]
   })
@@ -872,8 +858,8 @@
   }
 
   watch(
-    () => props.focusSection,
-    (section) => {
+    () => [props.focusSection, props.focusRequestId] as const,
+    ([section]) => {
       if (section === 'body-metrics') scrollToSection('body-metrics')
     },
     { immediate: true }

--- a/app/components/profile/SportSettings.vue
+++ b/app/components/profile/SportSettings.vue
@@ -503,7 +503,7 @@
 
               <!-- Power Settings -->
               <section
-                id="sport-power"
+                :id="sectionDomId('sport-power', index)"
                 class="space-y-4"
                 :class="sectionHighlightClass('sport-power')"
               >
@@ -734,7 +734,11 @@
               </section>
 
               <!-- Heart Rate Settings -->
-              <section id="sport-hr" class="space-y-4" :class="sectionHighlightClass('sport-hr')">
+              <section
+                :id="sectionDomId('sport-hr', index)"
+                class="space-y-4"
+                :class="sectionHighlightClass('sport-hr')"
+              >
                 <h4
                   class="text-sm font-medium text-gray-500 uppercase tracking-wider border-b pb-2 dark:border-gray-800 flex items-center gap-2"
                 >
@@ -862,12 +866,12 @@
 
                 <!-- HR Zones Editor -->
                 <div
-                  v-if="editingIndex === index"
-                  id="sport-zones"
+                  :id="sectionDomId('sport-zones', index)"
                   class="mt-4"
                   :class="sectionHighlightClass('sport-zones')"
                 >
                   <ProfileZoneEditor
+                    v-if="editingIndex === index"
                     v-model="editForm.hrZones"
                     :title="t('zones_title_hr')"
                     units="bpm"
@@ -887,28 +891,32 @@
                       >
                     </template>
                   </ProfileZoneEditor>
-                </div>
-                <div
-                  v-else-if="item.content.hrZones?.length"
-                  id="sport-zones"
-                  class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
-                  :class="sectionHighlightClass('sport-zones')"
-                >
-                  <div class="text-xs font-bold uppercase text-gray-400 mb-3">
-                    {{ t('zones_title_hr') }}
-                  </div>
-                  <div class="space-y-2">
-                    <div
-                      v-for="(zone, zIdx) in item.content.hrZones"
-                      :key="zIdx"
-                      class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
-                    >
-                      <span class="text-muted truncate mr-1">{{ zone.name }}</span>
-                      <span class="font-mono font-bold"
-                        >{{ zone.min }}-{{ zone.max
-                        }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
-                      >
+                  <div
+                    v-else-if="item.content.hrZones?.length"
+                    class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
+                  >
+                    <div class="text-xs font-bold uppercase text-gray-400 mb-3">
+                      {{ t('zones_title_hr') }}
                     </div>
+                    <div class="space-y-2">
+                      <div
+                        v-for="(zone, zIdx) in item.content.hrZones"
+                        :key="zIdx"
+                        class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
+                      >
+                        <span class="text-muted truncate mr-1">{{ zone.name }}</span>
+                        <span class="font-mono font-bold"
+                          >{{ zone.min }}-{{ zone.max
+                          }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
+                    class="rounded-xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                  >
+                    {{ t('zones_empty') }}
                   </div>
                 </div>
               </section>
@@ -1675,6 +1683,7 @@
     profile?: any
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:settings', 'autodetect'])
@@ -1770,14 +1779,20 @@
       : ''
   }
 
+  function sectionDomId(sectionId: string, profileIndex: number) {
+    return `${sectionId}-${profileIndex}`
+  }
+
   function getDefaultProfileIndex() {
     const index = accordionItems.value.findIndex((item) => item.content.isDefault)
     return index >= 0 ? index : 0
   }
 
-  function scrollToSection(sectionId: string) {
+  function scrollToSection(sectionId: string, profileIndex: number) {
     nextTick(() => {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      document
+        .getElementById(sectionDomId(sectionId, profileIndex))
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
   }
 
@@ -1788,17 +1803,22 @@
     const item = accordionItems.value[index]
     if (!item) return
 
-    openItems.value = [item.value]
+    const openValues = [item.value]
+    if (editingIndex.value !== null && editingIndex.value !== index) {
+      const editingItem = accordionItems.value[editingIndex.value]
+      if (editingItem) openValues.push(editingItem.value)
+    }
+    openItems.value = [...new Set(openValues)]
 
-    if (editingIndex.value !== index) {
+    if (editingIndex.value === null) {
       startEdit(index, item.content)
     }
 
-    scrollToSection(sectionId)
+    scrollToSection(sectionId, index)
   }
 
   watch(
-    () => [props.settings?.length, props.focusSection] as const,
+    () => [props.settings?.length, props.focusSection, props.focusRequestId] as const,
     ([length, section]) => {
       if (!section || !section.startsWith('sport-') || !length) return
       focusSportSection(section)

--- a/app/i18n/en/dashboard.json
+++ b/app/i18n/en/dashboard.json
@@ -157,6 +157,8 @@
   "share_modal_title_reward": "Share Coach Watts",
   "sync_toast_description": "Your data has been updated successfully!",
   "sync_toast_title": "Sync Complete",
+  "sync_toast_partial_title": "Sync Partially Complete",
+  "sync_toast_partial_description": "Your data was refreshed, but {count} connected app failed to sync. Check integrations for details. | Your data was refreshed, but {count} connected apps failed to sync. Check integrations for details.",
   "system_message_no_commitment": "No commitment • Cancel anytime",
   "system_message_reward": "One-time reward • +3 days",
   "training_recommendation_accept_button": "Accept",

--- a/app/i18n/nl/dashboard.json
+++ b/app/i18n/nl/dashboard.json
@@ -157,6 +157,8 @@
   "share_modal_title_reward": "Deel Coach Watts",
   "sync_toast_description": "Je gegevens zijn succesvol bijgewerkt!",
   "sync_toast_title": "Sync voltooid",
+  "sync_toast_partial_title": "Synchronisatie gedeeltelijk voltooid",
+  "sync_toast_partial_description": "Je gegevens zijn bijgewerkt, maar {count} gekoppelde app kon niet synchroniseren. Controleer je integraties voor details. | Je gegevens zijn bijgewerkt, maar {count} gekoppelde apps konden niet synchroniseren. Controleer je integraties voor details.",
   "system_message_no_commitment": "Geen verplichtingen • Altijd opzegbaar",
   "system_message_reward": "Eenmalige beloning • +3 dagen",
   "training_recommendation_accept_button": "Accepteren",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -243,6 +243,7 @@
 
                   <!-- Performance Overview Card -->
                   <DashboardPerformanceScoresCard
+                    ref="performanceScoresCard"
                     @open-score-modal="openScoreModal"
                     @open-training-load="openTrainingLoadModal"
                   />
@@ -548,6 +549,7 @@
       userStore.user?.nutritionTrackingEnabled !== false
   )
   const isOnboarded = computed(() => activationComplete.value)
+  const performanceScoresCard = ref<{ refresh: () => Promise<unknown> } | null>(null)
 
   // Background Task Monitoring
   const { refresh: refreshRuns } = useUserRuns()
@@ -572,16 +574,24 @@
     ])
   }
 
-  async function handleIngestAllComplete() {
+  async function handleIngestAllComplete(run: {
+    output?: { success?: boolean; failedCount?: number; results?: any[] }
+  }) {
     await handleIngestTaskComplete()
+    await performanceScoresCard.value?.refresh()
+
+    const failedCount = Number(run.output?.failedCount || 0)
+    const fullySuccessful = run.output?.success !== false && failedCount === 0
 
     showDashboardProgressToast(
       toast,
       {
-        title: t.value('sync_toast_title'),
-        description: t.value('sync_toast_description'),
-        color: 'success',
-        icon: 'i-heroicons-check-circle',
+        title: fullySuccessful ? t.value('sync_toast_title') : t.value('sync_toast_partial_title'),
+        description: fullySuccessful
+          ? t.value('sync_toast_description')
+          : t.value('sync_toast_partial_description', { count: failedCount }),
+        color: fullySuccessful ? 'success' : 'warning',
+        icon: fullySuccessful ? 'i-heroicons-check-circle' : 'i-heroicons-exclamation-triangle',
         duration: 2500
       },
       'dashboard.sync.complete'

--- a/app/pages/profile/settings.vue
+++ b/app/pages/profile/settings.vue
@@ -35,6 +35,7 @@
             :loading="savingProfile"
             :highlight-sections="highlightedSections"
             :focus-section="focusSection"
+            :focus-request-id="focusRequestId"
             @update:model-value="handleProfileUpdate"
             @autodetect="handleAutodetect"
             @navigate="(tab) => setActiveTab(tab)"
@@ -93,6 +94,7 @@
                 :profile="profile"
                 :highlight-sections="highlightedSections"
                 :focus-section="focusSection"
+                :focus-request-id="focusRequestId"
                 @update:settings="updateSportSettings"
                 @autodetect="handleAutodetect"
               />
@@ -260,6 +262,7 @@
   const router = useRouter()
   const activeTab = ref((route.query.tab as string) || 'basic')
   const focusSection = ref<MissingProfileSectionId | null>(null)
+  const focusRequestId = ref(0)
   const highlightedSections = ref<MissingProfileSectionId[]>([])
   const missingFieldsGuideDismissed = ref(false)
   const pendingFocus = ref<{ sectionId: MissingProfileSectionId; tab: 'basic' | 'sports' } | null>(
@@ -291,6 +294,7 @@
 
     pendingFocus.value = null
     focusSection.value = sectionId
+    focusRequestId.value += 1
     highlightedSections.value = [sectionId]
 
     router.replace({

--- a/app/stores/activities.ts
+++ b/app/stores/activities.ts
@@ -4,11 +4,7 @@ export const useActivityStore = defineStore('activity', () => {
   const recentActivity = ref<any>(null)
   const loading = ref(false)
 
-  const integrationStore = useIntegrationStore()
-
   async function fetchRecentActivity() {
-    if (!integrationStore.intervalsConnected) return
-
     loading.value = true
     try {
       const data = await ($fetch as any)('/api/activity/recent')

--- a/app/stores/recommendations.ts
+++ b/app/stores/recommendations.ts
@@ -13,11 +13,7 @@ export const useRecommendationStore = defineStore('recommendation', () => {
   const { refresh: refreshRuns } = useUserRuns()
   const { onTaskCompleted, onTaskFailed } = useUserRunsState()
 
-  // We need to know if intervals is connected to fetch
-  const integrationStore = useIntegrationStore()
-
   async function fetchTodayWorkout() {
-    if (!integrationStore.intervalsConnected) return
     loadingWorkout.value = true
     try {
       const data = (await ($fetch as any)('/api/workouts/planned/today')) as any[]
@@ -41,9 +37,6 @@ export const useRecommendationStore = defineStore('recommendation', () => {
   }
 
   async function fetchTodayRecommendation() {
-    // If not connected, don't fetch (or handle appropriately)
-    if (!integrationStore.intervalsConnected) return
-
     loading.value = true
     try {
       const data = await ($fetch as any)('/api/recommendations/today')

--- a/tests/unit/app/profile-basic-settings-focus.test.ts
+++ b/tests/unit/app/profile-basic-settings-focus.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BasicSettings from '../../../app/components/profile/BasicSettings.vue'
+
+vi.mock('@tolgee/vue', () => ({
+  useTranslate: () => ({ t: (key: string) => key })
+}))
+
+mockNuxtImport('useAuth', () => () => ({ signIn: vi.fn() }))
+mockNuxtImport('useFormat', () => () => ({ formatDateUTC: vi.fn(() => '') }))
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }))
+
+describe('ProfileBasicSettings focus requests', () => {
+  const scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('scrollTo', vi.fn())
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockReset()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  it('scrolls again when the same section receives a new focus request', async () => {
+    const wrapper = await mountSuspended(BasicSettings, {
+      attachTo: document.body,
+      shallow: true,
+      props: {
+        modelValue: {
+          accounts: [],
+          integrations: [],
+          dob: null,
+          weight: null,
+          weightUnits: 'Kilograms',
+          height: null,
+          heightUnits: 'cm'
+        },
+        email: 'athlete@example.com',
+        focusSection: null,
+        focusRequestId: 0
+      }
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(document.getElementById('body-metrics')).not.toBeNull()
+
+    await wrapper.setProps({ focusSection: 'body-metrics', focusRequestId: 1 })
+    await nextTick()
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ focusRequestId: 2 })
+    await nextTick()
+    await nextTick()
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+  })
+})

--- a/trigger/ingest-all.ts
+++ b/trigger/ingest-all.ts
@@ -48,8 +48,11 @@ export const ingestAllTask = task({
     // We do this first so external systems are up-to-date before we fetch from them.
     try {
       logger.log('📤 Triggering Sync Queue Processing (Push)...')
-      await processSyncQueueTask.trigger({})
-      logger.log('✅ Sync Queue flushed')
+      const queueRun = await processSyncQueueTask.triggerAndWait({})
+      if (!queueRun.ok) {
+        throw new Error(`Sync queue processing failed: ${String(queueRun.error)}`)
+      }
+      logger.log('✅ Sync Queue processing completed')
     } catch (error) {
       logger.warn('⚠️ Failed to trigger sync queue processing', { error })
     }


### PR DESCRIPTION
## What changed

- waits for outbound sync-queue processing before provider pulls
- shows a partial-success warning when `ingest-all` reports provider failures
- refreshes profile scores and PMC data after sync completion
- removes Intervals-only gates from recent activity and recommendation fetches
- adds English and Dutch partial-sync copy

## Root cause

`ingest-all` completed at the task level even when its structured output reported provider failures, while the dashboard treated every completed run as a full success. Score fetches also had no explicit post-sync refresh path.

## Impact

The dashboard reports truthful completion state and refreshes data for athletes using any supported provider.

## Validation

- targeted ESLint passed
- formatting and `git diff --check` passed
