### PR TITLE
feat(email): document email preference key mapping & annotate upcoming channels (CW-112)

### DIFF
--- a/app/components/profile/CommunicationSettings.vue
+++ b/app/components/profile/CommunicationSettings.vue
@@ -268,9 +268,14 @@
               />
             </UFormField>
             <UFormField name="planUpdates">
+              <template #label>
+                <div class="flex items-center gap-2">
+                  <span>{{ t('comm_label_plan_updates') }}</span>
+                  <UBadge color="neutral" variant="subtle" size="xs">Coming Soon</UBadge>
+                </div>
+              </template>
               <UCheckbox
                 v-model="state.planUpdates"
-                :label="t('comm_label_plan_updates')"
                 :description="t('comm_desc_plan_updates')"
                 :disabled="state.globalUnsubscribe"
               />
@@ -299,9 +304,14 @@
 
           <div class="space-y-6">
             <UFormField name="productUpdates">
+              <template #label>
+                <div class="flex items-center gap-2">
+                  <span>{{ t('comm_label_product_updates') }}</span>
+                  <UBadge color="neutral" variant="subtle" size="xs">Coming Soon</UBadge>
+                </div>
+              </template>
               <UCheckbox
                 v-model="state.productUpdates"
-                :label="t('comm_label_product_updates')"
                 :description="t('comm_desc_product_updates')"
                 :disabled="state.globalUnsubscribe"
               />

--- a/docs/02-features/email-communication.md
+++ b/docs/02-features/email-communication.md
@@ -62,6 +62,20 @@ Users can manage their experience in **Settings > Profile > Communication**:
 - **Plan Updates**: Notification of coaching adjustments.
 - **Global Unsubscribe**: Instantly opt-out of all optional communication.
 
+### Preference Key to Template Mapping
+
+| Preference Key     | Setting Channel               | Active Templates / Senders                                                         | Audience & Default Opt-In |
+| :----------------- | :---------------------------- | :--------------------------------------------------------------------------------- | :------------------------ |
+| `dailyCoach`       | Daily Training Recommendation | `DailyRecommendation`                                                              | ENGAGEMENT (Opt-in)       |
+| `workoutAnalysis`  | Workout Analysis              | `WorkoutAnalysisReady`, `WorkoutReceived`                                          | ENGAGEMENT (Opt-in)       |
+| `thresholdUpdates` | Threshold Updates             | `ThresholdUpdateDetected`                                                          | ENGAGEMENT (Opt-in)       |
+| `retentionNudges`  | Retention & Trial Nudges      | `TrialEndingSoon`                                                                  | ENGAGEMENT (Opt-in)       |
+| `onboarding`       | Onboarding Sequence           | `Welcome`, `OnboardingDripDay2`, `OnboardingDripDay7`                              | ENGAGEMENT (Opt-in)       |
+| `billing`          | Subscription & Billing        | `PaymentFailed`, `PaymentSucceeded`, `SubscriptionCanceled`, `SubscriptionStarted` | TRANSACTIONAL (Required)  |
+| `planUpdates`      | Plan Updates                  | _(Sender in development)_                                                          | ENGAGEMENT (Opt-in)       |
+| `productUpdates`   | Product Updates               | _(Sender in development)_                                                          | ENGAGEMENT (Opt-in)       |
+| `marketing`        | Marketing & News              | Broadcast emails (`/api/admin/email-deliveries/broadcast`)                         | ENGAGEMENT (Opt-out)      |
+
 ## Developer CLI Commands
 
 - `pnpm cw:cli email queue-welcome <userId>`: Test the welcome sequence.


### PR DESCRIPTION
Fixes CW-112

### Summary
1. Documented complete `Preference Key -> Active Templates / Senders` mapping table in `docs/02-features/email-communication.md`.
2. Annotated upcoming preference channels (`planUpdates`, `productUpdates`) with a subtle `Coming Soon` badge in `CommunicationSettings.vue` so users clearly understand channel statuses without overpromising live senders.

### Verification
- Passed `pnpm typecheck:server`