### PR TITLE
feat(email): implement Day 2 and Day 7 onboarding drip sequence (CW-109)

### DIFF
--- a/app/emails/OnboardingDripDay2.vue
+++ b/app/emails/OnboardingDripDay2.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+  import {
+    EText,
+    EContainer,
+    EHeading,
+    EButton,
+    EHtml,
+    EHead,
+    EPreview,
+    EBody,
+    ESection,
+    EImg,
+    ELink,
+    EFont
+  } from 'vue-email'
+
+  withDefaults(
+    defineProps<{
+      name?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+</script>
+
+<template>
+  <EHtml lang="en">
+    <EHead>
+      <EFont
+        font-family="Public Sans"
+        fallback-font-family="sans-serif"
+        :web-font="{
+          url: 'https://fonts.gstatic.com/s/publicsans/v14/ijwQs572Xtc6ZYQws9YVwnNGfJ4.woff2',
+          format: 'woff2'
+        }"
+        :font-weight="400"
+        font-style="normal"
+      />
+    </EHead>
+    <EPreview
+      >Connect your fitness apps to unlock personalized AI coaching on Coach Watts.</EPreview
+    >
+    <EBody
+      style="
+        background-color: #f4f4f5;
+        font-family: 'Public Sans', Inter, sans-serif;
+        padding: 40px 0;
+      "
+    >
+      <EContainer
+        style="
+          background-color: #ffffff;
+          margin: 0 auto;
+          border-radius: 12px;
+          border: 1px solid #e4e4e7;
+          overflow: hidden;
+          max-width: 600px;
+          box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.05),
+            0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        "
+      >
+        <ESection
+          style="
+            background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+            height: 4px;
+            width: 100%;
+          "
+        ></ESection>
+        <ESection style="padding: 32px 40px 0; text-align: center">
+          <ELink :href="siteUrl + (utmQuery || '')">
+            <EImg
+              :src="logoUrl"
+              width="64"
+              height="64"
+              alt="Coach Watts"
+              style="margin: 0 auto; border-radius: 12px; display: block"
+            />
+          </ELink>
+        </ESection>
+        <ESection style="padding: 32px 40px">
+          <EHeading
+            style="
+              font-size: 24px;
+              font-weight: 700;
+              color: #09090b;
+              margin-top: 0;
+              margin-bottom: 18px;
+              letter-spacing: -0.025em;
+            "
+          >
+            Connect Your Training Platforms
+          </EHeading>
+          <EText style="font-size: 16px; line-height: 1.6; color: #71717a; margin-bottom: 14px">
+            Hi {{ name || 'Athlete' }},
+          </EText>
+          <EText style="font-size: 15px; line-height: 1.6; color: #71717a; margin-bottom: 20px">
+            To get the most out of Coach Watts, connect your favorite fitness platforms like Strava,
+            Garmin, Oura, or Intervals.icu. Once connected, your workouts and recovery metrics
+            automatically sync to power your daily AI recommendations.
+          </EText>
+          <div style="text-align: center; margin-bottom: 24px">
+            <EButton
+              :href="
+                siteUrl +
+                '/settings/integrations' +
+                (utmQuery || '') +
+                '&utm_content=cta_connect_integrations'
+              "
+              style="
+                background-color: #00c16a;
+                background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+                color: #ffffff;
+                padding: 14px 28px;
+                border-radius: 12px;
+                font-weight: 600;
+                text-decoration: none;
+                display: inline-block;
+              "
+            >
+              Connect Integrations
+            </EButton>
+          </div>
+        </ESection>
+        <ESection
+          style="background-color: #fafafa; padding: 32px 40px; border-top: 1px solid #e4e4e7"
+        >
+          <EText style="font-size: 14px; font-weight: 600; color: #09090b; margin: 0 0 8px">
+            Coach Watts
+          </EText>
+          <EText style="font-size: 12px; color: #71717a; line-height: 1.6; margin: 0 0 12px">
+            AI-powered endurance coaching that adapts to you.
+          </EText>
+          <EText v-if="unsubscribeUrl" style="font-size: 12px; color: #a1a1aa; margin: 0">
+            Don't want these emails?
+            <ELink :href="unsubscribeUrl" style="color: #00c16a; text-decoration: underline">
+              Unsubscribe
+            </ELink>
+          </EText>
+        </ESection>
+      </EContainer>
+    </EBody>
+  </EHtml>
+</template>

