### PR TITLE
fix(security): address CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   # PR runs supersede each other; workflow_call runs are keyed per-commit so they
   # never queue behind (or deadlock with) the calling deploy workflow's group.

--- a/.github/workflows/debug-trigger-auth.yml
+++ b/.github/workflows/debug-trigger-auth.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: [self-hosted, Linux]
     timeout-minutes: 15
     environment: preview
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
       packages: write
     env:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   e2e:
     name: Playwright E2E

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,6 +16,8 @@ jobs:
     environment: mcp-registry-publish
     permissions:
       contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/reusable-trigger-deploy.yml
+++ b/.github/workflows/reusable-trigger-deploy.yml
@@ -57,6 +57,7 @@ jobs:
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://dummy:dummy@localhost:5432/dummy' }}
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   analyze:
     name: CodeQL Security Scan
@@ -29,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/cli/changelog/generate.ts
+++ b/cli/changelog/generate.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import chalk from 'chalk'
 import * as fs from 'fs'
 import * as path from 'path'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import 'dotenv/config'
 import { generateCoachAnalysis } from '../../server/utils/gemini'
 
@@ -31,8 +31,9 @@ export const generateCommand = new Command('generate')
       try {
         version = options.releaseVersion
         // Get commits: subject, hash
-        latestVersionBlock = execSync(
-          `git log ${options.from}..HEAD --pretty=format:"- %s (%h)" --no-merges`,
+        latestVersionBlock = execFileSync(
+          'git',
+          ['log', `${options.from}..HEAD`, '--pretty=format:- %s (%h)', '--no-merges'],
           { encoding: 'utf-8' }
         )
       } catch (error) {
@@ -117,8 +118,10 @@ Format as Markdown.
       if (options.write) {
         // 1. Update master USER_CHANGELOG.md
         let existingContent = ''
-        if (fs.existsSync(outputFile)) {
+        try {
           existingContent = fs.readFileSync(outputFile, 'utf-8')
+        } catch {
+          // File does not exist yet
         }
         const newContent = userChangelog + '\n\n' + existingContent
         fs.writeFileSync(outputFile, newContent)
@@ -126,9 +129,7 @@ Format as Markdown.
 
         // 2. Create version-specific release file
         const releasesDir = path.resolve(projectRoot, 'public/content/releases')
-        if (!fs.existsSync(releasesDir)) {
-          fs.mkdirSync(releasesDir, { recursive: true })
-        }
+        fs.mkdirSync(releasesDir, { recursive: true })
 
         const releaseFile = path.join(releasesDir, `v${version}.md`)
 

--- a/cli/db/backup.ts
+++ b/cli/db/backup.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import chalk from 'chalk'
 import * as fs from 'fs'
 import * as path from 'path'
@@ -34,9 +34,13 @@ backupCommand
     const [, dbUser, dbPassword, dbHost, dbPort, dbName] = dbUrlMatch
 
     try {
-      execSync(`docker ps --format '{{.Names}}' | grep -q "^${options.container}$"`, {
-        stdio: 'inherit'
+      const psOutput = execFileSync('docker', ['ps', '--format', '{{.Names}}'], {
+        encoding: 'utf-8'
       })
+      const runningContainers = psOutput.split('\n').map((name) => name.trim())
+      if (!runningContainers.includes(options.container)) {
+        throw new Error(`Container ${options.container} not running`)
+      }
     } catch (error) {
       console.error(chalk.red(`Error: Docker container '${options.container}' is not running`))
       process.exit(1)
@@ -62,10 +66,24 @@ backupCommand
     console.log(chalk.yellow('Starting backup...'))
 
     try {
-      execSync(
-        `docker exec -e PGPASSWORD=${dbPassword} ${options.container} pg_dump -U ${dbUser} -h localhost ${formatFlag} ${dbName} > ${backupFile}`,
-        { stdio: 'inherit' }
+      const dumpOutput = execFileSync(
+        'docker',
+        [
+          'exec',
+          '-e',
+          `PGPASSWORD=${dbPassword}`,
+          options.container,
+          'pg_dump',
+          '-U',
+          dbUser,
+          '-h',
+          'localhost',
+          formatFlag,
+          dbName
+        ],
+        { maxBuffer: 1024 * 1024 * 500 }
       )
+      fs.writeFileSync(backupFile, dumpOutput)
 
       const stats = fs.statSync(backupFile)
       console.log(chalk.green('✓ Backup completed successfully'))

--- a/cli/debug/workout.ts
+++ b/cli/debug/workout.ts
@@ -41,9 +41,21 @@ troubleshootWorkoutsCommand
         console.log(chalk.green(`Extracted Workout ID/Token: ${workoutId}`))
       }
 
-      if (url.includes('coachwatts.com')) {
-        isProd = true
-        console.log(chalk.yellow('Detected coachwatts.com URL. Forcing --prod mode.'))
+      try {
+        const parsedUrl = new URL(url.startsWith('http') ? url : `https://${url}`)
+        if (
+          parsedUrl.hostname === 'coachwatts.com' ||
+          parsedUrl.hostname.endsWith('.coachwatts.com')
+        ) {
+          isProd = true
+          console.log(chalk.yellow('Detected coachwatts.com URL. Forcing --prod mode.'))
+        }
+      } catch {
+        // Fallback for malformed URLs
+        if (url.includes('coachwatts.com')) {
+          isProd = true
+          console.log(chalk.yellow('Detected coachwatts.com URL. Forcing --prod mode.'))
+        }
       }
     }
 

--- a/cli/debug/workout.ts
+++ b/cli/debug/workout.ts
@@ -51,8 +51,7 @@ troubleshootWorkoutsCommand
           console.log(chalk.yellow('Detected coachwatts.com URL. Forcing --prod mode.'))
         }
       } catch {
-        // Fallback for malformed URLs
-        if (url.includes('coachwatts.com')) {
+        if (/^https?:\/\/(?:[a-z0-9-]+\.)*coachwatts\.com(?::\d+)?(?:\/|$)/i.test(url)) {
           isProd = true
           console.log(chalk.yellow('Detected coachwatts.com URL. Forcing --prod mode.'))
         }

--- a/cli/translations/check.ts
+++ b/cli/translations/check.ts
@@ -65,10 +65,10 @@ const checkCommand = new Command('check')
     console.log(chalk.bold('\n🔍 Extraction Check'))
     console.log(chalk.gray(`Running tolgee extract check on: ${patterns.join(', ')}\n`))
 
-    const patternArgs = patterns.map((p) => `"${p}"`).join(' ')
-
     try {
-      execSync(`npx tolgee extract check --patterns ${patternArgs}`, { stdio: 'inherit' })
+      execFileSync('npx', ['tolgee', 'extract', 'check', '--patterns', ...patterns], {
+        stdio: 'inherit'
+      })
       console.log(chalk.green('\n✓ No extraction warnings.'))
     } catch {
       // tolgee extract check exits non-zero on warnings — output already printed

--- a/cli/translations/sync-all.ts
+++ b/cli/translations/sync-all.ts
@@ -180,9 +180,11 @@ const syncAllCommand = new Command('sync-all')
 
     // 5. Pull translations
     console.log(chalk.bold('\n📥 Pulling translations from platform...\n'))
-    const { execSync } = await import('child_process')
+    const { execFileSync } = await import('child_process')
     try {
-      execSync(`npx tolgee pull --api-url "${apiUrl}" --api-key "${apiKey}"`, { stdio: 'inherit' })
+      execFileSync('npx', ['tolgee', 'pull', '--api-url', apiUrl, '--api-key', apiKey], {
+        stdio: 'inherit'
+      })
     } catch {
       console.error(chalk.red('Pull failed — run `pnpm i18n:pull` manually'))
       process.exit(1)

--- a/cli/translations/sync.ts
+++ b/cli/translations/sync.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import chalk from 'chalk'
 
 const syncCommand = new Command('sync')
@@ -25,17 +25,19 @@ const syncCommand = new Command('sync')
       process.exit(1)
     }
 
-    const patterns = (options.patterns as string[]).map((p) => `"${p}"`).join(' ')
+    const patterns = options.patterns as string[]
 
-    const cmd = [
-      `npx tolgee sync`,
-      `--api-url "${apiUrl}"`,
-      `--api-key "${apiKey}"`,
-      `--patterns ${patterns}`,
+    const args = [
+      'tolgee',
+      'sync',
+      '--api-url',
+      apiUrl,
+      '--api-key',
+      apiKey,
+      '--patterns',
+      ...patterns,
       dryRun ? '--dry-run' : '-Y'
     ]
-      .filter(Boolean)
-      .join(' ')
 
     console.log(chalk.bold('\n🔄 Syncing keys to Tolgee platform...\n'))
     if (dryRun) {
@@ -43,7 +45,7 @@ const syncCommand = new Command('sync')
     }
 
     try {
-      execSync(cmd, { stdio: 'inherit' })
+      execFileSync('npx', args, { stdio: 'inherit' })
       console.log(chalk.green('\n✓ Sync complete.'))
       if (!dryRun) {
         console.log(

--- a/cli/users/location.ts
+++ b/cli/users/location.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
+import { execFile } from 'child_process'
 import 'dotenv/config'
 import { PrismaClient } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
@@ -519,9 +520,9 @@ locationCommand
       const geoipPath = require.resolve('geoip-lite/package.json').replace('/package.json', '')
       console.log(chalk.gray(`Found geoip-lite at: ${geoipPath}`))
 
-      const command = `cd "${geoipPath}" && npm run-script updatedb license_key=${licenseKey}`
-
-      const child = exec(command)
+      const child = execFile('npm', ['run-script', 'updatedb', `license_key=${licenseKey}`], {
+        cwd: geoipPath
+      })
 
       child.stdout?.on('data', (data) => {
         console.log(chalk.gray(data.toString()))

--- a/server/api/nutrition/plan/meal.post.ts
+++ b/server/api/nutrition/plan/meal.post.ts
@@ -18,9 +18,7 @@ export default defineEventHandler(async (event) => {
     slotName: body.slotName,
     windowAssignmentsCount: Array.isArray(body.windowAssignments)
       ? body.windowAssignments.length
-      : 0,
-    mealTitle: body.meal?.title,
-    mealTotals: body.meal?.totals
+      : 0
   })
 
   try {

--- a/server/api/profile/index.patch.ts
+++ b/server/api/profile/index.patch.ts
@@ -50,9 +50,8 @@ export default defineEventHandler(async (event) => {
 
   if (!result.success) {
     console.warn('[PATCH /api/profile] Validation failed:', {
-      user: user.email,
-      errors: result.error.issues,
-      body: body
+      userId: user.id,
+      errors: result.error.issues
     })
     throw createError({
       statusCode: 400,
@@ -231,9 +230,8 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error) {
     console.error('[PATCH /api/profile] Update failed:', {
-      user: user.email,
-      error: error,
-      payload: data
+      userId: user.id,
+      error
     })
     throw createError({
       statusCode: 500,

--- a/server/api/releases/index.get.ts
+++ b/server/api/releases/index.get.ts
@@ -13,17 +13,20 @@ export default defineEventHandler(async () => {
       if (file.endsWith('.md')) {
         const filePath = path.join(releasesDir, file)
         try {
-          const [stats, content] = await Promise.all([
-            fs.stat(filePath),
-            fs.readFile(filePath, 'utf-8')
-          ])
-          const version = file.replace(/^v/, '').replace(/\.md$/, '')
+          const handle = await fs.open(filePath, 'r')
+          try {
+            const content = await handle.readFile('utf-8')
+            const stats = await handle.stat()
+            const version = file.replace(/^v/, '').replace(/\.md$/, '')
 
-          releaseNotes.push({
-            version: `v${version}`,
-            content,
-            date: stats.mtime
-          })
+            releaseNotes.push({
+              version: `v${version}`,
+              content,
+              date: stats.mtime
+            })
+          } finally {
+            await handle.close()
+          }
         } catch {
           // File may have been deleted or moved concurrently
           continue

--- a/server/api/releases/index.get.ts
+++ b/server/api/releases/index.get.ts
@@ -12,15 +12,22 @@ export default defineEventHandler(async () => {
     for (const file of files) {
       if (file.endsWith('.md')) {
         const filePath = path.join(releasesDir, file)
-        const stats = await fs.stat(filePath)
-        const content = await fs.readFile(filePath, 'utf-8')
-        const version = file.replace(/^v/, '').replace(/\.md$/, '')
+        try {
+          const [stats, content] = await Promise.all([
+            fs.stat(filePath),
+            fs.readFile(filePath, 'utf-8')
+          ])
+          const version = file.replace(/^v/, '').replace(/\.md$/, '')
 
-        releaseNotes.push({
-          version: `v${version}`,
-          content,
-          date: stats.mtime
-        })
+          releaseNotes.push({
+            version: `v${version}`,
+            content,
+            date: stats.mtime
+          })
+        } catch {
+          // File may have been deleted or moved concurrently
+          continue
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
Addresses open CodeQL code scanning alerts in the repository:
- Refactored CLI commands in `cli/changelog/generate.ts`, `cli/db/backup.ts`, `cli/translations/*.ts`, and `cli/users/location.ts` to use parameterized `execFileSync` / `execFile` array calls to prevent indirect command injection warnings.
- Resolved TOCTOU file system race condition in `server/api/releases/index.get.ts` and `cli/changelog/generate.ts`.
- Fixed incomplete URL domain substring check in `cli/debug/workout.ts` using `new URL()`.
- Redacted sensitive fields (email, raw input payload) from console log statements in server profile and nutrition plan handlers.
- Dismissed false positives (SHA-256 API key hashing, HMAC WS token signing, CLI output/export, and `ride-atlas.html` POC) on GitHub Security.