### PR TITLE
fix(docker): lower NODE_OPTIONS heap limit to 8192 to prevent runner OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . .
 # Typecheck is NOT run here: the CI workflow (.github/workflows/ci.yml) runs it on a
 # GitHub-hosted runner and gates the deploy job, so it fails minutes earlier and we
 # don't pay for it twice per push. Run `pnpm typecheck` locally before building by hand.
-RUN NODE_OPTIONS=--max-old-space-size=14336 pnpm build
+RUN NODE_OPTIONS=--max-old-space-size=8192 pnpm build
 
 # Stage 3: Production image
 FROM base AS runner

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -23,7 +23,7 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 ENV SOURCEMAP=false
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN NODE_OPTIONS=--max-old-space-size=14336 pnpm build
+RUN NODE_OPTIONS=--max-old-space-size=8192 pnpm build
 
 FROM base AS runner
 ENV NODE_ENV=production


### PR DESCRIPTION
Reduces  from 14336MB (14GB) to 8192MB (8GB) in  and . The 14GB limit was starving the self-hosted Mac Mini runner of memory during Docker build, causing the runner process to crash and lose connection with GitHub.