### PR TITLE
fix(garmin): add constant-time OAuth state parameter validation (CW-98)

### DIFF
--- a/server/api/integrations/garmin/authorize.get.ts
+++ b/server/api/integrations/garmin/authorize.get.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto'
 import { getServerSession } from '../../../utils/session'
 import { generateCodeVerifier, generateCodeChallenge } from '../../../utils/pkce'
 
@@ -18,9 +19,18 @@ export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
   if (!session?.user?.email) throw createError({ statusCode: 401, message: 'Unauthorized' })
 
-  const config = useRuntimeConfig()
+  let config: any
+  try {
+    config = useRuntimeConfig()
+  } catch {
+    config = {}
+  }
   const clientId = process.env.GARMIN_CLIENT_ID
-  const siteUrl = (config.public.siteUrl || 'http://localhost:3000').replace(/\/+$/, '')
+  const siteUrl = (
+    config?.public?.siteUrl ||
+    process.env.NUXT_PUBLIC_SITE_URL ||
+    'http://localhost:3000'
+  ).replace(/\/+$/, '')
   const redirectUri = `${siteUrl}/api/integrations/garmin/callback`
 
   if (!clientId) {
@@ -32,15 +42,19 @@ export default defineEventHandler(async (event) => {
 
   const verifier = generateCodeVerifier()
   const challenge = generateCodeChallenge(verifier)
+  const state = randomBytes(32).toString('hex')
 
-  // Store verifier in a cookie to retrieve in callback
-  setCookie(event, 'garmin_code_verifier', verifier, {
+  // Store verifier and state in cookies to retrieve and validate in callback
+  const cookieOpts = {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: 'lax' as const,
     maxAge: 600,
     path: '/'
-  })
+  }
+
+  setCookie(event, 'garmin_code_verifier', verifier, cookieOpts)
+  setCookie(event, 'garmin_oauth_state', state, cookieOpts)
 
   const authUrl = new URL('https://connect.garmin.com/oauth2Confirm')
   authUrl.searchParams.set('client_id', clientId)
@@ -48,6 +62,7 @@ export default defineEventHandler(async (event) => {
   authUrl.searchParams.set('response_type', 'code')
   authUrl.searchParams.set('code_challenge', challenge)
   authUrl.searchParams.set('code_challenge_method', 'S256')
+  authUrl.searchParams.set('state', state)
 
   return sendRedirect(event, authUrl.toString())
 })

--- a/server/api/integrations/garmin/callback.get.ts
+++ b/server/api/integrations/garmin/callback.get.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto'
 import { dispatchTask } from '../../../utils/task-dispatcher'
 import { getServerSession } from '../../../utils/session'
 import { prisma } from '../../../utils/db'
@@ -16,17 +17,39 @@ defineRouteMeta({
   }
 })
 
+function safeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
+}
+
+function clearAuthCookies(event: any) {
+  deleteCookie(event, 'garmin_code_verifier')
+  deleteCookie(event, 'garmin_oauth_state')
+}
+
 export default defineEventHandler(async (event) => {
   const session = await getServerSession(event)
   if (!session?.user?.id) throw createError({ statusCode: 401, message: 'Unauthorized' })
 
-  const { code, error: garminError } = getQuery(event)
+  const { code, state, error: garminError } = getQuery(event)
   const verifier = getCookie(event, 'garmin_code_verifier')
+  const savedState = getCookie(event, 'garmin_oauth_state')
 
   if (garminError) {
     console.error('[GarminCallback] Garmin returned authorization error:', garminError)
-    deleteCookie(event, 'garmin_code_verifier')
+    clearAuthCookies(event)
     return sendRedirect(event, '/settings/apps?garmin_error=access-denied')
+  }
+
+  if (!state || !savedState || !safeCompare(state as string, savedState)) {
+    console.warn('[GarminCallback] OAuth state mismatch or missing', {
+      hasState: !!state,
+      hasSavedState: !!savedState
+    })
+    clearAuthCookies(event)
+    return sendRedirect(event, '/settings/apps?garmin_error=state-mismatch')
   }
 
   if (!code || !verifier) {
@@ -34,7 +57,7 @@ export default defineEventHandler(async (event) => {
       hasCode: !!code,
       hasVerifier: !!verifier
     })
-    deleteCookie(event, 'garmin_code_verifier')
+    clearAuthCookies(event)
     return sendRedirect(event, '/settings/apps?garmin_error=missing-verifier')
   }
 
@@ -61,6 +84,7 @@ export default defineEventHandler(async (event) => {
     const errorData = await response.json().catch(() => ({}))
     console.error('[GarminCallback] Token exchange failed', errorData)
     deleteCookie(event, 'garmin_code_verifier')
+    deleteCookie(event, 'garmin_oauth_state')
     return sendRedirect(event, '/settings/apps?garmin_error=token-exchange-failed')
   }
 
@@ -76,6 +100,7 @@ export default defineEventHandler(async (event) => {
       status: userResponse.status
     })
     deleteCookie(event, 'garmin_code_verifier')
+    deleteCookie(event, 'garmin_oauth_state')
     return sendRedirect(event, '/settings/apps?garmin_error=profile-fetch-failed')
   }
 
@@ -85,6 +110,7 @@ export default defineEventHandler(async (event) => {
   if (!externalUserId) {
     console.error('[GarminCallback] Garmin user profile missing externalUserId')
     deleteCookie(event, 'garmin_code_verifier')
+    deleteCookie(event, 'garmin_oauth_state')
     return sendRedirect(event, '/settings/apps?garmin_error=profile-fetch-failed')
   }
 
@@ -108,6 +134,7 @@ export default defineEventHandler(async (event) => {
       existingOwnerUserId: existingOwner.userId
     })
     deleteCookie(event, 'garmin_code_verifier')
+    deleteCookie(event, 'garmin_oauth_state')
     return sendRedirect(event, '/settings/apps?garmin_error=account-already-linked')
   }
 

--- a/tests/unit/server/api/integrations/garmin-oauth-state.test.ts
+++ b/tests/unit/server/api/integrations/garmin-oauth-state.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', vi.fn())
+vi.stubGlobal('useRuntimeConfig', () => ({ public: { siteUrl: 'https://coachwatts.com' } }))
+vi.stubGlobal('getQuery', (event: any) => event.query || {})
+vi.stubGlobal('getCookie', (event: any, key: string) => event.cookies?.[key])
+vi.stubGlobal('setCookie', (event: any, key: string, value: string) => {
+  event.setCookies = event.setCookies || {}
+  event.setCookies[key] = value
+})
+vi.stubGlobal('deleteCookie', (event: any, key: string) => {
+  event.deletedCookies = event.deletedCookies || []
+  event.deletedCookies.push(key)
+})
+vi.stubGlobal('sendRedirect', (event: any, location: string) => ({ redirect: location }))
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => ({ public: { siteUrl: 'https://coachwatts.com' } }),
+  defineRouteMeta: vi.fn(),
+  defineEventHandler: (fn: any) => fn,
+  getQuery: (event: any) => event.query || {},
+  getCookie: (event: any, key: string) => event.cookies?.[key],
+  setCookie: (event: any, key: string, value: string) => {
+    event.setCookies = event.setCookies || {}
+    event.setCookies[key] = value
+  },
+  deleteCookie: (event: any, key: string) => {
+    event.deletedCookies = event.deletedCookies || []
+    event.deletedCookies.push(key)
+  },
+  sendRedirect: (event: any, location: string) => ({ redirect: location }),
+  createError: (err: any) => {
+    const error = new Error(err.message || err.statusMessage)
+    ;(error as any).statusCode = err.statusCode
+    return error
+  }
+}))
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/pkce', () => ({
+  generateCodeVerifier: () => 'test-verifier-12345678901234567890',
+  generateCodeChallenge: () => 'test-challenge'
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    integration: {
+      findFirst: vi.fn(),
+      upsert: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/garmin', () => ({
+  refreshGarminIntegrationPermissions: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/task-dispatcher', () => ({
+  dispatchTask: vi.fn()
+}))
+
+const getAuthorizeHandler = async () => {
+  const mod = await import('../../../../../server/api/integrations/garmin/authorize.get')
+  return mod.default
+}
+
+const getCallbackHandler = async () => {
+  const mod = await import('../../../../../server/api/integrations/garmin/callback.get')
+  return mod.default
+}
+
+describe('Garmin OAuth State Binding (CW-98)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.GARMIN_CLIENT_ID = 'test-client-id'
+    process.env.GARMIN_CLIENT_SECRET = 'test-client-secret'
+  })
+
+  describe('GET /api/integrations/garmin/authorize', () => {
+    it('sets garmin_oauth_state cookie and includes state in authUrl', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({
+        user: { email: 'athlete@example.com' }
+      } as any)
+
+      const handler = await getAuthorizeHandler()
+      const event: any = { setCookies: {} }
+      const res = await handler(event)
+
+      expect(event.setCookies.garmin_code_verifier).toBe('test-verifier-12345678901234567890')
+      expect(event.setCookies.garmin_oauth_state).toBeDefined()
+      expect(event.setCookies.garmin_oauth_state).toHaveLength(64) // hex 32 bytes
+
+      const url = new URL(res.redirect)
+      expect(url.searchParams.get('state')).toBe(event.setCookies.garmin_oauth_state)
+    })
+  })
+
+  describe('GET /api/integrations/garmin/callback', () => {
+    it('redirects with state-mismatch error when state is missing or mismatched', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+
+      const handler = await getCallbackHandler()
+      const event: any = {
+        query: { code: 'valid-code', state: 'invalid-state' },
+        cookies: { garmin_code_verifier: 'verifier', garmin_oauth_state: 'correct-state' },
+        deletedCookies: []
+      }
+
+      const res = await handler(event)
+
+      expect(res.redirect).toContain('garmin_error=state-mismatch')
+      expect(event.deletedCookies).toContain('garmin_code_verifier')
+      expect(event.deletedCookies).toContain('garmin_oauth_state')
+    })
+
+    it('rejects missing state query parameter', async () => {
+      vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+
+      const handler = await getCallbackHandler()
+      const event: any = {
+        query: { code: 'valid-code' },
+        cookies: { garmin_code_verifier: 'verifier', garmin_oauth_state: 'correct-state' },
+        deletedCookies: []
+      }
+
+      const res = await handler(event)
+      expect(res.redirect).toContain('garmin_error=state-mismatch')
+    })
+  })
+})


### PR DESCRIPTION
Fixes CW-98

### Summary
Adds cryptographic OAuth `state` parameter generation in `authorize.get.ts` and constant-time `timingSafeEqual` validation in `callback.get.ts` with full cookie cleanup.

### Verification
- Ran `pnpm test:unit tests/unit/server/api/integrations/garmin-oauth-state.test.ts` (3/3 tests passed).
- Ran `pnpm typecheck:server` (clean pass).