### PR TITLE
Decouple and harden workout analysis enqueue

### DIFF
--- a/app/components/profile/BasicSettings.vue
+++ b/app/components/profile/BasicSettings.vue
@@ -412,17 +412,9 @@
                     on {{ formatDateUTC(method.linkedAt, 'PPP') }}
                   </span>
                 </p>
-                <p v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5">
-                  ID: {{ method.profileId }}
-                </p>
               </div>
-              <p v-else-if="method.isIntegrated" class="flex flex-col">
-                <span class="text-xs text-amber-500 font-medium">{{
-                  t('basic_login_methods_linked')
-                }}</span>
-                <span v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5"
-                  >ID: {{ method.profileId }}</span
-                >
+              <p v-else-if="method.isIntegrated" class="text-xs text-amber-500 font-medium">
+                {{ t('basic_login_methods_linked') }}
               </p>
               <p v-else class="text-xs text-gray-500 dark:text-gray-400">
                 {{ t('basic_login_methods_not_connected') }}
@@ -563,6 +555,7 @@
     loading?: boolean
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:modelValue', 'autodetect', 'navigate'])
@@ -583,8 +576,7 @@
         iconClass: 'text-gray-900 dark:text-white',
         isConnected: accounts.some((a: any) => a.provider === 'google'),
         isIntegrated: false, // Google is login-only for now
-        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt,
-        profileId: accounts.find((a: any) => a.provider === 'google')?.providerAccountId
+        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt
       },
       {
         id: 'strava',
@@ -593,10 +585,7 @@
         iconClass: 'text-[#FC4C02]',
         isConnected: accounts.some((a: any) => a.provider === 'strava'),
         isIntegrated: integrations.some((i: any) => i.provider === 'strava'),
-        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'strava')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'strava')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt
       },
       {
         id: 'intervals',
@@ -605,10 +594,7 @@
         iconClass: 'text-primary',
         isConnected: accounts.some((a: any) => a.provider === 'intervals'),
         isIntegrated: integrations.some((i: any) => i.provider === 'intervals'),
-        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'intervals')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'intervals')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt
       }
     ]
   })
