### PR TITLE
feat(email): register CoachInvite and TeamInvite templates & route invite emails through EmailDeliveryService (CW-108)

### DIFF
--- a/app/emails/CoachInvite.vue
+++ b/app/emails/CoachInvite.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+  import {
+    EText,
+    EContainer,
+    EHeading,
+    EButton,
+    EHtml,
+    EHead,
+    EPreview,
+    EBody,
+    ESection,
+    EImg,
+    ELink,
+    EFont
+  } from 'vue-email'
+
+  withDefaults(
+    defineProps<{
+      coachName?: string
+      joinUrl?: string
+      code?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      coachName: 'A coach',
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+</script>
+
+<template>
+  <EHtml lang="en">
+    <EHead>
+      <EFont
+        font-family="Public Sans"
+        fallback-font-family="sans-serif"
+        :web-font="{
+          url: 'https://fonts.gstatic.com/s/publicsans/v14/ijwQs572Xtc6ZYQws9YVwnNGfJ4.woff2',
+          format: 'woff2'
+        }"
+        :font-weight="400"
+        font-style="normal"
+      />
+    </EHead>
+    <EPreview>{{ coachName }} invited you to Coach Watts.</EPreview>
+    <EBody
+      style="
+        background-color: #f4f4f5;
+        font-family: 'Public Sans', Inter, sans-serif;
+        padding: 40px 0;
+      "
+    >
+      <EContainer
+        style="
+          background-color: #ffffff;
+          margin: 0 auto;
+          border-radius: 12px;
+          border: 1px solid #e4e4e7;
+          overflow: hidden;
+          max-width: 600px;
+          box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.05),
+            0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        "
+      >
+        <ESection
+          style="
+            background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+            height: 4px;
+            width: 100%;
+          "
+        ></ESection>
+        <ESection style="padding: 32px 40px 0; text-align: center">
+          <ELink :href="siteUrl + (utmQuery || '')">
+            <EImg
+              :src="logoUrl"
+              width="64"
+              height="64"
+              alt="Coach Watts"
+              style="margin: 0 auto; border-radius: 12px; display: block"
+            />
+          </ELink>
+        </ESection>
+        <ESection style="padding: 32px 40px">
+          <EHeading
+            style="
+              font-size: 24px;
+              font-weight: 700;
+              color: #09090b;
+              margin-top: 0;
+              margin-bottom: 18px;
+              letter-spacing: -0.025em;
+            "
+          >
+            {{ coachName }} wants to coach you
+          </EHeading>
+          <EText style="font-size: 15px; line-height: 1.6; color: #71717a; margin-bottom: 20px">
+            Open the invitation below to connect your athlete account with your coach inside Coach
+            Watts.
+          </EText>
+          <div
+            v-if="code"
+            style="
+              background-color: #fafafa;
+              border: 1px solid #e4e4e7;
+              border-radius: 12px;
+              padding: 16px;
+              margin-bottom: 24px;
+              text-align: center;
+            "
+          >
+            <EText
+              style="
+                font-size: 10px;
+                font-weight: 900;
+                color: #71717a;
+                margin: 0 0 6px;
+                letter-spacing: 0.2em;
+                text-transform: uppercase;
+              "
+            >
+              Invite Code
+            </EText>
+            <EText
+              style="
+                font-size: 24px;
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-weight: 800;
+                color: #00c16a;
+                margin: 0;
+              "
+            >
+              {{ code.toUpperCase() }}
+            </EText>
+          </div>
+          <div style="text-align: center; margin-bottom: 24px">
+            <EButton
+              :href="
+                (joinUrl || siteUrl) + (utmQuery || '') + '&utm_content=cta_accept_coach_invite'
+              "
+              style="
+                background-color: #00c16a;
+                background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+                color: #ffffff;
+                padding: 14px 28px;
+                border-radius: 12px;
+                font-weight: 600;
+                text-decoration: none;
+                display: inline-block;
+              "
+            >
+              Accept Invitation
+            </EButton>
+          </div>
+        </ESection>
+        <ESection
+          style="background-color: #fafafa; padding: 32px 40px; border-top: 1px solid #e4e4e7"
+        >
+          <EText style="font-size: 14px; font-weight: 600; color: #09090b; margin: 0 0 8px">
+            Coach Watts
+          </EText>
+          <EText style="font-size: 12px; color: #71717a; line-height: 1.6; margin: 0">
+            AI-powered endurance coaching that adapts to you.
+          </EText>
+        </ESection>
+      </EContainer>
+    </EBody>
+  </EHtml>
+</template>

