### PR TITLE
fix(trigger): add schedule-onboarding-drip to task manifest and loader

### DIFF
--- a/cli/worker/task-handler-loader.ts
+++ b/cli/worker/task-handler-loader.ts
@@ -161,6 +161,7 @@ async function loadTriggerModules() {
     import('../../trigger/recommend-nutrition-meal'),
     import('../../trigger/recommend-today-activity'),
     import('../../trigger/review-goals'),
+    import('../../trigger/schedule-onboarding-drip'),
     import('../../trigger/send-email'),
     import('../../trigger/sentry-error-test'),
     import('../../trigger/suggest-goals'),

--- a/server/utils/task-manifest.json
+++ b/server/utils/task-manifest.json
@@ -63,6 +63,21 @@
     }
   },
   {
+    "id": "schedule-onboarding-drip",
+    "maxDuration": 900,
+    "retry": {
+      "maxAttempts": 3,
+      "factor": 2,
+      "minTimeoutInMs": 1000,
+      "maxTimeoutInMs": 10000,
+      "randomize": true
+    },
+    "queue": {
+      "name": "email-queue",
+      "concurrencyLimit": 10
+    }
+  },
+  {
     "id": "send-email",
     "maxDuration": 300,
     "retry": {

--- a/tests/unit/server/utils/task-handler-loader.test.ts
+++ b/tests/unit/server/utils/task-handler-loader.test.ts
@@ -30,7 +30,7 @@ describe('Redis task parity', () => {
       .sort()
     const manifestIds = taskManifest.map((definition) => definition.id).sort()
 
-    expect(sourceIds).toHaveLength(65)
+    expect(sourceIds).toHaveLength(66)
     expect(new Set(sourceIds).size).toBe(sourceIds.length)
     expect(loadedIds).toEqual(sourceIds)
     expect(manifestIds).toEqual(sourceIds)


### PR DESCRIPTION
Fixes test failure on develop caused by missing task manifest registration.