### PR TITLE
chore: add .eslintcache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ coverage
 
 .tolgeerc
 /.pi
+.eslintcache


### PR DESCRIPTION
Adds .eslintcache to .gitignore so local linting runs do not create untracked file noise.