### PR TITLE
feat(quotas): return a typed limit contract on 429

### DIFF
--- a/server/api/chat/transcribe.post.ts
+++ b/server/api/chat/transcribe.post.ts
@@ -33,7 +33,8 @@ export default defineEventHandler(async (event) => {
   await assertQuotaAllowed(
     userId,
     'chat',
-    'Chat quota exceeded. Voice transcription is unavailable until your limit resets.'
+    'Chat quota exceeded. Voice transcription is unavailable until your limit resets.',
+    event
   )
 
   const formData = await readMultipartFormData(event)

--- a/server/api/chat/tts.post.ts
+++ b/server/api/chat/tts.post.ts
@@ -167,7 +167,8 @@ export default defineEventHandler(async (event) => {
   await assertQuotaAllowed(
     userId,
     'chat',
-    'Chat quota exceeded. Text-to-speech is unavailable until your limit resets.'
+    'Chat quota exceeded. Text-to-speech is unavailable until your limit resets.',
+    event
   )
 
   if (!process.env.GEMINI_API_KEY) {

--- a/server/api/chat/turns/[id]/retry.post.ts
+++ b/server/api/chat/turns/[id]/retry.post.ts
@@ -27,7 +27,8 @@ export default defineEventHandler(async (event) => {
   await assertQuotaAllowed(
     userId,
     'chat',
-    'Chat quota exceeded. Turn retry is unavailable until your limit resets.'
+    'Chat quota exceeded. Turn retry is unavailable until your limit resets.',
+    event
   )
 
   const originalMessage = await prisma.chatMessage.findUnique({

--- a/server/api/checkin/generate.post.ts
+++ b/server/api/checkin/generate.post.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
   const user = await requireAuth(event, ['health:write'])
   const userId = user.id
   // 0. Quota Check
-  await assertQuotaAllowed(userId, 'daily_checkin')
+  await assertQuotaAllowed(userId, 'daily_checkin', undefined, event)
 
   const timezone = await getUserTimezone(userId)
   const today = getUserLocalDate(timezone)

--- a/server/api/nutrition/[id]/analyze.post.ts
+++ b/server/api/nutrition/[id]/analyze.post.ts
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  await assertQuotaAllowed(userId, 'nutrition_analysis')
+  await assertQuotaAllowed(userId, 'nutrition_analysis', undefined, event)
 
   let nutrition: any = null
 

--- a/server/api/profile/quotas.get.ts
+++ b/server/api/profile/quotas.get.ts
@@ -1,10 +1,6 @@
 import { getServerSession } from '../../utils/session'
 import { getQuotaSummary } from '../../utils/quotas/engine'
-import {
-  QUOTA_REGISTRY,
-  mapOperationToQuota,
-  type QuotaOperation
-} from '../../utils/quotas/registry'
+import { getNextTier, resolveUpgradeForOperation } from '../../utils/quotas/registry'
 import type { SubscriptionTier } from '@prisma/client'
 import type { QuotaStatus } from '~~/app/types/quotas'
 
@@ -16,12 +12,6 @@ function resolveEffectiveTier(user: {
   return user.subscriptionTier === 'FREE' && isTrialActive ? 'SUPPORTER' : user.subscriptionTier
 }
 
-function getNextTier(tier: SubscriptionTier): 'SUPPORTER' | 'PRO' | null {
-  if (tier === 'FREE') return 'SUPPORTER'
-  if (tier === 'SUPPORTER') return 'PRO'
-  return null
-}
-
 function enrichQuotasWithNextTier(
   quotas: QuotaStatus[],
   effectiveTier: SubscriptionTier
@@ -30,12 +20,12 @@ function enrichQuotasWithNextTier(
   if (!nextTier) return quotas
 
   return quotas.map((quota) => {
-    const canonicalOp = mapOperationToQuota(quota.operation) || (quota.operation as QuotaOperation)
-    const nextTierLimit = QUOTA_REGISTRY[nextTier][canonicalOp]?.limit ?? null
+    // Only surface an upgrade that actually raises this operation's limit.
+    const upgrade = resolveUpgradeForOperation(quota.operation, effectiveTier)
     return {
       ...quota,
-      nextTier,
-      nextTierLimit
+      nextTier: upgrade?.nextTier ?? nextTier,
+      nextTierLimit: upgrade?.nextTierLimit ?? null
     }
   })
 }

--- a/server/api/recommendations/generate.post.ts
+++ b/server/api/recommendations/generate.post.ts
@@ -55,7 +55,8 @@ export default defineEventHandler(async (event) => {
   await assertQuotaAllowed(
     user.id,
     'unified_report_generation',
-    'Recommendation update quota exceeded. Please wait or upgrade your plan.'
+    'Recommendation update quota exceeded. Please wait or upgrade your plan.',
+    event
   )
 
   try {

--- a/server/api/reports/generate.post.ts
+++ b/server/api/reports/generate.post.ts
@@ -74,7 +74,7 @@ export default defineEventHandler(async (event) => {
   const userId = (session.user as any).id
 
   // 0. Quota Check
-  await assertQuotaAllowed(userId, 'unified_report_generation')
+  await assertQuotaAllowed(userId, 'unified_report_generation', undefined, event)
 
   const body = await readBody(event)
   const reportType = body.type || 'WEEKLY_ANALYSIS'

--- a/server/api/wellness/[wellnessId]/analyze.post.ts
+++ b/server/api/wellness/[wellnessId]/analyze.post.ts
@@ -7,7 +7,7 @@ import { assertQuotaAllowed } from '../../../utils/quotas/http'
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event, ['health:write'])
   const userId = user.id
-  await assertQuotaAllowed(userId, 'wellness_analysis')
+  await assertQuotaAllowed(userId, 'wellness_analysis', undefined, event)
 
   const param = getRouterParam(event, 'wellnessId') || getRouterParam(event, 'id')
 

--- a/server/api/wellness/analyze.post.ts
+++ b/server/api/wellness/analyze.post.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const { wellnessId } = await readValidatedBody(event, analyzeSchema.parse)
   const userId = user.id
 
-  await assertQuotaAllowed(userId, 'wellness_analysis')
+  await assertQuotaAllowed(userId, 'wellness_analysis', undefined, event)
 
   const wellness = await prisma.wellness.findUnique({
     where: { id: wellnessId }

--- a/server/api/workouts/[id]/analyze.post.ts
+++ b/server/api/workouts/[id]/analyze.post.ts
@@ -53,7 +53,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const userId = user.id
-  await assertQuotaAllowed(userId, 'workout_analysis')
+  await assertQuotaAllowed(userId, 'workout_analysis', undefined, event)
 
   // Fetch the workout
   const workout = await workoutRepository.getById(id, userId)

--- a/server/utils/quotas/engine.ts
+++ b/server/utils/quotas/engine.ts
@@ -2,7 +2,12 @@ import { Prisma } from '@prisma/client'
 import type { SubscriptionTier } from '@prisma/client'
 import { prisma } from '../db'
 import type { QuotaOperation } from './registry'
-import { QUOTA_REGISTRY, mapOperationToQuota } from './registry'
+import {
+  QUOTA_REGISTRY,
+  mapOperationToQuota,
+  quotaFeatureCode,
+  resolveUpgradeForOperation
+} from './registry'
 import type { QuotaStatus } from '~~/app/types/quotas'
 import { getUserTimezone, getStartOfDayUTC, getEndOfDayUTC } from '../date'
 import { resolveEffectiveTier } from '../../../shared/effective-tier'
@@ -156,6 +161,8 @@ export async function getQuotaStatus(
       resetsAt = new Date(firstUsedAt.getTime() + parseIntervalToMs(quotaDef.window))
     }
 
+    const upgrade = resolveUpgradeForOperation(operation, effectiveTier)
+
     return {
       operation,
       allowed: quotaDef.enforcement === 'MEASURE' || used < quotaDef.limit,
@@ -164,7 +171,9 @@ export async function getQuotaStatus(
       remaining,
       window: isCalendarReset ? 'calendar day' : quotaDef.window,
       resetsAt,
-      enforcement: quotaDef.enforcement
+      enforcement: quotaDef.enforcement,
+      nextTier: upgrade?.nextTier ?? null,
+      nextTierLimit: upgrade?.nextTierLimit ?? null
     }
   } catch (error) {
     console.error(`Failed to get quota status for ${operation}:`, error)
@@ -215,15 +224,52 @@ export async function checkQuota(userId: string, operation: string): Promise<Quo
     }
     error.statusCode = 429
     error.statusMessage = `Quota exceeded for ${operation}. Upgrade your plan for higher limits.`
-    error.data = {
-      operation,
-      quotaExceeded: true
-    }
+    error.data = buildQuotaErrorPayload(status)
     error.quotaExceeded = true
     throw error
   }
 
   return status
+}
+
+/**
+ * Seconds until the allowance refills, for the `Retry-After` header.
+ * Null when the reset time is unknown or already in the past.
+ */
+export function quotaRetryAfterSeconds(
+  resetsAt: Date | string | null | undefined,
+  now: Date = new Date()
+): number | null {
+  if (!resetsAt) return null
+  const reset = new Date(resetsAt)
+  if (Number.isNaN(reset.getTime())) return null
+  const seconds = Math.ceil((reset.getTime() - now.getTime()) / 1000)
+  return seconds > 0 ? seconds : null
+}
+
+/**
+ * The 429 body contract shared with API clients: what was limited, how much of
+ * the allowance was used, when it comes back, and which tier lifts it. Clients
+ * must never have to parse English copy to build a plan-limit state.
+ */
+export function buildQuotaErrorPayload(status: QuotaStatus): Record<string, unknown> {
+  const retryAfterSeconds = quotaRetryAfterSeconds(status.resetsAt)
+
+  return {
+    code: 'QUOTA_EXCEEDED',
+    operation: status.operation,
+    feature: quotaFeatureCode(status.operation),
+    limit: status.limit,
+    used: status.used,
+    remaining: status.remaining,
+    window: status.window,
+    resetsAt: status.resetsAt instanceof Date ? status.resetsAt.toISOString() : status.resetsAt,
+    retryAfterSeconds,
+    requiredTier: status.nextTier ?? null,
+    requiredTierLimit: status.nextTierLimit ?? null,
+    // Retained for existing consumers that branch on this flag.
+    quotaExceeded: true
+  }
 }
 
 /**

--- a/server/utils/quotas/http.ts
+++ b/server/utils/quotas/http.ts
@@ -1,15 +1,29 @@
-import { createError } from 'h3'
+import { createError, setHeader, type H3Event } from 'h3'
 import { checkQuota } from './engine'
 
+/**
+ * Enforce a quota for an operation, turning a denial into a 429 that carries the
+ * full limit contract (`code`, `feature`, `limit`, `used`, `resetsAt`,
+ * `requiredTier`) plus a `Retry-After` header.
+ *
+ * Pass `event` wherever it is available: without it the body still describes the
+ * limit, but clients lose the transport-level retry hint.
+ */
 export async function assertQuotaAllowed(
   userId: string,
   operation: string,
-  fallbackMessage?: string
+  fallbackMessage?: string,
+  event?: H3Event
 ) {
   try {
     await checkQuota(userId, operation)
   } catch (error: any) {
     if (error?.statusCode === 429) {
+      const retryAfter = error.data?.retryAfterSeconds
+      if (event && typeof retryAfter === 'number' && retryAfter > 0) {
+        setHeader(event, 'Retry-After', retryAfter)
+      }
+
       throw createError({
         statusCode: 429,
         statusMessage: error.statusMessage || error.message || fallbackMessage,

--- a/server/utils/quotas/registry.ts
+++ b/server/utils/quotas/registry.ts
@@ -132,3 +132,58 @@ export function mapOperationToQuota(operation: string): QuotaOperation | null {
 
   return null
 }
+
+/**
+ * Feature codes shared with API clients (mobile app, MCP) so a 429 identifies
+ * *what* was limited without parsing operation names or English copy.
+ * Operations without a client-facing feature are omitted; clients then fall back
+ * to the feature they asked for.
+ */
+export const QUOTA_FEATURE_BY_OPERATION: Partial<Record<QuotaOperation, string>> = {
+  chat: 'COACH_CHAT',
+  workout_analysis: 'ACTIVITY_ANALYSIS',
+  athlete_profile_generation: 'ATHLETE_REPORT',
+  daily_checkin: 'DAILY_CHECKIN',
+  activity_recommendation: 'READINESS_RECOMMENDATION',
+  meal_recommendation: 'MEAL_RECOMMENDATION',
+  generate_structured_workout: 'WORKOUT_GENERATION'
+}
+
+export function quotaFeatureCode(operation: string): string | null {
+  const canonical = mapOperationToQuota(operation)
+  if (!canonical) return null
+  return QUOTA_FEATURE_BY_OPERATION[canonical] ?? null
+}
+
+/** Next paid tier above `tier`, or null when already on the top tier. */
+export function getNextTier(tier: SubscriptionTier): 'SUPPORTER' | 'PRO' | null {
+  if (tier === 'FREE') return 'SUPPORTER'
+  if (tier === 'SUPPORTER') return 'PRO'
+  return null
+}
+
+/**
+ * Lowest tier above `tier` that actually raises the limit for `operation`.
+ * Returns null when no higher tier improves it — never point at an upgrade that
+ * would not lift the limit the user just hit.
+ */
+export function resolveUpgradeForOperation(
+  operation: string,
+  tier: SubscriptionTier
+): { nextTier: 'SUPPORTER' | 'PRO'; nextTierLimit: number } | null {
+  const canonical = mapOperationToQuota(operation)
+  if (!canonical) return null
+
+  const currentLimit = QUOTA_REGISTRY[tier][canonical]?.limit ?? 0
+  const candidates: ('SUPPORTER' | 'PRO')[] =
+    tier === 'FREE' ? ['SUPPORTER', 'PRO'] : tier === 'SUPPORTER' ? ['PRO'] : []
+
+  for (const candidate of candidates) {
+    const limit = QUOTA_REGISTRY[candidate][canonical]?.limit
+    if (limit !== undefined && limit > currentLimit) {
+      return { nextTier: candidate, nextTierLimit: limit }
+    }
+  }
+
+  return null
+}

--- a/tests/unit/server/utils/quota-error-contract.test.ts
+++ b/tests/unit/server/utils/quota-error-contract.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prisma } from '../../../../server/utils/db'
+import { getActivePromotionalGrant } from '../../../../server/utils/partner-campaigns'
+import {
+  buildQuotaErrorPayload,
+  quotaRetryAfterSeconds
+} from '../../../../server/utils/quotas/engine'
+import {
+  quotaFeatureCode,
+  resolveUpgradeForOperation
+} from '../../../../server/utils/quotas/registry'
+
+vi.mock('../../../../server/utils/partner-campaigns', () => ({
+  getActivePromotionalGrant: vi.fn()
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), create: vi.fn() },
+    quotaDenial: { create: vi.fn() },
+    $queryRaw: vi.fn()
+  }
+}))
+
+vi.mock('../../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn(),
+  getStartOfDayUTC: vi.fn(() => new Date('2026-03-08T00:00:00.000Z')),
+  getEndOfDayUTC: vi.fn(() => new Date('2026-03-08T23:59:59.999Z'))
+}))
+
+describe('quota feature codes', () => {
+  it('maps metered operations to the client-facing feature', () => {
+    expect(quotaFeatureCode('workout_analysis')).toBe('ACTIVITY_ANALYSIS')
+    expect(quotaFeatureCode('activity_recommendation')).toBe('READINESS_RECOMMENDATION')
+    expect(quotaFeatureCode('generate_structured_workout')).toBe('WORKOUT_GENERATION')
+    expect(quotaFeatureCode('daily_checkin')).toBe('DAILY_CHECKIN')
+  })
+
+  it('resolves legacy operation aliases through the canonical map', () => {
+    expect(quotaFeatureCode('chat_ws')).toBe('COACH_CHAT')
+    expect(quotaFeatureCode('last_3_workouts_analysis')).toBe('ACTIVITY_ANALYSIS')
+  })
+
+  it('returns null for operations with no client feature, so clients fall back', () => {
+    expect(quotaFeatureCode('goal_review')).toBeNull()
+    expect(quotaFeatureCode('not_an_operation')).toBeNull()
+  })
+})
+
+describe('upgrade resolution', () => {
+  it('points at the lowest tier that actually raises the limit', () => {
+    expect(resolveUpgradeForOperation('workout_analysis', 'FREE')).toEqual({
+      nextTier: 'SUPPORTER',
+      nextTierLimit: 30
+    })
+    expect(resolveUpgradeForOperation('workout_analysis', 'SUPPORTER')).toEqual({
+      nextTier: 'PRO',
+      nextTierLimit: 150
+    })
+  })
+
+  it('offers no upgrade on the top tier', () => {
+    expect(resolveUpgradeForOperation('workout_analysis', 'PRO')).toBeNull()
+  })
+})
+
+describe('retry-after', () => {
+  const now = new Date('2026-03-08T10:00:00.000Z')
+
+  it('returns whole seconds until the allowance refills', () => {
+    expect(quotaRetryAfterSeconds('2026-03-08T10:02:30.000Z', now)).toBe(150)
+  })
+
+  it('returns null for missing, invalid or elapsed reset times', () => {
+    expect(quotaRetryAfterSeconds(null, now)).toBeNull()
+    expect(quotaRetryAfterSeconds('not-a-date', now)).toBeNull()
+    expect(quotaRetryAfterSeconds('2026-03-08T09:00:00.000Z', now)).toBeNull()
+  })
+})
+
+describe('429 payload', () => {
+  it('describes the limit without the client parsing English copy', () => {
+    const payload = buildQuotaErrorPayload({
+      operation: 'workout_analysis',
+      allowed: false,
+      used: 6,
+      limit: 6,
+      remaining: 0,
+      window: '7 days',
+      resetsAt: new Date('2099-01-01T00:00:00.000Z'),
+      enforcement: 'STRICT',
+      nextTier: 'SUPPORTER',
+      nextTierLimit: 30
+    })
+
+    expect(payload).toMatchObject({
+      code: 'QUOTA_EXCEEDED',
+      operation: 'workout_analysis',
+      feature: 'ACTIVITY_ANALYSIS',
+      limit: 6,
+      used: 6,
+      remaining: 0,
+      window: '7 days',
+      resetsAt: '2099-01-01T00:00:00.000Z',
+      requiredTier: 'SUPPORTER',
+      requiredTierLimit: 30,
+      quotaExceeded: true
+    })
+    expect(payload.retryAfterSeconds).toBeGreaterThan(0)
+  })
+
+  it('keeps the legacy quotaExceeded flag for existing consumers', () => {
+    const payload = buildQuotaErrorPayload({
+      operation: 'goal_review',
+      allowed: false,
+      used: 1,
+      limit: 1,
+      remaining: 0,
+      window: '24 hours',
+      resetsAt: null,
+      enforcement: 'STRICT'
+    })
+
+    expect(payload.quotaExceeded).toBe(true)
+    expect(payload.feature).toBeNull()
+    expect(payload.retryAfterSeconds).toBeNull()
+    expect(payload.requiredTier).toBeNull()
+  })
+})
+
+describe('checkQuota', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws a 429 carrying the full contract', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      subscriptionTier: 'FREE',
+      subscriptionStatus: 'NONE',
+      subscriptionPeriodEnd: null,
+      trialEndsAt: null,
+      timezone: 'UTC'
+    } as any)
+    vi.mocked(getActivePromotionalGrant).mockResolvedValue(null)
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([
+      { count: 6, firstUsedAt: new Date('2026-03-01T00:00:00.000Z') }
+    ] as any)
+    vi.mocked(prisma.quotaDenial.create).mockResolvedValue({} as any)
+
+    const { checkQuota } = await import('../../../../server/utils/quotas/engine')
+
+    await expect(checkQuota('user-123', 'workout_analysis')).rejects.toMatchObject({
+      statusCode: 429,
+      data: {
+        code: 'QUOTA_EXCEEDED',
+        feature: 'ACTIVITY_ANALYSIS',
+        operation: 'workout_analysis',
+        limit: 6,
+        used: 6,
+        requiredTier: 'SUPPORTER',
+        requiredTierLimit: 30,
+        quotaExceeded: true
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Why

A quota denial currently returns `{ operation, quotaExceeded: true }`. Every client therefore has to detect limits by sniffing the status code and matching English copy, and none can tell the athlete **how much of the allowance was used, when it comes back, or which tier lifts it** — even though `getQuotaStatus` already computes all of it.

This is the server half of the mobile plan-limit work: the app now has one `parseQuotaError` + one plan-limit card wired into every metered surface, and it degrades to generic copy without these fields.

## What changed

**`buildQuotaErrorPayload`** — the 429 body now carries:

```jsonc
{
  "code": "QUOTA_EXCEEDED",
  "operation": "workout_analysis",
  "feature": "ACTIVITY_ANALYSIS",   // null when the operation has no client feature
  "limit": 6, "used": 6, "remaining": 0,
  "window": "7 days",
  "resetsAt": "2026-03-15T00:00:00.000Z",
  "retryAfterSeconds": 518400,
  "requiredTier": "SUPPORTER", "requiredTierLimit": 30,
  "quotaExceeded": true             // retained for existing consumers
}
```

- **`Retry-After`** — `assertQuotaAllowed` now accepts the H3 event and sets the header; all ten API call sites pass it.
- **`quotaFeatureCode(operation)`** — stable client-facing feature codes, resolved through `mapOperationToQuota` so legacy aliases (`chat_ws`, `last_3_workouts_analysis`) map correctly. Operations without a client feature return `null` and clients fall back to the feature they requested.
- **`resolveUpgradeForOperation(operation, tier)`** — returns the lowest tier that *actually raises the limit that was hit*, rather than "the next tier up". Now populated centrally in `getQuotaStatus`, so `/api/profile/quotas` and the web paywall composable get it for free; the duplicate `getNextTier` in `quotas.get.ts` is gone.

## Compatibility

Additive. `statusCode`, `statusMessage`, `message` and `data.quotaExceeded` are unchanged, so `turn-executor`, `checkin-service` and `wellness-analysis` keep working as-is. `QuotaStatus.nextTier`/`nextTierLimit` were already declared optional in `app/types/quotas.ts` and are now always populated.

## Testing

- New `tests/unit/server/utils/quota-error-contract.test.ts` — 15 assertions over feature mapping (incl. aliases), upgrade resolution (incl. top-tier → none), `Retry-After` seconds (missing/invalid/elapsed), payload shape and an end-to-end `checkQuota` rejection.
- `npx vitest run` — 1556 passing. One failure, `tests/unit/server/utils/services/wellness-analysis.test.ts`, **pre-exists on `develop`** (its prisma mock lacks `wellness`); verified by stashing this branch's changes and re-running.
- `nuxt typecheck --checker=vue-tsc` clean; `eslint` clean on changed files.

## Follow-ups (not in this PR)

- Return `limit`/`used`/`remaining` on **successful** metered responses so clients can warn before hitting zero ("2 analyses left") instead of blocking at the moment of use.
- Expose per-tier feature lists so the mobile paywall stops hardcoding them.