### PR TITLE
fix(profile): correct heightUnits enum check across AI prompts and profile writes

### DIFF
--- a/server/utils/ai-prompt-format.ts
+++ b/server/utils/ai-prompt-format.ts
@@ -27,8 +27,12 @@ export function formatPromptHeight(
 
   if (heightUnits === 'ft/in') {
     const totalInches = heightCm / 2.54
-    const feet = Math.floor(totalInches / 12)
-    const inches = Math.round(totalInches % 12)
+    let feet = Math.floor(totalInches / 12)
+    let inches = Math.round(totalInches % 12)
+    if (inches === 12) {
+      feet += 1
+      inches = 0
+    }
     return `${feet}'${inches}"`
   }
 

--- a/server/utils/ai-prompt-format.ts
+++ b/server/utils/ai-prompt-format.ts
@@ -25,7 +25,7 @@ export function formatPromptHeight(
 ): string {
   if (heightCm === null || heightCm === undefined) return 'Unknown'
 
-  if (heightUnits === 'Feet') {
+  if (heightUnits === 'ft/in') {
     const totalInches = heightCm / 2.54
     const feet = Math.floor(totalInches / 12)
     const inches = Math.round(totalInches % 12)

--- a/server/utils/ai-tools/profile.ts
+++ b/server/utils/ai-tools/profile.ts
@@ -135,8 +135,8 @@ export const profileTools = (userId: string, timezone: string, aiSettings: AiSet
 
           // Convert Height to CM if provided in Feet
           if (payload.height !== undefined) {
-            const heightUnits = payload.heightUnits || user?.heightUnits || 'Centimeters'
-            if (heightUnits === 'Feet') {
+            const heightUnits = payload.heightUnits || user?.heightUnits || 'cm'
+            if (heightUnits === 'ft/in') {
               payload.height = payload.height * 2.54
             }
           }

--- a/server/utils/services/chatContextService.ts
+++ b/server/utils/services/chatContextService.ts
@@ -8,7 +8,7 @@ import { generateTrainingContext, formatTrainingContextForPrompt } from '../trai
 import { getInjuryLabel } from '../../utils/wellness'
 import { filterGoalsForContext } from '../goal-context'
 import { getUserAiSettings } from '../ai-user-settings'
-import { formatPromptDistance } from '../ai-prompt-format'
+import { formatPromptDistance, formatPromptHeight } from '../ai-prompt-format'
 
 type BuildAthleteContextOptions = {
   includeDomainToolInstructions?: boolean
@@ -321,8 +321,7 @@ export async function buildAthleteContext(
       metrics.push(`Weight: ${userProfile.weight.toFixed(2)}${weightUnit}`)
     }
     if (userProfile.height) {
-      const heightUnit = userProfile.heightUnits === 'ft/in' ? 'ft/in' : 'cm'
-      metrics.push(`Height: ${userProfile.height}${heightUnit}`)
+      metrics.push(`Height: ${formatPromptHeight(userProfile.height, userProfile.heightUnits)}`)
     }
     if (userProfile.dob) {
       const age = Math.floor(

--- a/tests/unit/server/utils/ai-prompt-format.test.ts
+++ b/tests/unit/server/utils/ai-prompt-format.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { formatPromptHeight } from '../../../../server/utils/ai-prompt-format'
+
+describe('formatPromptHeight', () => {
+  it('returns a feet/inches string when heightUnits is ft/in', () => {
+    // 180.34 cm ~= 5'11"
+    const result = formatPromptHeight(180.34, 'ft/in')
+
+    expect(result).toBe(`5'11"`)
+  })
+
+  it('returns a cm string when heightUnits is cm', () => {
+    const result = formatPromptHeight(180, 'cm')
+
+    expect(result).toBe('180 cm')
+  })
+
+  it('defaults to cm when heightUnits is missing/unrecognized', () => {
+    expect(formatPromptHeight(175, undefined)).toBe('175 cm')
+    expect(formatPromptHeight(175, null)).toBe('175 cm')
+    expect(formatPromptHeight(175, 'Centimeters')).toBe('175 cm')
+  })
+
+  it('returns Unknown when height is null or undefined', () => {
+    expect(formatPromptHeight(null, 'ft/in')).toBe('Unknown')
+    expect(formatPromptHeight(undefined, 'cm')).toBe('Unknown')
+  })
+})

--- a/tests/unit/server/utils/ai-prompt-format.test.ts
+++ b/tests/unit/server/utils/ai-prompt-format.test.ts
@@ -9,6 +9,13 @@ describe('formatPromptHeight', () => {
     expect(result).toBe(`5'11"`)
   })
 
+  it('carries inches into feet when rounding lands on 12"', () => {
+    // 181.61 cm => 71.5 total inches => rounds to 5'12" without the carry fix
+    const result = formatPromptHeight(181.61, 'ft/in')
+
+    expect(result).toBe(`6'0"`)
+  })
+
   it('returns a cm string when heightUnits is cm', () => {
     const result = formatPromptHeight(180, 'cm')
 

--- a/tests/unit/server/utils/ai-tools/profile.test.ts
+++ b/tests/unit/server/utils/ai-tools/profile.test.ts
@@ -96,5 +96,30 @@ describe('profileTools', () => {
 
       expect(userRepository.update).toHaveBeenCalledWith(userId, { sex: 'Female' })
     })
+
+    it('should convert height to cm when the athlete prefers ft/in', async () => {
+      vi.mocked(userRepository.getById).mockResolvedValue({
+        id: userId,
+        heightUnits: 'ft/in'
+      } as any)
+      vi.mocked(userRepository.update).mockResolvedValue({ id: userId, height: 182.88 } as any)
+
+      // "set my height to 6 feet" -> tool receives 6 (interpreted in user's preferred units)
+      await tools.update_user_profile.execute({ height: 6 }, { toolCallId: '4', messages: [] })
+
+      expect(userRepository.update).toHaveBeenCalledWith(userId, { height: 6 * 2.54 })
+    })
+
+    it('should leave height unconverted when the athlete prefers cm (regression guard)', async () => {
+      vi.mocked(userRepository.getById).mockResolvedValue({
+        id: userId,
+        heightUnits: 'cm'
+      } as any)
+      vi.mocked(userRepository.update).mockResolvedValue({ id: userId, height: 180 } as any)
+
+      await tools.update_user_profile.execute({ height: 180 }, { toolCallId: '5', messages: [] })
+
+      expect(userRepository.update).toHaveBeenCalledWith(userId, { height: 180 })
+    })
   })
 })

--- a/trigger/daily-coach.ts
+++ b/trigger/daily-coach.ts
@@ -22,6 +22,7 @@ import { isWithinPreferredEmailTime } from '../server/utils/email-schedule'
 import { getCurrentFitnessSummary } from '../server/utils/training-stress'
 import { evaluateFitbitRecoveryAlert } from '../server/utils/wellness'
 import { dispatchTask } from '../server/utils/task-dispatcher'
+import { formatPromptHeight } from '../server/utils/ai-prompt-format'
 
 const suggestionSchema = {
   type: 'object',
@@ -204,7 +205,7 @@ Current Focus: ${profile.planning_context?.current_focus || 'General training'}
 USER INFO:
 - FTP: ${user?.ftp || 'Unknown'} watts
 - Weight: ${user?.weight || 'Unknown'} ${user?.weightUnits === 'Pounds' ? 'lbs' : 'kg'}
-- Height: ${user?.height || 'Unknown'} ${user?.heightUnits || 'cm'}
+- Height: ${formatPromptHeight(user?.height, user?.heightUnits)}
 - Max HR: ${user?.maxHr || 'Unknown'} bpm
 `
     }

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -1,6 +1,7 @@
 import './init'
 import { logger, task } from '@trigger.dev/sdk/v3'
 import { generateStructuredAnalysis } from '../server/utils/gemini'
+import { formatPromptHeight } from '../server/utils/ai-prompt-format'
 import { prisma } from '../server/utils/db'
 import { userReportsQueue } from './queues'
 import {
@@ -336,7 +337,7 @@ CURRENT CONTEXT:
 ATHLETE PROFILE:
 - Age: ${userAge || 'Unknown'}
 - Sex: ${user?.sex || 'Unknown'}
-- Height: ${user?.height || 'Unknown'} ${user?.heightUnits || 'cm'}
+- Height: ${formatPromptHeight(user?.height, user?.heightUnits)}
 - FTP: ${user?.ftp || 'Unknown'} W
 - Weight: ${user?.weight || 'Unknown'} ${user?.weightUnits === 'Pounds' ? 'lbs' : 'kg'}
 - Coach Persona: ${aiSettings.aiPersona}

--- a/trigger/review-goals.ts
+++ b/trigger/review-goals.ts
@@ -14,6 +14,7 @@ import {
 import { getUserAiSettings } from '../server/utils/ai-user-settings'
 import { filterGoalsForContext } from '../server/utils/goal-context'
 import { LBS_TO_KG } from '../server/utils/number'
+import { formatPromptHeight } from '../server/utils/ai-prompt-format'
 import { bodyMetricResolver } from '../server/utils/services/bodyMetricResolver'
 import { checkQuota } from '../server/utils/quotas/engine'
 
@@ -461,7 +462,7 @@ USER PROFILE:
             : effectiveWeight.value.toFixed(1) + ' kg'
           : 'Unknown'
       }
-- Height: ${user.height || 'Unknown'} ${user.heightUnits || 'cm'}
+- Height: ${formatPromptHeight(user.height, user.heightUnits)}
 - W/kg: ${user.ftp && effectiveWeight.value ? (user.ftp / effectiveWeight.value).toFixed(2) : 'Unknown'}
 - Max HR: ${user.maxHr || 'Unknown'} bpm
 


### PR DESCRIPTION
Fixes CW-194

## Summary

The real `heightUnits` enum is `'cm' | 'ft/in'` (see `server/utils/schemas/profile.ts:26` and the Prisma default `"cm"`), but two code paths checked for `'Feet'` / `'Centimeters'` — values that never occur — so the height-in-feet conversion silently never ran.

- `server/utils/ai-prompt-format.ts`: `formatPromptHeight` now checks `heightUnits === 'ft/in'` (was `'Feet'`) before formatting as `5'11"`.
- `server/utils/ai-tools/profile.ts`: `update_user_profile`'s write path now checks `heightUnits === 'ft/in'` (was `'Feet'`) and defaults to `'cm'` (was `'Centimeters'`) before converting a submitted height to cm (`* 2.54`). This was the more serious half of the bug — a user with `ft/in` preference saying "set my height to 6 feet" previously stored `height = 6` directly, silently corrupting the profile since downstream code reads it as cm.
- `server/utils/services/chatContextService.ts`, `trigger/daily-coach.ts`, `trigger/review-goals.ts`: the height line in each AI prompt-context builder previously concatenated the raw, unconverted cm value with a unit label (e.g. `${user.height} ft/in`) instead of actually converting it. All three now call `formatPromptHeight` instead. The adjacent weight lines (a separate ticket, CW-195) were left untouched.

## Test plan

- Added `tests/unit/server/utils/ai-prompt-format.test.ts`: proves `formatPromptHeight` returns a feet/inches string for `heightUnits: 'ft/in'`, a cm string for `'cm'`/missing/unrecognized units, and `'Unknown'` for null/undefined height.
- Extended `tests/unit/server/utils/ai-tools/profile.test.ts`: proves a chat-submitted height is converted to cm via `* 2.54` when the athlete's `heightUnits` is `'ft/in'`, and left unconverted when `'cm'` (regression guard).
- Ran and confirmed clean:
  - `pnpm vitest run tests/unit/server/utils/ai-prompt-format.test.ts tests/unit/server/utils/ai-tools/profile.test.ts` — 2 files, 10 tests passed
  - `pnpm vitest run tests/unit/server/utils/services/chatContextService.test.ts tests/unit/server/utils/services/chatContextService.timezone.test.ts` — 2 files, 8 tests passed (no regressions)