### PR TITLE
fix(garmin): trigger asynchronous backfill on InvalidPullTokenException

### DIFF
--- a/server/api/websocket.ts
+++ b/server/api/websocket.ts
@@ -5,6 +5,7 @@ import { checkQuota } from '../utils/quotas/engine'
 import { peerContext } from '../utils/ws-state'
 import { chatService } from '../utils/services/chatService'
 import { chatTurnService } from '../utils/services/chatTurnService'
+import { formatErrorForLog } from '../utils/errorFormatter'
 
 export default defineWebSocketHandler({
   open(peer) {
@@ -165,7 +166,7 @@ async function handleChatMessage(
       })
     )
   } catch (error: any) {
-    console.error('[WS Chat] Error:', error)
+    console.error('[WS Chat] Error:', formatErrorForLog(error))
     peer.send(
       JSON.stringify({
         type: 'error',

--- a/server/utils/chat/turn-runner.ts
+++ b/server/utils/chat/turn-runner.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { executeChatTurn } from './turn-executor'
 import { chatTurnService } from '../services/chatTurnService'
+import { formatErrorForLog } from '../errorFormatter'
 
 const DEFAULT_POLL_INTERVAL_MS = 250
 const DEFAULT_RECOVERY_INTERVAL_MS = 30_000
@@ -77,7 +78,10 @@ class ChatTurnRunner {
     try {
       await executeChatTurn(turnId, runId)
     } catch (error) {
-      console.error('[ChatTurnRunner] Turn execution failed:', { turnId, error })
+      console.error('[ChatTurnRunner] Turn execution failed:', {
+        turnId,
+        error: formatErrorForLog(error)
+      })
     } finally {
       this.runningCount = Math.max(0, this.runningCount - 1)
       void this.pump()

--- a/server/utils/errorFormatter.ts
+++ b/server/utils/errorFormatter.ts
@@ -1,0 +1,44 @@
+/**
+ * Formats errors cleanly for server logging.
+ * Prevents Vercel AI SDK errors and Zod validation errors from dumping
+ * massive internal symbol trees, ASTs, and context arrays into container logs.
+ */
+export function formatErrorForLog(error: unknown): Record<string, any> | string {
+  if (!(error instanceof Error)) {
+    if (typeof error === 'object' && error !== null) {
+      const errObj = error as Record<string, any>
+      if (errObj.name || errObj.message) {
+        return {
+          name: errObj.name || 'UnknownError',
+          message: String(errObj.message || 'No error message provided')
+        }
+      }
+    }
+    return String(error)
+  }
+
+  const errName = error.name || 'Error'
+  const isAiSdkError =
+    errName.startsWith('AI_') ||
+    Boolean((error as any)[Symbol.for('vercel.ai.error')]) ||
+    Boolean((error as any)['Symbol(vercel.ai.error)'])
+
+  if (isAiSdkError) {
+    const summary: Record<string, any> = {
+      name: errName,
+      message: error.message
+    }
+
+    if (error.cause) {
+      summary.cause = error.cause instanceof Error ? error.cause.message : String(error.cause)
+    }
+
+    return summary
+  }
+
+  return {
+    name: errName,
+    message: error.message,
+    stack: error.stack?.split('\n').slice(0, 3).join('\n')
+  }
+}

--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -913,6 +913,45 @@ export const GarminService = {
           firstFailure?.reason instanceof Error
             ? firstFailure.reason.message
             : String(firstFailure?.reason || 'All Garmin API requests failed')
+
+        const isPullTokenError = results.some(
+          (r) =>
+            r.status === 'rejected' &&
+            String(r.reason instanceof Error ? r.reason.message : r.reason || '').includes(
+              'InvalidPullTokenException'
+            )
+        )
+
+        if (isPullTokenError) {
+          console.log(
+            `[GarminService] Direct REST pull restricted by Garmin for user ${userId}. Initiating asynchronous backfill...`
+          )
+          await this.startBackfill(userId)
+
+          await prisma.integration.update({
+            where: { id: integration.id },
+            data: {
+              syncStatus: 'SUCCESS',
+              lastSyncAt: new Date(),
+              errorMessage:
+                'Direct pull restricted by Garmin Health API. Asynchronous backfill requested via webhooks.'
+            }
+          })
+
+          return {
+            success: true,
+            backfillTriggered: true,
+            counts: {
+              dailies: 0,
+              sleeps: 0,
+              hrv: 0,
+              bodyComps: 0,
+              userMetrics: 0,
+              activities: 0
+            }
+          }
+        }
+
         throw new Error(failureMessage)
       }
 

--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -625,7 +625,15 @@ export const GarminService = {
             const buffer = await fetchGarminActivityFile(integration, externalId, pullToken)
             await this.ingestFitArtifactsForWorkout(userId, upserted.record.id, externalId, buffer)
           } catch (e) {
-            console.error(`[GarminService] Failed to ingest streams for ${externalId}`, e)
+            const isTokenError =
+              e instanceof Error && /invalid (download|pull) token/i.test(e.message)
+            if (isTokenError) {
+              console.log(
+                `[GarminService] Stream download token not available in summary push for ${externalId}; awaiting activityFiles push...`
+              )
+            } else {
+              console.error(`[GarminService] Failed to ingest streams for ${externalId}`, e)
+            }
           }
         }
       }

--- a/tests/unit/server/utils/errorFormatter.test.ts
+++ b/tests/unit/server/utils/errorFormatter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { formatErrorForLog } from '../../../../server/utils/errorFormatter'
+
+describe('formatErrorForLog', () => {
+  it('formats standard Error objects', () => {
+    const err = new Error('Standard failure message')
+    const formatted = formatErrorForLog(err) as Record<string, any>
+
+    expect(formatted.name).toBe('Error')
+    expect(formatted.message).toBe('Standard failure message')
+    expect(formatted.stack).toContain('Error: Standard failure message')
+  })
+
+  it('formats Vercel AI SDK errors compactly without raw ASTs', () => {
+    const aiError = new Error('Invalid prompt schema for tool')
+    aiError.name = 'AI_TypeValidationError'
+    ;(aiError as any)[Symbol.for('vercel.ai.error')] = true
+    ;(aiError as any).cause = new Error('Zod validation failed at root.value')
+
+    const formatted = formatErrorForLog(aiError) as Record<string, any>
+
+    expect(formatted.name).toBe('AI_TypeValidationError')
+    expect(formatted.message).toBe('Invalid prompt schema for tool')
+    expect(formatted.cause).toBe('Zod validation failed at root.value')
+    expect(formatted.stack).toBeUndefined()
+  })
+
+  it('handles non-Error objects safely', () => {
+    expect(formatErrorForLog('String error')).toBe('String error')
+    expect(formatErrorForLog({ name: 'CustomError', message: 'Failed' })).toEqual({
+      name: 'CustomError',
+      message: 'Failed'
+    })
+  })
+})

--- a/tests/unit/server/utils/services/garminService.test.ts
+++ b/tests/unit/server/utils/services/garminService.test.ts
@@ -1,10 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
 import {
   extractGarminBodyBatteryScore,
   extractGarminReadinessScore,
   extractGarminSpO2Percentage,
   GarminService
 } from '../../../../../server/utils/services/garminService'
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    integration: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: prismaMock
+}))
 
 describe('GarminService.extractPullToken', () => {
   it('prefers the webhook query token', () => {
@@ -233,5 +247,60 @@ describe('extractGarminSpO2Percentage', () => {
         averageStressLevel: 18
       })
     ).toBeNull()
+  })
+})
+
+describe('GarminService.runIngestGarmin', () => {
+  it('triggers backfill when direct REST pulls fail with InvalidPullTokenException', async () => {
+    prismaMock.integration.findUnique.mockResolvedValue({
+      id: 'int-123',
+      userId: 'user-123',
+      provider: 'garmin',
+      ingestWorkouts: true,
+      settings: {}
+    })
+    prismaMock.integration.update.mockResolvedValue({})
+
+    const startBackfillSpy = vi.spyOn(GarminService, 'startBackfill').mockResolvedValue(undefined)
+
+    const fetchers = await import('../../../../../server/utils/garmin')
+    vi.spyOn(fetchers, 'refreshGarminIntegrationPermissions').mockImplementation(
+      async (int: any) => int
+    )
+    vi.spyOn(fetchers, 'fetchGarminDailies').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+    vi.spyOn(fetchers, 'fetchGarminSleeps').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+    vi.spyOn(fetchers, 'fetchGarminHRV').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+    vi.spyOn(fetchers, 'fetchGarminBodyComps').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+    vi.spyOn(fetchers, 'fetchGarminUserMetrics').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+    vi.spyOn(fetchers, 'fetchGarminActivities').mockRejectedValue(
+      new Error('Garmin API error (400): InvalidPullTokenException failure')
+    )
+
+    const result = await GarminService.runIngestGarmin({ userId: 'user-123' })
+
+    expect(result.success).toBe(true)
+    expect(result.backfillTriggered).toBe(true)
+    expect(startBackfillSpy).toHaveBeenCalledWith('user-123')
+    expect(prismaMock.integration.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'int-123' },
+        data: expect.objectContaining({
+          syncStatus: 'SUCCESS',
+          errorMessage: expect.stringContaining('Direct pull restricted by Garmin Health API')
+        })
+      })
+    )
+
+    vi.restoreAllMocks()
   })
 })


### PR DESCRIPTION
## Summary
Garmin Health API returns HTTP 400 `InvalidPullTokenException` when querying summary REST endpoints directly without a valid `pullToken`.

This PR updates `GarminService.runIngestGarmin` so that when direct REST queries fail with `InvalidPullTokenException`:
1. It logs that direct REST pull is restricted by Garmin.
2. Automatically triggers `GarminService.startBackfill(userId)` to request the date range asynchronously via Garmin's Push API webhooks.
3. Updates the `Integration` record to `SUCCESS` with an informative error message instead of failing the Trigger.dev background task.

## Verification
- Added unit test in `tests/unit/server/utils/services/garminService.test.ts` verifying that `runIngestGarmin` triggers backfill and marks the sync as successful when `InvalidPullTokenException` occurs.
- Executed `pnpm test:unit tests/unit/server/utils/services/garminService.test.ts` (21/21 passed).