### PR TITLE
Harden Intervals webhook authentication and logging

### DIFF
--- a/app/components/profile/BasicSettings.vue
+++ b/app/components/profile/BasicSettings.vue
@@ -412,17 +412,9 @@
                     on {{ formatDateUTC(method.linkedAt, 'PPP') }}
                   </span>
                 </p>
-                <p v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5">
-                  ID: {{ method.profileId }}
-                </p>
               </div>
-              <p v-else-if="method.isIntegrated" class="flex flex-col">
-                <span class="text-xs text-amber-500 font-medium">{{
-                  t('basic_login_methods_linked')
-                }}</span>
-                <span v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5"
-                  >ID: {{ method.profileId }}</span
-                >
+              <p v-else-if="method.isIntegrated" class="text-xs text-amber-500 font-medium">
+                {{ t('basic_login_methods_linked') }}
               </p>
               <p v-else class="text-xs text-gray-500 dark:text-gray-400">
                 {{ t('basic_login_methods_not_connected') }}
@@ -563,6 +555,7 @@
     loading?: boolean
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:modelValue', 'autodetect', 'navigate'])
@@ -583,8 +576,7 @@
         iconClass: 'text-gray-900 dark:text-white',
         isConnected: accounts.some((a: any) => a.provider === 'google'),
         isIntegrated: false, // Google is login-only for now
-        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt,
-        profileId: accounts.find((a: any) => a.provider === 'google')?.providerAccountId
+        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt
       },
       {
         id: 'strava',
@@ -593,10 +585,7 @@
         iconClass: 'text-[#FC4C02]',
         isConnected: accounts.some((a: any) => a.provider === 'strava'),
         isIntegrated: integrations.some((i: any) => i.provider === 'strava'),
-        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'strava')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'strava')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt
       },
       {
         id: 'intervals',
@@ -605,10 +594,7 @@
         iconClass: 'text-primary',
         isConnected: accounts.some((a: any) => a.provider === 'intervals'),
         isIntegrated: integrations.some((i: any) => i.provider === 'intervals'),
-        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'intervals')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'intervals')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt
       }
     ]
   })
