### PR TITLE
feat(email): implement marketing broadcast template and admin broadcast API endpoint (CW-116)

### DIFF
--- a/app/emails/MarketingBroadcast.vue
+++ b/app/emails/MarketingBroadcast.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+  import {
+    EText,
+    EContainer,
+    EHeading,
+    EButton,
+    EHtml,
+    EHead,
+    EPreview,
+    EBody,
+    ESection,
+    EImg,
+    ELink,
+    EFont
+  } from 'vue-email'
+
+  withDefaults(
+    defineProps<{
+      name?: string
+      headline?: string
+      bodyContent?: string
+      ctaLabel?: string
+      ctaUrl?: string
+      siteUrl?: string
+      logoUrl?: string
+      unsubscribeUrl?: string
+      utmQuery?: string
+    }>(),
+    {
+      siteUrl: 'https://coachwatts.com',
+      logoUrl: 'https://coachwatts.com/icon.png'
+    }
+  )
+</script>
+
+<template>
+  <EHtml lang="en">
+    <EHead>
+      <EFont
+        font-family="Public Sans"
+        fallback-font-family="sans-serif"
+        :web-font="{
+          url: 'https://fonts.gstatic.com/s/publicsans/v14/ijwQs572Xtc6ZYQws9YVwnNGfJ4.woff2',
+          format: 'woff2'
+        }"
+        :font-weight="400"
+        font-style="normal"
+      />
+    </EHead>
+    <EPreview>{{ headline || 'Coach Watts Announcement' }}</EPreview>
+    <EBody
+      style="
+        background-color: #f4f4f5;
+        font-family: 'Public Sans', Inter, sans-serif;
+        padding: 40px 0;
+      "
+    >
+      <EContainer
+        style="
+          background-color: #ffffff;
+          margin: 0 auto;
+          border-radius: 12px;
+          border: 1px solid #e4e4e7;
+          overflow: hidden;
+          max-width: 600px;
+          box-shadow:
+            0 4px 6px -1px rgba(0, 0, 0, 0.05),
+            0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        "
+      >
+        <ESection
+          style="
+            background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+            height: 4px;
+            width: 100%;
+          "
+        ></ESection>
+        <ESection style="padding: 32px 40px 0; text-align: center">
+          <ELink :href="siteUrl + (utmQuery || '')">
+            <EImg
+              :src="logoUrl"
+              width="64"
+              height="64"
+              alt="Coach Watts"
+              style="margin: 0 auto; border-radius: 12px; display: block"
+            />
+          </ELink>
+        </ESection>
+        <ESection style="padding: 32px 40px">
+          <EHeading
+            style="
+              font-size: 24px;
+              font-weight: 700;
+              color: #09090b;
+              margin-top: 0;
+              margin-bottom: 18px;
+              letter-spacing: -0.025em;
+            "
+          >
+            {{ headline || 'Coach Watts Announcement' }}
+          </EHeading>
+          <EText style="font-size: 16px; line-height: 1.6; color: #71717a; margin-bottom: 14px">
+            Hi {{ name || 'Athlete' }},
+          </EText>
+          <EText
+            style="
+              font-size: 15px;
+              line-height: 1.6;
+              color: #71717a;
+              margin-bottom: 20px;
+              white-space: pre-line;
+            "
+          >
+            {{ bodyContent }}
+          </EText>
+          <div v-if="ctaLabel && ctaUrl" style="text-align: center; margin-bottom: 24px">
+            <EButton
+              :href="ctaUrl + (utmQuery || '') + '&utm_content=cta_broadcast'"
+              style="
+                background-color: #00c16a;
+                background: linear-gradient(135deg, #00dc82 0%, #00c16a 100%);
+                color: #ffffff;
+                padding: 14px 28px;
+                border-radius: 12px;
+                font-weight: 600;
+                text-decoration: none;
+                display: inline-block;
+              "
+            >
+              {{ ctaLabel }}
+            </EButton>
+          </div>
+        </ESection>
+        <ESection
+          style="background-color: #fafafa; padding: 32px 40px; border-top: 1px solid #e4e4e7"
+        >
+          <EText style="font-size: 14px; font-weight: 600; color: #09090b; margin: 0 0 8px">
+            Coach Watts
+          </EText>
+          <EText style="font-size: 12px; color: #71717a; line-height: 1.6; margin: 0 0 12px">
+            AI-powered endurance coaching that adapts to you.
+          </EText>
+          <EText v-if="unsubscribeUrl" style="font-size: 12px; color: #a1a1aa; margin: 0">
+            You are receiving this update because you opted into marketing emails.
+            <ELink :href="unsubscribeUrl" style="color: #00c16a; text-decoration: underline">
+              Unsubscribe
+            </ELink>
+          </EText>
+        </ESection>
+      </EContainer>
+    </EBody>
+  </EHtml>
+</template>

--- a/docs/02-features/email-communication.md
+++ b/docs/02-features/email-communication.md
@@ -44,6 +44,10 @@ The Coach Watts Email Communication System is a centralized, compliant, and bran
 - **Payment Succeeded**: Renewal receipt when a recurring subscription payment succeeds.
 - **Subscription Canceled**: Notice when a subscription is canceled or entitlement expires.
 
+### 4. Marketing & Announcements (Marketing)
+
+- **Marketing Broadcasts**: Sent via `POST /api/admin/email-deliveries/broadcast`. Enforces opt-in verification (`marketing: true`, `globalUnsubscribe: false`), suppression check, and includes standard HMAC unsubscribe footers. Uses `MarketingBroadcast` template.
+
 ## Compliance & Security
 
 ### Cryptographic Unsubscribe Tokens

--- a/server/api/admin/email-deliveries/broadcast.post.ts
+++ b/server/api/admin/email-deliveries/broadcast.post.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod'
+import { requireAdmin } from '../../../utils/auth-guard'
+import { prisma } from '../../../utils/db'
+import { dispatchTask } from '../../../utils/task-dispatcher'
+
+const broadcastSchema = z.object({
+  subject: z.string().min(1),
+  headline: z.string().min(1),
+  bodyContent: z.string().min(1),
+  ctaLabel: z.string().optional(),
+  ctaUrl: z.string().url().optional(),
+  dryRun: z.boolean().optional().default(false)
+})
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Admin'],
+    summary: 'Broadcast marketing email',
+    description:
+      'Enqueues a marketing broadcast to all opted-in, unsuppressed users with opt-in preference enforcement.',
+    responses: {
+      200: { description: 'Success' },
+      401: { description: 'Unauthorized' },
+      403: { description: 'Forbidden' }
+    }
+  }
+})
+
+export default defineEventHandler(async (event) => {
+  await requireAdmin(event)
+  const body = await readValidatedBody(event, broadcastSchema.parse)
+
+  const users = await prisma.user.findMany({
+    where: {
+      deactivatedAt: null,
+      emailStatus: 'VALID',
+      emailPreferences: {
+        some: {
+          channel: 'EMAIL',
+          marketing: true,
+          globalUnsubscribe: false
+        }
+      }
+    },
+    select: {
+      id: true,
+      email: true,
+      name: true
+    }
+  })
+
+  const activeSuppressions = await prisma.emailSuppression.findMany({
+    where: { active: true },
+    select: { email: true }
+  })
+  const suppressedEmails = new Set(activeSuppressions.map((s) => s.email.toLowerCase()))
+
+  const targetUsers = users.filter((user) => !suppressedEmails.has(user.email.toLowerCase()))
+
+  if (body.dryRun) {
+    return {
+      success: true,
+      dryRun: true,
+      targetCount: targetUsers.length,
+      sampleRecipients: targetUsers.slice(0, 5).map((u) => u.email)
+    }
+  }
+
+  const campaignId = `mkt_${Date.now()}`
+  let queuedCount = 0
+
+  for (const user of targetUsers) {
+    try {
+      await dispatchTask('send-email', {
+        userId: user.id,
+        templateKey: 'MarketingBroadcast',
+        eventKey: 'MARKETING_BROADCAST',
+        audience: 'MARKETING',
+        subject: body.subject,
+        idempotencyKey: `broadcast:${campaignId}:${user.id}`,
+        props: {
+          name: user.name || 'Athlete',
+          headline: body.headline,
+          bodyContent: body.bodyContent,
+          ctaLabel: body.ctaLabel,
+          ctaUrl: body.ctaUrl
+        }
+      })
+      queuedCount++
+    } catch (err) {
+      console.error(`Failed to queue broadcast for ${user.id}`, err)
+    }
+  }
+
+  return {
+    success: true,
+    campaignId,
+    targetCount: targetUsers.length,
+    queuedCount
+  }
+})

