### PR TITLE
chore(ci): update self-hosted runner labels to Org Linux pool

### DIFF
--- a/.github/workflows/debug-trigger-auth.yml
+++ b/.github/workflows/debug-trigger-auth.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   debug:
-    runs-on: [self-hosted, shadow]
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 15
     environment: preview
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,9 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     needs: ci
-    # Pin to the Linux deploy runner. Bare `self-hosted` can also match
-    # `mac-mini-e2e`, which fails GHCR push with anonymous-token 403.
-    runs-on: [self-hosted, shadow]
+    # Pin to Linux self-hosted runner pool. Bare `self-hosted` can also match
+    # `mac-mini`, which fails GHCR push with anonymous-token 403.
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 60
     environment: preview
     permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,9 @@ jobs:
             sleep 2
           fi
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and start Docker e2e stack
         run: pnpm e2e:setup
 

--- a/.github/workflows/reusable-trigger-deploy.yml
+++ b/.github/workflows/reusable-trigger-deploy.yml
@@ -45,8 +45,8 @@ on:
 jobs:
   deploy:
     name: Deploy Trigger.dev Tasks
-    # Keep Trigger deploys on the Linux `shadow` runner; do not share with `e2e`.
-    runs-on: [self-hosted, shadow]
+    # Keep Trigger deploys on the Linux self-hosted runner pool.
+    runs-on: [self-hosted, Linux]
     timeout-minutes: 30
     environment: ${{ inputs.environment }}
     # Job-level (not workflow-level) so the group stays distinct from the caller's

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -15,8 +15,19 @@ if docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
   docker tag "$IMAGE_TAG" coach-e2e-app:local
 else
   echo "=> Building Docker image for app source hash $APP_HASH"
-  pnpm e2e:build
-  docker tag coach-e2e-app:local "$IMAGE_TAG" || true
+  if [ -n "$CI" ] && docker buildx version >/dev/null 2>&1; then
+    echo "=> Using Docker Buildx with GitHub Actions layer cache (type=gha)"
+    docker buildx build \
+      --cache-from type=gha \
+      --cache-to type=gha,mode=max \
+      -f Dockerfile.e2e \
+      -t coach-e2e-app:local \
+      -t "$IMAGE_TAG" \
+      --load .
+  else
+    pnpm e2e:build
+    docker tag coach-e2e-app:local "$IMAGE_TAG" || true
+  fi
 fi
 
 docker compose --env-file .env.e2e -p coach-e2e -f docker-compose.e2e.yml up -d --wait app-e2e


### PR DESCRIPTION
Updates runner labels from deprecated 'shadow' tag to '[self-hosted, Linux]' to use the shared watt-mind Org runner pool.