### PR TITLE
fix(workouts): add shared pace formatter and fix hardcoded /km across frontend and API

### DIFF
--- a/app/components/IntervalTable.vue
+++ b/app/components/IntervalTable.vue
@@ -122,6 +122,8 @@
 </template>
 
 <script setup lang="ts">
+  import { formatPace as formatPaceShared } from '~/utils/metrics'
+
   const props = withDefaults(
     defineProps<{
       intervals: any[]
@@ -134,6 +136,9 @@
   )
 
   defineEmits(['interval-hover', 'interval-leave'])
+
+  const userStore = useUserStore()
+  const distanceUnits = computed(() => userStore.profile?.distanceUnits || 'Kilometers')
 
   function formatDuration(seconds: number) {
     const mins = Math.floor(seconds / 60)
@@ -149,9 +154,6 @@
 
   function formatPace(mps: number) {
     if (!mps) return '-'
-    const paceMinPerKm = 16.6667 / mps
-    const mins = Math.floor(paceMinPerKm)
-    const secs = Math.round((paceMinPerKm - mins) * 60)
-    return `${mins}:${secs.toString().padStart(2, '0')}/km`
+    return formatPaceShared(1000 / mps, distanceUnits.value)
   }
 </script>

--- a/app/components/IntervalsAnalysis.vue
+++ b/app/components/IntervalsAnalysis.vue
@@ -285,6 +285,7 @@
     Filler
   } from 'chart.js'
   import { ensureChartJsAnnotationDefaults } from '~/utils/chartjs-annotation'
+  import { formatPace as formatPaceShared } from '~/utils/metrics'
 
   ChartJS.register(
     CategoryScale,
@@ -309,6 +310,9 @@
     workoutId: string
     publicToken?: string
   }>()
+
+  const userStore = useUserStore()
+  const distanceUnits = computed(() => userStore.profile?.distanceUnits || 'Kilometers')
 
   const loading = ref(true)
   const error = ref<string | null>(null)
@@ -538,10 +542,7 @@
 
   function formatPace(mps: number): string {
     if (!mps) return '-'
-    const paceMinPerKm = 16.6667 / mps // convert m/s to min/km (1000m / 60s = 16.66)
-    const mins = Math.floor(paceMinPerKm)
-    const secs = Math.round((paceMinPerKm - mins) * 60)
-    return `${mins}:${secs.toString().padStart(2, '0')} /km`
+    return formatPaceShared(1000 / mps, distanceUnits.value)
   }
 
   onMounted(() => {

--- a/app/components/PacingAnalysis.vue
+++ b/app/components/PacingAnalysis.vue
@@ -341,6 +341,7 @@
 <script setup lang="ts">
   import {
     convertVelocity,
+    formatPace as formatPaceShared,
     getVelocityUnitLabel,
     isRideWorkoutType,
     usesImperialDistance
@@ -431,16 +432,12 @@
 
   function formatPace(paceMinPerKm: number | null | undefined): string {
     if (!paceMinPerKm) return 'N/A'
-    const minutes = Math.floor(paceMinPerKm)
-    const seconds = Math.round((paceMinPerKm - minutes) * 60)
-    return `${minutes}:${seconds.toString().padStart(2, '0')}/km`
+    return formatPaceShared(paceMinPerKm * 60, distanceUnits.value)
   }
 
   function formatPaceSeconds(paceSeconds: number | null | undefined): string {
     if (!paceSeconds) return 'N/A'
-    const minutes = Math.floor(paceSeconds / 60)
-    const seconds = Math.round(paceSeconds % 60)
-    return `${minutes}:${seconds.toString().padStart(2, '0')}/km`
+    return formatPaceShared(paceSeconds, distanceUnits.value)
   }
 
   function paceMinPerKmToMps(paceMinPerKm: number | null | undefined): number | null {

--- a/app/pages/workouts/[id]/map.vue
+++ b/app/pages/workouts/[id]/map.vue
@@ -692,6 +692,7 @@
 <script setup lang="ts">
   import { decode } from '@googlemaps/polyline-codec'
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
+  import { formatDistance as formatDist, formatPace as formatPaceShared } from '~/utils/metrics'
 
   import { ref, computed, watch, toRaw, nextTick } from 'vue'
   import draggable from 'vuedraggable'
@@ -1517,7 +1518,7 @@
   }
 
   function formatDistance(meters: number) {
-    return (meters / 1000).toFixed(2) + ' km'
+    return formatDist(meters, userStore.profile?.distanceUnits || 'Kilometers')
   }
 
   function formatNullableWatts(value: unknown) {
@@ -1531,9 +1532,7 @@
   function formatPace(metersPerSecond: number) {
     if (!metersPerSecond || metersPerSecond <= 0) return '-'
     const paceSeconds = 1000 / metersPerSecond
-    const mins = Math.floor(paceSeconds / 60)
-    const secs = Math.round(paceSeconds % 60)
-    return `${mins}:${secs.toString().padStart(2, '0')}/km`
+    return formatPaceShared(paceSeconds, userStore.profile?.distanceUnits || 'Kilometers')
   }
 
   function formatTime(seconds: number) {

--- a/app/pages/workouts/planned/[id]/index.vue
+++ b/app/pages/workouts/planned/[id]/index.vue
@@ -3239,18 +3239,6 @@
     return `${mins}m`
   }
 
-  function formatPace(seconds: number, meters: number) {
-    if (!seconds || !meters) return '-'
-    const minutes = seconds / 60
-    const km = meters / 1000
-    const paceDec = minutes / km
-
-    const pMin = Math.floor(paceDec)
-    const pSec = Math.round((paceDec - pMin) * 60)
-
-    return `${pMin}:${pSec.toString().padStart(2, '0')}`
-  }
-
   function getWorkoutComponent(type: string) {
     switch (type) {
       case 'Ride':

--- a/app/utils/metrics.ts
+++ b/app/utils/metrics.ts
@@ -2,6 +2,7 @@ export const KG_TO_LBS = 2.20462262185
 export const LBS_TO_KG = 0.45359237
 const MPS_TO_KPH = 3.6
 const MPS_TO_MPH = 2.2369362921
+const KM_TO_MILE_PACE_FACTOR = 1.609344
 
 export interface MetricDefinition {
   label: string
@@ -271,4 +272,44 @@ export function formatVelocity(
 
   const converted = convertVelocity(metersPerSecond, units)
   return `${converted.toFixed(decimals)} ${getVelocityUnitLabel(units)}`
+}
+
+/**
+ * Format a run/swim pace (given in seconds per kilometer) for display based on
+ * the athlete's distance unit preference, converting to seconds-per-mile when
+ * appropriate. Mirrors the conversion math in
+ * `server/utils/ai-prompt-format.ts`'s `formatPromptPace`.
+ *
+ * @param secondsPerKm - Pace expressed in seconds per kilometer.
+ * @param distanceUnits - 'Kilometers' | 'Miles' (defaults to Kilometers/'/km').
+ * @param decimals - Optional fractional-second precision (default 0, i.e. "M:SS").
+ */
+export function formatPace(
+  secondsPerKm: number | null | undefined,
+  distanceUnits: string | null | undefined,
+  decimals = 0
+): string {
+  if (
+    secondsPerKm === null ||
+    secondsPerKm === undefined ||
+    !Number.isFinite(secondsPerKm) ||
+    secondsPerKm <= 0
+  ) {
+    return 'N/A'
+  }
+
+  const imperial = usesImperialDistance(distanceUnits)
+  const effectiveSeconds = imperial ? secondsPerKm * KM_TO_MILE_PACE_FACTOR : secondsPerKm
+  const unitLabel = imperial ? '/mi' : '/km'
+
+  const scale = 10 ** decimals
+  const totalSeconds = Math.round(effectiveSeconds * scale) / scale
+  const minutes = Math.floor(totalSeconds / 60)
+  const remainingSeconds = totalSeconds - minutes * 60
+  const secondsLabel =
+    decimals > 0
+      ? remainingSeconds.toFixed(decimals).padStart(3 + decimals, '0')
+      : Math.round(remainingSeconds).toString().padStart(2, '0')
+
+  return `${minutes}:${secondsLabel}${unitLabel}`
 }

--- a/server/api/share/workouts/[token]/streams.get.ts
+++ b/server/api/share/workouts/[token]/streams.get.ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, createError, getRouterParam } from 'h3'
 import { prisma } from '../../../../utils/db'
 import { workoutStreamRepository } from '../../../../utils/repositories/workoutStreamRepository'
+import { formatPromptPace } from '../../../../utils/ai-prompt-format'
 
 defineRouteMeta({
   openAPI: {
@@ -71,6 +72,13 @@ export default defineEventHandler(async (event) => {
   const workout = await (prisma as any).workout.findUnique({
     where: {
       id: shareToken.resourceId
+    },
+    include: {
+      user: {
+        select: {
+          distanceUnits: true
+        }
+      }
     }
   })
 
@@ -97,13 +105,10 @@ export default defineEventHandler(async (event) => {
       // Transform Strava splits into component-expected format
       const lapSplits = splits.map((split: any, index: number) => {
         const time = split.moving_time || split.elapsed_time
-        const paceMinPerKm = split.distance > 0 ? time / 60 / (split.distance / 1000) : 0
         const paceSeconds = split.distance > 0 ? time / (split.distance / 1000) : 0
 
-        // Format pace as "M:SS/km"
-        const paceMin = Math.floor(paceMinPerKm)
-        const paceSec = Math.round((paceMinPerKm - paceMin) * 60)
-        const paceFormatted = `${paceMin}:${paceSec.toString().padStart(2, '0')}/km`
+        // Format pace respecting the workout owner's distance unit preference
+        const paceFormatted = formatPromptPace(paceSeconds, workout.user?.distanceUnits)
 
         return {
           lap: index + 1,

--- a/server/api/workouts/[id]/streams.get.ts
+++ b/server/api/workouts/[id]/streams.get.ts
@@ -9,6 +9,7 @@ import {
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import { detectIntervals } from '../../../utils/interval-detection'
 import { detectClimbs } from '../../../utils/climb-detection'
+import { formatPromptPace } from '../../../utils/ai-prompt-format'
 
 defineRouteMeta({
   openAPI: {
@@ -74,7 +75,8 @@ export default defineEventHandler(async (event) => {
         user: {
           select: {
             ftp: true,
-            maxHr: true
+            maxHr: true,
+            distanceUnits: true
           }
         }
       }
@@ -443,13 +445,10 @@ export default defineEventHandler(async (event) => {
         // Transform Strava splits into component-expected format
         const lapSplits = splits.map((split: any, index: number) => {
           const time = split.moving_time || split.elapsed_time
-          const paceMinPerKm = split.distance > 0 ? time / 60 / (split.distance / 1000) : 0
           const paceSeconds = split.distance > 0 ? time / (split.distance / 1000) : 0
 
-          // Format pace as "M:SS/km"
-          const paceMin = Math.floor(paceMinPerKm)
-          const paceSec = Math.round((paceMinPerKm - paceMin) * 60)
-          const paceFormatted = `${paceMin}:${paceSec.toString().padStart(2, '0')}/km`
+          // Format pace respecting the athlete's distance unit preference
+          const paceFormatted = formatPromptPace(paceSeconds, user.distanceUnits)
 
           return {
             lap: index + 1,

--- a/tests/unit/app/metrics.test.ts
+++ b/tests/unit/app/metrics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   convertVelocity,
+  formatPace,
   formatVelocity,
   getVelocityUnitLabel,
   isRideWorkoutType
@@ -23,5 +24,42 @@ describe('velocity display helpers', () => {
     expect(isRideWorkoutType('EBike Ride')).toBe(true)
     expect(isRideWorkoutType('VirtualRide')).toBe(true)
     expect(isRideWorkoutType('Run')).toBe(false)
+  })
+})
+
+describe('formatPace', () => {
+  it('formats pace in minutes:seconds/km for a Kilometers-preference athlete', () => {
+    // 5:00 per km == 300 seconds/km
+    expect(formatPace(300, 'Kilometers')).toBe('5:00/km')
+  })
+
+  it('leaves Kilometers-preference athletes unaffected (existing behavior preserved)', () => {
+    expect(formatPace(330, 'Kilometers')).toBe('5:30/km')
+    expect(formatPace(330, null)).toBe('5:30/km')
+    expect(formatPace(330, undefined)).toBe('5:30/km')
+    expect(formatPace(330, 'SomethingElse')).toBe('5:30/km')
+  })
+
+  it('converts to minutes:seconds/mi for a Miles-preference athlete', () => {
+    // 300 seconds/km * 1.609344 = 482.8032 seconds/mile -> rounds to 483s -> 8:03/mi
+    expect(formatPace(300, 'Miles')).toBe('8:03/mi')
+  })
+
+  it('rounds seconds correctly without letting them overflow to 60', () => {
+    // 359.6s/km rounds to 360s -> 6:00, not 5:60
+    expect(formatPace(359.6, 'Kilometers')).toBe('6:00/km')
+  })
+
+  it('supports fractional-second precision via the decimals parameter', () => {
+    expect(formatPace(369.65, 'Kilometers', 1)).toBe('6:09.7/km')
+  })
+
+  it('returns N/A for invalid input', () => {
+    expect(formatPace(0, 'Kilometers')).toBe('N/A')
+    expect(formatPace(-5, 'Kilometers')).toBe('N/A')
+    expect(formatPace(null, 'Kilometers')).toBe('N/A')
+    expect(formatPace(undefined, 'Kilometers')).toBe('N/A')
+    expect(formatPace(NaN, 'Kilometers')).toBe('N/A')
+    expect(formatPace(Infinity, 'Kilometers')).toBe('N/A')
   })
 })

--- a/tests/unit/server/api/share/streams-pace-units.test.ts
+++ b/tests/unit/server/api/share/streams-pace-units.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const shareTokenFindUnique = vi.fn()
+const workoutFindUnique = vi.fn()
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    shareToken: { findUnique: shareTokenFindUnique },
+    workout: { findUnique: workoutFindUnique }
+  }
+}))
+
+const findByWorkoutId = vi.fn()
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  workoutStreamRepository: { findByWorkoutId }
+}))
+
+function makeRawSplitsWorkout(distanceUnits: string | null) {
+  return {
+    id: 'workout-1',
+    userId: 'user-1',
+    user: { distanceUnits },
+    rawJson: {
+      splits_metric: [
+        // 1000m in 300s -> 300 seconds/km
+        { distance: 1000, moving_time: 300, average_heartrate: 150, average_speed: 3.33 },
+        // 1000m in 330s -> 330 seconds/km
+        { distance: 1000, moving_time: 330, average_heartrate: 155, average_speed: 3.03 }
+      ]
+    }
+  }
+}
+
+describe('GET /api/share/workouts/[token]/streams pace unit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findByWorkoutId.mockResolvedValue(null)
+    shareTokenFindUnique.mockResolvedValue({
+      resourceType: 'WORKOUT',
+      resourceId: 'workout-1',
+      expiresAt: null
+    })
+  })
+
+  it('formats lap pace in /km for a Kilometers-preference athlete (unaffected/existing behavior)', async () => {
+    workoutFindUnique.mockResolvedValue(makeRawSplitsWorkout('Kilometers'))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/streams.get')
+    const result = await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(result.lapSplits[0].pace).toBe('5:00/km')
+    expect(result.lapSplits[1].pace).toBe('5:30/km')
+  })
+
+  it('formats lap pace in /mi for a Miles-preference athlete', async () => {
+    workoutFindUnique.mockResolvedValue(makeRawSplitsWorkout('Miles'))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/streams.get')
+    const result = await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(result.lapSplits[0].pace).toBe('8:03/mi')
+    expect(result.lapSplits[1].pace).toBe('8:51/mi')
+  })
+
+  it('defaults to /km when the workout owner has no distance unit preference on record', async () => {
+    workoutFindUnique.mockResolvedValue(makeRawSplitsWorkout(null))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/streams.get')
+    const result = await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(result.lapSplits[0].pace).toBe('5:00/km')
+  })
+})

--- a/tests/unit/server/api/workouts/streams-pace-units.test.ts
+++ b/tests/unit/server/api/workouts/streams-pace-units.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const workoutFindFirst = vi.fn()
+
+vi.stubGlobal('prisma', {
+  workout: { findFirst: workoutFindFirst }
+})
+
+const findByWorkoutId = vi.fn()
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  workoutStreamRepository: { findByWorkoutId }
+}))
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn(async () => ({ id: 'user-1' }))
+}))
+
+function makeRawSplitsWorkout(distanceUnits: string | null) {
+  return {
+    id: 'workout-1',
+    userId: 'user-1',
+    user: { ftp: 200, maxHr: 190, distanceUnits },
+    rawJson: {
+      splits_metric: [
+        // 1000m in 300s -> 300 seconds/km
+        { distance: 1000, moving_time: 300, average_heartrate: 150, average_speed: 3.33 },
+        // 1000m in 330s -> 330 seconds/km
+        { distance: 1000, moving_time: 330, average_heartrate: 155, average_speed: 3.03 }
+      ]
+    }
+  }
+}
+
+describe('GET /api/workouts/[id]/streams pace unit handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findByWorkoutId.mockResolvedValue(null)
+  })
+
+  it('formats lap pace in /km for a Kilometers-preference athlete (unaffected/existing behavior)', async () => {
+    workoutFindFirst.mockResolvedValue(makeRawSplitsWorkout('Kilometers'))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    const result = await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    expect(result.lapSplits[0].pace).toBe('5:00/km')
+    expect(result.lapSplits[1].pace).toBe('5:30/km')
+  })
+
+  it('formats lap pace in /mi for a Miles-preference athlete', async () => {
+    workoutFindFirst.mockResolvedValue(makeRawSplitsWorkout('Miles'))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    const result = await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    expect(result.lapSplits[0].pace).toBe('8:03/mi')
+    expect(result.lapSplits[1].pace).toBe('8:51/mi')
+  })
+})


### PR DESCRIPTION
Fixes CW-200

## Summary

`app/utils/metrics.ts` had correct, tested unit-aware helpers for distance/temperature/height/velocity, but no shared pace formatter — 5 frontend spots and 2 API endpoints each hardcoded `/km`, ignoring the athlete's `distanceUnits` preference (Miles-preference athletes always saw a `/km` label).

- Added `formatPace(secondsPerKm, distanceUnits, decimals?)` to `app/utils/metrics.ts`, mirroring the km→mile conversion math (`1.609344`) already used in `server/utils/ai-prompt-format.ts`'s `formatPromptPace`.
- Migrated all 4 live frontend call sites to the shared helper, each now sourcing `distanceUnits` from `useUserStore().profile?.distanceUnits` (defaulting to `'Kilometers'`), matching the existing convention seen in `CalendarDayCell.vue`/`activities.vue`/etc.:
  - `app/components/IntervalTable.vue`
  - `app/components/IntervalsAnalysis.vue`
  - `app/components/PacingAnalysis.vue` (only the run/swim pace path was touched — the ride speed path via `convertVelocity`/`formatSpeedFromMps` was already correct and untouched)
  - `app/pages/workouts/[id]/map.vue` — also removed the locally-shadowed, hardcoded-km `formatDistance` in favor of importing the real `formatDistance` from `~/utils/metrics`
- `app/pages/workouts/planned/[id]/index.vue`: the `formatPace(seconds, meters)` function here had **no callers anywhere in the file** (confirmed dead code) — removed rather than fixed.
- Fixed both API endpoints that pre-format the `pace` string server-side (rawJson-splits fallback path only — the primary DB-precomputed `lapSplits` path lives in `server/utils/pacing.ts`, out of scope/ownership for this ticket and flagged below):
  - `server/api/workouts/[id]/streams.get.ts` — added `distanceUnits` to the `user` select, formats via `formatPromptPace`
  - `server/api/share/workouts/[token]/streams.get.ts` — added `user: { select: { distanceUnits: true } }` to the workout include (public share link resolves the workout owner's preference this way), formats via `formatPromptPace`

## Note: dead code

Item 5 in the ticket (`planned/[id]/index.vue`'s `formatPace`) was confirmed dead — the function was defined but had zero call sites in the file. Removed instead of fixed.

## Note: follow-up needed (out of scope)

`server/utils/pacing.ts`'s `calculateLapSplits` (used for the primary, non-fallback `lapSplits` path — i.e. workouts with proper stream data ingested) has the identical hardcoded `/km` bug, and that pre-formatted string is stored in the DB at ingestion time. This file wasn't in this ticket's owned paths, so it's untouched here; recommend a follow-up ticket to fix it and backfill/re-ingest historical `lapSplits` pace strings.

## Test plan

- [x] `pnpm vitest run tests/unit/app/utils/metrics.test.ts` — extended the **existing** `tests/unit/app/metrics.test.ts` (repo convention already covers `app/utils/metrics.ts` there; a separate `tests/unit/app/utils/metrics.test.ts` would have duplicated coverage of the same module) with `formatPace` cases: Kilometers, Miles, null/undefined/custom-unit fallback to km, 0/negative/NaN/Infinity → `N/A`, no-overflow rounding (`359.6s → 6:00`, not `5:60`), and fractional-decimals support.
- [x] Added `tests/unit/server/api/workouts/streams-pace-units.test.ts` and `tests/unit/server/api/share/streams-pace-units.test.ts` covering the rawJson-splits fallback path for both endpoints — Miles-preference athlete gets `/mi` pace, Kilometers-preference (and missing-preference) athlete is unaffected.
- [x] `pnpm vitest run` — full suite: 303 files / 1651 tests passing.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm exec eslint` on all touched files — clean.