### PR TITLE
fix(server): resolve duplicate convertStructuredToMarkdown auto-import warning

### DIFF
--- a/server/utils/services/workoutAnalysisService.ts
+++ b/server/utils/services/workoutAnalysisService.ts
@@ -618,7 +618,7 @@ Format your analysis according to the requested schema. Provide clear, objective
   return prompt
 }
 
-export function convertStructuredToMarkdown(analysis: any): string {
+export function convertWorkoutAnalysisToMarkdown(analysis: any): string {
   let markdown = `# ${analysis.title}\n\n`
 
   if (analysis.date) {
@@ -836,7 +836,7 @@ export async function runWorkoutAnalysis(payload: {
       }
     )
 
-    const markdownAnalysis = convertStructuredToMarkdown(structuredAnalysis)
+    const markdownAnalysis = convertWorkoutAnalysisToMarkdown(structuredAnalysis)
 
     const clampScore = (val?: number | null) => {
       if (typeof val !== 'number' || isNaN(val)) return null

--- a/tests/unit/server/utils/services/workoutAnalysisService.test.ts
+++ b/tests/unit/server/utils/services/workoutAnalysisService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   buildWorkoutAnalysisData,
-  convertStructuredToMarkdown,
+  convertWorkoutAnalysisToMarkdown,
   runWorkoutAnalysis,
   type StructuredAnalysis
 } from '../../../../../server/utils/services/workoutAnalysisService'
@@ -106,7 +106,7 @@ describe('Workout Analysis Service', () => {
       ]
     }
 
-    const md = convertStructuredToMarkdown(structured)
+    const md = convertWorkoutAnalysisToMarkdown(structured)
 
     expect(md).toContain('# Endurance Run Analysis')
     expect(md).toContain('Solid steady-state run with excellent pacing.')


### PR DESCRIPTION
## Summary
Fixes Nitro build warning where `convertStructuredToMarkdown` was exported by both `server/utils/report-engine.ts` and `server/utils/services/workoutAnalysisService.ts`, causing Nitro auto-import collision.

## Changes
- Renamed `convertStructuredToMarkdown` in `server/utils/services/workoutAnalysisService.ts` to `convertWorkoutAnalysisToMarkdown`.
- Updated internal call site in `workoutAnalysisService.ts`.
- Updated unit test import and call in `tests/unit/server/utils/services/workoutAnalysisService.test.ts`.

## Verification
- Unit tests (`workoutAnalysisService.test.ts`) pass cleanly.
- Verified `pnpm build` no longer emits the duplicate import warning.