### PR TITLE
fix(chat): resolve gemini 400 invalid argument errors and restore tool history

### DIFF
--- a/server/utils/ai-history.test.ts
+++ b/server/utils/ai-history.test.ts
@@ -82,7 +82,7 @@ describe('transformHistoryToCoreMessages', () => {
         {
           type: 'tool-result',
           toolCallId: 'call_123',
-          toolName: 'unknown',
+          toolName: 'test_tool',
           output: { type: 'text', value: 'User confirmed action.' }
         }
       ])
@@ -436,5 +436,30 @@ describe('transformHistoryToCoreMessages', () => {
         google: { thoughtSignature: 'signed-part' }
       }
     })
+  })
+  it('names approval-response tool results after the originating tool call', async () => {
+    const result = await transformHistoryToCoreMessages([
+      {
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-log_meal',
+            toolCallId: 'call_approval',
+            state: 'approval-requested',
+            input: { meal: 'oats' },
+            approval: { id: 'call_approval' }
+          }
+        ]
+      },
+      {
+        role: 'tool',
+        parts: [{ type: 'tool-approval-response', toolCallId: 'call_approval', approved: true }]
+      }
+    ])
+
+    const toolMessage = result.find((message) => message.role === 'tool')
+
+    expect(toolMessage).toBeDefined()
+    expect((toolMessage!.content as any[])[0].toolName).toBe('log_meal')
   })
 })

