### PR TITLE
chore(ops): remove unused POSTMARK_API_KEY stub from .env.example (CW-114)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,9 +91,6 @@ SENTRY_AUTH_TOKEN="your-sentry-auth-token"
 SENTRY_ORG="your-sentry-org"
 SENTRY_PROJECT="your-sentry-project"
 
-# Postmark Email API
-POSTMARK_API_KEY="your-postmark-api-key"
-
 # Rate Limiting
 WEBHOOK_RATE_LIMIT_MAX=100
 WEBHOOK_RATE_LIMIT_TTL=60


### PR DESCRIPTION
Fixes CW-114

### Summary
Removes the unused `POSTMARK_API_KEY` environment variable stub from `.env.example` to eliminate ops noise and ensure configuration accuracy (Coach Watts uses Resend exclusively for outbound email).

### Verification
- Verified no TypeScript/runtime references to `POSTMARK_API_KEY` exist.
- Passed `pnpm typecheck:server`.