### PR TITLE
feat(quotas): report remaining allowance on successful metered calls

### DIFF
--- a/app/components/dashboard/DailyCheckinModal.vue
+++ b/app/components/dashboard/DailyCheckinModal.vue
@@ -346,6 +346,15 @@
             >
               {{ lockedTierLabel }}
             </UBadge>
+            <UBadge
+              v-else-if="checkinRemainingLabel"
+              color="neutral"
+              variant="subtle"
+              size="xs"
+              class="shrink-0 uppercase tracking-wide font-bold"
+            >
+              {{ checkinRemainingLabel }}
+            </UBadge>
           </div>
           <div class="flex gap-2 ml-auto">
             <UButton
@@ -412,7 +421,11 @@
   const showRecentCheckins = ref(false)
   const deleting = ref(false)
   const { showQuotaPaywall, handleLockedAction, useOperationLockState } = useQuotaPaywall()
-  const { locked: isCheckinLocked, lockedTierLabel } = useOperationLockState('daily_checkin')
+  const {
+    locked: isCheckinLocked,
+    lockedTierLabel,
+    remainingLabel: checkinRemainingLabel
+  } = useOperationLockState('daily_checkin')
   const toast = useToast()
   const { formatDateUTC } = useFormat()
   const { trackDailyCheckinStart, trackDailyCheckinComplete } = useAnalytics()

--- a/app/components/dashboard/TrainingRecommendationCard.vue
+++ b/app/components/dashboard/TrainingRecommendationCard.vue
@@ -423,6 +423,15 @@
             >
               {{ lockedTierLabel }}
             </UBadge>
+            <UBadge
+              v-else-if="recommendationRemainingLabel"
+              color="neutral"
+              variant="subtle"
+              size="xs"
+              class="shrink-0 uppercase tracking-wide font-bold"
+            >
+              {{ recommendationRemainingLabel }}
+            </UBadge>
           </div>
           <p
             v-if="!recommendationStore.todayRecommendation"
@@ -477,8 +486,11 @@
   const recommendationStore = useRecommendationStore()
   const userStore = useUserStore()
   const { handleLockedAction, useOperationLockState } = useQuotaPaywall()
-  const { locked: isRecommendationLocked, lockedTierLabel } =
-    useOperationLockState('activity_recommendation')
+  const {
+    locked: isRecommendationLocked,
+    lockedTierLabel,
+    remainingLabel: recommendationRemainingLabel
+  } = useOperationLockState('activity_recommendation')
   const checkinStore = useCheckinStore()
   const { checkProfileStale } = useDataStatus()
   const toast = useToast()

