### PR TITLE
Clarify completed workout update sync scope

### DIFF
--- a/app/components/profile/BasicSettings.vue
+++ b/app/components/profile/BasicSettings.vue
@@ -412,17 +412,9 @@
                     on {{ formatDateUTC(method.linkedAt, 'PPP') }}
                   </span>
                 </p>
-                <p v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5">
-                  ID: {{ method.profileId }}
-                </p>
               </div>
-              <p v-else-if="method.isIntegrated" class="flex flex-col">
-                <span class="text-xs text-amber-500 font-medium">{{
-                  t('basic_login_methods_linked')
-                }}</span>
-                <span v-if="method.profileId" class="text-[10px] font-mono text-zinc-500 mt-0.5"
-                  >ID: {{ method.profileId }}</span
-                >
+              <p v-else-if="method.isIntegrated" class="text-xs text-amber-500 font-medium">
+                {{ t('basic_login_methods_linked') }}
               </p>
               <p v-else class="text-xs text-gray-500 dark:text-gray-400">
                 {{ t('basic_login_methods_not_connected') }}
@@ -563,6 +555,7 @@
     loading?: boolean
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:modelValue', 'autodetect', 'navigate'])
@@ -583,8 +576,7 @@
         iconClass: 'text-gray-900 dark:text-white',
         isConnected: accounts.some((a: any) => a.provider === 'google'),
         isIntegrated: false, // Google is login-only for now
-        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt,
-        profileId: accounts.find((a: any) => a.provider === 'google')?.providerAccountId
+        linkedAt: accounts.find((a: any) => a.provider === 'google')?.createdAt
       },
       {
         id: 'strava',
@@ -593,10 +585,7 @@
         iconClass: 'text-[#FC4C02]',
         isConnected: accounts.some((a: any) => a.provider === 'strava'),
         isIntegrated: integrations.some((i: any) => i.provider === 'strava'),
-        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'strava')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'strava')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'strava')?.createdAt
       },
       {
         id: 'intervals',
@@ -605,10 +594,7 @@
         iconClass: 'text-primary',
         isConnected: accounts.some((a: any) => a.provider === 'intervals'),
         isIntegrated: integrations.some((i: any) => i.provider === 'intervals'),
-        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt,
-        profileId:
-          accounts.find((a: any) => a.provider === 'intervals')?.providerAccountId ||
-          integrations.find((i: any) => i.provider === 'intervals')?.externalUserId
+        linkedAt: accounts.find((a: any) => a.provider === 'intervals')?.createdAt
       }
     ]
   })
