### PR TITLE
fix(chat): make direct-time-question guard multilingual and compound-question-aware

### DIFF
--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -640,15 +640,23 @@ const NON_TIME_DOMAIN_PATTERN =
 
 /**
  * Splits a message into clause-sized candidates on sentence-ending
- * punctuation. A compound message like "What time is it? Should I ride
- * now?" must be evaluated clause-by-clause: the NON_TIME_DOMAIN_PATTERN
- * exclusion is only meaningful scoped to the clause it actually describes,
- * otherwise an unrelated clause's domain word (e.g. "ride") suppresses a
- * genuine, independent time question elsewhere in the same message.
+ * punctuation, or on comma/dash conjunction boundaries that plausibly join
+ * two independent clauses (e.g. "What time is it, and should I ride now?"
+ * or "What time is it - should I ride now?"). A compound message must be
+ * evaluated clause-by-clause: the NON_TIME_DOMAIN_PATTERN exclusion is only
+ * meaningful scoped to the clause it actually describes, otherwise an
+ * unrelated clause's domain word (e.g. "ride") suppresses a genuine,
+ * independent time question elsewhere in the same message.
+ *
+ * The comma branch only fires when the comma is followed by whitespace, so
+ * a thousands separator like "1,000" (no space after the comma) is left
+ * intact. The dash branch only fires when the dash/en dash/em dash is
+ * surrounded by whitespace on both sides, so a mid-word hyphen like
+ * "trail-run" is never treated as a clause break.
  */
 function splitIntoClauses(text: string) {
   return text
-    .split(/[.?!]+/)
+    .split(/[.?!]+|,\s+(?:(?:and|but|then)\s+)?|\s+[-–—]\s+(?:(?:and|but|then)\s+)?/i)
     .map((clause) => clause.trim())
     .filter(Boolean)
 }

--- a/server/utils/chat/skills.ts
+++ b/server/utils/chat/skills.ts
@@ -615,29 +615,66 @@ function latestUserLooksLikeMissingReplyComplaint(messages: any[]) {
 }
 
 const DIRECT_TIME_QUESTION_PATTERNS = [
+  // English
   /\bwhat(?:'s| is|s) (?:the )?(?:current )?time\b/i,
   /\bwhat time (?:is it|do you have)\b/i,
   /\bcurrent time\b/i,
   /\btell me the time\b/i,
   /\bdo you know what time it is\b/i,
-  /\bhány óra van\b/i
+  // Hungarian
+  /\bhány óra van\b/i,
+  // German
+  /\bwie spät ist es\b/i,
+  /\bwie viel uhr ist es\b/i,
+  /\bwieviel uhr ist es\b/i,
+  // Spanish
+  /\bqué hora es\b/i,
+  /\bque hora es\b/i,
+  // French
+  /\bquelle heure est[- ]il\b/i,
+  /\bquelle heure il est\b/i
 ]
 
 const NON_TIME_DOMAIN_PATTERN =
   /\b(workout|activity|ride|run|swim|session|training|plan|planned|schedule|nutrition|meal|hydration|wellness|recovery|goal|ticket|bug|recommend)\b/i
 
 /**
+ * Splits a message into clause-sized candidates on sentence-ending
+ * punctuation. A compound message like "What time is it? Should I ride
+ * now?" must be evaluated clause-by-clause: the NON_TIME_DOMAIN_PATTERN
+ * exclusion is only meaningful scoped to the clause it actually describes,
+ * otherwise an unrelated clause's domain word (e.g. "ride") suppresses a
+ * genuine, independent time question elsewhere in the same message.
+ */
+function splitIntoClauses(text: string) {
+  return text
+    .split(/[.?!]+/)
+    .map((clause) => clause.trim())
+    .filter(Boolean)
+}
+
+/**
  * A direct "what time is it?" question must not silently fall back to a
  * tool-less general_chat turn: get_current_time is the only source of the
  * athlete's actual configured timezone, and the model will otherwise guess
  * (often UTC).
+ *
+ * The router this guard supports must work across languages (see
+ * buildRouterPrompt), so this deterministic pre-check covers common direct
+ * time-question phrasings in English, Hungarian, German, Spanish, and
+ * French, in addition to per-clause evaluation for compound messages.
  */
 export function looksLikeDirectTimeQuestion(text: string) {
   const trimmed = text.trim()
   if (!trimmed) return false
-  if (NON_TIME_DOMAIN_PATTERN.test(trimmed)) return false
 
-  return DIRECT_TIME_QUESTION_PATTERNS.some((pattern) => pattern.test(trimmed))
+  const clauses = splitIntoClauses(trimmed)
+  const candidates = clauses.length ? clauses : [trimmed]
+
+  return candidates.some((clause) => {
+    if (NON_TIME_DOMAIN_PATTERN.test(clause)) return false
+    return DIRECT_TIME_QUESTION_PATTERNS.some((pattern) => pattern.test(clause))
+  })
 }
 
 export function getDirectTimeQuestionSkillSelection(messages: any[]): ChatSkillSelection | null {

--- a/tests/unit/server/utils/chat/skills.test.ts
+++ b/tests/unit/server/utils/chat/skills.test.ts
@@ -50,6 +50,50 @@ describe('CW-193: direct time questions must not silently drop to a tool-less re
     })
   })
 
