### PR TITLE
fix(email): inject siteUrl and logoUrl props into vue email templates (CW-115)

### DIFF
--- a/app/emails/AccountDeletionScheduled.vue
+++ b/app/emails/AccountDeletionScheduled.vue
@@ -18,6 +18,8 @@
     initiatedBy: 'self' | 'admin'
     actorEmail?: string | null
     requestedAt: string
+    siteUrl?: string
+    logoUrl?: string
     unsubscribeUrl?: string
     utmQuery?: string
   }
@@ -25,12 +27,12 @@
   const props = withDefaults(defineProps<Props>(), {
     name: 'Athlete',
     actorEmail: null,
+    siteUrl: 'https://coachwatts.com',
+    logoUrl: 'https://coachwatts.com/icon.png',
     unsubscribeUrl: '',
     utmQuery: ''
   })
 
-  const siteUrl = 'https://coachwatts.com'
-  const logoUrl = 'https://coachwatts.com/icon.png'
   const supportEmail = 'hello@coachwatts.com'
   const formattedRequestedAt = new Date(props.requestedAt).toLocaleString('en-US', {
     dateStyle: 'medium',

--- a/app/emails/DailyRecommendation.vue
+++ b/app/emails/DailyRecommendation.vue
@@ -15,17 +15,22 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    date: string
-    recommendation: string
-    reasoning: string
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const siteUrl = 'https://coachwatts.com'
+  withDefaults(
+    defineProps<{
+      name?: string
+      date: string
+      recommendation: string
+      reasoning: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/app/emails/SubscriptionStarted.vue
+++ b/app/emails/SubscriptionStarted.vue
@@ -15,15 +15,20 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    tier: string
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const siteUrl = 'https://coachwatts.com'
+  withDefaults(
+    defineProps<{
+      name?: string
+      tier: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/app/emails/ThresholdUpdateDetected.vue
+++ b/app/emails/ThresholdUpdateDetected.vue
@@ -14,24 +14,29 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    workoutId?: string
-    workoutUrl?: string
-    workoutTitle: string
-    metricLabel: string // e.g. "Functional Threshold Power"
-    sportProfileName?: string
-    oldValue: number
-    newValue: number
-    unit: string // e.g. "W" or "bpm"
-    peakValue: number
-    percentIncrease?: number
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const siteUrl = 'https://coachwatts.com'
+  withDefaults(
+    defineProps<{
+      name?: string
+      workoutId?: string
+      workoutUrl?: string
+      workoutTitle: string
+      metricLabel: string // e.g. "Functional Threshold Power"
+      sportProfileName?: string
+      oldValue: number
+      newValue: number
+      unit: string // e.g. "W" or "bpm"
+      peakValue: number
+      percentIncrease?: number
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/app/emails/TrialEndingSoon.vue
+++ b/app/emails/TrialEndingSoon.vue
@@ -14,18 +14,23 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    trialEndsAt: string
-    usageHighlights?: Array<{ operation: string; count: number }>
-    supporterHighlights?: Array<{ label: string; value: string }>
-    pricingUrl?: string
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-
-  const siteUrl = 'https://coachwatts.com'
-  const logoUrl = 'https://coachwatts.com/icon.png'
+  withDefaults(
+    defineProps<{
+      name?: string
+      trialEndsAt: string
+      usageHighlights?: Array<{ operation: string; count: number }>
+      supporterHighlights?: Array<{ label: string; value: string }>
+      pricingUrl?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/app/emails/Welcome.vue
+++ b/app/emails/Welcome.vue
@@ -14,14 +14,22 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-  const siteUrl = 'https://coachwatts.com'
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const connectSourceUrl = 'https://coachwatts.com/settings/apps'
+  import { computed } from 'vue'
+
+  const props = withDefaults(
+    defineProps<{
+      name?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+  const connectSourceUrl = computed(() => `${props.siteUrl}/settings/apps`)
   const discordUrl = 'https://discord.gg/dPYkzg49T9'
 </script>
 

--- a/app/emails/WorkoutAnalysisReady.vue
+++ b/app/emails/WorkoutAnalysisReady.vue
@@ -17,28 +17,33 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    workoutId?: string
-    workoutUrl?: string
-    workoutTitle: string
-    workoutDate?: string
-    workoutType?: string
-    durationMinutes?: number
-    averageHr?: number
-    averageWatts?: number
-    tss?: number
-    overallScore?: number
-    analysisSummary?: string
-    recommendationHighlights?: string[]
-    adherenceSummary?: string
-    adherenceScore?: number
-    unsubscribeUrl?: string
-    utmQuery?: string
-  }>()
-
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const siteUrl = 'https://coachwatts.com'
+  withDefaults(
+    defineProps<{
+      name?: string
+      workoutId?: string
+      workoutUrl?: string
+      workoutTitle: string
+      workoutDate?: string
+      workoutType?: string
+      durationMinutes?: number
+      averageHr?: number
+      averageWatts?: number
+      tss?: number
+      overallScore?: number
+      analysisSummary?: string
+      recommendationHighlights?: string[]
+      adherenceSummary?: string
+      adherenceScore?: number
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/app/emails/WorkoutReceived.vue
+++ b/app/emails/WorkoutReceived.vue
@@ -57,6 +57,7 @@
       streamInsightBullets?: string[]
       streamInsightWhatItMeans?: string
       streamInsightNextSuggestion?: string
+      workoutUrl?: string
       siteUrl?: string
       logoUrl?: string
       unsubscribeUrl?: string

--- a/app/emails/WorkoutReceived.vue
+++ b/app/emails/WorkoutReceived.vue
@@ -17,54 +17,58 @@
     EFont
   } from 'vue-email'
 
-  defineProps<{
-    name?: string
-    workoutId: string
-    workoutTitle: string
-    previewLine?: string
-    heroTitle?: string
-    introLine?: string
-    workoutDate?: string
-    workoutType?: string
-    durationMinutes?: number
-    distanceKm?: number
-    elevationGain?: number
-    averageCadence?: number
-    cadenceUnit?: string
-    averageHr?: number
-    maxHr?: number
-    averageWatts?: number
-    normalizedPower?: number
-    tss?: number
-    tss7d?: number
-    weeklyTssBaseline28d?: number
-    loadContextLabel?: string
-    loadContextBody?: string
-    loadDeltaPct?: number
-    sportLensLabel?: string
-    sportLensBody?: string
-    kilojoules?: number
-    calories?: number
-    workoutsLast7Days?: number
-    consistencyMessage?: string
-    quickTakeLabel?: string
-    quickTakeBody?: string
-    efficiencyMessage?: string
-    recoveryMessage?: string
-    ctaLabel?: string
-    nextStepMessage?: string
-    streamInsightBullets?: string[]
-    streamInsightWhatItMeans?: string
-    streamInsightNextSuggestion?: string
-    workoutUrl?: string
-    unsubscribeUrl?: string
-    shareUrl?: string
-    chatUrl?: string
-    utmQuery?: string
-  }>()
-
-  const logoUrl = 'https://coachwatts.com/icon.png'
-  const siteUrl = 'https://coachwatts.com'
+  withDefaults(
+    defineProps<{
+      name?: string
+      workoutId: string
+      workoutTitle: string
+      previewLine?: string
+      heroTitle?: string
+      introLine?: string
+      workoutDate?: string
+      workoutType?: string
+      durationMinutes?: number
+      distanceKm?: number
+      elevationGain?: number
+      averageCadence?: number
+      cadenceUnit?: string
+      averageHr?: number
+      maxHr?: number
+      averageWatts?: number
+      normalizedPower?: number
+      tss?: number
+      tss7d?: number
+      weeklyTssBaseline28d?: number
+      loadContextLabel?: string
+      loadContextBody?: string
+      loadDeltaPct?: number
+      sportLensLabel?: string
+      sportLensBody?: string
+      kilojoules?: number
+      calories?: number
+      workoutsLast7Days?: number
+      consistencyMessage?: string
+      quickTakeLabel?: string
+      quickTakeBody?: string
+      efficiencyMessage?: string
+      recoveryMessage?: string
+      ctaLabel?: string
+      nextStepMessage?: string
+      streamInsightBullets?: string[]
+      streamInsightWhatItMeans?: string
+      streamInsightNextSuggestion?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      shareUrl?: string
+      chatUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
 </script>
 
 <template>

--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -178,6 +178,8 @@ export const EmailDeliveryService = {
     }
 
     const finalProps: Record<string, any> = {
+      siteUrl: baseUrl,
+      logoUrl: `${baseUrl}/icon.png`,
       ...props,
       unsubscribeUrl,
       utmQuery


### PR DESCRIPTION
Fixes CW-115

### Summary
Injects `siteUrl` and `logoUrl` into Vue email templates (`app/emails/*.vue`) via `withDefaults(defineProps(...))` and `emailDeliveryService.ts` `finalProps`. Replaces hardcoded `https://coachwatts.com` links to support custom environment site URLs (staging, local, preview).

### Verification
- Passed `pnpm test:unit`
- Passed `pnpm typecheck:server`