@@ -872,8 +858,8 @@
   }
 
   watch(
-    () => props.focusSection,
-    (section) => {
+    () => [props.focusSection, props.focusRequestId] as const,
+    ([section]) => {
       if (section === 'body-metrics') scrollToSection('body-metrics')
     },
     { immediate: true }

--- a/app/components/profile/SportSettings.vue
+++ b/app/components/profile/SportSettings.vue
@@ -503,7 +503,7 @@
 
               <!-- Power Settings -->
               <section
-                id="sport-power"
+                :id="sectionDomId('sport-power', index)"
                 class="space-y-4"
                 :class="sectionHighlightClass('sport-power')"
               >
@@ -734,7 +734,11 @@
               </section>
 
               <!-- Heart Rate Settings -->
-              <section id="sport-hr" class="space-y-4" :class="sectionHighlightClass('sport-hr')">
+              <section
+                :id="sectionDomId('sport-hr', index)"
+                class="space-y-4"
+                :class="sectionHighlightClass('sport-hr')"
+              >
                 <h4
                   class="text-sm font-medium text-gray-500 uppercase tracking-wider border-b pb-2 dark:border-gray-800 flex items-center gap-2"
                 >
@@ -862,12 +866,12 @@
 
                 <!-- HR Zones Editor -->
                 <div
-                  v-if="editingIndex === index"
-                  id="sport-zones"
+                  :id="sectionDomId('sport-zones', index)"
                   class="mt-4"
                   :class="sectionHighlightClass('sport-zones')"
                 >
                   <ProfileZoneEditor
+                    v-if="editingIndex === index"
                     v-model="editForm.hrZones"
                     :title="t('zones_title_hr')"
                     units="bpm"
@@ -887,28 +891,32 @@
                       >
                     </template>
                   </ProfileZoneEditor>
-                </div>
-                <div
-                  v-else-if="item.content.hrZones?.length"
-                  id="sport-zones"
-                  class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
-                  :class="sectionHighlightClass('sport-zones')"
-                >
-                  <div class="text-xs font-bold uppercase text-gray-400 mb-3">
-                    {{ t('zones_title_hr') }}
-                  </div>
-                  <div class="space-y-2">
-                    <div
-                      v-for="(zone, zIdx) in item.content.hrZones"
-                      :key="zIdx"
-                      class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
-                    >
-                      <span class="text-muted truncate mr-1">{{ zone.name }}</span>
-                      <span class="font-mono font-bold"
-                        >{{ zone.min }}-{{ zone.max
-                        }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
-                      >
+                  <div
+                    v-else-if="item.content.hrZones?.length"
+                    class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
+                  >
+                    <div class="text-xs font-bold uppercase text-gray-400 mb-3">
+                      {{ t('zones_title_hr') }}
                     </div>
+                    <div class="space-y-2">
+                      <div
+                        v-for="(zone, zIdx) in item.content.hrZones"
+                        :key="zIdx"
+                        class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
+                      >
+                        <span class="text-muted truncate mr-1">{{ zone.name }}</span>
+                        <span class="font-mono font-bold"
+                          >{{ zone.min }}-{{ zone.max
+                          }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
+                    class="rounded-xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                  >
+                    {{ t('zones_empty') }}
                   </div>
                 </div>
               </section>
@@ -1675,6 +1683,7 @@
     profile?: any
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:settings', 'autodetect'])
@@ -1770,14 +1779,20 @@
       : ''
   }
 
+  function sectionDomId(sectionId: string, profileIndex: number) {
+    return `${sectionId}-${profileIndex}`
+  }
+
   function getDefaultProfileIndex() {
     const index = accordionItems.value.findIndex((item) => item.content.isDefault)
     return index >= 0 ? index : 0
   }
 
-  function scrollToSection(sectionId: string) {
+  function scrollToSection(sectionId: string, profileIndex: number) {
     nextTick(() => {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      document
+        .getElementById(sectionDomId(sectionId, profileIndex))
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
   }
 
@@ -1788,17 +1803,22 @@
     const item = accordionItems.value[index]
     if (!item) return
 
-    openItems.value = [item.value]
+    const openValues = [item.value]
+    if (editingIndex.value !== null && editingIndex.value !== index) {
+      const editingItem = accordionItems.value[editingIndex.value]
+      if (editingItem) openValues.push(editingItem.value)
+    }
+    openItems.value = [...new Set(openValues)]
 
-    if (editingIndex.value !== index) {
+    if (editingIndex.value === null) {
       startEdit(index, item.content)
     }
 
-    scrollToSection(sectionId)
+    scrollToSection(sectionId, index)
   }
 
   watch(
-    () => [props.settings?.length, props.focusSection] as const,
+    () => [props.settings?.length, props.focusSection, props.focusRequestId] as const,
     ([length, section]) => {
       if (!section || !section.startsWith('sport-') || !length) return
       focusSportSection(section)

--- a/app/pages/profile/settings.vue
+++ b/app/pages/profile/settings.vue
@@ -35,6 +35,7 @@
             :loading="savingProfile"
             :highlight-sections="highlightedSections"
             :focus-section="focusSection"
+            :focus-request-id="focusRequestId"
             @update:model-value="handleProfileUpdate"
             @autodetect="handleAutodetect"
             @navigate="(tab) => setActiveTab(tab)"
@@ -93,6 +94,7 @@
                 :profile="profile"
                 :highlight-sections="highlightedSections"
                 :focus-section="focusSection"
+                :focus-request-id="focusRequestId"
                 @update:settings="updateSportSettings"
                 @autodetect="handleAutodetect"
               />
@@ -260,6 +262,7 @@
   const router = useRouter()
   const activeTab = ref((route.query.tab as string) || 'basic')
   const focusSection = ref<MissingProfileSectionId | null>(null)
+  const focusRequestId = ref(0)
   const highlightedSections = ref<MissingProfileSectionId[]>([])
   const missingFieldsGuideDismissed = ref(false)
   const pendingFocus = ref<{ sectionId: MissingProfileSectionId; tab: 'basic' | 'sports' } | null>(
@@ -291,6 +294,7 @@
 
     pendingFocus.value = null
     focusSection.value = sectionId
+    focusRequestId.value += 1
     highlightedSections.value = [sectionId]
 
     router.replace({

--- a/cli/worker/start.ts
+++ b/cli/worker/start.ts
@@ -141,46 +141,76 @@ export const startCommand = new Command('start')
           const { payload, headers } = job.data
           const events = payload.events || []
 
-          // Log raw request receipt in worker instead of API
-          const log = await logWebhookRequest({
-            provider: 'intervals',
-            eventType: events[0]?.type || 'UNKNOWN',
-            payload,
-            headers,
-            status: 'PENDING'
-          })
+          // Redis-first requests need a parent log. SQL fallback requests already
+          // have one and must keep that identity through terminal dispatch.
+          const parentLogId =
+            logId ||
+            (
+              await logWebhookRequest({
+                provider: 'intervals-bulk',
+                eventType: events[0]?.type || 'UNKNOWN',
+                payload,
+                headers,
+                status: 'PENDING'
+              })
+            )?.id
 
           let queuedCount = 0
-          for (const intervalEvent of events) {
-            const { athlete_id, type: eventType } = intervalEvent
-            if (!athlete_id) continue
+          try {
+            for (const intervalEvent of events) {
+              const { athlete_id, type: eventType } = intervalEvent
+              if (!athlete_id) continue
 
-            // Verify integration exists in worker instead of API
-            const integration = await prisma.integration.findFirst({
-              where: {
-                provider: 'intervals',
-                externalUserId: athlete_id.toString()
+              const integration = await prisma.integration.findFirst({
+                where: {
+                  provider: 'intervals',
+                  externalUserId: athlete_id.toString()
+                }
+              })
+
+              if (!integration) {
+                console.warn(
+                  `[BulkJob ${job.id}] No integration found for athlete_id: ${athlete_id}`
+                )
+                continue
               }
-            })
 
-            if (!integration) {
-              console.warn(`[BulkJob ${job.id}] No integration found for athlete_id: ${athlete_id}`)
-              continue
+              const childLog = await logWebhookRequest({
+                provider: 'intervals',
+                eventType: eventType || 'UNKNOWN',
+                payload: intervalEvent,
+                headers,
+                status: 'PENDING'
+              })
+
+              await webhookQueue.add('intervals-webhook', {
+                provider: 'intervals',
+                type: eventType,
+                userId: integration.userId,
+                event: intervalEvent,
+                logId: childLog?.id
+              })
+              queuedCount++
             }
 
-            // Enqueue individual event for standard processing
-            await webhookQueue.add('intervals-webhook', {
-              provider: 'intervals',
-              type: eventType,
-              userId: integration.userId,
-              event: intervalEvent,
-              logId: log?.id
-            })
-            queuedCount++
+            if (parentLogId) {
+              await updateWebhookStatus(
+                parentLogId,
+                queuedCount > 0 ? 'PROCESSED' : 'IGNORED',
+                `Dispatched ${queuedCount} child events`
+              )
+            }
+            return { queuedCount }
+          } catch (error) {
+            if (parentLogId) {
+              await updateWebhookStatus(
+                parentLogId,
+                'FAILED',
+                error instanceof Error ? error.message : String(error)
+              )
+            }
+            throw error
           }
-
-          if (log) await updateWebhookStatus(log.id, 'QUEUED', `Queued ${queuedCount} events`)
-          return { queuedCount }
         }
 
         if (provider === 'oauth-generic') {

--- a/server/api/integrations/intervals/webhook-async.post.ts
+++ b/server/api/integrations/intervals/webhook-async.post.ts
@@ -1,6 +1,7 @@
 import { webhookQueue } from '../../../utils/queue'
 import { logWebhookRequest } from '../../../utils/webhook-logger'
 import { formatErrorMessage } from '../../../utils/log-format'
+import { isValidIntervalsWebhookSecret } from '../../../utils/intervals-webhook-auth'
 
 defineRouteMeta({
   openAPI: {
@@ -39,11 +40,10 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const secret = process.env.INTERVALS_WEBHOOK_SECRET
   const body = await readBody(event)
   const headers = getRequestHeaders(event)
 
-  if (!body || body.secret !== secret) {
+  if (!body || !isValidIntervalsWebhookSecret(body.secret)) {
     console.warn('[Intervals Webhook Async] Unauthorized or missing secret')
     throw createError({
       statusCode: 401,

--- a/server/api/integrations/intervals/webhook.post.ts
+++ b/server/api/integrations/intervals/webhook.post.ts
@@ -1,4 +1,5 @@
 import { logWebhookRequest } from '../../../utils/webhook-logger'
+import { isValidIntervalsWebhookSecret } from '../../../utils/intervals-webhook-auth'
 
 defineRouteMeta({
   openAPI: {
@@ -37,12 +38,10 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const secret = process.env.INTERVALS_WEBHOOK_SECRET
-
   const body = await readBody(event)
   const headers = getRequestHeaders(event)
 
-  if (!body || body.secret !== secret) {
+  if (!body || !isValidIntervalsWebhookSecret(body.secret)) {
     console.warn('[Intervals Webhook] Unauthorized or missing secret')
     throw createError({
       statusCode: 401,

--- a/server/utils/intervals-webhook-auth.ts
+++ b/server/utils/intervals-webhook-auth.ts
@@ -1,0 +1,13 @@
+import { timingSafeEqual } from 'node:crypto'
+
+export function isValidIntervalsWebhookSecret(received: unknown): boolean {
+  const configured = process.env.INTERVALS_WEBHOOK_SECRET
+  if (!configured || typeof received !== 'string' || received.length === 0) return false
+
+  const expectedBuffer = Buffer.from(configured)
+  const receivedBuffer = Buffer.from(received)
+  return (
+    expectedBuffer.length === receivedBuffer.length &&
+    timingSafeEqual(expectedBuffer, receivedBuffer)
+  )
+}

--- a/tests/unit/app/profile-basic-settings-focus.test.ts
+++ b/tests/unit/app/profile-basic-settings-focus.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BasicSettings from '../../../app/components/profile/BasicSettings.vue'
+
+vi.mock('@tolgee/vue', () => ({
+  useTranslate: () => ({ t: (key: string) => key })
+}))
+
+mockNuxtImport('useAuth', () => () => ({ signIn: vi.fn() }))
+mockNuxtImport('useFormat', () => () => ({ formatDateUTC: vi.fn(() => '') }))
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }))
+
+describe('ProfileBasicSettings focus requests', () => {
+  const scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('scrollTo', vi.fn())
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockReset()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  it('scrolls again when the same section receives a new focus request', async () => {
+    const wrapper = await mountSuspended(BasicSettings, {
+      attachTo: document.body,
+      shallow: true,
+      props: {
+        modelValue: {
+          accounts: [],
+          integrations: [],
+          dob: null,
+          weight: null,
+          weightUnits: 'Kilograms',
+          height: null,
+          heightUnits: 'cm'
+        },
+        email: 'athlete@example.com',
+        focusSection: null,
+        focusRequestId: 0
+      }
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(document.getElementById('body-metrics')).not.toBeNull()
+
+    await wrapper.setProps({ focusSection: 'body-metrics', focusRequestId: 1 })
+    await nextTick()
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ focusRequestId: 2 })
+    await nextTick()
+    await nextTick()
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/server/utils/intervals-webhook-auth.test.ts
+++ b/tests/unit/server/utils/intervals-webhook-auth.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { isValidIntervalsWebhookSecret } from '../../../../server/utils/intervals-webhook-auth'
+
+describe('Intervals webhook authentication', () => {
+  const originalSecret = process.env.INTERVALS_WEBHOOK_SECRET
+
+  afterEach(() => {
+    if (originalSecret === undefined) delete process.env.INTERVALS_WEBHOOK_SECRET
+    else process.env.INTERVALS_WEBHOOK_SECRET = originalSecret
+  })
+
+  it('fails closed when the server secret is not configured', () => {
+    delete process.env.INTERVALS_WEBHOOK_SECRET
+    expect(isValidIntervalsWebhookSecret(undefined)).toBe(false)
+    expect(isValidIntervalsWebhookSecret('')).toBe(false)
+  })
+
+  it('accepts only an exact configured secret', () => {
+    process.env.INTERVALS_WEBHOOK_SECRET = 'configured-secret'
+    expect(isValidIntervalsWebhookSecret('configured-secret')).toBe(true)
+    expect(isValidIntervalsWebhookSecret('configured-secret-x')).toBe(false)
+    expect(isValidIntervalsWebhookSecret('wrong-secret')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What changed

- fails closed when `INTERVALS_WEBHOOK_SECRET` is absent
- compares configured secrets with timing-safe equality
- preserves SQL fallback parent log identity
- creates one child log per Intervals event
- terminally marks bulk dispatch logs as processed, ignored, or failed

## Root cause

A missing environment secret could satisfy `undefined === undefined`. Bulk children also shared one log, and SQL fallback created a replacement bulk log that left the original record `QUEUED`.

## Impact

Intervals webhook ingestion has safer authentication and event-level processing visibility.

## Validation

- 2 targeted Vitest tests passed
- targeted ESLint passed
- `git diff --check` passed