@@ -872,8 +858,8 @@
   }
 
   watch(
-    () => props.focusSection,
-    (section) => {
+    () => [props.focusSection, props.focusRequestId] as const,
+    ([section]) => {
       if (section === 'body-metrics') scrollToSection('body-metrics')
     },
     { immediate: true }

--- a/app/components/profile/SportSettings.vue
+++ b/app/components/profile/SportSettings.vue
@@ -503,7 +503,7 @@
 
               <!-- Power Settings -->
               <section
-                id="sport-power"
+                :id="sectionDomId('sport-power', index)"
                 class="space-y-4"
                 :class="sectionHighlightClass('sport-power')"
               >
@@ -734,7 +734,11 @@
               </section>
 
               <!-- Heart Rate Settings -->
-              <section id="sport-hr" class="space-y-4" :class="sectionHighlightClass('sport-hr')">
+              <section
+                :id="sectionDomId('sport-hr', index)"
+                class="space-y-4"
+                :class="sectionHighlightClass('sport-hr')"
+              >
                 <h4
                   class="text-sm font-medium text-gray-500 uppercase tracking-wider border-b pb-2 dark:border-gray-800 flex items-center gap-2"
                 >
@@ -862,12 +866,12 @@
 
                 <!-- HR Zones Editor -->
                 <div
-                  v-if="editingIndex === index"
-                  id="sport-zones"
+                  :id="sectionDomId('sport-zones', index)"
                   class="mt-4"
                   :class="sectionHighlightClass('sport-zones')"
                 >
                   <ProfileZoneEditor
+                    v-if="editingIndex === index"
                     v-model="editForm.hrZones"
                     :title="t('zones_title_hr')"
                     units="bpm"
@@ -887,28 +891,32 @@
                       >
                     </template>
                   </ProfileZoneEditor>
-                </div>
-                <div
-                  v-else-if="item.content.hrZones?.length"
-                  id="sport-zones"
-                  class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
-                  :class="sectionHighlightClass('sport-zones')"
-                >
-                  <div class="text-xs font-bold uppercase text-gray-400 mb-3">
-                    {{ t('zones_title_hr') }}
-                  </div>
-                  <div class="space-y-2">
-                    <div
-                      v-for="(zone, zIdx) in item.content.hrZones"
-                      :key="zIdx"
-                      class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
-                    >
-                      <span class="text-muted truncate mr-1">{{ zone.name }}</span>
-                      <span class="font-mono font-bold"
-                        >{{ zone.min }}-{{ zone.max
-                        }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
-                      >
+                  <div
+                    v-else-if="item.content.hrZones?.length"
+                    class="p-4 bg-gray-50/50 dark:bg-gray-800/20 rounded-xl"
+                  >
+                    <div class="text-xs font-bold uppercase text-gray-400 mb-3">
+                      {{ t('zones_title_hr') }}
                     </div>
+                    <div class="space-y-2">
+                      <div
+                        v-for="(zone, zIdx) in item.content.hrZones"
+                        :key="zIdx"
+                        class="p-2 border dark:border-gray-800 rounded text-xs flex justify-between bg-white dark:bg-gray-900"
+                      >
+                        <span class="text-muted truncate mr-1">{{ zone.name }}</span>
+                        <span class="font-mono font-bold"
+                          >{{ zone.min }}-{{ zone.max
+                          }}<span class="text-[10px] ml-0.5 text-gray-400">bpm</span></span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    v-else
+                    class="rounded-xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                  >
+                    {{ t('zones_empty') }}
                   </div>
                 </div>
               </section>
@@ -1675,6 +1683,7 @@
     profile?: any
     highlightSections?: string[]
     focusSection?: string | null
+    focusRequestId?: number
   }>()
 
   const emit = defineEmits(['update:settings', 'autodetect'])
@@ -1770,14 +1779,20 @@
       : ''
   }
 
+  function sectionDomId(sectionId: string, profileIndex: number) {
+    return `${sectionId}-${profileIndex}`
+  }
+
   function getDefaultProfileIndex() {
     const index = accordionItems.value.findIndex((item) => item.content.isDefault)
     return index >= 0 ? index : 0
   }
 
-  function scrollToSection(sectionId: string) {
+  function scrollToSection(sectionId: string, profileIndex: number) {
     nextTick(() => {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      document
+        .getElementById(sectionDomId(sectionId, profileIndex))
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
   }
 
@@ -1788,17 +1803,22 @@
     const item = accordionItems.value[index]
     if (!item) return
 
-    openItems.value = [item.value]
+    const openValues = [item.value]
+    if (editingIndex.value !== null && editingIndex.value !== index) {
+      const editingItem = accordionItems.value[editingIndex.value]
+      if (editingItem) openValues.push(editingItem.value)
+    }
+    openItems.value = [...new Set(openValues)]
 
-    if (editingIndex.value !== index) {
+    if (editingIndex.value === null) {
       startEdit(index, item.content)
     }
 
-    scrollToSection(sectionId)
+    scrollToSection(sectionId, index)
   }
 
   watch(
-    () => [props.settings?.length, props.focusSection] as const,
+    () => [props.settings?.length, props.focusSection, props.focusRequestId] as const,
     ([length, section]) => {
       if (!section || !section.startsWith('sport-') || !length) return
       focusSportSection(section)

--- a/app/pages/profile/settings.vue
+++ b/app/pages/profile/settings.vue
@@ -35,6 +35,7 @@
             :loading="savingProfile"
             :highlight-sections="highlightedSections"
             :focus-section="focusSection"
+            :focus-request-id="focusRequestId"
             @update:model-value="handleProfileUpdate"
             @autodetect="handleAutodetect"
             @navigate="(tab) => setActiveTab(tab)"
@@ -93,6 +94,7 @@
                 :profile="profile"
                 :highlight-sections="highlightedSections"
                 :focus-section="focusSection"
+                :focus-request-id="focusRequestId"
                 @update:settings="updateSportSettings"
                 @autodetect="handleAutodetect"
               />
@@ -260,6 +262,7 @@
   const router = useRouter()
   const activeTab = ref((route.query.tab as string) || 'basic')
   const focusSection = ref<MissingProfileSectionId | null>(null)
+  const focusRequestId = ref(0)
   const highlightedSections = ref<MissingProfileSectionId[]>([])
   const missingFieldsGuideDismissed = ref(false)
   const pendingFocus = ref<{ sectionId: MissingProfileSectionId; tab: 'basic' | 'sports' } | null>(
@@ -291,6 +294,7 @@
 
     pendingFocus.value = null
     focusSection.value = sectionId
+    focusRequestId.value += 1
     highlightedSections.value = [sectionId]
 
     router.replace({

--- a/server/utils/ai-tools/workouts.ts
+++ b/server/utils/ai-tools/workouts.ts
@@ -3,7 +3,6 @@ import { z } from 'zod/v3'
 import { prisma } from '../db'
 import { workoutRepository } from '../repositories/workoutRepository'
 import { attachStreamToWorkout } from '../repositories/workoutStreamRepository'
-import { plannedWorkoutRepository } from '../repositories/plannedWorkoutRepository'
 import {
   getStartOfDaysAgoUTC,
   formatUserDate,
@@ -14,7 +13,6 @@ import {
 import { analyzeWorkoutTask } from '../../../trigger/analyze-workout'
 import type { AiSettings } from '../ai-user-settings'
 import { hasProtectedIntervalsTags, mergeWorkoutTags } from '../workout-tags'
-import { getPendingSyncStatus } from '../structured-workout-persistence'
 import { calculateWorkoutStress } from '../calculate-workout-stress'
 import { metabolicService } from '../services/metabolicService'
 import { isNutritionTrackingEnabled } from '../nutrition/feature'
@@ -390,21 +388,12 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
       feel
     }) => {
       const workout = await workoutRepository.getById(workout_id, userId)
-      const plannedWorkout = workout
-        ? null
-        : await plannedWorkoutRepository.getById(workout_id, userId, {
-            select: {
-              id: true,
-              title: true,
-              type: true,
-              date: true,
-              durationSec: true,
-              tss: true,
-              syncStatus: true
-            }
-          })
-
-      if (!workout && !plannedWorkout) return { error: 'Workout not found' }
+      if (!workout) {
+        return {
+          error:
+            'Completed workout not found. Planned workouts must be changed with the planned-workout tools.'
+        }
+      }
 
       try {
         const updateData: Record<string, any> = {}
@@ -436,50 +425,13 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
           return { error: 'No fields provided to update.' }
         }
 
-        if (plannedWorkout) {
-          const plannedUpdateData: Record<string, any> = {
-            modifiedLocally: true,
-            syncStatus: getPendingSyncStatus((plannedWorkout as any).syncStatus),
-            syncError: null
-          }
-          if (title !== undefined) plannedUpdateData.title = title
-          if (type !== undefined) plannedUpdateData.type = type
-          if (description !== undefined) plannedUpdateData.description = description
-          if (duration_seconds !== undefined) plannedUpdateData.durationSec = duration_seconds
-          if (distance_meters !== undefined) plannedUpdateData.distanceMeters = distance_meters
-          if (tss !== undefined) plannedUpdateData.tss = tss
-
-          if (date !== undefined) {
-            const parsedDate = new Date(date)
-            if (Number.isNaN(parsedDate.getTime())) {
-              return { error: 'Invalid date format. Use ISO date/time or YYYY-MM-DD.' }
-            }
-            plannedUpdateData.date = parsedDate
-          }
-
-          const updatedPlannedWorkout = await plannedWorkoutRepository.update(
-            workout_id,
-            userId,
-            plannedUpdateData
-          )
-          return {
-            success: true,
-            message: 'Planned workout update prepared successfully.',
-            workout: {
-              id: updatedPlannedWorkout.id,
-              title: updatedPlannedWorkout.title,
-              type: updatedPlannedWorkout.type,
-              date: formatUserDate(updatedPlannedWorkout.date, timezone),
-              duration: updatedPlannedWorkout.durationSec,
-              tss: updatedPlannedWorkout.tss
-            }
-          }
-        }
-
         const updatedWorkout = await workoutRepository.update(workout_id, updateData)
         return {
           success: true,
-          message: 'Workout update prepared successfully.',
+          message:
+            'Completed workout updated locally. Intervals.icu activity metrics are not changed by this action.',
+          entity_type: 'completed_workout',
+          sync_scope: 'local_only',
           workout: {
             id: updatedWorkout.id,
             title: updatedWorkout.title,

--- a/tests/unit/app/profile-basic-settings-focus.test.ts
+++ b/tests/unit/app/profile-basic-settings-focus.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BasicSettings from '../../../app/components/profile/BasicSettings.vue'
+
+vi.mock('@tolgee/vue', () => ({
+  useTranslate: () => ({ t: (key: string) => key })
+}))
+
+mockNuxtImport('useAuth', () => () => ({ signIn: vi.fn() }))
+mockNuxtImport('useFormat', () => () => ({ formatDateUTC: vi.fn(() => '') }))
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }))
+
+describe('ProfileBasicSettings focus requests', () => {
+  const scrollIntoView = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('scrollTo', vi.fn())
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+  })
+
+  afterEach(() => {
+    scrollIntoView.mockReset()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ''
+  })
+
+  it('scrolls again when the same section receives a new focus request', async () => {
+    const wrapper = await mountSuspended(BasicSettings, {
+      attachTo: document.body,
+      shallow: true,
+      props: {
+        modelValue: {
+          accounts: [],
+          integrations: [],
+          dob: null,
+          weight: null,
+          weightUnits: 'Kilograms',
+          height: null,
+          heightUnits: 'cm'
+        },
+        email: 'athlete@example.com',
+        focusSection: null,
+        focusRequestId: 0
+      }
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(document.getElementById('body-metrics')).not.toBeNull()
+
+    await wrapper.setProps({ focusSection: 'body-metrics', focusRequestId: 1 })
+    await nextTick()
+    await nextTick()
+    expect(scrollIntoView).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ focusRequestId: 2 })
+    await nextTick()
+    await nextTick()
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/server/utils/ai-tools/workouts.test.ts
+++ b/tests/unit/server/utils/ai-tools/workouts.test.ts
@@ -7,7 +7,8 @@ import { prisma } from '../../../../../server/utils/db'
 vi.mock('../../../../../server/utils/repositories/workoutRepository', () => ({
   workoutRepository: {
     getForUser: vi.fn(),
-    getById: vi.fn()
+    getById: vi.fn(),
+    update: vi.fn()
   }
 }))
 
@@ -281,6 +282,55 @@ describe('workoutTools', () => {
         aiAnalysis: '# Legacy workout report',
         aiAnalysisJson: null
       })
+    })
+  })
+
+  describe('update_workout', () => {
+    it('reports that completed workout edits are local only', async () => {
+      vi.mocked(workoutRepository.getById).mockResolvedValue({
+        id: 'w1',
+        userId,
+        title: 'Morning Ride',
+        type: 'Ride',
+        date: new Date('2026-07-24T08:00:00Z'),
+        durationSec: 3600,
+        tss: 58
+      } as any)
+      vi.mocked(workoutRepository.update).mockResolvedValue({
+        id: 'w1',
+        title: 'Morning Ride',
+        type: 'Ride',
+        date: new Date('2026-07-24T08:00:00Z'),
+        durationSec: 3600,
+        tss: 110
+      } as any)
+
+      const result = await tools.update_workout.execute(
+        { workout_id: 'w1', tss: 110 },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(result).toMatchObject({
+        success: true,
+        entity_type: 'completed_workout',
+        sync_scope: 'local_only',
+        message: expect.stringContaining('Intervals.icu activity metrics are not changed')
+      })
+    })
+
+    it('does not route planned workout IDs through the completed workout tool', async () => {
+      vi.mocked(workoutRepository.getById).mockResolvedValue(null)
+
+      const result = await tools.update_workout.execute(
+        { workout_id: 'planned-1', tss: 80 },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(result).toEqual({
+        error:
+          'Completed workout not found. Planned workouts must be changed with the planned-workout tools.'
+      })
+      expect(workoutRepository.update).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## What changed

- prevents the completed-workout tool from silently falling back to planned workouts
- returns `entity_type=completed_workout` and `sync_scope=local_only`
- explicitly states that Intervals.icu activity metrics are unchanged
- adds tests for local-only results and planned-ID rejection

## Root cause

The tool updated local completed-workout metrics and returned generic success, creating the expectation that Intervals.icu TSS was also updated. It could also blur completed and planned entity routing.

## Impact

Chat no longer overstates outbound synchronization. This is the truthful minimal fix for issue #181 while a supported remote activity-metric API is evaluated.

This PR intentionally does not close #181 or implement speculative remote writes.

## Validation

- 10 targeted Vitest tests passed
- targeted ESLint passed
- `git diff --check` passed