--- a/app/emails/OnboardingDripDay7.vue
+++ b/app/emails/OnboardingDripDay7.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+  import {
+    EText,
+    EContainer,
+    EHeading,
+    EButton,
+    EHtml,
+    EHead,
+    EPreview,
+    EBody,
+    ESection,
+    EImg,
+    ELink,
+    EFont
+  } from 'vue-email'
+
+  withDefaults(
+    defineProps<{
+      name?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+</script>
+
+<template>
+  <EHtml lang="en">
+    <EHead>
+      <EFont
+        font-family="Public Sans"
+        fallback-font-family="sans-serif"
+        :web-font="{
+          url: 'https://fonts.gstatic.com/s/publicsans/v14/ijwQs572Xtc6ZYQws9YVwnNGfJ4.woff2',
+          format: 'woff2'
+        }"
+        :font-weight="400"
+        font-style="normal"
+      />
+    </EHead>
+    <EPreview>How was your first week with Coach Watts?</EPreview>
+    <EBody
+      style="
+        background-color: #f4f4f5;
+        font-family: 'Public Sans', Inter, sans-serif;
+        padding: 40px 0;
+      "
+    >
+      <EContainer
+        style="
+          background-color: #ffffff;
+          margin: 0 auto;
+          border-radius: 12px;
+          border: 1px solid #e4e4e7;
+          overflow: hidden;
+          max-width: 600px;
+          box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.05),
+            0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        "
+      >
+        <ESection
+          style="
+            background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+            height: 4px;
+            width: 100%;
+          "
+        ></ESection>
+        <ESection style="padding: 32px 40px 0; text-align: center">
+          <ELink :href="siteUrl + (utmQuery || '')">
+            <EImg
+              :src="logoUrl"
+              width="64"
+              height="64"
+              alt="Coach Watts"
+              style="margin: 0 auto; border-radius: 12px; display: block"
+            />
+          </ELink>
+        </ESection>
+        <ESection style="padding: 32px 40px">
+          <EHeading
+            style="
+              font-size: 24px;
+              font-weight: 700;
+              color: #09090b;
+              margin-top: 0;
+              margin-bottom: 18px;
+              letter-spacing: -0.025em;
+            "
+          >
+            Your First Week Review
+          </EHeading>
+          <EText style="font-size: 16px; line-height: 1.6; color: #71717a; margin-bottom: 14px">
+            Hi {{ name || 'Athlete' }},
+          </EText>
+          <EText style="font-size: 15px; line-height: 1.6; color: #71717a; margin-bottom: 20px">
+            You've been with Coach Watts for one week! Check out your updated athlete profile,
+            fitness trends, and personalized recommendations on your dashboard.
+          </EText>
+          <div style="text-align: center; margin-bottom: 24px">
+            <EButton
+              :href="siteUrl + '/dashboard' + (utmQuery || '') + '&utm_content=cta_view_dashboard'"
+              style="
+                background-color: #00c16a;
+                background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+                color: #ffffff;
+                padding: 14px 28px;
+                border-radius: 12px;
+                font-weight: 600;
+                text-decoration: none;
+                display: inline-block;
+              "
+            >
+              View Dashboard & Trends
+            </EButton>
+          </div>
+        </ESection>
+        <ESection
+          style="background-color: #fafafa; padding: 32px 40px; border-top: 1px solid #e4e4e7"
+        >
+          <EText style="font-size: 14px; font-weight: 600; color: #09090b; margin: 0 0 8px">
+            Coach Watts
+          </EText>
+          <EText style="font-size: 12px; color: #71717a; line-height: 1.6; margin: 0 0 12px">
+            AI-powered endurance coaching that adapts to you.
+          </EText>
+          <EText v-if="unsubscribeUrl" style="font-size: 12px; color: #a1a1aa; margin: 0">
+            Don't want these emails?
+            <ELink :href="unsubscribeUrl" style="color: #00c16a; text-decoration: underline">
+              Unsubscribe
+            </ELink>
+          </EText>
+        </ESection>
+      </EContainer>
+    </EBody>
+  </EHtml>
+</template>

