### PR TITLE
fix(ai-tools): use athlete timezone instead of raw UTC for DateTime filtering and construction

### DIFF
--- a/server/utils/ai-tools/analysis.ts
+++ b/server/utils/ai-tools/analysis.ts
@@ -164,7 +164,7 @@ export const analysisTools = (userId: string, timezone: string, settings: AiSett
       // athlete's local-day boundaries rather than the raw UTC-midnight anchors
       // used for calendar-day bookkeeping (startDate/endDate/historicalEndDate).
       const historicalQueryStart = getStartOfLocalDateUTC(timezone, start_date)
-      const historicalQueryEnd = getStartOfLocalDateUTC(timezone, formatDateUTC(historicalEndDate))
+      const historicalQueryEnd = getEndOfLocalDateUTC(timezone, formatDateUTC(historicalEndDate))
 
       const completedWorkloads = hasHistoricalWindow
         ? (

--- a/server/utils/ai-tools/analysis.ts
+++ b/server/utils/ai-tools/analysis.ts
@@ -7,7 +7,9 @@ import {
   getStartOfDaysAgoUTC,
   formatDateUTC,
   formatUserDate,
-  getUserLocalDate
+  getUserLocalDate,
+  getStartOfLocalDateUTC,
+  getEndOfLocalDateUTC
 } from '../../utils/date'
 import { calculateProjectedPMC, getInitialPMCValues } from '../../utils/training-stress'
 import type { AiSettings } from '../ai-user-settings'
@@ -87,8 +89,8 @@ export const analysisTools = (userId: string, timezone: string, settings: AiSett
       end_date: z.string().optional().describe('End date (YYYY-MM-DD)')
     }),
     execute: async ({ start_date, end_date }) => {
-      const start = new Date(start_date)
-      const end = end_date ? new Date(end_date) : new Date()
+      const start = getStartOfLocalDateUTC(timezone, start_date)
+      const end = end_date ? getEndOfLocalDateUTC(timezone, end_date) : new Date()
 
       const workouts = await workoutRepository.getForUser(userId, {
         startDate: start,
@@ -157,13 +159,20 @@ export const analysisTools = (userId: string, timezone: string, settings: AiSett
       const historicalEndDate = endDate < todayDate ? endDate : todayDate
       const hasHistoricalWindow = startDate <= historicalEndDate
 
+      // Workout.date is a genuine DateTime timestamp (unlike PlannedWorkout.date's
+      // @db.Date calendar column below), so the historical query must use the
+      // athlete's local-day boundaries rather than the raw UTC-midnight anchors
+      // used for calendar-day bookkeeping (startDate/endDate/historicalEndDate).
+      const historicalQueryStart = getStartOfLocalDateUTC(timezone, start_date)
+      const historicalQueryEnd = getStartOfLocalDateUTC(timezone, formatDateUTC(historicalEndDate))
+
       const completedWorkloads = hasHistoricalWindow
         ? (
             await prisma.workout.findMany({
               where: {
                 userId,
                 isDuplicate: false,
-                date: { gte: startDate, lte: historicalEndDate }
+                date: { gte: historicalQueryStart, lte: historicalQueryEnd }
               },
               select: {
                 date: true,

--- a/server/utils/ai-tools/journey.ts
+++ b/server/utils/ai-tools/journey.ts
@@ -1,7 +1,14 @@
 import { tool } from 'ai'
 import { z } from 'zod/v3'
 import { journeyService } from '../services/journeyService'
-import { getUserTimezone } from '../date'
+import { prisma } from '../db'
+import {
+  getUserTimezone,
+  getUserLocalDate,
+  buildZonedDateTimeFromUtcDate,
+  getStartOfLocalDateUTC,
+  getEndOfLocalDateUTC
+} from '../date'
 import { JourneyEventType, JourneyEventCategory } from '@prisma/client'
 
 export const journeyTools = (userId: string, timezone: string) => ({
@@ -34,13 +41,9 @@ export const journeyTools = (userId: string, timezone: string) => ({
         if (timestamp.includes('T')) {
           eventTime = new Date(timestamp)
         } else if (/^\d{1,2}:\d{2}/.test(timestamp)) {
-          // Handle HH:mm
-          const parts = timestamp.split(':').map(Number)
-          const h = parts[0]
-          const m = parts[1]
-          if (h !== undefined && m !== undefined) {
-            eventTime.setHours(h, m, 0, 0)
-          }
+          // Handle HH:mm anchored to the athlete's local "today", not the
+          // server process's local/UTC time.
+          eventTime = buildZonedDateTimeFromUtcDate(getUserLocalDate(timezone), timestamp, timezone)
         }
       }
 
@@ -82,8 +85,8 @@ export const journeyTools = (userId: string, timezone: string) => ({
         .describe('Filter by specific category')
     }),
     execute: async ({ start_date, end_date, category }) => {
-      const start = new Date(`${start_date}T00:00:00Z`)
-      const end = end_date ? new Date(`${end_date}T23:59:59Z`) : new Date(`${start_date}T23:59:59Z`)
+      const start = getStartOfLocalDateUTC(timezone, start_date)
+      const end = getEndOfLocalDateUTC(timezone, end_date || start_date)
 
       const events = await prisma.athleteJourneyEvent.findMany({
         where: {
@@ -140,13 +143,13 @@ export const journeyTools = (userId: string, timezone: string) => ({
         if (timestamp.includes('T')) {
           eventTime = new Date(timestamp)
         } else if (/^\d{1,2}:\d{2}/.test(timestamp)) {
-          const parts = timestamp.split(':').map(Number)
-          const h = parts[0]
-          const m = parts[1]
-          if (h !== undefined && m !== undefined) {
-            eventTime = new Date(existing.timestamp)
-            eventTime.setHours(h, m, 0, 0)
-          }
+          // Handle HH:mm, preserving the existing event's local calendar day
+          // (in the athlete's timezone) while updating the time-of-day.
+          eventTime = buildZonedDateTimeFromUtcDate(
+            getUserLocalDate(timezone, existing.timestamp),
+            timestamp,
+            timezone
+          )
         }
       }
 

--- a/server/utils/ai-tools/workouts.ts
+++ b/server/utils/ai-tools/workouts.ts
@@ -8,8 +8,8 @@ import {
   getStartOfDaysAgoUTC,
   formatUserDate,
   formatDateUTC,
-  getStartOfDayUTC,
-  getEndOfDayUTC
+  getStartOfLocalDateUTC,
+  getEndOfLocalDateUTC
 } from '../../utils/date'
 import type { AiSettings } from '../ai-user-settings'
 import { hasProtectedIntervalsTags, mergeWorkoutTags } from '../workout-tags'
@@ -83,8 +83,8 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
       if (title_search) where.title = { contains: title_search, mode: 'insensitive' }
       if (type) where.type = { contains: type, mode: 'insensitive' }
       if (date) {
-        const start = new Date(`${date}T00:00:00.000Z`)
-        const end = new Date(`${date}T23:59:59.999Z`)
+        const start = getStartOfLocalDateUTC(timezone, date)
+        const end = getEndOfLocalDateUTC(timezone, date)
 
         if (!Number.isNaN(start.getTime()) && !Number.isNaN(end.getTime())) {
           where.date = {

--- a/tests/unit/server/utils/ai-tools/analysis.test.ts
+++ b/tests/unit/server/utils/ai-tools/analysis.test.ts
@@ -188,7 +188,7 @@ describe('analysisTools', () => {
           isDuplicate: false,
           date: {
             gte: new Date('2026-03-01T00:00:00Z'),
-            lte: new Date('2026-03-03T00:00:00Z')
+            lte: new Date('2026-03-03T23:59:59.999Z')
           }
         },
         select: {
@@ -241,7 +241,7 @@ describe('analysisTools', () => {
           isDuplicate: false,
           date: {
             gte: new Date('2026-03-01T08:00:00.000Z'),
-            lte: new Date('2026-03-03T08:00:00.000Z')
+            lte: new Date('2026-03-04T07:59:59.999Z')
           }
         },
         select: {
@@ -252,6 +252,74 @@ describe('analysisTools', () => {
         },
         orderBy: { date: 'asc' }
       })
+    })
+
+    it('should include a same-day workout logged after local midnight in the historical query window', async () => {
+      // Regression test for the day-boundary bug: historicalQueryEnd was
+      // computed with getStartOfLocalDateUTC instead of getEndOfLocalDateUTC,
+      // so a workout completed later in the local day (after local midnight,
+      // i.e. later than the raw UTC start-of-day anchor) was excluded from
+      // the `lte` bound and silently dropped from the forecast's historical
+      // training-load calculation.
+      //
+      // America/Los_Angeles is UTC-8 (PST) in early March 2026. An athlete
+      // completes a workout at 09:00 local on 2026-03-03 (17:00 UTC) and
+      // requests a same-day forecast. The historical query's `lte` bound
+      // must extend through end-of-day local time (2026-03-04T07:59:59.999Z)
+      // so the workout is included, not truncated at start-of-day
+      // (2026-03-03T08:00:00.000Z).
+      const workoutAfterLocalMidnight = {
+        date: new Date('2026-03-03T17:00:00.000Z'),
+        tss: 65,
+        durationSec: 3600,
+        type: 'Ride'
+      }
+
+      vi.mocked(getInitialPMCValues).mockResolvedValue({ ctl: 10, atl: 12 })
+      vi.mocked(prisma.workout.findMany).mockResolvedValue([workoutAfterLocalMidnight] as any)
+      vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([] as any)
+      vi.mocked(calculateProjectedPMC).mockReturnValue([
+        { date: new Date('2026-03-01T00:00:00Z'), ctl: 10, atl: 12, tsb: -2, tss: 0 },
+        { date: new Date('2026-03-03T00:00:00Z'), ctl: 10, atl: 12, tsb: -2, tss: 65 }
+      ] as any)
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({ ftp: null } as any)
+      vi.mocked(prisma.workout.findFirst).mockResolvedValue(null as any)
+
+      const laTools = analysisTools(userId, 'America/Los_Angeles', mockSettings)
+
+      await laTools.forecast_training_load.execute(
+        {
+          start_date: '2026-03-01',
+          end_date: '2026-03-03'
+        },
+        { toolCallId: '1', messages: [] }
+      )
+
+      // The query window must reach end-of-local-day so the 17:00Z workout
+      // (09:00 local) falls within the `lte` bound.
+      expect(prisma.workout.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            date: {
+              gte: new Date('2026-03-01T08:00:00.000Z'),
+              lte: new Date('2026-03-04T07:59:59.999Z')
+            }
+          })
+        })
+      )
+      expect(workoutAfterLocalMidnight.date.getTime()).toBeLessThanOrEqual(
+        new Date('2026-03-04T07:59:59.999Z').getTime()
+      )
+
+      expect(calculateProjectedPMC).toHaveBeenCalledWith(
+        expect.any(Date),
+        expect.any(Date),
+        10,
+        12,
+        expect.arrayContaining([
+          expect.objectContaining({ date: workoutAfterLocalMidnight.date, tss: 65 })
+        ])
+      )
     })
 
     it('should reject invalid date ranges', async () => {

--- a/tests/unit/server/utils/ai-tools/analysis.test.ts
+++ b/tests/unit/server/utils/ai-tools/analysis.test.ts
@@ -75,6 +75,29 @@ describe('analysisTools', () => {
         metrics: expect.any(String)
       })
     })
+
+    it('should use the athlete local-day boundaries (not raw UTC) when timezone is behind UTC', async () => {
+      // America/Los_Angeles is UTC-7 in late July (PDT). A workout at
+      // 2025-07-30T02:00:00Z is 2025-07-29T19:00 local (still "the 29th" in
+      // LA), so the query window for start/end_date=2025-07-29 must extend
+      // into 2025-07-30 in UTC to capture it. Raw UTC boundaries would stop
+      // at 2025-07-29T23:59:59.999Z and miss it.
+      const laTools = analysisTools(userId, 'America/Los_Angeles', mockSettings)
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([])
+
+      await laTools.analyze_training_load.execute(
+        { start_date: '2025-07-29', end_date: '2025-07-29' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(workoutRepository.getForUser).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          startDate: new Date('2025-07-29T07:00:00.000Z'),
+          endDate: new Date('2025-07-30T06:59:59.999Z')
+        })
+      )
+    })
   })
 
   describe('generate_report', () => {
@@ -186,6 +209,49 @@ describe('analysisTools', () => {
           { date: new Date('2026-03-03T00:00:00Z'), tss: 50 }
         ]
       )
+    })
+
+    it('should use athlete local-day boundaries (not raw UTC) for the historical workout query', async () => {
+      // America/Los_Angeles is UTC-8 (PST) in early March 2026. Fixing this
+      // bug means the historical Workout query boundaries must reflect the
+      // LA calendar day rather than raw UTC midnight of the date strings.
+      vi.mocked(getInitialPMCValues).mockResolvedValue({ ctl: 10, atl: 12 })
+      vi.mocked(prisma.workout.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([] as any)
+      vi.mocked(calculateProjectedPMC).mockReturnValue([
+        { date: new Date('2026-03-01T00:00:00Z'), ctl: 10, atl: 12, tsb: -2, tss: 0 },
+        { date: new Date('2026-03-03T00:00:00Z'), ctl: 10, atl: 12, tsb: -2, tss: 0 }
+      ] as any)
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({ ftp: null } as any)
+      vi.mocked(prisma.workout.findFirst).mockResolvedValue(null as any)
+
+      const laTools = analysisTools(userId, 'America/Los_Angeles', mockSettings)
+
+      await laTools.forecast_training_load.execute(
+        {
+          start_date: '2026-03-01',
+          end_date: '2026-03-03'
+        },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(prisma.workout.findMany).toHaveBeenCalledWith({
+        where: {
+          userId,
+          isDuplicate: false,
+          date: {
+            gte: new Date('2026-03-01T08:00:00.000Z'),
+            lte: new Date('2026-03-03T08:00:00.000Z')
+          }
+        },
+        select: {
+          date: true,
+          tss: true,
+          durationSec: true,
+          type: true
+        },
+        orderBy: { date: 'asc' }
+      })
     })
 
     it('should reject invalid date ranges', async () => {

--- a/tests/unit/server/utils/ai-tools/journey.test.ts
+++ b/tests/unit/server/utils/ai-tools/journey.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { journeyTools } from '../../../../../server/utils/ai-tools/journey'
+import { journeyService } from '../../../../../server/utils/services/journeyService'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.mock('../../../../../server/utils/services/journeyService', () => ({
+  journeyService: {
+    recordEvent: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    athleteJourneyEvent: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn()
+    }
+  }
+}))
+
+describe('journeyTools', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('record_wellness_event', () => {
+    it('defaults to now when no timestamp is provided', async () => {
+      const now = new Date('2026-07-28T12:00:00Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(now)
+
+      const tools = journeyTools(userId, 'UTC')
+      vi.mocked(journeyService.recordEvent).mockResolvedValue({
+        event: { id: 'e1', timestamp: now, category: 'FATIGUE', severity: 5 },
+        rca: null,
+        remediation: null
+      } as any)
+
+      await tools.record_wellness_event.execute(
+        {
+          event_type: 'WELLNESS_CHECK',
+          category: 'FATIGUE',
+          severity: 5
+        } as any,
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(journeyService.recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ userId, timestamp: now })
+      )
+    })
+
+    it('passes through an absolute ISO timestamp unchanged', async () => {
+      const tools = journeyTools(userId, 'America/Los_Angeles')
+      vi.mocked(journeyService.recordEvent).mockResolvedValue({
+        event: { id: 'e1', timestamp: new Date(), category: 'FATIGUE', severity: 5 },
+        rca: null,
+        remediation: null
+      } as any)
+
+      await tools.record_wellness_event.execute(
+        {
+          timestamp: '2026-07-15T09:00:00Z',
+          event_type: 'WELLNESS_CHECK',
+          category: 'FATIGUE',
+          severity: 5
+        } as any,
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(journeyService.recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: new Date('2026-07-15T09:00:00Z') })
+      )
+    })
+
+    it('anchors an HH:mm timestamp to the athlete local "today", not server/UTC time', async () => {
+      // "Now" is 2026-07-28T03:00:00Z, which is already 2026-07-28 in UTC but
+      // still the evening of 2026-07-27 in America/Los_Angeles (PDT, UTC-7).
+      // A bare "22:00" should be interpreted as 22:00 on the athlete's local
+      // calendar day (2026-07-27), not on the server/UTC calendar day.
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-28T03:00:00Z'))
+
+      const tools = journeyTools(userId, 'America/Los_Angeles')
+      vi.mocked(journeyService.recordEvent).mockResolvedValue({
+        event: { id: 'e1', timestamp: new Date(), category: 'SLEEP', severity: 3 },
+        rca: null,
+        remediation: null
+      } as any)
+
+      await tools.record_wellness_event.execute(
+        {
+          timestamp: '22:00',
+          event_type: 'RECOVERY_NOTE',
+          category: 'SLEEP',
+          severity: 3
+        } as any,
+        { toolCallId: '1', messages: [] }
+      )
+
+      // 2026-07-27T22:00 local (PDT, UTC-7) => 2026-07-28T05:00:00Z
+      expect(journeyService.recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: new Date('2026-07-28T05:00:00.000Z') })
+      )
+    })
+  })
+
+  describe('get_wellness_events', () => {
+    it('should search across the full local day (UTC timezone) for a single date', async () => {
+      const tools = journeyTools(userId, 'UTC')
+      vi.mocked(prisma.athleteJourneyEvent.findMany).mockResolvedValue([])
+
+      await tools.get_wellness_events.execute(
+        { start_date: '2025-07-29' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(prisma.athleteJourneyEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId,
+            timestamp: {
+              gte: new Date('2025-07-29T00:00:00.000Z'),
+              lte: new Date('2025-07-29T23:59:59.999Z')
+            }
+          })
+        })
+      )
+    })
+
+    it('should use athlete local-day boundaries (not raw UTC) when timezone is behind UTC', async () => {
+      // America/Los_Angeles is UTC-7 in late July (PDT). An event recorded
+      // late on the LA calendar day 2025-07-29 lands on 2025-07-30 in UTC, so
+      // the query window must extend past raw UTC midnight of 2025-07-29 to
+      // capture it.
+      const tools = journeyTools(userId, 'America/Los_Angeles')
+      vi.mocked(prisma.athleteJourneyEvent.findMany).mockResolvedValue([])
+
+      await tools.get_wellness_events.execute(
+        { start_date: '2025-07-29' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(prisma.athleteJourneyEvent.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            timestamp: {
+              gte: new Date('2025-07-29T07:00:00.000Z'),
+              lte: new Date('2025-07-30T06:59:59.999Z')
+            }
+          })
+        })
+      )
+    })
+  })
+
+  describe('update_wellness_event', () => {
+    it('returns an error when the event is not found', async () => {
+      const tools = journeyTools(userId, 'UTC')
+      vi.mocked(prisma.athleteJourneyEvent.findUnique).mockResolvedValue(null)
+
+      const result = await tools.update_wellness_event.execute(
+        { id: 'missing' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(result).toEqual({ error: 'Event not found or unauthorized.' })
+    })
+
+    it('anchors an HH:mm timestamp update to the event local calendar day, not raw UTC', async () => {
+      // existing.timestamp (2026-07-16T05:00:00Z) is 2026-07-15T22:00 local
+      // in America/Los_Angeles (PDT, UTC-7) -- i.e. already "the 16th" in
+      // UTC but still "the 15th" locally. Updating the time-of-day must
+      // preserve the athlete's local day (the 15th), not the server/UTC day.
+      const tools = journeyTools(userId, 'America/Los_Angeles')
+      const existing = {
+        id: 'evt-1',
+        userId,
+        timestamp: new Date('2026-07-16T05:00:00Z'),
+        category: 'SLEEP',
+        severity: 4
+      }
+      vi.mocked(prisma.athleteJourneyEvent.findUnique).mockResolvedValue(existing as any)
+      vi.mocked(prisma.athleteJourneyEvent.update).mockResolvedValue({
+        ...existing,
+        timestamp: new Date('2026-07-15T13:30:00.000Z')
+      } as any)
+
+      await tools.update_wellness_event.execute(
+        { id: 'evt-1', timestamp: '06:30' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      // 2026-07-15T06:30 local (PDT, UTC-7) => 2026-07-15T13:30:00Z
+      expect(prisma.athleteJourneyEvent.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'evt-1' },
+          data: expect.objectContaining({
+            timestamp: new Date('2026-07-15T13:30:00.000Z')
+          })
+        })
+      )
+    })
+  })
+
+  describe('delete_wellness_event', () => {
+    it('deletes an existing event', async () => {
+      const tools = journeyTools(userId, 'UTC')
+      vi.mocked(prisma.athleteJourneyEvent.findUnique).mockResolvedValue({
+        id: 'evt-1',
+        userId
+      } as any)
+      vi.mocked(prisma.athleteJourneyEvent.delete).mockResolvedValue({} as any)
+
+      const result = await tools.delete_wellness_event.execute(
+        { id: 'evt-1' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(prisma.athleteJourneyEvent.delete).toHaveBeenCalledWith({ where: { id: 'evt-1' } })
+      expect(result).toEqual({ message: 'Successfully deleted wellness event.' })
+    })
+  })
+})

--- a/tests/unit/server/utils/ai-tools/workouts.test.ts
+++ b/tests/unit/server/utils/ai-tools/workouts.test.ts
@@ -184,7 +184,7 @@ describe('workoutTools', () => {
   })
 
   describe('search_workouts', () => {
-    it('should search across the full UTC day when a date is provided', async () => {
+    it('should search across the full local day (UTC timezone) when a date is provided', async () => {
       vi.mocked(workoutRepository.getForUser).mockResolvedValue([
         {
           id: 'blur-ride',
@@ -229,6 +229,35 @@ describe('workoutTools', () => {
           calories: 1200
         }
       ])
+    })
+
+    it('should use the athlete local-day boundaries (not raw UTC) when timezone is behind UTC', async () => {
+      // America/Los_Angeles is UTC-7 in late July (PDT). A late-evening
+      // workout on the LA calendar day 2025-07-29 lands on 2025-07-30 in UTC.
+      // Raw UTC day boundaries for "2025-07-29" would miss it entirely; the
+      // correct LA-local boundaries must span into 2025-07-30 UTC.
+      const laTools = workoutTools(userId, 'America/Los_Angeles', {
+        aiRequireToolApproval: false
+      } as any)
+
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([])
+
+      await laTools.search_workouts.execute(
+        { date: '2025-07-29' },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(workoutRepository.getForUser).toHaveBeenCalledWith(
+        userId,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            date: {
+              gte: new Date('2025-07-29T07:00:00.000Z'),
+              lte: new Date('2025-07-30T06:59:59.999Z')
+            }
+          })
+        })
+      )
     })
   })
 


### PR DESCRIPTION
Fixes CW-198

## Summary

A cluster of AI-tool functions did raw UTC date math on genuine `DateTime` timestamp columns (not `@db.Date` calendar columns), substituting server/UTC time for the athlete's actual local day. All of these already receive the athlete's `timezone` parameter (threaded through `getToolsWithContext`), so the fix is to use it correctly at each site rather than adding new plumbing.

**Read-path day-boundary fixes** (all switched from raw `T00:00:00.000Z`/`T23:59:59.999Z` string interpolation to timezone-aware boundaries via `server/utils/date.ts`):
- `search_workouts` (`server/utils/ai-tools/workouts.ts`) — now uses `getStartOfLocalDateUTC`/`getEndOfLocalDateUTC` for the `date` filter against `Workout.date`.
- `analyze_training_load` (`server/utils/ai-tools/analysis.ts`) — `start_date`/`end_date` now resolve to the athlete's local-day boundaries instead of `new Date(str)`.
- `forecast_training_load` (`server/utils/ai-tools/analysis.ts`) — the historical `Workout.date` query (genuine timestamp column) now uses tz-aware local-day boundaries, consistent with the tz-aware `getUserLocalDate(timezone)` already used for "today" in the same function. The `PlannedWorkout` (`@db.Date`) query and the internal PMC day-by-day iteration intentionally keep using UTC-midnight calendar keys, since that's the correct representation for a `@db.Date` column and for day-count math.
- `get_wellness_events` (`server/utils/ai-tools/journey.ts`) — filters `AthleteJourneyEvent.timestamp` with the same tz-aware boundaries.

**Write-path timezone-naive timestamp construction:**
- `record_wellness_event` / `update_wellness_event` (`server/utils/ai-tools/journey.ts`) — HH:mm inputs are now anchored using `buildZonedDateTimeFromUtcDate` (the pattern already used correctly in `time.ts`), instead of `Date.setHours(h, m, 0, 0)` which applied in the server process's local/UTC time rather than the athlete's configured timezone. `record_wellness_event` anchors to the athlete's local "today" (`getUserLocalDate(timezone)`); `update_wellness_event` anchors to the existing event's local calendar day (`getUserLocalDate(timezone, existing.timestamp)`) so it preserves the day while only changing the time-of-day.

**Note on `by-date.get.ts` reference pattern:** the ticket referenced `server/api/workouts/by-date.get.ts`'s `new Date(date)` + `getStartOfDayUTC`/`getEndOfDayUTC` combo as the pattern to mirror. I found that this specific combo has an off-by-one-day defect for negative-UTC-offset timezones (e.g. `America/Los_Angeles`): parsing the date string as UTC midnight first, then re-deriving the local day from that instant, actually resolves to the *previous* local calendar day. I verified this with a standalone script before writing any code. Since the acceptance criteria explicitly requires correct behavior for this exact scenario, I used the existing `getStartOfLocalDateUTC`/`getEndOfLocalDateUTC` helpers instead (already in `server/utils/date.ts`, built specifically for "convert a calendar date string to a UTC boundary in the user's timezone"), which are mathematically correct. `by-date.get.ts` itself is untouched (out of scope / not in Owned Paths) but likely has the same latent bug — flagging separately, not fixed here.

**Also:** `journey.ts` previously relied on Nuxt's implicit `server/utils/**` auto-import for `prisma` (no explicit import). That's invisible in the running app but breaks when the module is loaded directly by Vitest (as the new unit tests do), so I added an explicit `import { prisma } from '../db'`, matching the convention already used in `workouts.ts` and `analysis.ts`.

## Test plan
- [x] Extended `tests/unit/server/utils/ai-tools/workouts.test.ts` with an `America/Los_Angeles` regression test for `search_workouts` proving a late-evening local instant (already next-day in UTC) falls in the correct query window.
- [x] Extended `tests/unit/server/utils/ai-tools/analysis.test.ts` with `America/Los_Angeles` regression tests for both `analyze_training_load` and `forecast_training_load`.
- [x] Created `tests/unit/server/utils/ai-tools/journey.test.ts` covering `record_wellness_event`, `get_wellness_events`, `update_wellness_event`, and `delete_wellness_event`, including `America/Los_Angeles` regression tests for the day-boundary and HH:mm-anchoring fixes.
- [x] `pnpm vitest run tests/unit/server/utils/ai-tools/workouts.test.ts tests/unit/server/utils/ai-tools/analysis.test.ts tests/unit/server/utils/ai-tools/journey.test.ts` — 31/31 passing.
- [x] `pnpm run typecheck:server` — clean.
- [x] `eslint` on all touched files — clean.