+  describe('CW-199: multilingual direct time questions', () => {
+    it.each([
+      ['German', 'Wie spät ist es?'],
+      ['Spanish', '¿Qué hora es?'],
+      ['French', 'Quelle heure est-il?'],
+      ['Hungarian', 'Hány óra van?']
+    ])('detects the %s phrasing "%s" as a direct time question', (_language, text) => {
+      expect(looksLikeDirectTimeQuestion(text)).toBe(true)
+    })
+
+    it.each(['what time is my next session?', 'what time should I ride tomorrow?'])(
+      'still does not treat the planning-flavored question "%s" as a direct time question',
+      (text) => {
+        expect(looksLikeDirectTimeQuestion(text)).toBe(false)
+      }
+    )
+  })
+
+  describe('CW-199: compound messages with an independent time-question clause', () => {
+    it('detects a direct time question even when followed by a workout-domain clause', () => {
+      expect(looksLikeDirectTimeQuestion('What time is it? Should I ride now?')).toBe(true)
+    })
+
+    it('detects a direct time question even when preceded by a workout-domain clause', () => {
+      expect(looksLikeDirectTimeQuestion('Should I ride now? What time is it?')).toBe(true)
+    })
+
+    it('still excludes a single clause that mixes a time word with a domain word', () => {
+      expect(looksLikeDirectTimeQuestion('What time should I ride tomorrow?')).toBe(false)
+    })
+
+    it('forces the tool-enabled selection for the compound time question via getDirectTimeQuestionSkillSelection', () => {
+      const selection = getDirectTimeQuestionSkillSelection([
+        { role: 'user', content: 'What time is it? Should I ride now?' }
+      ])
+
+      expect(selection).toMatchObject({
+        skillIds: ['general_chat'],
+        useTools: true,
+        usedFallback: false
+      })
+    })
+  })
+
   describe('getDirectTimeQuestionSkillSelection', () => {
     it('forces tool-enabled general_chat for a direct time question', () => {
       const selection = getDirectTimeQuestionSkillSelection([

--- a/tests/unit/server/utils/chat/skills.test.ts
+++ b/tests/unit/server/utils/chat/skills.test.ts
@@ -90,6 +90,18 @@ describe('CW-193: direct time questions must not silently drop to a tool-less re
       expect(looksLikeDirectTimeQuestion('What time is it for my ride?')).toBe(false)
     })
 
+    it('detects a direct time question when the compound clauses are joined by a comma instead of a full stop', () => {
+      expect(looksLikeDirectTimeQuestion('What time is it, and should I ride now?')).toBe(true)
+    })
+
+    it('detects a direct time question when the compound clauses are joined by a dash instead of a full stop', () => {
+      expect(looksLikeDirectTimeQuestion('What time is it - should I ride now?')).toBe(true)
+    })
+
+    it('does not treat a mid-word hyphen as a clause break', () => {
+      expect(looksLikeDirectTimeQuestion('I did a 5k trail-run today')).toBe(false)
+    })
+
     it('forces the tool-enabled selection for the compound time question via getDirectTimeQuestionSkillSelection', () => {
       const selection = getDirectTimeQuestionSkillSelection([
         { role: 'user', content: 'What time is it? Should I ride now?' }

--- a/tests/unit/server/utils/chat/skills.test.ts
+++ b/tests/unit/server/utils/chat/skills.test.ts
@@ -81,6 +81,15 @@ describe('CW-193: direct time questions must not silently drop to a tool-less re
       expect(looksLikeDirectTimeQuestion('What time should I ride tomorrow?')).toBe(false)
     })
 
+    it('excludes a single clause that literally matches a time pattern but also names a domain word', () => {
+      // Unlike the two cases above (which never match DIRECT_TIME_QUESTION_PATTERNS regardless
+      // of the domain exclusion), this clause DOES match "what time is it" verbatim, so it only
+      // gets excluded if NON_TIME_DOMAIN_PATTERN is still being checked per-clause after the
+      // clause-splitting change. This is the case the split-by-clause fix could most plausibly
+      // have broken by widening the exclusion's scope in the wrong direction.
+      expect(looksLikeDirectTimeQuestion('What time is it for my ride?')).toBe(false)
+    })
+
     it('forces the tool-enabled selection for the compound time question via getDirectTimeQuestionSkillSelection', () => {
       const selection = getDirectTimeQuestionSkillSelection([
         { role: 'user', content: 'What time is it? Should I ride now?' }


### PR DESCRIPTION
Fixes CW-199

## Summary

`looksLikeDirectTimeQuestion` / `getDirectTimeQuestionSkillSelection` in `server/utils/chat/skills.ts` deterministically force `get_current_time` tool availability for direct "what time is it?" questions, so the model can't answer with an inferred/UTC time. Two gaps existed:

1. **English-only patterns** in a router that's explicitly documented as multilingual (`buildRouterPrompt`: "This router must work across languages. Infer intent semantically, not by English-only wording."). `DIRECT_TIME_QUESTION_PATTERNS` only covered English plus one Hungarian phrase.
2. **`NON_TIME_DOMAIN_PATTERN` swallowed compound questions.** The exclusion regex was tested against the whole message, so "What time is it? Should I ride now?" was excluded just because it contained "ride" — even though it has a genuine, independent time-question clause.

## Changes

- `DIRECT_TIME_QUESTION_PATTERNS` now includes German, Spanish, and French direct-time-question phrasings (plus the existing Hungarian entry), following the same multilingual pattern-list style already used elsewhere in this file (e.g. `latestUserLooksLikeApprovalContinuation`'s Hungarian `igen`/`jó`/`jo`/`mehet` entries).
- `looksLikeDirectTimeQuestion` now splits the message into clauses on `.`/`?`/`!` and evaluates each clause independently against both the time-question patterns and the `NON_TIME_DOMAIN_PATTERN` exclusion. A compound message fires if *any* clause is an unexclued direct time question; a single clause that genuinely mixes a time word with a domain word (e.g. "what time should I ride tomorrow?") is still excluded, since that clause alone contains both.

## Test cases added (`tests/unit/server/utils/chat/skills.test.ts`)

MUST fire:
- German: `Wie spät ist es?`
- Spanish: `¿Qué hora es?`
- French: `Quelle heure est-il?`
- Hungarian (pre-existing, re-verified): `Hány óra van?`
- Compound: `What time is it? Should I ride now?` (and the domain-clause-first variant `Should I ride now? What time is it?`)
- `getDirectTimeQuestionSkillSelection` forces the tool-enabled selection for the compound case too.

MUST NOT fire (regression guards):
- `what time is my next session?`
- `what time should I ride tomorrow?`
- All pre-existing negative-case tests in the suite (unchanged).

## Verification

```
pnpm vitest run tests/unit/server/utils/chat/skills.test.ts server/utils/chat/skills.test.ts
```

```
 Test Files  2 passed (2)
      Tests  62 passed (62)
```

62 tests pass total (52 pre-existing + 10 new). The pre-existing, untouched `server/utils/chat/skills.test.ts` (666 lines, unrelated skill-routing tests) has zero regressions — it was run before and after the change with identical pass counts.

Only `server/utils/chat/skills.ts` and `tests/unit/server/utils/chat/skills.test.ts` were touched, per the ticket's owned paths.