### PR TITLE
fix(billing): only show checkout success UI when subscription activation is confirmed (CW-3)

### DIFF
--- a/app/i18n/en/settings.json
+++ b/app/i18n/en/settings.json
@@ -43,6 +43,8 @@
   "automation_workouts_upgrade_desc": "Upgrade to Supporter to enable automatic workout analysis.",
   "banner_exit": "Exit",
   "billing_access_expires": "Access Expires",
+  "billing_activation_pending_desc": "Your checkout was received, but account activation is taking a moment. If your tier has not updated yet, click Sync to refresh status.",
+  "billing_activation_pending_title": "Subscription Activation Pending",
   "billing_active_subscription": "Active Subscription",
   "billing_amount": "Amount",
   "billing_button_change_plan": "Change Plan",

--- a/app/pages/settings/billing.vue
+++ b/app/pages/settings/billing.vue
@@ -55,7 +55,8 @@
 
   const loadingPortal = ref(false)
   const syncing = ref(false)
-  const showSuccessMessage = ref(route.query.success === 'true')
+  const showSuccessMessage = ref(false)
+  const showPendingActivationMessage = ref(false)
   const showRefreshMessage = ref(route.query.refresh === 'true')
   const showCanceledMessage = ref(route.query.canceled === 'true')
   const showPlansModal = ref(false)
@@ -108,12 +109,20 @@
       window.addEventListener('focus', handleFocus)
     }
 
-    if (showSuccessMessage.value || showRefreshMessage.value) {
+    const hasSuccessQuery = route.query.success === 'true'
+    if (hasSuccessQuery || showRefreshMessage.value) {
       await pollSubscription()
-      if (userStore.user?.subscriptionStatus === 'ACTIVE') {
+      if (
+        userStore.user?.subscriptionStatus === 'ACTIVE' &&
+        userStore.user?.subscriptionTier !== 'FREE'
+      ) {
         triggerCelebration()
         showSuccessMessage.value = true
+        showPendingActivationMessage.value = false
         maybeTrackPurchase()
+      } else {
+        showSuccessMessage.value = false
+        showPendingActivationMessage.value = true
       }
     } else {
       try {
@@ -414,6 +423,18 @@
       await $fetch<any, string & {}>('/api/stripe/sync', { method: 'POST' })
       await userStore.fetchUser(true)
 
+      if (
+        userStore.user?.subscriptionStatus === 'ACTIVE' &&
+        userStore.user?.subscriptionTier !== 'FREE'
+      ) {
+        showPendingActivationMessage.value = false
+        if (!showSuccessMessage.value) {
+          showSuccessMessage.value = true
+          triggerCelebration()
+          maybeTrackPurchase()
+        }
+      }
+
       if (!silent) {
         const toast = useToast()
         toast.add({
@@ -438,6 +459,7 @@
 
   function dismissSuccessMessage() {
     showSuccessMessage.value = false
+    showPendingActivationMessage.value = false
     confettiPieces.value = []
   }
 
@@ -659,6 +681,34 @@
       >
         <template #icon>
           <UIcon name="i-heroicons-arrow-path" class="w-5 h-5 animate-spin" />
+        </template>
+      </UAlert>
+
+      <UAlert
+        v-if="showPendingActivationMessage && !isPremium && !polling"
+        :title="tr('billing_activation_pending_title', 'Subscription Activation Pending')"
+        icon="i-heroicons-clock"
+        color="warning"
+        variant="soft"
+        :close="{ color: 'warning', variant: 'link', label: t('billing_dismiss') }"
+        :description="
+          tr(
+            'billing_activation_pending_desc',
+            'Your checkout was received, but account activation is taking a moment. If your tier has not updated yet, click Sync to refresh status.'
+          )
+        "
+        @update:open="dismissSuccessMessage"
+      >
+        <template #actions>
+          <UButton
+            color="warning"
+            variant="solid"
+            size="sm"
+            :loading="syncing"
+            @click="() => handleSync(false)"
+          >
+            {{ t('billing_button_sync') }}
+          </UButton>
         </template>
       </UAlert>
 

--- a/tests/unit/app/pages/billing-activation.test.ts
+++ b/tests/unit/app/pages/billing-activation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+describe('Billing Checkout Success UI (CW-3)', () => {
+  it('determines success message visibility based on confirmed ACTIVE status', () => {
+    const isConfirmedActive = (status: string, tier: string) => {
+      return status === 'ACTIVE' && tier !== 'FREE'
+    }
+
+    expect(isConfirmedActive('ACTIVE', 'PRO')).toBe(true)
+    expect(isConfirmedActive('ACTIVE', 'SUPPORTER')).toBe(true)
+    expect(isConfirmedActive('NONE', 'FREE')).toBe(false)
+    expect(isConfirmedActive('PAST_DUE', 'SUPPORTER')).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes CW-3

### Summary
Prevents billing checkout success/celebration UI from persisting when subscription status polling completes without finding an ACTIVE subscription. Displays a pending activation warning banner with manual Sync button instead.

### Verification
- Ran `pnpm test:unit tests/unit/app/pages/billing-activation.test.ts` (1/1 test passed).
- Ran `pnpm typecheck:app` (clean pass).