--- a/app/emails/TeamInvite.vue
+++ b/app/emails/TeamInvite.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+  import {
+    EText,
+    EContainer,
+    EHeading,
+    EButton,
+    EHtml,
+    EHead,
+    EPreview,
+    EBody,
+    ESection,
+    EImg,
+    ELink,
+    EFont
+  } from 'vue-email'
+
+  withDefaults(
+    defineProps<{
+      teamName?: string
+      roleLabel?: string
+      joinUrl?: string
+      code?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      teamName: 'A team',
+      roleLabel: 'a member',
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+</script>
+
+<template>
+  <EHtml lang="en">
+    <EHead>
+      <EFont
+        font-family="Public Sans"
+        fallback-font-family="sans-serif"
+        :web-font="{
+          url: 'https://fonts.gstatic.com/s/publicsans/v14/ijwQs572Xtc6ZYQws9YVwnNGfJ4.woff2',
+          format: 'woff2'
+        }"
+        :font-weight="400"
+        font-style="normal"
+      />
+    </EHead>
+    <EPreview>You're invited to join {{ teamName }} on Coach Watts.</EPreview>
+    <EBody
+      style="
+        background-color: #f4f4f5;
+        font-family: 'Public Sans', Inter, sans-serif;
+        padding: 40px 0;
+      "
+    >
+      <EContainer
+        style="
+          background-color: #ffffff;
+          margin: 0 auto;
+          border-radius: 12px;
+          border: 1px solid #e4e4e7;
+          overflow: hidden;
+          max-width: 600px;
+          box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.05),
+            0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        "
+      >
+        <ESection
+          style="
+            background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+            height: 4px;
+            width: 100%;
+          "
+        ></ESection>
+        <ESection style="padding: 32px 40px 0; text-align: center">
+          <ELink :href="siteUrl + (utmQuery || '')">
+            <EImg
+              :src="logoUrl"
+              width="64"
+              height="64"
+              alt="Coach Watts"
+              style="margin: 0 auto; border-radius: 12px; display: block"
+            />
+          </ELink>
+        </ESection>
+        <ESection style="padding: 32px 40px">
+          <EHeading
+            style="
+              font-size: 24px;
+              font-weight: 700;
+              color: #09090b;
+              margin-top: 0;
+              margin-bottom: 18px;
+              letter-spacing: -0.025em;
+            "
+          >
+            Join {{ teamName }}
+          </EHeading>
+          <EText style="font-size: 15px; line-height: 1.6; color: #71717a; margin-bottom: 20px">
+            You've been invited to join <strong>{{ teamName }}</strong> as {{ roleLabel }} inside
+            Coach Watts.
+          </EText>
+          <div
+            v-if="code"
+            style="
+              background-color: #fafafa;
+              border: 1px solid #e4e4e7;
+              border-radius: 12px;
+              padding: 16px;
+              margin-bottom: 24px;
+              text-align: center;
+            "
+          >
+            <EText
+              style="
+                font-size: 10px;
+                font-weight: 900;
+                color: #71717a;
+                margin: 0 0 6px;
+                letter-spacing: 0.2em;
+                text-transform: uppercase;
+              "
+            >
+              Invite Code
+            </EText>
+            <EText
+              style="
+                font-size: 24px;
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-weight: 800;
+                color: #00c16a;
+                margin: 0;
+              "
+            >
+              {{ code.toUpperCase() }}
+            </EText>
+          </div>
+          <div style="text-align: center; margin-bottom: 24px">
+            <EButton
+              :href="
+                (joinUrl || siteUrl) + (utmQuery || '') + '&utm_content=cta_accept_team_invite'
+              "
+              style="
+                background-color: #00c16a;
+                background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+                color: #ffffff;
+                padding: 14px 28px;
+                border-radius: 12px;
+                font-weight: 600;
+                text-decoration: none;
+                display: inline-block;
+              "
+            >
+              Accept Invitation
+            </EButton>
+          </div>
+        </ESection>
+        <ESection
+          style="background-color: #fafafa; padding: 32px 40px; border-top: 1px solid #e4e4e7"
+        >
+          <EText style="font-size: 14px; font-weight: 600; color: #09090b; margin: 0 0 8px">
+            Coach Watts
+          </EText>
+          <EText style="font-size: 12px; color: #71717a; line-height: 1.6; margin: 0">
+            AI-powered endurance coaching that adapts to you.
+          </EText>
+        </ESection>
+      </EContainer>
+    </EBody>
+  </EHtml>
+</template>