--- a/app/composables/useQuotaPaywall.ts
+++ b/app/composables/useQuotaPaywall.ts
@@ -21,6 +21,9 @@ interface QuotaSummaryResponse {
 
 const QUOTA_CACHE_TTL_MS = 30_000
 
+/** Warn from this many uses left; above it the countdown stays hidden. */
+const LOW_ALLOWANCE_THRESHOLD = 2
+
 export interface QuotaPaywallOptions {
   operation?: QuotaPaywallOperation
   title?: string
@@ -178,11 +181,30 @@ export function useQuotaPaywall() {
       return recommendedTier === 'pro' ? 'Pro' : recommendedTier === 'supporter' ? 'Supporter' : ''
     })
 
+    const remaining = computed(() => {
+      const quota = getQuotaForOperation(operation)
+      if (!quota || !Number.isFinite(quota.limit)) return null
+      if (hasQuotaResetPassed(quota.resetsAt, now.value)) return quota.limit
+      return Math.max(0, quota.remaining)
+    })
+
+    /**
+     * Short warning for the trigger control, so an athlete is never surprised
+     * mid-task. Silent until the allowance is nearly gone — a countdown on every
+     * button would just be noise.
+     */
+    const remainingLabel = computed(() => {
+      const left = remaining.value
+      if (left === null || left > LOW_ALLOWANCE_THRESHOLD || locked.value) return null
+      if (left === 0) return 'None left'
+      return left === 1 ? '1 left' : `${left} left`
+    })
+
     onMounted(() => {
       void ensureQuotasLoaded()
     })
 
-    return { locked, lockedTierLabel }
+    return { locked, lockedTierLabel, remaining, remainingLabel }
   }
 
   return {

--- a/app/types/quotas.ts
+++ b/app/types/quotas.ts
@@ -7,6 +7,8 @@ export interface QuotaStatus {
   window: string
   resetsAt: Date | string | null
   enforcement: 'STRICT' | 'MEASURE'
+  /** Client-facing feature code, matching the 429 payload. */
+  feature?: string | null
   nextTier?: 'SUPPORTER' | 'PRO' | null
   nextTierLimit?: number | null
 }

--- a/server/api/profile/quotas.get.ts
+++ b/server/api/profile/quotas.get.ts
@@ -1,6 +1,10 @@
-import { getServerSession } from '../../utils/session'
+import { requireAuth } from '../../utils/auth-guard'
 import { getQuotaSummary } from '../../utils/quotas/engine'
-import { getNextTier, resolveUpgradeForOperation } from '../../utils/quotas/registry'
+import {
+  getNextTier,
+  quotaFeatureCode,
+  resolveUpgradeForOperation
+} from '../../utils/quotas/registry'
 import type { SubscriptionTier } from '@prisma/client'
 import type { QuotaStatus } from '~~/app/types/quotas'
 
@@ -24,6 +28,8 @@ function enrichQuotasWithNextTier(
     const upgrade = resolveUpgradeForOperation(quota.operation, effectiveTier)
     return {
       ...quota,
+      // Same feature codes the 429 payload uses, so clients keep one mapping.
+      feature: quotaFeatureCode(quota.operation),
       nextTier: upgrade?.nextTier ?? nextTier,
       nextTierLimit: upgrade?.nextTierLimit ?? null
     }
@@ -72,16 +78,11 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
-
-  if (!session?.user) {
-    throw createError({
-      statusCode: 401,
-      message: 'Unauthorized'
-    })
-  }
-
-  const userId = (session.user as any).id
+  // Session-only auth kept this endpoint unreachable from the mobile app, which
+  // authenticates with an OAuth bearer token — so the app had no way to warn an
+  // athlete before an allowance ran out.
+  const authUser = await requireAuth(event, ['profile:read'])
+  const userId = authUser.id
 
   const user = await prisma.user.findUnique({
     where: { id: userId },

--- a/server/utils/quotas/http.ts
+++ b/server/utils/quotas/http.ts
@@ -1,13 +1,39 @@
 import { createError, setHeader, type H3Event } from 'h3'
 import { checkQuota } from './engine'
+import { quotaFeatureCode } from './registry'
+import type { QuotaStatus } from '~~/app/types/quotas'
+
+/**
+ * Publish the athlete's standing on this operation.
+ *
+ * Clients previously learned a limit existed only by being blocked, after
+ * waiting through a generation. These headers ride along with the success
+ * response so a caller can warn ("2 analyses left") before the allowance runs
+ * out, without a second round trip.
+ */
+export function setQuotaHeaders(event: H3Event, status: QuotaStatus): void {
+  const feature = quotaFeatureCode(status.operation)
+  if (feature) setHeader(event, 'X-Quota-Feature', feature)
+  setHeader(event, 'X-Quota-Operation', status.operation)
+  setHeader(event, 'X-Quota-Limit', String(status.limit))
+  setHeader(event, 'X-Quota-Used', String(status.used))
+  setHeader(event, 'X-Quota-Remaining', String(status.remaining))
+  if (status.resetsAt) {
+    const reset =
+      status.resetsAt instanceof Date ? status.resetsAt.toISOString() : String(status.resetsAt)
+    setHeader(event, 'X-Quota-Reset', reset)
+  }
+}
 
 /**
  * Enforce a quota for an operation, turning a denial into a 429 that carries the
  * full limit contract (`code`, `feature`, `limit`, `used`, `resetsAt`,
  * `requiredTier`) plus a `Retry-After` header.
  *
+ * On success the same numbers go out as `X-Quota-*` headers.
+ *
  * Pass `event` wherever it is available: without it the body still describes the
- * limit, but clients lose the transport-level retry hint.
+ * limit, but clients lose both the retry hint and the remaining-allowance hint.
  */
 export async function assertQuotaAllowed(
   userId: string,
@@ -16,7 +42,12 @@ export async function assertQuotaAllowed(
   event?: H3Event
 ) {
   try {
-    await checkQuota(userId, operation)
+    const status = await checkQuota(userId, operation)
+    // `limit` is Infinity when no quota is defined — nothing useful to publish.
+    if (event && Number.isFinite(status.limit)) {
+      setQuotaHeaders(event, status)
+    }
+    return status
   } catch (error: any) {
     if (error?.statusCode === 429) {
       const retryAfter = error.data?.retryAfterSeconds

--- a/tests/unit/server/utils/quota-headers.test.ts
+++ b/tests/unit/server/utils/quota-headers.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { H3Event } from 'h3'
+
+import { setQuotaHeaders } from '../../../../server/utils/quotas/http'
+import type { QuotaStatus } from '~~/app/types/quotas'
+
+const headers = new Map<string, unknown>()
+
+vi.mock('h3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('h3')>()
+  return {
+    ...actual,
+    setHeader: (_event: H3Event, name: string, value: unknown) => headers.set(name, value)
+  }
+})
+
+function status(overrides: Partial<QuotaStatus> = {}): QuotaStatus {
+  return {
+    operation: 'workout_analysis',
+    allowed: true,
+    used: 4,
+    limit: 6,
+    remaining: 2,
+    window: '7 days',
+    resetsAt: new Date('2026-03-15T00:00:00.000Z'),
+    enforcement: 'STRICT',
+    ...overrides
+  }
+}
+
+describe('setQuotaHeaders', () => {
+  beforeEach(() => {
+    headers.clear()
+  })
+
+  it('publishes the athlete’s standing alongside a successful response', () => {
+    setQuotaHeaders({} as H3Event, status())
+
+    expect(Object.fromEntries(headers)).toEqual({
+      'X-Quota-Feature': 'ACTIVITY_ANALYSIS',
+      'X-Quota-Operation': 'workout_analysis',
+      'X-Quota-Limit': '6',
+      'X-Quota-Used': '4',
+      'X-Quota-Remaining': '2',
+      'X-Quota-Reset': '2026-03-15T00:00:00.000Z'
+    })
+  })
+
+  it('omits the feature header for operations with no client feature', () => {
+    setQuotaHeaders({} as H3Event, status({ operation: 'goal_review' }))
+
+    expect(headers.has('X-Quota-Feature')).toBe(false)
+    expect(headers.get('X-Quota-Operation')).toBe('goal_review')
+  })
+
+  it('omits the reset header when the window has no known end', () => {
+    setQuotaHeaders({} as H3Event, status({ resetsAt: null }))
+
+    expect(headers.has('X-Quota-Reset')).toBe(false)
+    expect(headers.get('X-Quota-Remaining')).toBe('2')
+  })
+
+  it('accepts a pre-serialised reset timestamp', () => {
+    setQuotaHeaders({} as H3Event, status({ resetsAt: '2026-04-01T10:00:00.000Z' }))
+
+    expect(headers.get('X-Quota-Reset')).toBe('2026-04-01T10:00:00.000Z')
+  })
+})


### PR DESCRIPTION
Server half of the "warn before you're blocked" work. Pairs with watt-mind/watts-mobile#17.

Today an athlete only discovers a limit by being blocked — typically after waiting through a generation. The engine already computes `used`/`limit`/`remaining`/`resetsAt` on every call; this stops throwing them away on the success path.

## Changes

**`X-Quota-*` headers on success.** `assertQuotaAllowed` now sets `X-Quota-Feature`, `-Operation`, `-Limit`, `-Used`, `-Remaining` and `-Reset` when the call is allowed, so a client can warn without a second round trip. Skipped when no quota is defined for the operation (`limit` is `Infinity` there). The 429 path is unchanged.

**`/api/profile/quotas` is reachable from the mobile app.** It used `getServerSession` only, so an OAuth bearer token got a 401 — the app had no way to read allowances at all, which is why it could never warn. Now uses `requireAuth(event, ['profile:read'])`, matching the other `/api/profile/*` reads. Session and API-key callers are unaffected.

**Feature codes in the summary.** Each quota carries the same `feature` code the 429 payload uses, so clients keep one operation→feature mapping instead of two.

**Web surfaces it.** `useOperationLockState` gains `remaining` and a `remainingLabel` that stays null until the allowance is nearly gone (≤2). The daily check-in and training recommendation triggers show it as a neutral badge beside the existing lock badge — deliberately quiet, since a counter on every button is noise.

## Testing

- New `quota-headers.test.ts`: header set on success, feature omitted for operations without a client code, reset omitted when the window has no end, pre-serialised timestamps accepted.
- `npx vitest run` — 291 files / 1570 tests passing. `nuxt typecheck --checker=vue-tsc` clean, `eslint` clean.

## Note

The mobile PR can merge first without breaking anything — its query just 401s and the hint stays hidden — but the feature only becomes visible once this ships.