@@ -872,8 +858,8 @@
   }
 
   watch(
-    () => props.focusSection,
-    (section) => {
+    () => [props.focusSection, props.focusRequestId] as const,
+    ([section]) => {
       if (section === 'body-metrics') scrollToSection('body-metrics')
     },
     { immediate: true }

--- a/app/components/profile/SportSettings.vue
+++ b/app/components/profile/SportSettings.vue
@@ -503,7 +503,7 @@
 
               <!-- Power Settings -->
               <section
-                id="sport-power"
+                :id="sectionDomId('sport-power', index)"
                 class="space-y-4"
                 :class="sectionHighlightClass('sport-power')"
               >
@@ -734,7 +734,11 @@
               </section>
 
               <!-- Heart Rate Settings -->
-              <section id="sport-hr" class="space-y-4" :class="sectionHighlightClass('sport-hr')">
+              <section
+                :id="sectionDomId('sport-hr', index)"
+                class="space-y-4"
+                :class="sectionHighlightClass('sport-hr')"
+              >
                 <h4
                   class="text-sm font-medium text-gray-500 uppercase tracking-wider border-b pb-2 dark:border-gray-800 flex items-center gap-2"
                 >
@@ -862,12 +866,12 @@
 
                 <!-- HR Zones Editor -->
                 <div
-                  v-if="editingIndex === index"
-                  id="sport-zones"
+                  :id="sectionDomId('sport-zones', index)"
                   class="mt-4"
                   :class="sectionHighlightClass('sport-zones')"
                 >
                   <ProfileZoneEditor
+                    v-if="editingIndex === index"
                     v-model="editForm.hrZones"
                     :title="t('zones_title_hr')"
                     units="bpm"
@@ -887,28 +891,32 @@
                       >
                     </template>
                   </ProfileZoneEditor>
-                </div>
-                <div
-                  v-else-if="item.content.hrZones?.length"
-                  id="sport-zones"
-                  class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
-                  :class="sectionHighlightClass('sport-zones')"
-                >
-                  <div class="text-xs font-bold uppercase text-gray-400 mb-3">
-                    {{ t('zones_title_hr') }}
-                  </div>
-                  <div class="space-y-2">
-                    <div
-                      v-for="(zone, zIdx) in item.content.hrZones"
-                      :key="zIdx"
-                      class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
-                    >
-                      <span class="text-muted truncate mr-1">{{ zone.name }}</span>
-                      <span class="font-mono font-bold"
-                        >{{ zone.min }}-{{ zone.max
-                        }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
-                      >
+                  <div
+                    v-else-if="item.content.hrZones?.length"
+                    class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
+                  >
+                    <div class="text-xs font-bold uppercase text-gray-400 mb-3">
+                      {{ t('zones_title_hr') }}
                     </div>
+                    <div class="space-y-2">
+                      <div
+                        v-for="(zone, zIdx) in item.content.hrZones"
+                        :key="zIdx"
+                        class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
+                      >
+                        <span class="text-muted truncate mr-1">{{ zone.name }}</span>
+                        <span class="font-mono font-bold"
+                          >{{ zone.min }}-{{ zone.max
+                          }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
+                    class="rounded-xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                  >
+                    {{ t('zones_empty') }}
                   </div>
                 </div>
               </section>
@@ -1675,6 +1683,7 @@
     profile?: any
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:settings', 'autodetect'])
@@ -1770,14 +1779,20 @@
       : ''
   }
 
+  function sectionDomId(sectionId: string, profileIndex: number) {
+    return `${sectionId}-${profileIndex}`
+  }
+
   function getDefaultProfileIndex() {
     const index = accordionItems.value.findIndex((item) => item.content.isDefault)
     return index >= 0 ? index : 0
   }
 
-  function scrollToSection(sectionId: string) {
+  function scrollToSection(sectionId: string, profileIndex: number) {
     nextTick(() => {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      document
+        .getElementById(sectionDomId(sectionId, profileIndex))
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
   }
 
@@ -1788,17 +1803,22 @@
     const item = accordionItems.value[index]
     if (!item) return
 
-    openItems.value = [item.value]
+    const openValues = [item.value]
+    if (editingIndex.value !== null && editingIndex.value !== index) {
+      const editingItem = accordionItems.value[editingIndex.value]
+      if (editingItem) openValues.push(editingItem.value)
+    }
+    openItems.value = [...new Set(openValues)]
 
-    if (editingIndex.value !== index) {
+    if (editingIndex.value === null) {
       startEdit(index, item.content)
     }
 
-    scrollToSection(sectionId)
+    scrollToSection(sectionId, index)
   }
 
   watch(
-    () => [props.settings?.length, props.focusSection] as const,
+    () => [props.settings?.length, props.focusSection, props.focusRequestId] as const,
     ([length, section]) => {
       if (!section || !section.startsWith('sport-') || !length) return
       focusSportSection(section)

--- a/app/pages/profile/settings.vue
+++ b/app/pages/profile/settings.vue
@@ -35,6 +35,7 @@
             :loading="savingProfile"
             :highlight-sections="highlightedSections"
             :focus-section="focusSection"
+            :focus-request-id="focusRequestId"
             @update:model-value="handleProfileUpdate"
             @autodetect="handleAutodetect"
             @navigate="(tab) => setActiveTab(tab)"
@@ -93,6 +94,7 @@
                 :profile="profile"
                 :highlight-sections="highlightedSections"
                 :focus-section="focusSection"
+                :focus-request-id="focusRequestId"
                 @update:settings="updateSportSettings"
                 @autodetect="handleAutodetect"
               />
@@ -260,6 +262,7 @@
   const router = useRouter()
   const activeTab = ref((route.query.tab as string) || 'basic')
   const focusSection = ref<MissingProfileSectionId | null>(null)
+  const focusRequestId = ref(0)
   const highlightedSections = ref<MissingProfileSectionId[]>([])
   const missingFieldsGuideDismissed = ref(false)
   const pendingFocus = ref<{ sectionId: MissingProfileSectionId; tab: 'basic' | 'sports' } | null>(
@@ -291,6 +294,7 @@
 
     pendingFocus.value = null
     focusSection.value = sectionId
+    focusRequestId.value += 1
     highlightedSections.value = [sectionId]
 
     router.replace({

--- a/server/utils/ai-tools/workouts.ts
+++ b/server/utils/ai-tools/workouts.ts
@@ -11,13 +11,13 @@ import {
   getStartOfDayUTC,
   getEndOfDayUTC
 } from '../../utils/date'
-import { analyzeWorkoutTask } from '../../../trigger/analyze-workout'
 import type { AiSettings } from '../ai-user-settings'
 import { hasProtectedIntervalsTags, mergeWorkoutTags } from '../workout-tags'
 import { getPendingSyncStatus } from '../structured-workout-persistence'
 import { calculateWorkoutStress } from '../calculate-workout-stress'
 import { metabolicService } from '../services/metabolicService'
 import { isNutritionTrackingEnabled } from '../nutrition/feature'
+import { enqueueWorkoutAnalysis } from '../workout-analysis-enqueue'
 
 export const workoutTools = (userId: string, timezone: string, aiSettings: AiSettings) => ({
   get_recent_workouts: tool({
@@ -271,10 +271,38 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
         typeof workout.aiAnalysisJson === 'object' &&
         !Array.isArray(workout.aiAnalysisJson)
 
+      let queueResult: Awaited<ReturnType<typeof enqueueWorkoutAnalysis>> | undefined
+      if (workout.aiAnalysisStatus === 'NOT_STARTED' || workout.aiAnalysisStatus === 'FAILED') {
+        try {
+          queueResult = await enqueueWorkoutAnalysis({
+            workoutId: workout_id,
+            userId,
+            currentStatus: workout.aiAnalysisStatus,
+            source: 'MANUAL'
+          })
+        } catch (error: any) {
+          return {
+            ...analysisResult,
+            ...(hasStructuredAnalysis ? {} : { aiAnalysis }),
+            date: formatUserDate(workout.date, timezone),
+            message: `Deep analysis is not ready and could not be queued automatically (${error?.message || 'unknown error'}).`
+          }
+        }
+      }
+
       return {
         ...analysisResult,
+        ...(queueResult ? { aiAnalysisStatus: queueResult.status } : {}),
         ...(hasStructuredAnalysis ? {} : { aiAnalysis }),
-        date: formatUserDate(workout.date, timezone)
+        date: formatUserDate(workout.date, timezone),
+        ...(queueResult?.queued
+          ? {
+              analysis_queued: true,
+              analysis_run_id: queueResult.runId,
+              message:
+                'Deep analysis was missing, so it has been queued. Summarize the available metrics now and tell the athlete to ask again shortly for the full breakdown.'
+            }
+          : {})
       }
     }
   }),
@@ -291,20 +319,22 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
       if (!workout) return { error: 'Workout not found' }
 
       try {
-        const handle = await analyzeWorkoutTask.trigger(
-          { workoutId: workout_id },
-          {
-            tags: [`user:${userId}`, `workout:${workout_id}`],
-            concurrencyKey: userId
-          }
-        )
-        await workoutRepository.updateStatus(workout_id, 'PENDING')
+        const result = await enqueueWorkoutAnalysis({
+          workoutId: workout_id,
+          userId,
+          currentStatus: workout.aiAnalysisStatus,
+          source: 'MANUAL',
+          allowReanalysis: true
+        })
         return {
           success: true,
-          message: 'Workout re-analysis has been queued for processing.',
+          message: result.queued
+            ? 'Workout re-analysis has been queued for processing.'
+            : `Workout analysis is already ${result.status.toLowerCase()}.`,
           job_type: 'workout_analysis',
           job_id: workout_id,
-          run_id: handle.id
+          run_id: result.runId,
+          queued: result.queued
         }
       } catch (e: any) {
         return { error: `Failed to trigger analysis: ${e.message}` }

--- a/server/utils/chat/turn-executor.test.ts
+++ b/server/utils/chat/turn-executor.test.ts
@@ -282,6 +282,8 @@ describe('write repair prompt helpers', () => {
     expect(result).toContain('tool-enabled read turn')
     expect(result).toContain('MUST produce a clear textual answer')
     expect(result).toContain('Do not end the turn with only tool calls')
+    expect(result).toContain('prose coaching reply')
+    expect(result).toContain('get_workout_analysis')
   })
 
   it('synthesizes a planned-workout fallback from successful tool results', () => {
@@ -375,6 +377,40 @@ describe('write repair prompt helpers', () => {
 
     expect(result).toContain('## Morning Run')
     expect(result).toContain('Well-paced aerobic session.')
+  })
+
+  it('explains missing workout analysis instead of returning null', () => {
+    const result = buildEmptyResponseFallbackFromToolResults([
+      {
+        toolName: 'get_workout_analysis',
+        result: {
+          title: 'VO2Max Sharpener',
+          date: '2026-07-23',
+          aiAnalysisStatus: 'NOT_STARTED',
+          aiAnalysisJson: null,
+          aiAnalysis: null
+        }
+      }
+    ])
+
+    expect(result).toContain('VO2Max Sharpener')
+    expect(result).toContain('not available yet')
+    expect(result).toContain('raw session metrics')
+  })
+
+  it('explains in-progress workout analysis', () => {
+    const result = buildEmptyResponseFallbackFromToolResults([
+      {
+        toolName: 'get_workout_analysis',
+        result: {
+          title: 'Afternoon Ride',
+          date: '2026-07-22',
+          aiAnalysisStatus: 'PENDING'
+        }
+      }
+    ])
+
+    expect(result).toContain('still generating')
   })
 
   it('builds a concise fallback for completed workout details', () => {

--- a/server/utils/chat/turn-executor.ts
+++ b/server/utils/chat/turn-executor.ts
@@ -379,6 +379,8 @@ export function buildReadRepairSystemInstruction(systemInstruction: string) {
 - Call the needed read tools if you still lack facts, then you MUST produce a clear textual answer for the athlete.
 - Do not end the turn with only tool calls and no assistant text.
 - Prefer a concise coaching summary over dumping raw tool JSON.
+- Write a prose coaching reply the athlete can read without tables or UI cards. Lead with the answer, then 3-6 short bullets with numbers.
+- If get_workout_analysis shows aiAnalysisStatus NOT_STARTED, PENDING, PROCESSING, or FAILED, say that clearly and summarize available metrics from get_workout_details.
 - If tools already answered the question, summarize the key guidance now.`
 }
 
@@ -538,8 +540,30 @@ function buildWorkoutAnalysisFallback(analysis: any): string | null {
         ? analysis.overallQualityExplanation.trim()
         : ''
   const markdown = typeof analysis?.aiAnalysis === 'string' ? analysis.aiAnalysis.trim() : ''
+  const status =
+    typeof analysis?.aiAnalysisStatus === 'string' ? analysis.aiAnalysisStatus.toUpperCase() : ''
 
-  if (!summary && !markdown && !structured) return null
+  if (!summary && !markdown && !structured) {
+    if (!status || status === 'COMPLETED') return null
+
+    const title = analysis?.title || 'Workout'
+    const dateLine = analysis?.date ? ` (${analysis.date})` : ''
+    if (status === 'PENDING' || status === 'PROCESSING' || status === 'IN_PROGRESS') {
+      return [
+        `Deep analysis for **${title}**${dateLine} is still generating.`,
+        '',
+        'I have the session loaded. Ask again shortly for the full breakdown.'
+      ].join('\n')
+    }
+    if (status === 'NOT_STARTED' || status === 'FAILED') {
+      return [
+        `Deep analysis for **${title}**${dateLine} is not available yet${status === 'FAILED' ? ' (the previous attempt failed)' : ''}.`,
+        '',
+        'I can still cover the raw session metrics now, and the full analysis can be queued from this workout.'
+      ].join('\n')
+    }
+    return null
+  }
 
   const title = analysis?.title || structured?.title || 'Workout analysis'
   const lines = [`## ${title}`]

--- a/server/utils/workout-analysis-enqueue.ts
+++ b/server/utils/workout-analysis-enqueue.ts
@@ -1,0 +1,119 @@
+import { analyzeWorkoutTask } from '../../trigger/analyze-workout'
+import { prisma } from './db'
+import { auditLogRepository } from './repositories/auditLogRepository'
+import { isWorkoutEligibleForAutomaticInsights } from './automatic-workout-insights'
+
+type AnalysisSource = 'AUTOMATIC' | 'MANUAL'
+
+export type WorkoutAnalysisEnqueueResult = {
+  queued: boolean
+  status: string
+  runId?: string
+}
+
+export async function enqueueWorkoutAnalysis(input: {
+  workoutId: string
+  userId: string
+  currentStatus: string | null
+  source: AnalysisSource
+  allowReanalysis?: boolean
+}): Promise<WorkoutAnalysisEnqueueResult> {
+  const currentStatus = input.currentStatus || 'NOT_STARTED'
+
+  if (currentStatus === 'PENDING' || currentStatus === 'PROCESSING') {
+    return { queued: false, status: currentStatus }
+  }
+
+  if (!input.allowReanalysis && currentStatus !== 'NOT_STARTED' && currentStatus !== 'FAILED') {
+    return { queued: false, status: currentStatus }
+  }
+
+  const claimed = await prisma.workout.updateMany({
+    where: {
+      id: input.workoutId,
+      userId: input.userId,
+      aiAnalysisStatus: input.currentStatus
+    },
+    data: { aiAnalysisStatus: 'PENDING' }
+  })
+
+  if (claimed.count === 0) {
+    const latest = await prisma.workout.findFirst({
+      where: { id: input.workoutId, userId: input.userId },
+      select: { aiAnalysisStatus: true }
+    })
+    return { queued: false, status: latest?.aiAnalysisStatus || currentStatus }
+  }
+
+  try {
+    const handle = await analyzeWorkoutTask.trigger(
+      { workoutId: input.workoutId, source: input.source },
+      {
+        tags: [`user:${input.userId}`, `workout:${input.workoutId}`],
+        concurrencyKey: input.userId,
+        idempotencyKey: `workout-analysis-${input.workoutId}-${input.source.toLowerCase()}`,
+        idempotencyKeyTTL: '5m'
+      }
+    )
+
+    return { queued: true, status: 'PENDING', runId: handle.id }
+  } catch (error) {
+    await prisma.workout.updateMany({
+      where: {
+        id: input.workoutId,
+        userId: input.userId,
+        aiAnalysisStatus: 'PENDING'
+      },
+      data: { aiAnalysisStatus: input.currentStatus || 'NOT_STARTED' }
+    })
+    throw error
+  }
+}
+
+export async function enqueueAutomaticWorkoutAnalysesForUser(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { aiAutoAnalyzeWorkouts: true }
+  })
+
+  if (!user?.aiAutoAnalyzeWorkouts) return { enabled: false, queued: 0 }
+
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+  const candidates = await prisma.workout.findMany({
+    where: {
+      userId,
+      date: { gte: thirtyDaysAgo },
+      isDuplicate: false,
+      OR: [
+        { aiAnalysisStatus: null },
+        { aiAnalysisStatus: 'NOT_STARTED' },
+        { aiAnalysisStatus: 'FAILED' }
+      ]
+    },
+    select: { id: true, title: true, date: true, type: true, aiAnalysisStatus: true }
+  })
+
+  let queued = 0
+  for (const workout of candidates) {
+    if (!isWorkoutEligibleForAutomaticInsights(workout.type)) continue
+
+    const result = await enqueueWorkoutAnalysis({
+      workoutId: workout.id,
+      userId,
+      currentStatus: workout.aiAnalysisStatus,
+      source: 'AUTOMATIC'
+    })
+
+    if (!result.queued) continue
+    queued++
+    await auditLogRepository.log({
+      userId,
+      action: 'AUTO_ANALYZE_WORKOUT',
+      resourceType: 'Workout',
+      resourceId: workout.id,
+      metadata: { title: workout.title, date: workout.date.toISOString() }
+    })
+  }
+
+  return { enabled: true, queued }
+}

--- a/tests/unit/app/profile-basic-settings-focus.test.ts
+++ b/tests/unit/app/profile-basic-settings-focus.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BasicSettings from '../../../app/components/profile/BasicSettings.vue'
+
+vi.mock('@tolgee/vue', () => ({
+  useTranslate: () => ({ t: (key: string) => key })
+}))
+
+mockNuxtImport('useAuth', () => () => ({ signIn: vi.fn() }))
+mockNuxtImport('useFormat', () => () => ({ formatDateUTC: vi.fn(() => '') }))
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }))
+
+describe('ProfileBasicSettings focus requests', () => {
+  const scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('scrollTo', vi.fn())
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockReset()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  it('scrolls again when the same section receives a new focus request', async () => {
+    const wrapper = await mountSuspended(BasicSettings, {
+      attachTo: document.body,
+      shallow: true,
+      props: {
+        modelValue: {
+          accounts: [],
+          integrations: [],
+          dob: null,
+          weight: null,
+          weightUnits: 'Kilograms',
+          height: null,
+          heightUnits: 'cm'
+        },
+        email: 'athlete@example.com',
+        focusSection: null,
+        focusRequestId: 0
+      }
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(document.getElementById('body-metrics')).not.toBeNull()
+
+    await wrapper.setProps({ focusSection: 'body-metrics', focusRequestId: 1 })
+    await nextTick()
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ focusRequestId: 2 })
+    await nextTick()
+    await nextTick()
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/server/utils/workout-analysis-enqueue.test.ts
+++ b/tests/unit/server/utils/workout-analysis-enqueue.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  enqueueAutomaticWorkoutAnalysesForUser,
+  enqueueWorkoutAnalysis
+} from '../../../../server/utils/workout-analysis-enqueue'
+import { analyzeWorkoutTask } from '../../../../trigger/analyze-workout'
+import { prisma } from '../../../../server/utils/db'
+
+vi.mock('../../../../trigger/analyze-workout', () => ({
+  analyzeWorkoutTask: { trigger: vi.fn() }
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    workout: {
+      updateMany: vi.fn(),
+      findFirst: vi.fn(),
+      findMany: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../server/utils/repositories/auditLogRepository', () => ({
+  auditLogRepository: { log: vi.fn() }
+}))
+
+describe('workout analysis enqueue', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('claims the workout before triggering analysis', async () => {
+    vi.mocked(prisma.workout.updateMany).mockResolvedValue({ count: 1 } as any)
+    vi.mocked(analyzeWorkoutTask.trigger).mockResolvedValue({ id: 'run-1' } as any)
+
+    const result = await enqueueWorkoutAnalysis({
+      workoutId: 'workout-1',
+      userId: 'user-1',
+      currentStatus: 'NOT_STARTED',
+      source: 'AUTOMATIC'
+    })
+
+    expect(prisma.workout.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'workout-1',
+        userId: 'user-1',
+        aiAnalysisStatus: 'NOT_STARTED'
+      },
+      data: { aiAnalysisStatus: 'PENDING' }
+    })
+    expect(analyzeWorkoutTask.trigger).toHaveBeenCalledOnce()
+    expect(result).toEqual({ queued: true, status: 'PENDING', runId: 'run-1' })
+  })
+
+  it('does not enqueue when another caller already claimed the workout', async () => {
+    vi.mocked(prisma.workout.updateMany).mockResolvedValue({ count: 0 } as any)
+    vi.mocked(prisma.workout.findFirst).mockResolvedValue({ aiAnalysisStatus: 'PENDING' } as any)
+
+    const result = await enqueueWorkoutAnalysis({
+      workoutId: 'workout-1',
+      userId: 'user-1',
+      currentStatus: 'NOT_STARTED',
+      source: 'MANUAL'
+    })
+
+    expect(analyzeWorkoutTask.trigger).not.toHaveBeenCalled()
+    expect(result).toEqual({ queued: false, status: 'PENDING' })
+  })
+
+  it('restores the prior status if triggering fails', async () => {
+    vi.mocked(prisma.workout.updateMany)
+      .mockResolvedValueOnce({ count: 1 } as any)
+      .mockResolvedValueOnce({ count: 1 } as any)
+    vi.mocked(analyzeWorkoutTask.trigger).mockRejectedValue(new Error('Trigger unavailable'))
+
+    await expect(
+      enqueueWorkoutAnalysis({
+        workoutId: 'workout-1',
+        userId: 'user-1',
+        currentStatus: 'FAILED',
+        source: 'AUTOMATIC'
+      })
+    ).rejects.toThrow('Trigger unavailable')
+
+    expect(prisma.workout.updateMany).toHaveBeenLastCalledWith({
+      where: {
+        id: 'workout-1',
+        userId: 'user-1',
+        aiAnalysisStatus: 'PENDING'
+      },
+      data: { aiAnalysisStatus: 'FAILED' }
+    })
+  })
+
+  it('runs independently for users with automatic analysis enabled', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({ aiAutoAnalyzeWorkouts: true } as any)
+    vi.mocked(prisma.workout.findMany).mockResolvedValue([
+      {
+        id: 'workout-1',
+        title: 'Intervals',
+        date: new Date('2026-07-24T10:00:00Z'),
+        type: 'Ride',
+        aiAnalysisStatus: 'NOT_STARTED'
+      }
+    ] as any)
+    vi.mocked(prisma.workout.updateMany).mockResolvedValue({ count: 1 } as any)
+    vi.mocked(analyzeWorkoutTask.trigger).mockResolvedValue({ id: 'run-1' } as any)
+
+    await expect(enqueueAutomaticWorkoutAnalysesForUser('user-1')).resolves.toEqual({
+      enabled: true,
+      queued: 1
+    })
+  })
+})

--- a/trigger/deduplicate-workouts.ts
+++ b/trigger/deduplicate-workouts.ts
@@ -6,9 +6,7 @@ import { attachStreamsToWorkouts } from '../server/utils/repositories/workoutStr
 import { recalculateStressAfterDate } from '../server/utils/calculate-workout-stress'
 import { userBackgroundQueue } from './queues'
 import { deduplicationService } from '../server/utils/services/deduplicationService'
-import { analyzeWorkoutTask } from './analyze-workout'
-import { auditLogRepository } from '../server/utils/repositories/auditLogRepository'
-import { isWorkoutEligibleForAutomaticInsights } from '../server/utils/automatic-workout-insights'
+import { enqueueAutomaticWorkoutAnalysesForUser } from '../server/utils/workout-analysis-enqueue'
 
 export const deduplicateWorkoutsTask = task({
   id: 'deduplicate-workouts',
@@ -45,12 +43,6 @@ export const deduplicateWorkoutsTask = task({
         actualUserId = user.id
         logger.log('Resolved user ID', { email: userId, actualUserId })
       }
-
-      // Fetch user settings for auto-analysis
-      const userSettings = await prisma.user.findUnique({
-        where: { id: actualUserId },
-        select: { aiAutoAnalyzeWorkouts: true }
-      })
 
       // Here we explicitly want ALL workouts, including potential duplicates, to analyze them.
       // So we use includeDuplicates: true
@@ -188,90 +180,8 @@ export const deduplicateWorkoutsTask = task({
         await recalculateStressAfterDate(actualUserId, earliestDate)
       }
 
-      // Auto-Analyze Primary Workouts
-      // We check if the user has enabled auto-analysis
-      if (userSettings?.aiAutoAnalyzeWorkouts) {
-        logger.log('🤖 [Auto-Analyze] Checking for unanalyzed workouts (last 30 days)...')
-
-        const thirtyDaysAgo = new Date()
-        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
-
-        // Find primary workouts that:
-        // 1. Are recent (last 30 days)
-        // 2. Have NOT been analyzed yet (or status is null/NOT_STARTED)
-        // 3. Are NOT duplicates (isDuplicate = false)
-        const unanalyzedWorkouts = await prisma.workout.findMany({
-          where: {
-            userId: actualUserId,
-            date: { gte: thirtyDaysAgo },
-            isDuplicate: false,
-            OR: [
-              { aiAnalysisStatus: null },
-              { aiAnalysisStatus: 'NOT_STARTED' },
-              { aiAnalysisStatus: 'FAILED' } // Retry failed ones too? Maybe safer to stick to NOT_STARTED.
-            ]
-          },
-          select: { id: true, title: true, date: true, type: true, aiAnalysisStatus: true }
-        })
-
-        const eligibleWorkouts = unanalyzedWorkouts.filter((workout) =>
-          isWorkoutEligibleForAutomaticInsights(workout.type)
-        )
-
-        if (eligibleWorkouts.length > 0) {
-          logger.log(
-            `🤖 [Auto-Analyze] Found ${eligibleWorkouts.length} eligible unanalyzed workouts. Triggering analysis...`
-          )
-          for (const workout of eligibleWorkouts) {
-            logger.log(
-              `🤖 [Auto-Analyze] Triggering analysis for: ${workout.title} (${workout.date.toISOString()})`
-            )
-            const claimed = await prisma.workout.updateMany({
-              where: {
-                id: workout.id,
-                aiAnalysisStatus: workout.aiAnalysisStatus
-              },
-              data: { aiAnalysisStatus: 'PENDING' }
-            })
-
-            if (claimed.count === 0) {
-              logger.log('🤖 [Auto-Analyze] Workout was already claimed by another run', {
-                workoutId: workout.id
-              })
-              continue
-            }
-
-            try {
-              await analyzeWorkoutTask.trigger(
-                {
-                  workoutId: workout.id,
-                  source: 'AUTOMATIC'
-                },
-                {
-                  concurrencyKey: actualUserId,
-                  tags: [`user:${actualUserId}`, `workout:${workout.id}`]
-                }
-              )
-              // Log the action
-              await auditLogRepository.log({
-                userId: actualUserId,
-                action: 'AUTO_ANALYZE_WORKOUT',
-                resourceType: 'Workout',
-                resourceId: workout.id,
-                metadata: { title: workout.title, date: workout.date.toISOString() }
-              })
-            } catch (error) {
-              await prisma.workout.updateMany({
-                where: { id: workout.id, aiAnalysisStatus: 'PENDING' },
-                data: { aiAnalysisStatus: workout.aiAnalysisStatus || 'NOT_STARTED' }
-              })
-              throw error
-            }
-          }
-        } else {
-          logger.log('🤖 [Auto-Analyze] No eligible unanalyzed workouts found in the last 30 days.')
-        }
-      }
+      const analysis = await enqueueAutomaticWorkoutAnalysesForUser(actualUserId)
+      logger.log('🤖 [Auto-Analyze] Enqueue complete', analysis)
 
       return {
         success: true,

--- a/trigger/ingest-all.ts
+++ b/trigger/ingest-all.ts
@@ -25,6 +25,7 @@ import { getUserAiSettings } from '../server/utils/ai-user-settings'
 import { auditLogRepository } from '../server/utils/repositories/auditLogRepository'
 import { nutritionRepository } from '../server/utils/repositories/nutritionRepository'
 import type { IngestionResult } from './types'
+import { enqueueAutomaticWorkoutAnalysesForUser } from '../server/utils/workout-analysis-enqueue'
 
 export const ingestAllTask = task({
   id: 'ingest-all',
@@ -333,6 +334,16 @@ export const ingestAllTask = task({
         }
       } catch (err) {
         logger.error('❌ Failed to chain deduplicate-workouts', { err })
+      }
+    }
+
+    // Run independently of deduplication and include existing 30-day backlog.
+    if (successCount > 0) {
+      try {
+        const analysis = await enqueueAutomaticWorkoutAnalysesForUser(userId)
+        logger.log('🤖 Automatic workout analysis enqueue complete', analysis)
+      } catch (error) {
+        logger.error('❌ Failed to enqueue automatic workout analysis', { error })
       }
     }
 


### PR DESCRIPTION
## What changed

- adds a shared CAS-based workout-analysis enqueue service
- invokes automatic analysis directly after successful ingestion, independently of deduplication
- reuses the service from chat and deduplication
- restores the prior analysis state when Trigger.dev enqueue fails
- adds deterministic chat copy for missing and in-progress analysis

## Root cause

Automatic workout analysis was hidden inside optional deduplication. Chat-triggered analysis also launched the external task before persisting `PENDING`, allowing duplicate or misleading enqueue results.

## Impact

Users with automatic analysis enabled no longer depend on deduplication being enabled or available. Concurrent chat requests cannot claim the same workout twice.

## Validation

- 35 targeted Vitest tests passed
- targeted ESLint passed
- `git diff --check` passed
