### PR TITLE
perf(e2e): enable Docker Buildx GHA layer caching for E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,9 @@ jobs:
             sleep 2
           fi
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and start Docker e2e stack
         run: pnpm e2e:setup
 

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -15,8 +15,19 @@ if docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
   docker tag "$IMAGE_TAG" coach-e2e-app:local
 else
   echo "=> Building Docker image for app source hash $APP_HASH"
-  pnpm e2e:build
-  docker tag coach-e2e-app:local "$IMAGE_TAG" || true
+  if [ -n "$CI" ] && docker buildx version >/dev/null 2>&1; then
+    echo "=> Using Docker Buildx with GitHub Actions layer cache (type=gha)"
+    docker buildx build \
+      --cache-from type=gha \
+      --cache-to type=gha,mode=max \
+      -f Dockerfile.e2e \
+      -t coach-e2e-app:local \
+      -t "$IMAGE_TAG" \
+      --load .
+  else
+    pnpm e2e:build
+    docker tag coach-e2e-app:local "$IMAGE_TAG" || true
+  fi
 fi
 
 docker compose --env-file .env.e2e -p coach-e2e -f docker-compose.e2e.yml up -d --wait app-e2e


### PR DESCRIPTION
### Summary
Enables GitHub Actions (`type=gha`) Docker layer caching in the E2E workflow to reuse unchanged build layers (like apt dependencies and `node_modules` installation), significantly reducing the `pnpm e2e:setup` build step duration.

- Added `docker/setup-buildx-action@v3` step to `e2e.yml`
- Updated `scripts/e2e-setup.sh` to invoke `docker buildx build --cache-from type=gha --cache-to type=gha,mode=max --load` when running in CI