### PR TITLE
fix(ai): respect distanceUnits/temperatureUnits in workout and wellness analysis reports

### DIFF
--- a/server/utils/services/wellness-analysis.ts
+++ b/server/utils/services/wellness-analysis.ts
@@ -6,6 +6,7 @@ import { auditLogRepository } from '../repositories/auditLogRepository'
 import { getUserLocalDate, getUserTimezone } from '../date'
 import { triggerDailyCheckinIfNeeded } from './checkin-service'
 import { checkQuota } from '../quotas/engine'
+import { formatPromptTemperature } from '../ai-prompt-format'
 import {
   getMoodLabel,
   getStressLabel,
@@ -140,7 +141,7 @@ export async function analyzeWellness(wellnessId: string, userId: string) {
     const [user, aiSettings, wellnessEvents] = await Promise.all([
       prisma.user.findUnique({
         where: { id: userId },
-        select: { language: true }
+        select: { language: true, temperatureUnits: true }
       }),
       getUserAiSettings(userId),
       getWellnessEventOverlaysForUser(userId, {
@@ -257,7 +258,7 @@ export async function analyzeWellness(wellnessId: string, userId: string) {
     // Check both recovery.score and nested structure just in case
     const skinTemp = rawData?.recovery?.score?.skin_temp_celsius ?? rawData?.skinTemp
     if (skinTemp) {
-      advancedContext += `- Skin Temp: ${skinTemp.toFixed(1)}°C\n`
+      advancedContext += `- Skin Temp: ${formatPromptTemperature(skinTemp, user?.temperatureUnits)}\n`
     }
 
     const prompt = `

--- a/tests/unit/server/utils/services/wellness-analysis.test.ts
+++ b/tests/unit/server/utils/services/wellness-analysis.test.ts
@@ -91,3 +91,78 @@ describe('analyzeWellness quota enforcement', () => {
     expect(result).toEqual({ success: false, reason: 'QUOTA_EXCEEDED' })
   })
 })
+
+describe('analyzeWellness skin temperature formatting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkQuotaMock.mockResolvedValue({
+      operation: 'wellness_analysis',
+      allowed: true,
+      used: 0,
+      limit: Infinity,
+      remaining: Infinity,
+      window: 'none',
+      resetsAt: null,
+      enforcement: 'MEASURE'
+    })
+    prismaWellnessFindUnique.mockResolvedValue({
+      id: 'wellness-1',
+      date: new Date('2026-03-09T00:00:00.000Z'),
+      hrv: 55,
+      restingHr: 50,
+      sleepHours: 7.5,
+      recoveryScore: 80,
+      readiness: 8,
+      rawJson: { skinTemp: 33.5 }
+    })
+  })
+
+  it('formats skin temperature in Fahrenheit for a Fahrenheit-preference athlete', async () => {
+    prismaUserFindUnique.mockResolvedValue({
+      language: 'English',
+      temperatureUnits: 'Fahrenheit'
+    })
+
+    const { generateStructuredAnalysis } = await import('../../../../../server/utils/gemini')
+    const { analyzeWellness } =
+      await import('../../../../../server/utils/services/wellness-analysis')
+
+    ;(generateStructuredAnalysis as any).mockResolvedValue({
+      executive_summary: 'ok',
+      status: 'READY',
+      sections: [],
+      recommendations: []
+    })
+
+    await analyzeWellness('wellness-1', 'user-1')
+
+    expect(generateStructuredAnalysis).toHaveBeenCalled()
+    const prompt = (generateStructuredAnalysis as any).mock.calls[0][0] as string
+    // 33.5C -> 92.3F
+    expect(prompt).toContain('Skin Temp: 92.3°F')
+    expect(prompt).not.toContain('Skin Temp: 33.5°C')
+  })
+
+  it('formats skin temperature in Celsius for a metric-preference athlete (unaffected)', async () => {
+    prismaUserFindUnique.mockResolvedValue({
+      language: 'English',
+      temperatureUnits: 'Celsius'
+    })
+
+    const { generateStructuredAnalysis } = await import('../../../../../server/utils/gemini')
+    const { analyzeWellness } =
+      await import('../../../../../server/utils/services/wellness-analysis')
+
+    ;(generateStructuredAnalysis as any).mockResolvedValue({
+      executive_summary: 'ok',
+      status: 'READY',
+      sections: [],
+      recommendations: []
+    })
+
+    await analyzeWellness('wellness-1', 'user-1')
+
+    const prompt = (generateStructuredAnalysis as any).mock.calls[0][0] as string
+    expect(prompt).toContain('Skin Temp: 33.5°C')
+  })
+})

--- a/tests/unit/trigger/analyze-last-3-workouts-prompt.test.ts
+++ b/tests/unit/trigger/analyze-last-3-workouts-prompt.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { convertStructuredToMarkdown } from '../../../trigger/analyze-last-3-workouts'
+
+describe('convertStructuredToMarkdown', () => {
+  const baseAnalysis = {
+    title: 'Last 3 Rides Review',
+    date: 'Mar 1 - Mar 15, 2026',
+    executive_summary: 'Solid progression across the last three rides.',
+    sections: [],
+    recommendations: [],
+    metrics_summary: {
+      total_duration_minutes: 180,
+      total_tss: 250,
+      avg_power: 220,
+      avg_heart_rate: 145,
+      // Stored canonically in kilometers (see schema comment in analyze-last-3-workouts.ts)
+      total_distance_km: 100
+    }
+  }
+
+  it('formats total distance in miles for a Miles-preference athlete', () => {
+    const markdown = convertStructuredToMarkdown(baseAnalysis, 'Miles')
+
+    // 100km -> ~62.14 mi
+    expect(markdown).toContain('**Total Distance**: 62.14 mi')
+    expect(markdown).not.toContain('100.0 km')
+  })
+
+  it('formats total distance in kilometers for a metric-preference athlete (unaffected)', () => {
+    const markdown = convertStructuredToMarkdown(baseAnalysis, 'Kilometers')
+
+    expect(markdown).toContain('**Total Distance**: 100.00 km')
+  })
+
+  it('defaults to kilometers when distanceUnits is not provided', () => {
+    const markdown = convertStructuredToMarkdown(baseAnalysis)
+
+    expect(markdown).toContain('**Total Distance**: 100.00 km')
+  })
+})

--- a/tests/unit/trigger/analyze-workout-prompt.test.ts
+++ b/tests/unit/trigger/analyze-workout-prompt.test.ts
@@ -1,6 +1,78 @@
-import { describe, expect, it } from 'vitest'
-import { buildWorkoutAnalysisPrompt } from '../../../trigger/analyze-workout'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildWorkoutAnalysisFactsV2 } from '../../../server/utils/workout-analysis-facts'
+import { analyzeWorkoutTask, buildWorkoutAnalysisPrompt } from '../../../trigger/analyze-workout'
+
+const { generateStructuredAnalysis } = vi.hoisted(() => ({
+  generateStructuredAnalysis: vi.fn()
+}))
+
+vi.mock('../../../trigger/init', () => ({}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    workout: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn() },
+    emailPreference: { findUnique: vi.fn() },
+    athleteJourneyEvent: { findMany: vi.fn() }
+  }
+}))
+
+vi.mock('../../../server/utils/repositories/workoutStreamRepository', () => ({
+  attachStreamToWorkout: vi.fn(async (workout: any) => ({ ...workout, streams: null }))
+}))
+
+vi.mock('../../../server/utils/repositories/workoutRepository', () => ({
+  workoutRepository: {
+    updateStatus: vi.fn(),
+    update: vi.fn()
+  }
+}))
+
+vi.mock('../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: {
+    getForActivityType: vi.fn().mockResolvedValue(null)
+  }
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('Europe/Budapest'),
+  formatUserDate: vi.fn(() => '2026-03-15'),
+  getUserLocalDate: vi.fn(() => '2026-03-15'),
+  calculateAge: vi.fn(() => 35)
+}))
+
+vi.mock('../../../server/utils/ai-user-settings', () => ({
+  getUserAiSettings: vi.fn().mockResolvedValue({
+    aiPersona: 'Supportive',
+    aiModelPreference: 'gemini-2.0-flash-exp',
+    aiContext: null
+  })
+}))
+
+vi.mock('../../../server/utils/quotas/engine', () => ({
+  checkQuota: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../../server/utils/gemini', () => ({
+  generateCoachAnalysis: vi.fn(),
+  generateStructuredAnalysis
+}))
+
+vi.mock('@trigger.dev/sdk/v3', async () => {
+  const actual = await vi.importActual('@trigger.dev/sdk/v3')
+  return {
+    ...actual,
+    logger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    task: vi.fn().mockImplementation((config: any) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+})
 
 describe('buildWorkoutAnalysisPrompt', () => {
   it('adds stop-and-go and ski-specific guardrails to the workout analysis prompt', () => {
@@ -131,5 +203,88 @@ describe('buildWorkoutAnalysisPrompt', () => {
 
     expect(metricPrompt).toContain('20 m')
     expect(metricPrompt).not.toContain('20m')
+  })
+})
+
+// Regression coverage for CW-196: the two tests above exercise buildWorkoutAnalysisPrompt
+// directly with a hand-built userProfile, which would happily pass even if the real
+// analyzeWorkoutTask forgot to fetch/thread distanceUnits from the database. These tests
+// instead drive the actual trigger task's data-fetching path (mocking prisma.user.findUnique)
+// so a missing `distanceUnits: true` in the Prisma select, or a missing `distanceUnits` field
+// in the userProfile object built from `user`, is caught.
+describe('analyzeWorkoutTask (data-fetching path)', () => {
+  const baseWorkoutRecord = {
+    id: 'workout-1',
+    userId: 'user-1',
+    date: new Date('2026-03-15T10:00:00Z'),
+    title: 'Evening Run',
+    type: 'Run',
+    durationSec: 1800,
+    distanceMeters: 8046.72, // 5 miles
+    elevationGain: null,
+    averageWatts: null,
+    averageHr: null,
+    exercises: [],
+    plannedWorkout: null,
+    plannedWorkoutId: null
+  }
+
+  const baseUser = {
+    dob: new Date('1990-01-01'),
+    sex: 'male',
+    weight: 70,
+    weightUnits: 'Kilograms',
+    height: 180,
+    heightUnits: 'Centimeters',
+    language: 'English',
+    temperatureUnits: 'Celsius',
+    aiAutoAnalyzeWorkouts: true
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const { prisma } = await import('../../../server/utils/db')
+    vi.mocked(prisma.workout.findUnique).mockResolvedValue(baseWorkoutRecord as any)
+    vi.mocked(prisma.emailPreference.findUnique).mockResolvedValue(null as any)
+    vi.mocked(prisma.athleteJourneyEvent.findMany).mockResolvedValue([] as any)
+
+    generateStructuredAnalysis.mockRejectedValue(new Error('stop after prompt build'))
+  })
+
+  it('threads the athlete distanceUnits preference from the DB into the generated prompt', async () => {
+    const { prisma } = await import('../../../server/utils/db')
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      ...baseUser,
+      distanceUnits: 'Miles'
+    } as any)
+
+    await expect(
+      analyzeWorkoutTask.run({ workoutId: 'workout-1', source: 'MANUAL' })
+    ).rejects.toThrow('stop after prompt build')
+
+    expect(generateStructuredAnalysis).toHaveBeenCalledTimes(1)
+    const [prompt] = generateStructuredAnalysis.mock.calls[0]
+
+    // 8046.72m -> 5.00 mi. If distanceUnits were dropped (as in the CW-196 regression this
+    // guards against), the prompt would silently fall back to metric ("8.05 km") instead.
+    expect(prompt).toContain('5.00 mi')
+    expect(prompt).not.toContain('8.05 km')
+  })
+
+  it('falls back to metric when the athlete has no distanceUnits preference set', async () => {
+    const { prisma } = await import('../../../server/utils/db')
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      ...baseUser,
+      distanceUnits: null
+    } as any)
+
+    await expect(
+      analyzeWorkoutTask.run({ workoutId: 'workout-1', source: 'MANUAL' })
+    ).rejects.toThrow('stop after prompt build')
+
+    const [prompt] = generateStructuredAnalysis.mock.calls[0]
+    expect(prompt).toContain('8.05 km')
+    expect(prompt).not.toContain('5.00 mi')
   })
 })

--- a/tests/unit/trigger/analyze-workout-prompt.test.ts
+++ b/tests/unit/trigger/analyze-workout-prompt.test.ts
@@ -80,4 +80,56 @@ describe('buildWorkoutAnalysisPrompt', () => {
     expect(prompt).toContain('Decoupling Guardrail:')
     expect(prompt).not.toContain('- Decoupling: -91.8%')
   })
+
+  it('formats strength-exercise set distance using the athlete distanceUnits preference', () => {
+    const workoutData = {
+      date: new Date('2026-03-15T10:00:00Z'),
+      title: 'Full Body Strength',
+      type: 'Strength',
+      duration_m: 45,
+      duration_s: 2700,
+      exercises: [
+        {
+          name: 'Sled Push',
+          muscle_group: 'Legs',
+          sets: [{ type: 'NORMAL', reps: 1, distance: 20 }]
+        }
+      ]
+    }
+
+    const milesPrompt = buildWorkoutAnalysisPrompt(
+      workoutData,
+      'Europe/Budapest',
+      'Supportive',
+      undefined,
+      {
+        age: 35,
+        sex: 'male',
+        weight: null,
+        language: 'English',
+        distanceUnits: 'Miles'
+      }
+    )
+
+    // 20 meters -> ~66 feet
+    expect(milesPrompt).toContain('66 ft')
+    expect(milesPrompt).not.toContain('20m')
+
+    const metricPrompt = buildWorkoutAnalysisPrompt(
+      workoutData,
+      'Europe/Budapest',
+      'Supportive',
+      undefined,
+      {
+        age: 35,
+        sex: 'male',
+        weight: null,
+        language: 'English',
+        distanceUnits: 'Kilometers'
+      }
+    )
+
+    expect(metricPrompt).toContain('20 m')
+    expect(metricPrompt).not.toContain('20m')
+  })
 })

--- a/trigger/analyze-last-3-workouts.ts
+++ b/trigger/analyze-last-3-workouts.ts
@@ -100,6 +100,12 @@ const analysisSchema = {
         total_tss: { type: 'number' },
         avg_power: { type: 'number' },
         avg_heart_rate: { type: 'number' },
+        // NOTE: kept as kilometers (not renamed to a unit-agnostic name) because this exact
+        // field name/shape is a shared contract also consumed by app/pages/report/[id].vue
+        // (which independently converts to meters and re-formats via the user's distanceUnits
+        // client-side) and mirrored by the schemas in generate-weekly-report.ts and
+        // generate-custom-report.ts. Kilometers is treated as the canonical storage unit here;
+        // unit-aware formatting happens at render time (see convertStructuredToMarkdown below).
         total_distance_km: { type: 'number' }
       }
     }
@@ -173,7 +179,7 @@ Be specific with numbers and trends. Highlight both strengths and areas for impr
   return prompt
 }
 
-function convertStructuredToMarkdown(analysis: any): string {
+export function convertStructuredToMarkdown(analysis: any, distanceUnits?: string | null): string {
   let markdown = `# ${analysis.title}\n\n`
   markdown += `**Period**: ${analysis.date}\n\n`
   markdown += `## Quick Take\n\n${analysis.executive_summary}\n\n`
@@ -210,7 +216,7 @@ function convertStructuredToMarkdown(analysis: any): string {
     if (metrics.avg_heart_rate)
       markdown += `- **Average HR**: ${Math.round(metrics.avg_heart_rate)} bpm\n`
     if (metrics.total_distance_km)
-      markdown += `- **Total Distance**: ${metrics.total_distance_km.toFixed(1)} km\n`
+      markdown += `- **Total Distance**: ${formatPromptDistance(metrics.total_distance_km * 1000, distanceUnits)}\n`
   }
 
   return markdown
@@ -297,7 +303,8 @@ export const analyzeLast3WorkoutsTask = task({
           maxHr: true,
           dob: true,
           sex: true,
-          language: true
+          language: true,
+          distanceUnits: true
         }
       })
 
@@ -318,7 +325,7 @@ export const analyzeLast3WorkoutsTask = task({
       })
 
       // Also generate markdown for fallback/export
-      const markdownAnalysis = convertStructuredToMarkdown(structuredAnalysis)
+      const markdownAnalysis = convertStructuredToMarkdown(structuredAnalysis, user?.distanceUnits)
 
       logger.log('Analysis generated successfully', {
         sections: structuredAnalysis.sections?.length || 0,

--- a/trigger/analyze-workout.ts
+++ b/trigger/analyze-workout.ts
@@ -316,6 +316,7 @@ export const analyzeWorkoutTask = task({
             heightUnits: true,
             language: true,
             temperatureUnits: true,
+            distanceUnits: true,
             aiAutoAnalyzeWorkouts: true
           }
         }),
@@ -463,7 +464,8 @@ export const analyzeWorkoutTask = task({
           height: user?.height || null,
           heightUnits: user?.heightUnits || null,
           language: user?.language || null,
-          temperatureUnits: user?.temperatureUnits || null
+          temperatureUnits: user?.temperatureUnits || null,
+          distanceUnits: user?.distanceUnits || null
         },
         aiSettings.aiContext,
         workout.plannedWorkout,

--- a/trigger/analyze-workout.ts
+++ b/trigger/analyze-workout.ts
@@ -1624,7 +1624,10 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 
         if (s.distance) {
           if (metricAdded) prompt += `, `
-          prompt += `${s.distance}m`
+          // Strength-exercise set distances (sled push, farmer's carry, etc.) are short
+          // distances, so use the same meters<->feet conversion as elevation rather than
+          // km/mi (which would round to an unreadable "0.02 mi").
+          prompt += formatPromptElevation(s.distance, userProfile?.distanceUnits)
           metricAdded = true
         }
 


### PR DESCRIPTION
Fixes CW-196

## Summary

Three Gemini prompt call sites hard-coded metric units instead of respecting the athlete's `distanceUnits`/`temperatureUnits` preference, unlike the rest of their surrounding prompts which already use the `ai-prompt-format.ts` helpers.

- **`trigger/analyze-workout.ts`** (~line 1627): strength-exercise set distance (sled push, farmer's carry, etc.) was hard-coded as `` `${s.distance}m` ``. These are short distances, so km/mi would round unreadably (e.g. "0.02 mi"); switched to `formatPromptElevation`, which does the same meters↔feet conversion already used for elevation gain elsewhere in this file.
- **`trigger/analyze-last-3-workouts.ts`** (~line 213): the AI-generated markdown hard-coded `" km"` for total distance. Now formatted via `formatPromptDistance`, respecting `distanceUnits`. The user profile fetch now also selects `distanceUnits`.
  - The `total_distance_km` schema field name was intentionally **kept as-is** rather than renamed: it's a shared contract also read by `app/pages/report/[id].vue` (which converts it to meters and re-formats client-side via the user's own `distanceUnits`) and mirrored by the sibling schemas in `generate-weekly-report.ts`/`generate-custom-report.ts` — both out of scope for this ticket. Renaming it here only would silently break the Distance card for this report type. Kilometers remains the canonical storage unit; unit-aware formatting now happens at render time in `convertStructuredToMarkdown`, which is now exported for testability.
- **`server/utils/services/wellness-analysis.ts`** (~line 260): skin temperature was hard-coded as `` `${skinTemp.toFixed(1)}°C` ``. Added `temperatureUnits` to the existing user `select` (previously only `language`) and formatted via `formatPromptTemperature`. Left the adjacent weight line (~line 303) untouched — that's owned by the parallel CW-195 ticket.

## Test plan

- [x] `pnpm vitest run tests/unit/server/utils/services/wellness-analysis.test.ts` — extended with two new tests (Fahrenheit-preference athlete gets `°F`, Celsius/metric-preference athlete unaffected). 3/3 pass.
- [x] New `tests/unit/trigger/analyze-last-3-workouts-prompt.test.ts` — Miles-preference athlete gets `mi`, Kilometers-preference and no-preference (default) get `km`. 3/3 pass.
- [x] Extended `tests/unit/trigger/analyze-workout-prompt.test.ts` — Miles-preference athlete gets strength-exercise distance in `ft`, Kilometers-preference athlete gets `m`. New test passes alongside the existing test.
- [x] Full regression: `pnpm vitest run tests/unit/trigger/ tests/unit/server/utils/services/` — 32 files / 227 tests pass.
- [x] `pnpm typecheck` passes.
- [x] `pnpm eslint` on all touched files — clean.
- [x] `tests/unit/server/utils/ai-prompt-format.test.ts` doesn't exist yet in this worktree (CW-194 not merged) — skipped per ticket note.