### PR TITLE
feat(email): reclassify Welcome email as TRANSACTIONAL (CW-107)

### DIFF
--- a/docs/02-features/email-communication.md
+++ b/docs/02-features/email-communication.md
@@ -27,9 +27,9 @@ The Coach Watts Email Communication System is a centralized, compliant, and bran
 
 ## Campaigns & Automated Flows
 
-### 1. Onboarding (Transactional/Engagement)
+### 1. Onboarding (Transactional)
 
-- **Welcome**: Sent immediately upon signup.
+- **Welcome**: Sent immediately upon signup as a required TRANSACTIONAL account creation notice (`preferenceKey: null`).
 - **Drip (Planned)**: Day 2 (Integration Check) and Day 7 (Trial Review) sequence using Trigger.dev delays.
 
 ### 2. Training Guidance (Engagement)

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -330,7 +330,7 @@ export default NuxtAuthHandler({
           userId: user.id,
           templateKey: 'Welcome',
           eventKey: 'USER_SIGNED_UP_FOLLOWUP',
-          audience: 'ENGAGEMENT',
+          audience: 'TRANSACTIONAL',
           subject: 'Welcome to Coach Watts!',
           props: {
             name: user.name || 'Athlete',

--- a/server/utils/email-template-registry.ts
+++ b/server/utils/email-template-registry.ts
@@ -27,11 +27,11 @@ export const EMAIL_TEMPLATE_REGISTRY: Record<string, EmailTemplateDefinition> = 
   Welcome: {
     templateKey: 'Welcome',
     defaultSubject: 'Welcome to Coach Watts!',
-    audience: 'ENGAGEMENT',
-    preferenceKey: 'onboarding',
+    audience: 'TRANSACTIONAL',
+    preferenceKey: null,
     requiredProps: [],
     utmCampaign: 'welcome_onboarding',
-    utmMedium: 'lifecycle'
+    utmMedium: 'transactional'
   },
   WorkoutReceived: {
     templateKey: 'WorkoutReceived',

--- a/tests/unit/trigger/send-email.test.ts
+++ b/tests/unit/trigger/send-email.test.ts
@@ -52,7 +52,7 @@ describe('sendEmailTask', () => {
     userId: 'user-123',
     templateKey: 'Welcome',
     eventKey: 'SIGNUP',
-    audience: 'ENGAGEMENT' as const,
+    audience: 'TRANSACTIONAL' as const,
     subject: 'Welcome!'
   }
 
@@ -63,12 +63,16 @@ describe('sendEmailTask', () => {
     emailStatus: 'VALID'
   }
 
-  it('should skip if email is suppressed', async () => {
+  it('should skip if email is suppressed for ENGAGEMENT audience', async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
     vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue({ id: 'sup-1' } as any)
 
-    const result = await EmailDeliveryService.runSendEmail(mockPayload)
+    const result = await EmailDeliveryService.runSendEmail({
+      ...mockPayload,
+      templateKey: 'WorkoutAnalysisReady',
+      audience: 'ENGAGEMENT'
+    })
 
     expect(result).toBeUndefined()
     expect(prisma.emailDelivery.create).not.toHaveBeenCalled()
@@ -141,7 +145,7 @@ describe('sendEmailTask', () => {
     expect(prisma.emailDelivery.create).not.toHaveBeenCalled()
   })
 
-  it('should skip if user email status is BOUNCED', async () => {
+  it('should skip if user email status is BOUNCED for ENGAGEMENT audience', async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       ...mockUser,
       emailStatus: 'BOUNCED'
@@ -149,9 +153,33 @@ describe('sendEmailTask', () => {
     vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
 
-    const result = await EmailDeliveryService.runSendEmail(mockPayload)
+    const result = await EmailDeliveryService.runSendEmail({
+      ...mockPayload,
+      templateKey: 'WorkoutAnalysisReady',
+      audience: 'ENGAGEMENT'
+    })
 
     expect(result).toBeUndefined()
     expect(prisma.emailDelivery.create).not.toHaveBeenCalled()
+  })
+
+  it('should deliver Welcome TRANSACTIONAL email even if globalUnsubscribe is true', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      ...mockUser,
+      emailPreferences: [{ channel: 'EMAIL', globalUnsubscribe: true }]
+    } as any)
+    vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailDelivery.create).mockResolvedValue({ id: 'delivery-welcome' } as any)
+    vi.spyOn(EmailDeliveryService, 'dispatch').mockResolvedValue({
+      id: 'delivery-welcome',
+      status: 'SENT'
+    } as any)
+
+    const result = await EmailDeliveryService.runSendEmail(mockPayload)
+
+    expect(result.success).toBe(true)
+    expect(result.deliveryId).toBe('delivery-welcome')
+    expect(prisma.emailDelivery.create).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Fixes CW-107

### Summary
Reclassifies the product `Welcome` email template as `audience: 'TRANSACTIONAL'` and `preferenceKey: null`. Ensures new account welcome emails are delivered reliably upon signup without risk of suppression from global unsubscribe or onboarding email preference toggles.

### Verification
- Ran `pnpm test:unit tests/unit/trigger/send-email.test.ts` (6/6 tests passed).
- Ran `pnpm typecheck:server` (clean pass).