--- a/docs/02-features/email-communication.md
+++ b/docs/02-features/email-communication.md
@@ -30,7 +30,9 @@ The Coach Watts Email Communication System is a centralized, compliant, and bran
 ### 1. Onboarding (Transactional)
 
 - **Welcome**: Sent immediately upon signup as a required TRANSACTIONAL account creation notice (`preferenceKey: null`).
-- **Drip (Planned)**: Day 2 (Integration Check) and Day 7 (Trial Review) sequence using Trigger.dev delays.
+- **Onboarding Drip Sequence**: Managed via `schedule-onboarding-drip` Trigger.dev task:
+  - **Day 2 Integration Check**: Evaluates user integration state; sent only if no training platforms are connected.
+  - **Day 7 First Week Review**: Check-in on trial progress and fitness dashboard trends.
 
 ### 2. Training Guidance (Engagement)
 

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -325,7 +325,7 @@ export default NuxtAuthHandler({
 
         await tryAttributeReferralDuringAuth(user.id)
 
-        // Trigger Welcome Email
+        // Trigger Welcome Email & Onboarding Drip Sequence
         await dispatchTask('send-email', {
           userId: user.id,
           templateKey: 'Welcome',
@@ -336,6 +336,10 @@ export default NuxtAuthHandler({
             name: user.name || 'Athlete',
             unsubscribeUrl: `${process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'}/profile/settings?tab=communication`
           }
+        })
+
+        await dispatchTask('schedule-onboarding-drip', {
+          userId: user.id
         })
       } catch (error) {
         console.error('[Auth] Failed to set user trial period or send welcome email:', error)

--- a/server/utils/email-template-registry.ts
+++ b/server/utils/email-template-registry.ts
@@ -157,6 +157,24 @@ export const EMAIL_TEMPLATE_REGISTRY: Record<string, EmailTemplateDefinition> = 
     requiredProps: ['headline', 'bodyContent'],
     utmCampaign: 'product_announcement',
     utmMedium: 'marketing'
+  },
+  OnboardingDripDay2: {
+    templateKey: 'OnboardingDripDay2',
+    defaultSubject: 'Connect your training apps to unlock Coach Watts',
+    audience: 'ENGAGEMENT',
+    preferenceKey: 'onboarding',
+    requiredProps: [],
+    utmCampaign: 'onboarding_drip_day2',
+    utmMedium: 'lifecycle'
+  },
+  OnboardingDripDay7: {
+    templateKey: 'OnboardingDripDay7',
+    defaultSubject: 'How was your first week with Coach Watts?',
+    audience: 'ENGAGEMENT',
+    preferenceKey: 'onboarding',
+    requiredProps: [],
+    utmCampaign: 'onboarding_drip_day7',
+    utmMedium: 'lifecycle'
   }
 }
 

--- a/trigger/schedule-onboarding-drip.ts
+++ b/trigger/schedule-onboarding-drip.ts
@@ -1,0 +1,99 @@
+import { task, wait, logger } from '@trigger.dev/sdk/v3'
+import { prisma } from '../server/utils/db'
+import { emailQueue } from './queues'
+import { dispatchTask } from '../server/utils/task-dispatcher'
+
+export const scheduleOnboardingDripTask = task({
+  id: 'schedule-onboarding-drip',
+  queue: emailQueue,
+  maxDuration: 900,
+  retry: {
+    maxAttempts: 3,
+    minTimeoutInMs: 1000,
+    maxTimeoutInMs: 10000
+  },
+  run: async (payload: { userId: string }) => {
+    const { userId } = payload
+    logger.log('Starting onboarding drip sequence', { userId })
+
+    // Wait 2 days for Day 2 integration check
+    await wait.for({ days: 2 })
+
+    const userDay2 = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        deactivatedAt: true,
+        stravaAccount: { select: { id: true } },
+        garminAccount: { select: { id: true } },
+        wahooAccount: { select: { id: true } },
+        intervalsProfile: { select: { id: true } },
+        ouraAccount: { select: { id: true } },
+        polarAccount: { select: { id: true } },
+        whoopAccount: { select: { id: true } },
+        fitbitAccount: { select: { id: true } },
+        withingsAccount: { select: { id: true } }
+      }
+    })
+
+    if (userDay2 && !userDay2.deactivatedAt) {
+      const hasIntegration = Boolean(
+        userDay2.stravaAccount ||
+        userDay2.garminAccount ||
+        userDay2.wahooAccount ||
+        userDay2.intervalsProfile ||
+        userDay2.ouraAccount ||
+        userDay2.polarAccount ||
+        userDay2.whoopAccount ||
+        userDay2.fitbitAccount ||
+        userDay2.withingsAccount
+      )
+
+      if (!hasIntegration) {
+        logger.log('User has no connected integrations on Day 2, sending OnboardingDripDay2', {
+          userId
+        })
+        await dispatchTask('send-email', {
+          userId,
+          templateKey: 'OnboardingDripDay2',
+          eventKey: 'ONBOARDING_DRIP_DAY2',
+          idempotencyKey: `onboarding-drip-day2:${userId}`,
+          audience: 'ENGAGEMENT',
+          subject: 'Connect your training apps to unlock Coach Watts',
+          props: {
+            name: userDay2.name || 'Athlete'
+          }
+        })
+      } else {
+        logger.log('User has connected integrations on Day 2, skipping Day 2 email', { userId })
+      }
+    }
+
+    // Wait 5 more days (Total 7 days since signup)
+    await wait.for({ days: 5 })
+
+    const userDay7 = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, deactivatedAt: true }
+    })
+
+    if (userDay7 && !userDay7.deactivatedAt) {
+      logger.log('Sending Day 7 onboarding trial check-in email', { userId })
+      await dispatchTask('send-email', {
+        userId,
+        templateKey: 'OnboardingDripDay7',
+        eventKey: 'ONBOARDING_DRIP_DAY7',
+        idempotencyKey: `onboarding-drip-day7:${userId}`,
+        audience: 'ENGAGEMENT',
+        subject: 'How was your first week with Coach Watts?',
+        props: {
+          name: userDay7.name || 'Athlete'
+        }
+      })
+    }
+
+    return { success: true, userId }
+  }
+})


### PR DESCRIPTION
Fixes CW-109

### Summary
1. Created Vue email templates `OnboardingDripDay2.vue` (integration check for users with 0 connected accounts) and `OnboardingDripDay7.vue` (first-week trial check-in) in `app/emails/`.
2. Registered both templates in `EMAIL_TEMPLATE_REGISTRY` (`server/utils/email-template-registry.ts`) with `audience: 'ENGAGEMENT'` and `preferenceKey: 'onboarding'`.
3. Created Trigger.dev background task `trigger/schedule-onboarding-drip.ts` that:
   - Delays 2 days after signup and checks if user has connected any integrations. If not, sends `OnboardingDripDay2`.
   - Delays 5 more days (7 days total) and sends `OnboardingDripDay7` check-in email.
4. Updated Auth signup handler (`server/api/auth/[...].ts`) to trigger `schedule-onboarding-drip` alongside immediate `Welcome` email.
5. Updated documentation (`docs/02-features/email-communication.md`).

### Verification
- Passed `pnpm typecheck:server`
- Passed `pnpm test:unit tests/unit/app/emails/templates.test.ts`