### PR TITLE
fix(chat): honor user timezone and unit preferences in chat replies

### DIFF
--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -100,6 +100,14 @@ export function expandSkillSelectionForRequest(
   }
 
   const skillIds = sortSkillIds(uniq(expanded)).filter((skillId) => skillId !== 'general_chat')
+
+  // Stripping general_chat can empty the selection outright when the caller
+  // deliberately chose a tool-enabled general_chat turn (see
+  // getDirectTimeQuestionSkillSelection). Expansion may only ADD companion
+  // domains, so an empty result means there was nothing to expand — keep the
+  // original selection rather than silently handing the model zero tools.
+  if (!skillIds.length) return selection
+
   if (
     skillIds.length === selection.skillIds.length &&
     skillIds.every((id) => selection.skillIds.includes(id))

--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -488,7 +488,7 @@ const CHAT_SKILL_MANIFESTS: Record<ChatSkillId, ChatSkillManifest> = {
 
 - Answer directly when tools are not needed.
 - Do not invent tool outputs or claim actions that were not executed.`,
-    contextFlags: [],
+    contextFlags: ['time'],
     approvalToolNames: [],
     priority: 10
   }
@@ -604,6 +604,50 @@ function latestUserLooksLikeMissingReplyComplaint(messages: any[]) {
   ]
 
   return patterns.some((pattern) => latestUserText.includes(pattern))
+}
+
+const DIRECT_TIME_QUESTION_PATTERNS = [
+  /\bwhat(?:'s| is|s) (?:the )?(?:current )?time\b/i,
+  /\bwhat time (?:is it|do you have)\b/i,
+  /\bcurrent time\b/i,
+  /\btell me the time\b/i,
+  /\bdo you know what time it is\b/i,
+  /\bhány óra van\b/i
+]
+
+const NON_TIME_DOMAIN_PATTERN =
+  /\b(workout|activity|ride|run|swim|session|training|plan|planned|schedule|nutrition|meal|hydration|wellness|recovery|goal|ticket|bug|recommend)\b/i
+
+/**
+ * A direct "what time is it?" question must not silently fall back to a
+ * tool-less general_chat turn: get_current_time is the only source of the
+ * athlete's actual configured timezone, and the model will otherwise guess
+ * (often UTC).
+ */
+export function looksLikeDirectTimeQuestion(text: string) {
+  const trimmed = text.trim()
+  if (!trimmed) return false
+  if (NON_TIME_DOMAIN_PATTERN.test(trimmed)) return false
+
+  return DIRECT_TIME_QUESTION_PATTERNS.some((pattern) => pattern.test(trimmed))
+}
+
+export function getDirectTimeQuestionSkillSelection(messages: any[]): ChatSkillSelection | null {
+  const latestUserText = getLatestUserText(messages)
+  if (!looksLikeDirectTimeQuestion(latestUserText)) {
+    return null
+  }
+
+  return {
+    skillIds: ['general_chat'],
+    confidence: 1,
+    useTools: true,
+    extractMemories: false,
+    reason:
+      "Direct question about the current time; force get_current_time so the reply uses the athlete's configured timezone instead of an inferred time.",
+    usedFallback: false,
+    source: 'fallback'
+  }
 }
 
 function getRecentAssistantReplyPresence(messages: any[]) {
@@ -1217,6 +1261,21 @@ export async function classifyChatSkills(
     return retryContinuation
   }
 
+  const directTimeQuestion = getDirectTimeQuestionSkillSelection(params.messages)
+  if (directTimeQuestion) {
+    await logRouterUsage({
+      userId: params.userId,
+      turnId: params.turnId,
+      provider: 'internal',
+      model: 'direct_time_question_guard',
+      success: true,
+      promptPreview: getLatestUserText(params.messages) || '(direct time question)',
+      responsePreview: JSON.stringify(directTimeQuestion),
+      durationMs: 0
+    })
+    return directTimeQuestion
+  }
+
   const prompt = buildRouterPrompt(params)
   const startedAt = Date.now()
   const google = createGoogle({
@@ -1353,7 +1412,18 @@ export function composeSkillInstructions(
   )
 
   if (!selectedSkills.length || selectedSkills.every((skillId) => skillId === 'general_chat')) {
-    return `${baseInstruction}\n\n${CHAT_SKILL_MANIFESTS.general_chat.instructionFragment}`
+    const contextFlags = uniq(
+      selectedSkills.flatMap((skillId) => CHAT_SKILL_MANIFESTS[skillId]?.contextFlags || [])
+    )
+    const timeToolInstruction =
+      context.useTools && contextFlags.includes('time')
+        ? `\n\n## Time Tool Usage (CRITICAL)
+
+- The athlete is asking about the current time or "now". Call \`get_current_time\` and answer using its returned \`local_formatted\` value and \`timezone\` field.
+- Do not infer, guess, or compute the time yourself, and never assume UTC. Always ground the answer in what the tool returns.`
+        : ''
+
+    return `${baseInstruction}\n\n${CHAT_SKILL_MANIFESTS.general_chat.instructionFragment}${timeToolInstruction}`
   }
 
   if (!context.useTools) {

--- a/server/utils/services/chatContextService.ts
+++ b/server/utils/services/chatContextService.ts
@@ -8,6 +8,7 @@ import { generateTrainingContext, formatTrainingContextForPrompt } from '../trai
 import { getInjuryLabel } from '../../utils/wellness'
 import { filterGoalsForContext } from '../goal-context'
 import { getUserAiSettings } from '../ai-user-settings'
+import { formatPromptDistance } from '../ai-prompt-format'
 
 type BuildAthleteContextOptions = {
   includeDomainToolInstructions?: boolean
@@ -501,7 +502,7 @@ export async function buildAthleteContext(
       athleteContext += `  - **ID**: ${workout.id} (use this ID to get detailed analysis)\n`
       athleteContext += `  - Duration: ${Math.round(workout.durationSec / 60)} min`
       if (workout.distanceMeters)
-        athleteContext += ` | Distance: ${(workout.distanceMeters / 1000).toFixed(1)} km`
+        athleteContext += ` | Distance: ${formatPromptDistance(workout.distanceMeters, userProfile?.distanceUnits)}`
       if (workout.averageWatts) athleteContext += ` | Avg Power: ${workout.averageWatts}W`
       if (workout.tss) athleteContext += ` | TSS: ${Math.round(workout.tss)}`
       if (workout.overallScore) athleteContext += ` | Score: ${workout.overallScore}/10`
@@ -809,6 +810,17 @@ You can create inline charts using the \`create_chart\` tool.
 For richer charts, include dataset styling (\`backgroundColor\`, \`borderColor\`, \`borderWidth\`) and \`options\` (axes, legend, stacked bars, dual-axis).`
     : ''
 
+  const distanceUnitLabel = userProfile?.distanceUnits === 'Miles' ? 'Miles' : 'Kilometers'
+  const temperatureUnitLabel =
+    userProfile?.temperatureUnits === 'Fahrenheit' ? 'Fahrenheit' : 'Celsius'
+
+  const unitsInstruction = `## Unit & Format Preferences (CRITICAL)
+
+The athlete's configured units are **${distanceUnitLabel}** for distance/pace/elevation and **${temperatureUnitLabel}** for temperature.
+- Always report distances, pace, elevation, and temperatures in these units unless the user explicitly asks for a different unit in their current message.
+- Never default to metric (km, meters, °C) for an athlete configured for imperial units, or to imperial (mi, ft, °F) for an athlete configured for metric units.
+- If a tool result or raw data returns metric values (meters, Celsius), convert them to the athlete's preferred units before presenting them in your reply.`
+
   const trainingPlanInstruction = includeDomainToolInstructions
     ? `## Training Plan Management (CRITICAL)
 
@@ -908,6 +920,8 @@ ${contextBullets}
 ${chartVisualizationInstruction}
 
 ${trainingPlanInstruction}
+
+${unitsInstruction}
 
 ## Response Requirement
 **CRITICAL: ALWAYS provide a text response after using a tool.**

--- a/tests/unit/server/utils/ai-tools/time.test.ts
+++ b/tests/unit/server/utils/ai-tools/time.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { timeTools } from '../../../../../server/utils/ai-tools/time'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    plannedWorkout: { findMany: vi.fn() }
+  }
+}))
+
+describe('CW-193: get_current_time must reflect the athlete configured timezone', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([])
+    // Wednesday, Feb 11, 2026, 14:30 UTC => 09:30 AM in America/New_York (EST, UTC-5)
+    vi.setSystemTime(new Date('2026-02-11T14:30:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns the New York local clock, not the UTC clock', async () => {
+    const tools = timeTools(userId, 'America/New_York')
+    const result = await tools.get_current_time.execute({}, {
+      toolCallId: '1',
+      messages: []
+    } as any)
+
+    expect(result.timezone).toBe('America/New_York')
+    expect(result.local_date).toBe('2026-02-11')
+    expect(result.local_time).toBe('09:30')
+    expect(result.hour_24).toBe(9)
+    expect(result.time_of_day).toBe('morning')
+    expect(result.local_formatted).toContain('Wednesday, February 11, 2026 9:30 AM')
+
+    // This is the assertion that must fail if UTC were substituted for the
+    // configured timezone: at 14:30 UTC the (wrong) UTC-based reading would be
+    // hour 14 / "afternoon", not hour 9 / "morning".
+    expect(result.hour_24).not.toBe(14)
+    expect(result.time_of_day).not.toBe('afternoon')
+  })
+
+  it('returns a different local clock for a different configured timezone', async () => {
+    const tools = timeTools(userId, 'Asia/Tokyo')
+    const result = await tools.get_current_time.execute({}, {
+      toolCallId: '1',
+      messages: []
+    } as any)
+
+    // 14:30 UTC => 23:30 in Asia/Tokyo (UTC+9) on the same calendar day.
+    expect(result.timezone).toBe('Asia/Tokyo')
+    expect(result.local_date).toBe('2026-02-11')
+    expect(result.local_time).toBe('23:30')
+    expect(result.hour_24).toBe(23)
+    expect(result.time_of_day).toBe('late night')
+  })
+})

--- a/tests/unit/server/utils/chat/skills.test.ts
+++ b/tests/unit/server/utils/chat/skills.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   classifyChatSkills,
   composeSkillInstructions,
+  expandSkillSelectionForRequest,
   getDirectTimeQuestionSkillSelection,
   looksLikeDirectTimeQuestion,
   selectToolsForSkills
@@ -133,5 +134,85 @@ describe('CW-193: direct time questions must not silently drop to a tool-less re
 
       expect(instructions).not.toContain('Time Tool Usage')
     })
+  })
+
+  /**
+   * Testing classify/select/compose in isolation is not enough: turn-executor.ts
+   * pipes the router result through expandSkillSelectionForRequest before tools
+   * are selected, and that step used to strip general_chat and empty the
+   * selection, silently reducing this fix to a no-op. These tests run the full
+   * chain in the same order as server/utils/chat/turn-executor.ts.
+   */
+  describe('full turn-executor chain (classify -> expand -> select -> compose)', () => {
+    const runChain = async (content: string) => {
+      const routed = await classifyChatSkills({
+        userId: 'user-1',
+        turnId: 'turn-chain',
+        messages: [{ role: 'user', content }]
+      })
+      const selection = expandSkillSelectionForRequest(routed, content)
+      const tools = selectToolsForSkills(
+        {
+          get_current_time: { name: 'get_current_time' },
+          ticket_create: { name: 'ticket_create' }
+        },
+        selection.skillIds,
+        { useTools: selection.useTools }
+      )
+      const instructions = composeSkillInstructions('Base instruction.', selection.skillIds, {
+        useTools: selection.useTools
+      })
+
+      return { selection, tools, instructions }
+    }
+
+    it('still exposes get_current_time and the time instruction after expansion', async () => {
+      const { selection, tools, instructions } = await runChain('What time is it for me?')
+
+      expect(selection.skillIds).toEqual(['general_chat'])
+      expect(selection.useTools).toBe(true)
+      expect(Object.keys(tools)).toContain('get_current_time')
+      expect(instructions).toContain('Time Tool Usage')
+      expect(instructions).toContain('local_formatted')
+    })
+
+    it('does not leave the selection empty, which would hand the model zero tools', async () => {
+      const { selection, tools } = await runChain('What time is it?')
+
+      expect(selection.skillIds.length).toBeGreaterThan(0)
+      expect(Object.keys(tools).length).toBeGreaterThan(0)
+    })
+  })
+})
+
+describe('expandSkillSelectionForRequest', () => {
+  it('preserves a deliberate tool-enabled general_chat selection', () => {
+    const selection = expandSkillSelectionForRequest(
+      {
+        skillIds: ['general_chat'],
+        confidence: 1,
+        useTools: true,
+        extractMemories: false
+      },
+      'What time is it?'
+    )
+
+    expect(selection.skillIds).toEqual(['general_chat'])
+    expect(selection.useTools).toBe(true)
+  })
+
+  it('still adds read-only companion domains for a mixed-intent write request', () => {
+    const selection = expandSkillSelectionForRequest(
+      {
+        skillIds: ['workout_update'],
+        confidence: 0.9,
+        useTools: true,
+        extractMemories: false
+      },
+      'Update the notes on my ride from yesterday'
+    )
+
+    expect(selection.skillIds).toContain('workout_update')
+    expect(selection.skillIds).toContain('workout_read')
   })
 })

--- a/tests/unit/server/utils/chat/skills.test.ts
+++ b/tests/unit/server/utils/chat/skills.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  classifyChatSkills,
+  composeSkillInstructions,
+  getDirectTimeQuestionSkillSelection,
+  looksLikeDirectTimeQuestion,
+  selectToolsForSkills
+} from '../../../../../server/utils/chat/skills'
+
+const generateObjectMock = vi.fn()
+const llmUsageCreateMock = vi.fn().mockResolvedValue(null)
+
+vi.mock('ai', () => ({
+  generateObject: (...args: any[]) => generateObjectMock(...args)
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    llmUsage: {
+      create: (...args: any[]) => llmUsageCreateMock(...args)
+    }
+  }
+}))
+
+describe('CW-193: direct time questions must not silently drop to a tool-less reply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('looksLikeDirectTimeQuestion', () => {
+    it.each([
+      'What time is it?',
+      "what's the time?",
+      'What time is it for me?',
+      'current time please',
+      'Do you know what time it is?',
+      'Hány óra van?'
+    ])('detects "%s" as a direct time question', (text) => {
+      expect(looksLikeDirectTimeQuestion(text)).toBe(true)
+    })
+
+    it.each([
+      '',
+      'How was my ride yesterday?',
+      'What time should I do my workout today?',
+      'What time is my next planned session?'
+    ])('does not treat "%s" as a direct time question', (text) => {
+      expect(looksLikeDirectTimeQuestion(text)).toBe(false)
+    })
+  })
+
+  describe('getDirectTimeQuestionSkillSelection', () => {
+    it('forces tool-enabled general_chat for a direct time question', () => {
+      const selection = getDirectTimeQuestionSkillSelection([
+        { role: 'user', content: 'What time is it right now?' }
+      ])
+
+      expect(selection).toMatchObject({
+        skillIds: ['general_chat'],
+        useTools: true,
+        usedFallback: false
+      })
+    })
+
+    it('returns null when the latest message is not a direct time question', () => {
+      const selection = getDirectTimeQuestionSkillSelection([
+        { role: 'user', content: 'How many calories did I burn on my last ride?' }
+      ])
+
+      expect(selection).toBeNull()
+    })
+  })
+
+  describe('classifyChatSkills', () => {
+    it('short-circuits the LLM router for a direct time question', async () => {
+      const selection = await classifyChatSkills({
+        userId: 'user-1',
+        turnId: 'turn-time-1',
+        messages: [{ role: 'user', content: 'What time is it for me?' }]
+      })
+
+      expect(selection).toMatchObject({
+        skillIds: ['general_chat'],
+        useTools: true,
+        usedFallback: false
+      })
+      expect(generateObjectMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('selectToolsForSkills', () => {
+    it('includes get_current_time for a tool-enabled general_chat selection', () => {
+      const tools = selectToolsForSkills(
+        {
+          get_current_time: { name: 'get_current_time' },
+          ticket_create: { name: 'ticket_create' }
+        },
+        ['general_chat'],
+        { useTools: true }
+      )
+
+      expect(Object.keys(tools)).toEqual(['get_current_time'])
+    })
+
+    it('still returns no tools for a plain (non-forced) general_chat turn', () => {
+      const tools = selectToolsForSkills(
+        {
+          get_current_time: { name: 'get_current_time' }
+        },
+        ['general_chat'],
+        { useTools: false }
+      )
+
+      expect(tools).toEqual({})
+    })
+  })
+
+  describe('composeSkillInstructions', () => {
+    it('instructs the model to use get_current_time instead of inferring a time', () => {
+      const instructions = composeSkillInstructions('Base instruction.', ['general_chat'], {
+        useTools: true
+      })
+
+      expect(instructions).toContain('get_current_time')
+      expect(instructions).toContain('local_formatted')
+      expect(instructions).toMatch(/do not infer|never assume UTC/i)
+    })
+
+    it('omits the time-tool instruction for a plain general_chat turn', () => {
+      const instructions = composeSkillInstructions('Base instruction.', ['general_chat'], {
+        useTools: false
+      })
+
+      expect(instructions).not.toContain('Time Tool Usage')
+    })
+  })
+})

--- a/tests/unit/server/utils/services/chatContextService.timezone.test.ts
+++ b/tests/unit/server/utils/services/chatContextService.timezone.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { buildAthleteContext } from '../../../../../server/utils/services/chatContextService'
 import { prisma } from '../../../../../server/utils/db'
+import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
 
 // Mock dependencies
 vi.mock('../../../../../server/utils/db', () => ({
@@ -131,5 +132,84 @@ describe('chatContextService Timezone Handling', () => {
     // Should NOT show Feb 14 (which would happen if we shifted Feb 15 00:00 UTC by -5h)
     expect(result.context).toContain('Target: 2026-02-15')
     expect(result.context).not.toContain('Target: 2026-02-14')
+  })
+})
+
+describe('CW-193: chat context honors distance/temperature unit preferences', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.setSystemTime(new Date('2026-02-11T02:20:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders recent workout distance in Miles for a Miles/Fahrenheit athlete, never hard-coded km', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      name: 'Billy Rusk',
+      timezone: 'America/New_York',
+      aiPersona: 'Supportive',
+      distanceUnits: 'Miles',
+      temperatureUnits: 'Fahrenheit'
+    } as any)
+
+    vi.mocked(prisma.goal.findMany).mockResolvedValue([])
+    vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([])
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.trainingAvailability.findMany).mockResolvedValue([])
+    vi.mocked(prisma.weeklyTrainingPlan.findFirst).mockResolvedValue(null)
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+      {
+        id: 'workout-1',
+        date: new Date('2026-02-10T12:00:00Z'),
+        title: 'Morning Ride',
+        type: 'Ride',
+        durationSec: 3600,
+        distanceMeters: 40233.6 // 25 miles
+      }
+    ] as any)
+
+    const result = await buildAthleteContext(userId)
+
+    expect(result.context).toContain('25.00 mi')
+    expect(result.context).not.toContain('km')
+    expect(result.systemInstruction).toContain('**Miles** for distance/pace/elevation')
+    expect(result.systemInstruction).toContain('**Fahrenheit** for temperature')
+  })
+
+  it('renders recent workout distance in Kilometers for a metric-preference athlete', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      name: 'Metric Athlete',
+      timezone: 'Europe/Brussels',
+      aiPersona: 'Supportive',
+      distanceUnits: 'Kilometers',
+      temperatureUnits: 'Celsius'
+    } as any)
+
+    vi.mocked(prisma.goal.findMany).mockResolvedValue([])
+    vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([])
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.trainingAvailability.findMany).mockResolvedValue([])
+    vi.mocked(prisma.weeklyTrainingPlan.findFirst).mockResolvedValue(null)
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+      {
+        id: 'workout-2',
+        date: new Date('2026-02-10T12:00:00Z'),
+        title: 'Morning Ride',
+        type: 'Ride',
+        durationSec: 3600,
+        distanceMeters: 40000 // 40 km
+      }
+    ] as any)
+
+    const result = await buildAthleteContext(userId)
+
+    expect(result.context).toContain('40.00 km')
+    expect(result.context).not.toMatch(/\d+\.\d+\s*mi\b/)
+    expect(result.systemInstruction).toContain('**Kilometers** for distance/pace/elevation')
+    expect(result.systemInstruction).toContain('**Celsius** for temperature')
   })
 })


### PR DESCRIPTION
## Summary

Fixes [CW-193](https://linear.app/watt-mind/issue/CW-193/chat-replies-ignore-user-timezone-and-measurement-preference): chat replies could ignore the athlete's configured timezone and measurement units.

- **Timezone**: A direct "what time is it?" question could route to the tool-less `general_chat` skill, so `get_current_time` wasn't guaranteed to run and the model could improvise a time (often UTC) instead of the athlete's configured timezone. Added a deterministic guard in `classifyChatSkills` that forces `get_current_time` to be available, plus an explicit instruction to use the tool's `local_formatted`/`timezone` output rather than inferring.
- **Units**: `buildAthleteContext` hard-coded recent workout distance as `/ 1000` → `km`, ignoring `distanceUnits`. Now uses the existing `formatPromptDistance` helper. Also added an explicit "Unit & Format Preferences" rule to the chat system instruction so distances/pace/elevation/temperature follow the athlete's configured units unless they ask otherwise.

## Commits

**1. `fix(chat): honor user timezone and unit preferences in chat replies`** — the two fixes above.

**2. `fix(chat): stop skill expansion from emptying a tool-enabled general_chat turn`** — found in self-review: the first commit was a **no-op on the real request path**. `turn-executor.ts:1019` pipes the router result through `expandSkillSelectionForRequest`, which unconditionally strips `general_chat`. For the deliberate tool-enabled `general_chat` turn produced by the new guard, that emptied `skillIds` entirely:

```
1. classifyChatSkills             -> ["general_chat"]  useTools: true
2. expandSkillSelectionForRequest -> []                useTools: true   <- stripped
3. selectToolsForSkills           -> []                                 <- no get_current_time
4. instruction has time rule      -> false
```

Expansion may only *add* companion domains, so an empty result means there was nothing to expand — the original selection is now preserved instead. This was a latent bug the first commit exposed: before it, `normalizeChatSkillSelection` forced `useTools: false` for every general_chat-only selection, so the strip could never empty the array.

## Changes

- `server/utils/chat/skills.ts` — direct-time-question guard, `general_chat` `time` context flag, time-tool-usage instruction, expansion-empties-selection fix.
- `server/utils/services/chatContextService.ts` — unit-aware distance formatting, explicit unit-output system instruction rule.
- New tests: `tests/unit/server/utils/chat/skills.test.ts`, `tests/unit/server/utils/ai-tools/time.test.ts`.
- Extended `tests/unit/server/utils/services/chatContextService.timezone.test.ts` with Miles/Fahrenheit vs Kilometers/Celsius coverage.

## Test plan

- [x] Ticket verification command — **28/28 passing**:
      `pnpm vitest run tests/unit/server/utils/services/chatContextService.timezone.test.ts tests/unit/server/utils/chat/skills.test.ts tests/unit/server/utils/ai-tools/time.test.ts`
- [x] No regressions in the pre-existing `server/utils/chat/skills.test.ts` and `tests/unit/server/utils/services/chatContextService.test.ts` — **62/62 across all 5 files**
- [x] The new full-chain test was verified to be load-bearing: with the commit-2 fix temporarily disabled it fails 3 assertions, and passes once restored.

**Testing note:** the first commit's tests exercised `classifyChatSkills`, `selectToolsForSkills`, and `composeSkillInstructions` in isolation, which is precisely why they missed the integration break. Commit 2 adds a test that runs the full `classify → expand → select → compose` chain in the same order as `turn-executor.ts`.

## Follow-ups (not in this PR)

Tracked separately in [CW-199](https://linear.app/watt-mind/issue/CW-199): the direct-time-question guard is English-only (misses "Wie spät ist es?", "¿Qué hora es?") despite the router's stated multilingual requirement, and `NON_TIME_DOMAIN_PATTERN` swallows compound questions like "What time is it? Should I ride now?".