--- a/server/utils/coach-athlete-invite-email.ts
+++ b/server/utils/coach-athlete-invite-email.ts
@@ -1,13 +1,5 @@
-import { sendEmail } from './email'
-
-function escapeHtml(value: string) {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;')
-}
+import { EmailDeliveryService } from './services/emailDeliveryService'
+import { getEmailTemplateDefinition } from './email-template-registry'
 
 export async function sendCoachAthleteInviteEmail(options: {
   to: string
@@ -16,46 +8,20 @@ export async function sendCoachAthleteInviteEmail(options: {
   code: string
 }) {
   const coachName = options.coachName.trim() || 'A coach'
-  const safeCoachName = escapeHtml(coachName)
-  const safeJoinUrl = escapeHtml(options.joinUrl)
-  const safeCode = escapeHtml(options.code.toUpperCase())
+  const template = getEmailTemplateDefinition('CoachInvite')
+  const subject = template?.defaultSubject || `${coachName} invited you to Coach Watts`
 
-  const subject = `${coachName} invited you to Coach Watts`
-  const html = `
-    <div style="font-family: Inter, Arial, sans-serif; color: #111827; line-height: 1.6; max-width: 560px; margin: 0 auto; padding: 24px;">
-      <p style="font-size: 12px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: #2563eb; margin: 0 0 12px;">
-        Coach Invitation
-      </p>
-      <h1 style="font-size: 28px; line-height: 1.1; margin: 0 0 16px;">${safeCoachName} wants to coach you</h1>
-      <p style="margin: 0 0 24px; color: #4b5563;">
-        Open the invitation below to connect your athlete account with your coach inside Coach Watts.
-      </p>
-      <p style="margin: 0 0 24px;">
-        <a href="${safeJoinUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; text-decoration: none; padding: 12px 18px; border-radius: 10px; font-weight: 700;">
-          Accept Invitation
-        </a>
-      </p>
-      <div style="border: 1px solid #e5e7eb; border-radius: 12px; padding: 16px; margin-bottom: 24px;">
-        <p style="margin: 0 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; color: #6b7280; font-weight: 700;">
-          Invite Code
-        </p>
-        <p style="margin: 0; font-size: 24px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 800; color: #1d4ed8;">
-          ${safeCode}
-        </p>
-      </div>
-      <p style="margin: 0 0 8px; color: #4b5563;">If the button does not work, use this link:</p>
-      <p style="margin: 0; word-break: break-all;">
-        <a href="${safeJoinUrl}" style="color: #2563eb;">${safeJoinUrl}</a>
-      </p>
-    </div>
-  `
-
-  const text = `${coachName} invited you to Coach Watts.\n\nAccept the invitation: ${options.joinUrl}\n\nInvite code: ${options.code.toUpperCase()}`
-
-  return await sendEmail({
-    to: options.to,
+  return await EmailDeliveryService.runSendEmail({
+    toEmail: options.to,
+    templateKey: 'CoachInvite',
+    eventKey: 'COACH_ATHLETE_INVITE',
+    audience: 'TRANSACTIONAL',
     subject,
-    html,
-    text
+    props: {
+      coachName,
+      joinUrl: options.joinUrl,
+      code: options.code.toUpperCase()
+    },
+    idempotencyKey: `coach-invite:${options.to}:${options.code.toUpperCase()}`
   })
 }

--- a/server/utils/email-template-registry.ts
+++ b/server/utils/email-template-registry.ts
@@ -130,6 +130,24 @@ export const EMAIL_TEMPLATE_REGISTRY: Record<string, EmailTemplateDefinition> = 
     requiredProps: [],
     utmCampaign: 'subscription_canceled',
     utmMedium: 'transactional'
+  },
+  CoachInvite: {
+    templateKey: 'CoachInvite',
+    defaultSubject: 'You have been invited to Coach Watts',
+    audience: 'TRANSACTIONAL',
+    preferenceKey: null,
+    requiredProps: ['coachName', 'joinUrl', 'code'],
+    utmCampaign: 'coach_invite',
+    utmMedium: 'transactional'
+  },
+  TeamInvite: {
+    templateKey: 'TeamInvite',
+    defaultSubject: 'You have been invited to join a team on Coach Watts',
+    audience: 'TRANSACTIONAL',
+    preferenceKey: null,
+    requiredProps: ['teamName', 'joinUrl', 'code'],
+    utmCampaign: 'team_invite',
+    utmMedium: 'transactional'
   }
 }
 

--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -95,7 +95,8 @@ export const EmailDeliveryService = {
   },
 
   async runSendEmail(payload: {
-    userId: string
+    userId?: string
+    toEmail?: string
     templateKey: string
     eventKey: string
     audience: EmailAudience
@@ -103,7 +104,16 @@ export const EmailDeliveryService = {
     props?: Record<string, any>
     idempotencyKey?: string
   }) {
-    const { userId, templateKey, eventKey, audience, subject, props = {}, idempotencyKey } = payload
+    const {
+      userId,
+      toEmail,
+      templateKey,
+      eventKey,
+      audience,
+      subject,
+      props = {},
+      idempotencyKey
+    } = payload
 
     const template = getEmailTemplateDefinition(templateKey)
 
@@ -111,61 +121,73 @@ export const EmailDeliveryService = {
       return
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      include: { emailPreferences: true }
-    })
+    const user = userId
+      ? await prisma.user.findUnique({
+          where: { id: userId },
+          include: { emailPreferences: true }
+        })
+      : toEmail
+        ? await prisma.user.findUnique({
+            where: { email: toEmail },
+            include: { emailPreferences: true }
+          })
+        : null
 
-    if (!user) return
+    const recipientEmail = toEmail || user?.email
+    if (!recipientEmail) return
 
-    if (user.emailStatus !== 'VALID' && audience !== 'TRANSACTIONAL') return
+    if (user && user.emailStatus !== 'VALID' && audience !== 'TRANSACTIONAL') return
 
-    const preference = user.emailPreferences.find((p) => p.channel === 'EMAIL')
-    const globalUnsub = Boolean(preference?.globalUnsubscribe)
-    if (globalUnsub && audience !== 'TRANSACTIONAL') return
+    if (user) {
+      const preference = user.emailPreferences.find((p) => p.channel === 'EMAIL')
+      const globalUnsub = Boolean(preference?.globalUnsubscribe)
+      if (globalUnsub && audience !== 'TRANSACTIONAL') return
 
-    if (template?.preferenceKey && audience !== 'TRANSACTIONAL') {
-      const isEnabled = preference ? Boolean((preference as any)[template.preferenceKey]) : true
-      if (!isEnabled) return
-    }
+      if (template?.preferenceKey && audience !== 'TRANSACTIONAL') {
+        const isEnabled = preference ? Boolean((preference as any)[template.preferenceKey]) : true
+        if (!isEnabled) return
+      }
 
-    if (template?.cooldownHours && template.cooldownHours > 0) {
-      const throttleKeys = Object.values(EMAIL_TEMPLATE_REGISTRY)
-        .filter((entry) => entry.throttleGroup && entry.throttleGroup === template.throttleGroup)
-        .map((entry) => entry.templateKey)
-      const throttleTemplateKeys = throttleKeys.length > 0 ? throttleKeys : [templateKey]
-      const lookbackFrom = new Date(Date.now() - template.cooldownHours * 60 * 60 * 1000)
-      const activeStatuses: EmailDeliveryStatus[] = [
-        'QUEUED',
-        'SENDING',
-        'SENT',
-        'DELIVERED',
-        'OPENED',
-        'CLICKED'
-      ]
+      if (template?.cooldownHours && template.cooldownHours > 0) {
+        const throttleKeys = Object.values(EMAIL_TEMPLATE_REGISTRY)
+          .filter((entry) => entry.throttleGroup && entry.throttleGroup === template.throttleGroup)
+          .map((entry) => entry.templateKey)
+        const throttleTemplateKeys = throttleKeys.length > 0 ? throttleKeys : [templateKey]
+        const lookbackFrom = new Date(Date.now() - template.cooldownHours * 60 * 60 * 1000)
+        const activeStatuses: EmailDeliveryStatus[] = [
+          'QUEUED',
+          'SENDING',
+          'SENT',
+          'DELIVERED',
+          'OPENED',
+          'CLICKED'
+        ]
 
-      const recentDelivery = await prisma.emailDelivery.findFirst({
-        where: {
-          userId,
-          templateKey: { in: throttleTemplateKeys },
-          createdAt: { gte: lookbackFrom },
-          status: { in: activeStatuses }
-        },
-        orderBy: { createdAt: 'desc' }
-      })
+        const recentDelivery = await prisma.emailDelivery.findFirst({
+          where: {
+            userId: user.id,
+            templateKey: { in: throttleTemplateKeys },
+            createdAt: { gte: lookbackFrom },
+            status: { in: activeStatuses }
+          },
+          orderBy: { createdAt: 'desc' }
+        })
 
-      if (recentDelivery) return
+        if (recentDelivery) return
+      }
     }
 
     const isSuppressed = await prisma.emailSuppression.findFirst({
-      where: { email: user.email, active: true }
+      where: { email: recipientEmail, active: true }
     })
 
     if (isSuppressed && audience !== 'TRANSACTIONAL') return
 
     const baseUrl = process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'
-    const unsubToken = generateUnsubscribeToken(userId)
-    const unsubscribeUrl = `${baseUrl}/unsubscribe?token=${unsubToken}`
+    const unsubToken = user ? generateUnsubscribeToken(user.id) : ''
+    const unsubscribeUrl = unsubToken
+      ? `${baseUrl}/unsubscribe?token=${unsubToken}`
+      : `${baseUrl}/profile/settings?tab=communication`
 
     let utmQuery = ''
     if (template) {
@@ -218,8 +240,8 @@ export const EmailDeliveryService = {
     try {
       delivery = await prisma.emailDelivery.create({
         data: {
-          userId: user.id,
-          toEmail: user.email,
+          userId: user?.id || null,
+          toEmail: recipientEmail,
           templateKey,
           eventKey,
           audience,

--- a/server/utils/team-invite-email.ts
+++ b/server/utils/team-invite-email.ts
@@ -1,13 +1,5 @@
-import { sendEmail } from './email'
-
-function escapeHtml(value: string) {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;')
-}
+import { EmailDeliveryService } from './services/emailDeliveryService'
+import { getEmailTemplateDefinition } from './email-template-registry'
 
 function formatRoleLabel(role: string) {
   switch (role) {
@@ -30,48 +22,22 @@ export async function sendTeamInviteEmail(options: {
   code: string
 }) {
   const teamName = options.teamName.trim() || 'A team'
-  const safeTeamName = escapeHtml(teamName)
-  const safeJoinUrl = escapeHtml(options.joinUrl)
-  const safeCode = escapeHtml(options.code.toUpperCase())
   const roleLabel = formatRoleLabel(options.role)
-  const safeRoleLabel = escapeHtml(roleLabel)
+  const template = getEmailTemplateDefinition('TeamInvite')
+  const subject = template?.defaultSubject || `You're invited to join ${teamName} on Coach Watts`
 
-  const subject = `You're invited to join ${teamName} on Coach Watts`
-  const html = `
-    <div style="font-family: Inter, Arial, sans-serif; color: #111827; line-height: 1.6; max-width: 560px; margin: 0 auto; padding: 24px;">
-      <p style="font-size: 12px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: #2563eb; margin: 0 0 12px;">
-        Team Invitation
-      </p>
-      <h1 style="font-size: 28px; line-height: 1.1; margin: 0 0 16px;">Join ${safeTeamName}</h1>
-      <p style="margin: 0 0 24px; color: #4b5563;">
-        You've been invited to join <strong>${safeTeamName}</strong> as ${safeRoleLabel} inside Coach Watts.
-      </p>
-      <p style="margin: 0 0 24px;">
-        <a href="${safeJoinUrl}" style="display: inline-block; background: #2563eb; color: #ffffff; text-decoration: none; padding: 12px 18px; border-radius: 10px; font-weight: 700;">
-          Accept Invitation
-        </a>
-      </p>
-      <div style="border: 1px solid #e5e7eb; border-radius: 12px; padding: 16px; margin-bottom: 24px;">
-        <p style="margin: 0 0 8px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; color: #6b7280; font-weight: 700;">
-          Invite Code
-        </p>
-        <p style="margin: 0; font-size: 24px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-weight: 800; color: #1d4ed8;">
-          ${safeCode}
-        </p>
-      </div>
-      <p style="margin: 0 0 8px; color: #4b5563;">If the button does not work, use this link:</p>
-      <p style="margin: 0; word-break: break-all;">
-        <a href="${safeJoinUrl}" style="color: #2563eb;">${safeJoinUrl}</a>
-      </p>
-    </div>
-  `
-
-  const text = `You've been invited to join ${teamName} as ${roleLabel} on Coach Watts.\n\nAccept the invitation: ${options.joinUrl}\n\nInvite code: ${options.code.toUpperCase()}`
-
-  return await sendEmail({
-    to: options.to,
+  return await EmailDeliveryService.runSendEmail({
+    toEmail: options.to,
+    templateKey: 'TeamInvite',
+    eventKey: 'TEAM_INVITE',
+    audience: 'TRANSACTIONAL',
     subject,
-    html,
-    text
+    props: {
+      teamName,
+      roleLabel,
+      joinUrl: options.joinUrl,
+      code: options.code.toUpperCase()
+    },
+    idempotencyKey: `team-invite:${options.to}:${options.code.toUpperCase()}`
   })
 }


### PR DESCRIPTION
Fixes CW-108

### Summary
1. Created branded Vue email templates `CoachInvite.vue` and `TeamInvite.vue` in `app/emails/`.
2. Registered both templates in `EMAIL_TEMPLATE_REGISTRY` (`server/utils/email-template-registry.ts`) with `audience: 'TRANSACTIONAL'`.
3. Updated `EmailDeliveryService.runSendEmail` (`server/utils/services/emailDeliveryService.ts`) to support `toEmail` payloads (attaching `userId` when an existing user account exists or sending transactional invite mail to target emails).
4. Refactored `sendCoachAthleteInviteEmail` (`server/utils/coach-athlete-invite-email.ts`) and `sendTeamInviteEmail` (`server/utils/team-invite-email.ts`) to dispatch registered Vue templates through `EmailDeliveryService.runSendEmail`.

### Verification
- Passed `pnpm typecheck:server`
- Passed `pnpm test:unit tests/unit/app/emails/templates.test.ts`