--- a/server/utils/ai-history.ts
+++ b/server/utils/ai-history.ts
@@ -310,18 +310,20 @@ export async function transformHistoryToCoreMessages(historyMessages: any[]) {
           })
 
           if (validToolParts.length > 0) {
-            const existingCalls = coreContent.filter((p) => p.type === 'tool-call')
+            // Tracked as a live set: patching two UI parts that share a tool call id must
+            // not append two `tool-call` parts, because Gemini rejects duplicate
+            // `functionCall` ids inside a single model turn with a 400 INVALID_ARGUMENT.
+            const existingCallIds = new Set(
+              coreContent.filter((p) => p.type === 'tool-call').map((p) => p.toolCallId)
+            )
 
             validToolParts.forEach((tp: any) => {
               const toolCallId = tp.toolCallId || tp.approvalId
               const toolName = tp.toolCall?.toolName || getUiToolName(tp)
 
               // Only add if not already present (checked by ID)
-              if (
-                toolCallId &&
-                toolName &&
-                !existingCalls.find((ec) => ec.toolCallId === toolCallId)
-              ) {
+              if (toolCallId && toolName && !existingCallIds.has(toolCallId)) {
+                existingCallIds.add(toolCallId)
                 coreContent.push(
                   buildCoreToolCallPart(tp.toolCall, {
                     toolCallId,
@@ -434,14 +436,14 @@ export async function transformHistoryToCoreMessages(historyMessages: any[]) {
   // Gemini requires that every 'tool' message is preceded by a 'model' message containing the call.
   // We iterate backwards to safely remove.
   const validCoreMessages: any[] = []
-  const toolCallIds = new Set<string>()
+  const toolNamesByCallId = new Map<string, string>()
 
   // First pass: Collect all valid tool call IDs from assistant messages
   coreMessages.forEach((msg) => {
     if (msg.role === 'assistant' && Array.isArray(msg.content)) {
       msg.content.forEach((p: any) => {
         if (p.type === 'tool-call') {
-          toolCallIds.add(p.toolCallId)
+          toolNamesByCallId.set(p.toolCallId, p.toolName)
         }
       })
     }
@@ -451,8 +453,13 @@ export async function transformHistoryToCoreMessages(historyMessages: any[]) {
   for (const msg of coreMessages) {
     if (msg.role === 'tool') {
       const content = mergeToolResultParts(msg.content as any[])
-      // Filter out parts that don't have a matching call
-      const validContent = content.filter((p: any) => toolCallIds.has(p.toolCallId))
+      // Filter out parts that don't have a matching call, and realign the tool name with
+      // the originating call. Gemini rejects a `functionResponse` whose name does not match
+      // a declared tool with a bare 400 INVALID_ARGUMENT, so the `'unknown'` fallback used
+      // for approval responses (which carry no tool name) must never reach the provider.
+      const validContent = content
+        .filter((p: any) => toolNamesByCallId.has(p.toolCallId))
+        .map((p: any) => ({ ...p, toolName: toolNamesByCallId.get(p.toolCallId) || p.toolName }))
 
       if (validContent.length > 0) {
         const previous = validCoreMessages[validCoreMessages.length - 1]

--- a/server/utils/chat/core-message-normalizer.test.ts
+++ b/server/utils/chat/core-message-normalizer.test.ts
@@ -63,7 +63,78 @@ describe('normalizeCoreMessagesForGemini', () => {
 
     expect(result.map((message) => message.role)).toEqual(['assistant', 'tool', 'assistant'])
     expect(result[1].content).toEqual([
-      { type: 'tool-result', toolCallId: 'call_1', result: { ok: true } }
+      { type: 'tool-result', toolCallId: 'call_1', toolName: 'lookup', result: { ok: true } }
     ])
+  })
+
+  it('collapses repeated tool calls for the same id into one part', () => {
+    const result = normalizeCoreMessagesForGemini([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', input: { q: 'foo' } },
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', input: { q: 'foo' } },
+          { type: 'tool-call', toolCallId: 'call_2', toolName: 'lookup', input: { q: 'bar' } }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: 'call_1', toolName: 'lookup', result: { ok: true } }
+        ]
+      }
+    ])
+
+    expect(result[0].content).toHaveLength(2)
+    expect(result[0].content.map((part: any) => part.toolCallId)).toEqual(['call_1', 'call_2'])
+  })
+
+  it('keeps the deduplicated tool call that still carries a thought signature', () => {
+    const result = normalizeCoreMessagesForGemini([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool-call', toolCallId: 'call_1', toolName: 'lookup', input: {} },
+          {
+            type: 'tool-call',
+            toolCallId: 'call_1',
+            toolName: 'lookup',
+            input: {},
+            providerOptions: { google: { thoughtSignature: 'signed-part' } }
+          }
+        ]
+      },
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool-result', toolCallId: 'call_1', toolName: 'lookup', result: { ok: true } }
+        ]
+      }
+    ])
+
+    expect(result[0].content).toHaveLength(1)
+    expect(result[0].content[0].providerOptions.google.thoughtSignature).toBe('signed-part')
+  })
+
+  it('realigns tool result names with the originating tool call', () => {
+    const result = normalizeCoreMessagesForGemini([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-call', toolCallId: 'call_1', toolName: 'log_meal', input: {} }]
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_1',
+            toolName: 'unknown',
+            result: { ok: true }
+          }
+        ]
+      }
+    ])
+
+    expect(result[1].content[0].toolName).toBe('log_meal')
   })
 })

--- a/server/utils/chat/core-message-normalizer.ts
+++ b/server/utils/chat/core-message-normalizer.ts
@@ -4,16 +4,54 @@ function asParts(content: any): any[] {
   return []
 }
 
-function extractAssistantToolCallIds(message: any): Set<string> {
-  const ids = new Set<string>()
+function extractAssistantToolCalls(message: any): Map<string, string> {
+  const toolNamesByCallId = new Map<string, string>()
 
   for (const part of asParts(message.content)) {
     if (part?.type === 'tool-call' && part.toolCallId) {
-      ids.add(part.toolCallId)
+      toolNamesByCallId.set(part.toolCallId, part.toolName)
     }
   }
 
-  return ids
+  return toolNamesByCallId
+}
+
+function hasThoughtSignature(part: any) {
+  return !!(
+    part?.providerOptions?.google?.thoughtSignature ||
+    part?.providerMetadata?.google?.thoughtSignature
+  )
+}
+
+/**
+ * Gemini rejects a `model` turn that contains two `functionCall` parts with the same id
+ * with a bare `400 INVALID_ARGUMENT: Request contains an invalid argument.` Collapse
+ * repeated tool calls to a single part, preferring the copy that still carries a
+ * thought signature so Gemini 3 does not fall back to the skip-validation sentinel.
+ */
+function dedupeAssistantToolCalls(content: any[]) {
+  const indexByToolCallId = new Map<string, number>()
+  const deduped: any[] = []
+
+  for (const part of content) {
+    if (part?.type !== 'tool-call' || !part.toolCallId) {
+      deduped.push(part)
+      continue
+    }
+
+    const existingIndex = indexByToolCallId.get(part.toolCallId)
+    if (existingIndex === undefined) {
+      indexByToolCallId.set(part.toolCallId, deduped.length)
+      deduped.push(part)
+      continue
+    }
+
+    if (!hasThoughtSignature(deduped[existingIndex]) && hasThoughtSignature(part)) {
+      deduped[existingIndex] = part
+    }
+  }
+
+  return deduped
 }
 
 export function normalizeCoreMessagesForGemini(coreMessages: any[]) {
@@ -44,6 +82,10 @@ export function normalizeCoreMessagesForGemini(coreMessages: any[]) {
   for (const msg of merged) {
     if (Array.isArray(msg.content)) {
       msg.content = msg.content.filter((part: any) => part.type !== 'text' || part.text?.trim())
+
+      if (msg.role === 'assistant') {
+        msg.content = dedupeAssistantToolCalls(msg.content)
+      }
 
       if (msg.role === 'user' || msg.role === 'system') {
         const textParts = msg.content.filter((part: any) => part.type === 'text')
@@ -76,37 +118,45 @@ export function normalizeCoreMessagesForGemini(coreMessages: any[]) {
   }
 
   const final: any[] = []
-  let pendingToolCallIds: Set<string> | null = null
+  let pendingToolCalls: Map<string, string> | null = null
 
   for (const msg of prevalidated) {
     if (msg.role === 'assistant') {
       final.push(msg)
-      const toolCallIds = extractAssistantToolCallIds(msg)
-      pendingToolCallIds = toolCallIds.size > 0 ? toolCallIds : null
+      const toolCalls = extractAssistantToolCalls(msg)
+      pendingToolCalls = toolCalls.size > 0 ? toolCalls : null
       continue
     }
 
     if (msg.role === 'tool') {
       const previous = final[final.length - 1]
-      if (previous?.role !== 'assistant' || !pendingToolCallIds) {
+      if (previous?.role !== 'assistant' || !pendingToolCalls) {
         continue
       }
 
-      const validContent = asParts(msg.content).filter(
-        (part: any) => part?.type === 'tool-result' && pendingToolCallIds?.has(part.toolCallId)
-      )
+      // The tool name must match the originating call: Gemini rejects a `functionResponse`
+      // naming an undeclared tool with a bare 400 INVALID_ARGUMENT.
+      const validContent = asParts(msg.content)
+        .filter(
+          (part: any) => part?.type === 'tool-result' && pendingToolCalls?.has(part.toolCallId)
+        )
+        .map((part: any) => {
+          const resolvedToolName = pendingToolCalls?.get(part.toolCallId)
+          if (!resolvedToolName || resolvedToolName === part.toolName) return part
+          return { ...part, toolName: resolvedToolName }
+        })
 
       if (validContent.length === 0) {
         continue
       }
 
       final.push({ ...msg, content: validContent })
-      pendingToolCallIds = null
+      pendingToolCalls = null
       continue
     }
 
     final.push(msg)
-    pendingToolCallIds = null
+    pendingToolCalls = null
   }
 
   return final

--- a/server/utils/chat/history.test.ts
+++ b/server/utils/chat/history.test.ts
@@ -63,6 +63,40 @@ describe('chat history helpers', () => {
     )
   })
 
+  it('emits a single tool part when legacy toolApprovals duplicate a stored tool call', () => {
+    const [expanded] = expandStoredChatMessages([
+      {
+        id: 'msg-legacy',
+        senderId: 'ai_agent',
+        content: '',
+        createdAt: new Date('2026-02-28T08:29:08.009Z'),
+        metadata: {
+          toolApprovals: [
+            { toolCallId: 'call-1', name: 'log_meal', args: { meal: 'oats' }, approvalId: 'call-1' }
+          ],
+          toolCalls: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'log_meal',
+              args: { meal: 'oats' },
+              response: { success: true }
+            }
+          ]
+        }
+      }
+    ])
+
+    const toolParts = (expanded!.parts as any[]).filter((part) => part.type.startsWith('tool-'))
+
+    expect(toolParts).toHaveLength(1)
+    expect(toolParts[0]).toMatchObject({
+      toolCallId: 'call-1',
+      state: 'output-available',
+      output: { success: true }
+    })
+  })
+
   it('merges tool calls and results into the persisted metadata shape', () => {
     const persisted = buildPersistedToolCalls(
       [

--- a/server/utils/chat/history.ts
+++ b/server/utils/chat/history.ts
@@ -185,8 +185,25 @@ export function expandStoredChatMessage(message: any) {
   const shouldHideEmptyFailure = !!metadata.hiddenBecauseEmptyFailure
   const shouldHideUntilContent = !!metadata.hideUntilContent
 
+  // A tool call must be represented by exactly one part per assistant message. Legacy
+  // messages persist the same call under both `toolApprovals` and `toolCalls`, and emitting
+  // both produces two `functionCall` parts with the same id inside one Gemini `model`
+  // content, which the API rejects with a bare 400 INVALID_ARGUMENT. The stored tool call
+  // wins because it also carries the args, the raw call (thought signature) and the output.
+  const storedToolCalls = normalizeStoredToolCalls(metadata, message.id)
+  const storedToolCallIds = new Set<string>(
+    storedToolCalls.map((toolCall: any) => toolCall.toolCallId).filter(Boolean)
+  )
+  const emittedToolCallIds = new Set<string>()
+
   if (Array.isArray(metadata.toolApprovals)) {
     metadata.toolApprovals.forEach((approval: any) => {
+      if (approval?.toolCallId) {
+        if (storedToolCallIds.has(approval.toolCallId)) return
+        if (emittedToolCallIds.has(approval.toolCallId)) return
+        emittedToolCallIds.add(approval.toolCallId)
+      }
+
       parts.push({
         type: `tool-${approval.name}`,
         toolCallId: approval.toolCallId,
@@ -208,7 +225,12 @@ export function expandStoredChatMessage(message: any) {
       : []
   )
 
-  normalizeStoredToolCalls(metadata, message.id).forEach((toolCall: any) => {
+  storedToolCalls.forEach((toolCall: any) => {
+    if (toolCall.toolCallId) {
+      if (emittedToolCallIds.has(toolCall.toolCallId)) return
+      emittedToolCallIds.add(toolCall.toolCallId)
+    }
+
     if (pendingApprovalIds.has(toolCall.toolCallId)) {
       parts.push({
         type: `tool-${toolCall.name}`,

--- a/server/utils/chat/turn-executor.test.ts
+++ b/server/utils/chat/turn-executor.test.ts
@@ -22,12 +22,189 @@ const {
   shouldScheduleChatRoomSummary,
   shouldUseReadRepairPrompt,
   shouldUseWriteRepairPrompt,
-  shouldRetryEmptyToolResponse
+  shouldRetryEmptyToolResponse,
+  stripAssistantToolOutputsWhenCanonicalToolMessagesExist
 } = await import('./turn-executor')
 
 beforeEach(() => {
   dispatchTaskMock.mockReset()
   dispatchTaskMock.mockResolvedValue({ id: 'run_123' })
+})
+
+describe('stripAssistantToolOutputsWhenCanonicalToolMessagesExist', () => {
+  const assistantWithOutput = () => [
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-get_recent_workouts',
+          toolCallId: 'call_1',
+          state: 'output-available',
+          input: { days: 7 },
+          output: { workouts: [] }
+        },
+        { type: 'text', text: 'Here you go' }
+      ]
+    },
+    {
+      id: 'tool-1',
+      role: 'tool',
+      parts: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'get_recent_workouts',
+          result: { workouts: [] }
+        }
+      ]
+    }
+  ]
+
+  it('keeps the tool call and drops only the duplicated output', () => {
+    const [assistant] =
+      stripAssistantToolOutputsWhenCanonicalToolMessagesExist(assistantWithOutput())
+    const toolPart = assistant.parts.find((part: any) => part.type.startsWith('tool-'))
+
+    expect(toolPart).toBeDefined()
+    expect(toolPart.toolCallId).toBe('call_1')
+    expect(toolPart.input).toEqual({ days: 7 })
+    expect(toolPart.state).toBe('input-available')
+    expect(toolPart).not.toHaveProperty('output')
+    expect(assistant.parts).toHaveLength(2)
+  })
+
+  it('leaves tool parts untouched when no canonical tool message covers them', () => {
+    const messages = assistantWithOutput()
+    messages.pop()
+
+    const [assistant] = stripAssistantToolOutputsWhenCanonicalToolMessagesExist(messages)
+    const toolPart = assistant.parts.find((part: any) => part.type.startsWith('tool-'))
+
+    expect(toolPart.state).toBe('output-available')
+    expect(toolPart.output).toEqual({ workouts: [] })
+  })
+
+  it('leaves approval-requested tool parts untouched', () => {
+    const [assistant] = stripAssistantToolOutputsWhenCanonicalToolMessagesExist([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-log_meal',
+            toolCallId: 'call_1',
+            state: 'approval-requested',
+            input: { meal: 'oats' },
+            approval: { id: 'call_1' }
+          }
+        ]
+      },
+      {
+        id: 'tool-1',
+        role: 'tool',
+        parts: [{ type: 'tool-approval-response', toolCallId: 'call_1', approved: true }]
+      }
+    ])
+
+    expect(assistant.parts[0].state).toBe('approval-requested')
+  })
+
+  it('keeps prior tool calls and results in the model history', async () => {
+    const { expandStoredChatMessages } = await import('./history')
+    const { transformHistoryToCoreMessages } = await import('../ai-history')
+    const { normalizeCoreMessagesForGemini } = await import('./core-message-normalizer')
+
+    const createdAt = new Date('2026-07-27T07:00:00Z')
+    const stored = [
+      {
+        id: 'm1',
+        senderId: 'user-1',
+        content: 'how did I train?',
+        files: [],
+        metadata: {},
+        createdAt,
+        updatedAt: createdAt
+      },
+      {
+        id: 'm2',
+        senderId: 'ai_agent',
+        content: 'Here you go',
+        files: [],
+        createdAt,
+        updatedAt: createdAt,
+        turn: { id: 't2', status: 'COMPLETED', metadata: {} },
+        metadata: {
+          toolCalls: [
+            {
+              toolCallId: 'call_1',
+              name: 'get_recent_workouts',
+              args: { days: 7 },
+              response: { workouts: [{ type: 'Ride' }] }
+            }
+          ]
+        }
+      },
+      {
+        id: 'm3',
+        senderId: 'system_tool',
+        content: '',
+        files: [],
+        createdAt,
+        updatedAt: createdAt,
+        metadata: {
+          toolResponse: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call_1',
+              toolName: 'get_recent_workouts',
+              result: { workouts: [{ type: 'Ride' }] }
+            }
+          ]
+        }
+      },
+      {
+        id: 'm4',
+        senderId: 'user-1',
+        content: 'and my sleep?',
+        files: [],
+        metadata: {},
+        createdAt,
+        updatedAt: createdAt
+      }
+    ]
+
+    const stripped = stripAssistantToolOutputsWhenCanonicalToolMessagesExist(
+      normalizeMessagesForSdk(expandStoredChatMessages(stored))
+    )
+    const modelMessages = normalizeCoreMessagesForGemini(
+      await transformHistoryToCoreMessages(stripped)
+    )
+
+    expect(modelMessages.map((message: any) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user'
+    ])
+
+    const toolCalls = modelMessages[1].content.filter((part: any) => part.type === 'tool-call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      toolCallId: 'call_1',
+      toolName: 'get_recent_workouts',
+      input: { days: 7 }
+    })
+
+    expect(modelMessages[2].content).toEqual([
+      {
+        type: 'tool-result',
+        toolCallId: 'call_1',
+        toolName: 'get_recent_workouts',
+        output: { type: 'json', value: { workouts: [{ type: 'Ride' }] } }
+      }
+    ])
+  })
 })
 
 describe('normalizeMessagesForSdk', () => {

--- a/server/utils/chat/turn-executor.ts
+++ b/server/utils/chat/turn-executor.ts
@@ -209,7 +209,7 @@ export async function buildTurnExecutionSkillConfig(input: {
   }
 }
 
-function stripAssistantToolOutputsWhenCanonicalToolMessagesExist(messages: any[]) {
+export function stripAssistantToolOutputsWhenCanonicalToolMessagesExist(messages: any[]) {
   const canonicalToolCallIds = new Set<string>()
 
   for (const message of messages) {
@@ -239,10 +239,19 @@ function stripAssistantToolOutputsWhenCanonicalToolMessagesExist(messages: any[]
 
     return {
       ...message,
-      parts: message.parts.filter((part: any) => {
-        if (!part?.type?.startsWith('tool-')) return true
-        if (part?.state !== 'output-available') return true
-        return !canonicalToolCallIds.has(part.toolCallId)
+      parts: message.parts.map((part: any) => {
+        if (!part?.type?.startsWith('tool-')) return part
+        if (part?.state !== 'output-available') return part
+        if (!canonicalToolCallIds.has(part.toolCallId)) return part
+
+        // Drop only the duplicated output, never the call itself. Downgrading to
+        // `input-available` makes convertToModelMessages emit the `tool-call` without a
+        // second `tool-result`, so the canonical tool message stays the single source of
+        // the result. Removing the whole part instead would leave that canonical result
+        // orphaned, and transformHistoryToCoreMessages would then drop it too, erasing
+        // the entire tool exchange from the model's view of the conversation.
+        const { output: _output, ...rest } = part
+        return { ...rest, state: 'input-available' }
       })
     }
   })


### PR DESCRIPTION
## Summary

Fixes intermittent `400 INVALID_ARGUMENT: "Request contains an invalid argument."` from the Gemini API during chat turns, plus a context-loss bug found while tracing the same pipeline.

## How the 400 was identified

Gemini's **bare** `"Request contains an invalid argument."` (no `details`, no field path) turns out to be a narrow fingerprint — every other 400 carries a specific message. I captured the real outgoing request body by passing a custom `fetch` to `createGoogle`, then bisected candidate payloads against the live API on both models in use (`gemini-3-flash-preview`, `gemini-3.1-flash-lite-preview`).

Ruled out by direct testing: tool JSON schemas (all 79 declarations, including the typeless `z.any()` properties, return 200), `providerOptions.google.thinkingConfig`, missing thought signatures (the provider injects Google's `skip_thought_signature_validator` sentinel), empty `parts` arrays, and message ordering. Image/MIME and corrupted-signature problems produce *different*, specific messages.

Only two payload shapes reproduce the exact production message:

1. Two `functionCall` parts with the **same id** inside one `model` content (the same id across *different* model turns is fine).
2. A `functionResponse.name` that does not match a declared tool — e.g. the literal `'unknown'`.

## What changed

### 1. `functionResponse.name: 'unknown'` — live path, no legacy data needed

A canonical `tool-approval-response` message carries no tool name, so `ai-history.ts` fell back to `toolName: 'unknown'`. Every turn after an approved tool call in that room then 400s. Reachable today whenever tool approval is used.

`transformHistoryToCoreMessages` now realigns each tool result's name with its originating tool call. An existing test asserted the buggy `'unknown'` value; it has been corrected.

### 2. Duplicate `functionCall` ids — legacy data

`expandStoredChatMessage` emitted one part from `metadata.toolApprovals` **and** another from `metadata.toolCalls` for the same `toolCallId`. Code removed in `7f8bb4647` (Jan 2026) persisted both fields together, so any room whose last-25-message window still contains such a message 400s permanently on every new message.

Now one part per tool call id — the stored tool call wins, since it also carries args, the thought signature and the output. The stale `existingCalls` snapshot in the `ai-history.ts` patch loop (same class of duplicate-id bug) became a live `Set`.

### 3. Last-gate guard

`normalizeCoreMessagesForGemini` now collapses duplicate tool calls (preferring the copy that still carries a thought signature) and realigns result names, so no future producer can reintroduce either failure.

### 4. Tool history erased from model context (separate bug, found while tracing)

`stripAssistantToolOutputsWhenCanonicalToolMessagesExist` filtered out the **whole** tool part, so the assistant lost its `tool-call` and `transformHistoryToCoreMessages` then dropped the canonical result as an orphan. On the normal path (canonical tool messages exist, the default today) the model saw **no tool calls or results from prior turns at all** — only assistant text.

It now drops only `output` and downgrades `state` from `output-available` to `input-available`. Verified against the AI SDK's conversion logic: `convertToModelMessages` emits a `tool-call` for any state other than `input-streaming`, but only emits a `tool-result` for `output-denied` / `output-error` / `output-available`. So `input-available` yields exactly the call with no duplicate result — the function's original intent — while the canonical `system_tool` message stays the single source of the result. `approval-requested` / `approval-responded` parts and parts with no canonical message are untouched.

## Verification

- Both failing payloads now return **200** from the live Gemini API; fixes confirmed to hold with the executor's strip step applied.
- Three realistic histories (single tool call, parallel tool calls, approval flow) run through the full pipeline now produce `assistant(tool-call…) → tool(tool-result…)` with args and results intact, and all return 200 live.
- Confirmed the model genuinely reads the restored history rather than merely accepting the payload: given the single-call scenario and asked "using only what the earlier tool already returned, what sport type was that workout?", it answered `Ride` — a value that lived solely in the previously-erased tool result.
- 13 regression tests added across the four suites.
- `pnpm typecheck` clean; `pnpm lint` clean (one pre-existing unrelated `vue/no-v-html` warning).
- Full unit suite: 1542 passed, 1 failed — `tests/unit/server/utils/services/wellness-analysis.test.ts`, a pre-existing prisma-mock failure confirmed to fail identically on the unmodified baseline.

## Reviewer notes

- Item 4 changes what is sent to the model on **every** chat turn — it restores tool context that was previously being dropped. Expect higher prompt token counts on multi-turn conversations with tool use, and better follow-up answers.
- Item 2 only affects rooms containing pre-March-2026 assistant messages; item 1 affects any room using tool approval.
