### PR TITLE
refactor(account): route account deletion notice through EmailDeliveryService.runSendEmail (CW-113)

### DIFF
--- a/server/utils/services/accountDeletionService.ts
+++ b/server/utils/services/accountDeletionService.ts
@@ -4,7 +4,6 @@ import { dispatchTask } from '../task-dispatcher'
 import { registerTaskHandler } from '../task-registry'
 import { deRegisterGarminUser } from '../garmin'
 import { getEmailTemplateDefinition } from '../email-template-registry'
-import { getInternalApiToken } from '../internal-api-token'
 import { EmailDeliveryService } from './emailDeliveryService'
 
 type DeletionActorType = 'self' | 'admin'
@@ -126,58 +125,20 @@ export async function runDeleteUserAccount(payload: {
 
       if (template) {
         try {
-          const baseUrl = process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'
-          const internalApiToken = getInternalApiToken()
-
-          if (!internalApiToken) {
-            throw new Error('INTERNAL_API_TOKEN is not configured')
-          }
-
-          const renderResponse = await fetch(`${baseUrl}/api/internal/render-email`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-internal-api-token': internalApiToken
+          await EmailDeliveryService.runSendEmail({
+            userId: user.id,
+            templateKey: 'AccountDeletionScheduled',
+            eventKey: 'ACCOUNT_DELETION_SCHEDULED',
+            audience: 'TRANSACTIONAL',
+            subject: template.defaultSubject,
+            props: {
+              name: user.name || 'Athlete',
+              requestedAt: notificationEmail.requestedAt,
+              initiatedBy: notificationEmail.initiatedBy,
+              actorEmail: notificationEmail.actorEmail || null
             },
-            body: JSON.stringify({
-              templateKey: 'AccountDeletionScheduled',
-              props: {
-                name: user.name || 'Athlete',
-                requestedAt: notificationEmail.requestedAt,
-                initiatedBy: notificationEmail.initiatedBy,
-                actorEmail: notificationEmail.actorEmail || null
-              }
-            })
+            idempotencyKey: `account-deletion-scheduled:${user.id}:${notificationEmail.requestedAt}`
           })
-
-          if (!renderResponse.ok) {
-            throw new Error(`Render API failed (${renderResponse.status})`)
-          }
-
-          const rendered = (await renderResponse.json()) as { html: string; text: string }
-          const delivery = await prisma.emailDelivery.create({
-            data: {
-              userId: user.id,
-              toEmail: user.email,
-              templateKey: template.templateKey,
-              eventKey: 'ACCOUNT_DELETION_SCHEDULED',
-              audience: template.audience,
-              subject: template.defaultSubject,
-              htmlBody: rendered.html,
-              textBody: rendered.text,
-              status: 'QUEUED',
-              idempotencyKey: `account-deletion-scheduled:${user.id}:${notificationEmail.requestedAt}`,
-              metadata: {
-                requestedAt: notificationEmail.requestedAt,
-                initiatedBy: notificationEmail.initiatedBy,
-                actorEmail: notificationEmail.actorEmail || null
-              } as any
-            }
-          })
-
-          if (process.env.DISABLE_EMAILS !== 'true') {
-            await EmailDeliveryService.dispatch(delivery.id)
-          }
         } catch (error) {
           console.error('Failed to send account deletion email', { userId, error })
         }


### PR DESCRIPTION
Fixes CW-113

### Summary
Refactors `runDeleteUserAccount` in `server/utils/services/accountDeletionService.ts` to use `EmailDeliveryService.runSendEmail` instead of executing custom render API fetch and manual `EmailDelivery` DB insertion/dispatch. This unifies account deletion notifications under the standard email delivery pipeline conventions (shared headers, token generation, idempotency tracking, and delivery logging).

### Verification
- Passed `pnpm typecheck:server`
- Passed `pnpm test:unit tests/unit/app/emails/templates.test.ts`