--- a/server/utils/email-template-registry.ts
+++ b/server/utils/email-template-registry.ts
@@ -148,6 +148,15 @@ export const EMAIL_TEMPLATE_REGISTRY: Record<string, EmailTemplateDefinition> = 
     requiredProps: ['teamName', 'joinUrl', 'code'],
     utmCampaign: 'team_invite',
     utmMedium: 'transactional'
+  },
+  MarketingBroadcast: {
+    templateKey: 'MarketingBroadcast',
+    defaultSubject: 'Coach Watts Update',
+    audience: 'MARKETING',
+    preferenceKey: 'marketing',
+    requiredProps: ['headline', 'bodyContent'],
+    utmCampaign: 'product_announcement',
+    utmMedium: 'marketing'
   }
 }
 


### PR DESCRIPTION
Fixes CW-116

### Summary
1. Created branded Vue email template `MarketingBroadcast.vue` in `app/emails/`.
2. Registered `MarketingBroadcast` in `EMAIL_TEMPLATE_REGISTRY` (`server/utils/email-template-registry.ts`) with `audience: 'MARKETING'` and `preferenceKey: 'marketing'`.
3. Implemented admin broadcast API endpoint `POST /api/admin/email-deliveries/broadcast` (`server/api/admin/email-deliveries/broadcast.post.ts`) that:
   - Requires admin authentication.
   - Enforces opt-in verification (`marketing: true`, `globalUnsubscribe: false`).
   - Filters active suppressions.
   - Supports `dryRun: true` mode for campaign audience validation.
   - Dispatches broadcast campaign tasks via Trigger.dev.
4. Updated documentation (`docs/02-features/email-communication.md`).

### Verification
- Passed `pnpm typecheck:server`
- Passed `pnpm test:unit tests/unit/app/emails/templates.test.ts`