### PR TITLE
chore(push): Expo push reliability and observability (CW-120)

### DIFF
--- a/docs/04-guides/deployment.md
+++ b/docs/04-guides/deployment.md
@@ -78,6 +78,7 @@ https://your-domain.com/api/integrations/whoop/callback
 - [ ] Google OAuth Console - Callback URLs updated
 - [ ] Strava API Settings - Callback domain updated (if applicable)
 - [ ] WHOOP Developer Portal - Callback URL updated (if applicable)
+- [ ] `EXPO_ACCESS_TOKEN` - Optional; recommended for production companion push (see [Expo Push](./expo-push.md))
 
 ### Testing Authentication
 

--- a/docs/04-guides/expo-push.md
+++ b/docs/04-guides/expo-push.md
@@ -1,0 +1,75 @@
+# Expo Push — Ops Configuration & Delivery Strategy
+
+Server-side Expo push for the Coach Watts mobile companion is implemented in
+`server/utils/expo-push.ts` via `sendExpoPushToUser`. Sends are **best-effort**:
+callers are never blocked on push failure.
+
+## Production configuration
+
+| Variable            | Required | Description                                                                                                                                                                                                                                                                    |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `EXPO_ACCESS_TOKEN` | Optional | Expo access token. When set, `sendExpoPushToUser` sends `Authorization: Bearer <token>` on `https://exp.host/--/api/v2/push/send`. Recommended in production so Expo can attribute / rate-limit traffic to your project and so higher send volumes stay within account limits. |
+
+Create a token in the [Expo access token settings](https://expo.dev/accounts/[account]/settings/access-tokens)
+with push-related scope. Store it only in the server environment (Vercel / host
+secrets) — never in the mobile client or public runtime config.
+
+Other push-related data lives in Postgres (`MobilePushDevice`,
+`MobilePushPreference`); no additional Expo env vars are required for basic
+sends.
+
+## Current send behavior
+
+1. Honor per-user preference gates (`isMobilePushTypeEnabled`).
+2. Load all registered device tokens for the user.
+3. POST a batch to Expo’s push API (with optional access-token header).
+4. Parse per-device tickets:
+   - `DeviceNotRegistered` → prune the token from `MobilePushDevice`.
+   - Any other ticket error → structured `console.warn` with `userId`,
+     `type`, `deviceId`, token suffix, Expo `error` code, and message.
+5. Emit a structured `send_completed` info log with
+   `deviceCount` / `ok` / `ticketErrors` / `pruned` / `receiptIdCount`.
+
+Domain callers keep best-effort semantics unless product later requires hard
+failure.
+
+## Receipt polling / delivery confirmation — decision
+
+**Decision: defer receipt polling until push volume or incident rate warrants it.**
+
+Expo push is two-phase:
+
+1. **Tickets** (immediate) — accept/reject at the push API. We already act on
+   these (prune + structured error logs).
+2. **Receipts** (async, via ticket `id`) — confirm APNs/FCM delivery and surface
+   delayed errors (`DeviceNotRegistered` after the fact, provider errors).
+
+### Why defer
+
+- Companion push volume is still low; ticket-level observability covers the
+  failures we can act on immediately.
+- Receipt polling needs durable storage of ticket IDs, a delayed job
+  (Trigger.dev task or cron), and prune/metrics wiring — outside the current
+  reliability scope and would expand owned surface into `trigger/`.
+- Successful tickets already expose `id`; we count them as `receiptIdCount` in
+  the completion log so a future worker can be scoped without changing the
+  send contract.
+
+### When to implement
+
+Revisit when any of these are true:
+
+- Production push volume makes silent APNs/FCM failures operationally costly.
+- Support tickets show “notification not received” with successful ticket logs.
+- Expo rate limits or `InvalidCredentials` appear in ticket-error logs.
+
+**Recommended future shape:** persist ticket IDs (or enqueue them) from
+`sendExpoPushToUser`, then a Trigger.dev task polls
+`https://exp.host/--/api/v2/push/getReceipts` after ~15 minutes, prunes
+`DeviceNotRegistered`, and emits delivery metrics.
+
+## Related
+
+- Preferences API / gates: issues 364–365
+- Event-type wiring: issues 366–367
+- Original reliability gap: issue 368 / Linear CW-120

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,6 +114,7 @@ Instructional documents for developers.
 
 - [**Implementation Guide**](./04-guides/implementation-guide.md) - Step-by-step build instructions.
 - [**Deployment Guide**](./04-guides/deployment.md) - Environment setup and deployment checklist.
+- [**Expo Push**](./04-guides/expo-push.md) - Mobile companion push ops config, ticket logging, and deferred receipt strategy.
 - [**Issue Management**](./04-guides/issue-management.md) - Guidelines for creating and managing GitHub issues.
 - [**Localization**](./04-guides/localization.md) - Guide to internationalization (i18n) using Tolgee and Nuxt UI.
 - [**Analytics Tracking**](./04-guides/analytics-tracking.md) - Documentation for GA4/GTM events and implementation.

--- a/docs/issues/368-expo-push-reliability-observability.md
+++ b/docs/issues/368-expo-push-reliability-observability.md
@@ -2,7 +2,7 @@
 
 **Priority:** Low  
 **Type:** Tech debt / Ops  
-**Status:** Open  
+**Status:** Resolved (CW-120)  
 **Area:** `mobile, notifications, push`
 
 ## Summary
@@ -26,6 +26,6 @@ best-effort semantics for domain callers unless product requires hard failure.
 
 ## Acceptance Criteria
 
-- [ ] Documented ops config for Expo push in production
-- [ ] At least ticket-level errors beyond DeviceNotRegistered are handled or logged clearly
-- [ ] Receipt or equivalent observability path decided (implement or explicitly defer)
+- [x] Documented ops config for Expo push in production — `docs/04-guides/expo-push.md`
+- [x] At least ticket-level errors beyond DeviceNotRegistered are handled or logged clearly — structured `ticket_error` / `send_completed` logs in `server/utils/expo-push.ts`
+- [x] Receipt or equivalent observability path decided (implement or explicitly defer) — deferred; rationale in expo-push guide

--- a/docs/issues/issues.md
+++ b/docs/issues/issues.md
@@ -802,7 +802,7 @@ Push inventory/policy from watts-marketing `knowledge/push/`. Device register +
 | [365](./365-expo-push-ignores-preferences.md)       | Expo push send ignores preference gates           | High     | Gap / Privacy          | Fixed  |
 | [366](./366-expo-high-value-event-types-unwired.md) | High-value Expo types unused (analysis, coaching) | Medium   | Feature / Gap          | Open   |
 | [367](./367-sync-completed-push-no-policy.md)       | SYNC_COMPLETED Expo type has no send policy       | Low      | Product decision / Gap | Open   |
-| [368](./368-expo-push-reliability-observability.md) | Expo push reliability and observability gaps      | Low      | Tech debt / Ops        | Open   |
+| [368](./368-expo-push-reliability-observability.md) | Expo push reliability and observability gaps      | Low      | Tech debt / Ops        | Fixed  |
 
 ### Suggested fix order (364–368)
 

--- a/server/utils/expo-push.ts
+++ b/server/utils/expo-push.ts
@@ -22,10 +22,33 @@ type ExpoPushTicket = {
 
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
 
+function buildExpoPushHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Accept-Encoding': 'gzip, deflate',
+    'Content-Type': 'application/json'
+  }
+
+  const accessToken = process.env.EXPO_ACCESS_TOKEN?.trim()
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`
+  }
+
+  return headers
+}
+
+function tokenSuffix(token: string | undefined): string | undefined {
+  if (!token || token.length < 8) return undefined
+  return token.slice(-8)
+}
+
 /**
  * Send an Expo push to all registered devices for a user.
  * Honors server push preferences (issue 365). Best-effort: never throws to
  * callers; logs skips / failures and prunes DeviceNotRegistered tokens.
+ *
+ * Optional `EXPO_ACCESS_TOKEN` is sent as `Authorization: Bearer …` when set.
+ * Receipt polling is intentionally deferred — see docs/04-guides/expo-push.md.
  */
 export async function sendExpoPushToUser(userId: string, payload: ExpoPushPayload): Promise<void> {
   try {
@@ -62,29 +85,61 @@ export async function sendExpoPushToUser(userId: string, payload: ExpoPushPayloa
 
     const response = await fetch(EXPO_PUSH_URL, {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Accept-Encoding': 'gzip, deflate',
-        'Content-Type': 'application/json'
-      },
+      headers: buildExpoPushHeaders(),
       body: JSON.stringify(messages)
     })
 
     if (!response.ok) {
-      console.warn(`Expo push send failed for user ${userId}: HTTP ${response.status}`)
+      console.warn(`Expo push send failed for user ${userId}: HTTP ${response.status}`, {
+        userId,
+        type: payload.type,
+        notificationId: payload.notificationId,
+        deviceCount: devices.length,
+        httpStatus: response.status,
+        reason: 'http_error'
+      })
       return
     }
 
     const json = (await response.json()) as { data?: ExpoPushTicket[] }
     const tickets = json.data ?? []
     const staleTokens: string[] = []
+    let okCount = 0
+    let ticketErrorCount = 0
+    let receiptIdCount = 0
 
     for (let i = 0; i < tickets.length; i++) {
       const ticket = tickets[i]
-      if (ticket?.status === 'error' && ticket.details?.error === 'DeviceNotRegistered') {
-        const token = devices[i]?.token
-        if (token) staleTokens.push(token)
+      const device = devices[i]
+      if (!ticket) continue
+
+      if (ticket.status === 'ok') {
+        okCount++
+        if (ticket.id) receiptIdCount++
+        continue
       }
+
+      ticketErrorCount++
+      const errorCode = ticket.details?.error
+
+      if (errorCode === 'DeviceNotRegistered') {
+        const token = device?.token
+        if (token) staleTokens.push(token)
+        continue
+      }
+
+      // MessageTooBig, MessageRateExceeded, InvalidCredentials, etc.
+      console.warn('Expo push ticket error', {
+        userId,
+        type: payload.type,
+        notificationId: payload.notificationId,
+        deviceId: device?.id,
+        tokenSuffix: tokenSuffix(device?.token),
+        ticketIndex: i,
+        error: errorCode ?? 'unknown',
+        message: ticket.message,
+        reason: 'ticket_error'
+      })
     }
 
     if (staleTokens.length > 0) {
@@ -92,6 +147,18 @@ export async function sendExpoPushToUser(userId: string, payload: ExpoPushPayloa
         where: { token: { in: staleTokens } }
       })
     }
+
+    console.info('Expo push send completed', {
+      userId,
+      type: payload.type,
+      notificationId: payload.notificationId,
+      deviceCount: devices.length,
+      ok: okCount,
+      ticketErrors: ticketErrorCount,
+      pruned: staleTokens.length,
+      receiptIdCount,
+      reason: 'send_completed'
+    })
   } catch (error) {
     console.warn(`Expo push send failed for user ${userId}:`, error)
   }


### PR DESCRIPTION
Fixes CW-120

## Summary
- Add optional `EXPO_ACCESS_TOKEN` Bearer header support in `sendExpoPushToUser`
- Log non-`DeviceNotRegistered` Expo ticket errors with structured context, plus send completion metrics
- Document production ops config and explicitly defer receipt polling in `docs/04-guides/expo-push.md`

## Test plan
- [x] `pnpm typecheck` (clean)
- [x] `pnpm exec vitest run tests/unit/server/utils/expo-push.test.ts` (3 passed)
- [ ] Confirm production env can set `EXPO_ACCESS_TOKEN` when ready for higher push volume