### PR TITLE
fix(workouts): prevent planned workout IDOR (CW-143)

### DIFF
--- a/server/api/workouts/manual.post.ts
+++ b/server/api/workouts/manual.post.ts
@@ -47,7 +47,8 @@ defineRouteMeta({
         }
       },
       400: { description: 'Invalid input' },
-      401: { description: 'Unauthorized' }
+      401: { description: 'Unauthorized' },
+      404: { description: 'Planned workout not found' }
     }
   }
 })
@@ -64,6 +65,25 @@ export default defineEventHandler(async (event) => {
       statusCode: 400,
       message: 'Title, date, and duration are required'
     })
+  }
+
+  // Authorize the optional link before creating anything. The centralized session
+  // resolves coach "act as" requests to the athlete, so userId is the effective owner.
+  if (body.plannedWorkoutId) {
+    const plannedWorkout = await prisma.plannedWorkout.findFirst({
+      where: {
+        id: body.plannedWorkoutId,
+        userId
+      },
+      select: { id: true }
+    })
+
+    if (!plannedWorkout) {
+      throw createError({
+        statusCode: 404,
+        message: 'Planned workout not found'
+      })
+    }
   }
 
   try {
@@ -96,7 +116,10 @@ export default defineEventHandler(async (event) => {
     // If linked to a planned workout, mark it as completed
     if (body.plannedWorkoutId) {
       await prisma.plannedWorkout.update({
-        where: { id: body.plannedWorkoutId },
+        where: {
+          id: body.plannedWorkoutId,
+          userId
+        },
         data: {
           completed: true,
           completionStatus: 'COMPLETED'

--- a/tests/unit/server/api/workouts/manual.post.test.ts
+++ b/tests/unit/server/api/workouts/manual.post.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import { prisma } from '../../../../../server/utils/db'
+import { calculateWorkoutStress } from '../../../../../server/utils/calculate-workout-stress'
+import { isNutritionTrackingEnabled } from '../../../../../server/utils/nutrition/feature'
+
+const workoutRepositoryMock = {
+  create: vi.fn()
+}
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('workoutRepository', workoutRepositoryMock)
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    plannedWorkout: {
+      findFirst: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/calculate-workout-stress', () => ({
+  calculateWorkoutStress: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/nutrition/feature', () => ({
+  isNutritionTrackingEnabled: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/services/metabolicService', () => ({
+  metabolicService: {
+    calculateFuelingPlanForDate: vi.fn()
+  }
+}))
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/workouts/manual.post')).default
+
+const body = {
+  title: 'Manual ride',
+  date: '2026-07-28T08:00:00.000Z',
+  durationSec: '3600',
+  plannedWorkoutId: 'planned-1'
+}
+
+describe('POST /api/workouts/manual', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    vi.mocked(isNutritionTrackingEnabled).mockResolvedValue(false)
+  })
+
+  it('rejects a foreign planned workout before creating or updating anything', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue(null)
+
+    await expect(handler({ context: {}, body } as any)).rejects.toMatchObject({
+      message: 'Planned workout not found',
+      statusCode: 404
+    })
+
+    expect(prisma.plannedWorkout.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'planned-1',
+        userId: 'user-1'
+      },
+      select: { id: true }
+    })
+    expect(workoutRepositoryMock.create).not.toHaveBeenCalled()
+    expect(prisma.plannedWorkout.update).not.toHaveBeenCalled()
+  })
+
+  it('scopes the completion update to an owned planned workout', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue({ id: 'planned-1' } as any)
+    workoutRepositoryMock.create.mockResolvedValue({
+      id: 'workout-1',
+      date: new Date(body.date)
+    })
+    vi.mocked(calculateWorkoutStress).mockResolvedValue({ ctl: 10, atl: 12 } as any)
+    vi.mocked(prisma.plannedWorkout.update).mockResolvedValue({ id: 'planned-1' } as any)
+
+    await expect(handler({ context: {}, body } as any)).resolves.toMatchObject({
+      success: true,
+      workout: { id: 'workout-1' }
+    })
+
+    expect(prisma.plannedWorkout.update).toHaveBeenCalledWith({
+      where: {
+        id: 'planned-1',
+        userId: 'user-1'
+      },
+      data: {
+        completed: true,
+        completionStatus: 'COMPLETED'
+      }
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Authorize an optional `plannedWorkoutId` against the effective user before creating a manual workout.
- Scope the planned-workout completion update by both `id` and `userId`.
- Return a documented 404 when the planned workout is absent or belongs to another user.
- Add regression tests for cross-user rejection before mutation and the valid owner-scoped update.

## Why

The manual workout endpoint accepted any planned workout ID and marked that record completed without verifying ownership.

## Impact

Authenticated users can no longer link a manual workout to, or mutate completion state on, a foreign planned workout. Coach act-as sessions continue to operate against the effective athlete resolved by the centralized session layer.

## Root cause

The route trusted the caller-provided planned-workout ID and used an ID-only Prisma update after creating the manual workout.

## Checks

- `pnpm vitest run tests/unit/server/api/workouts` — 4 files passed, 7 tests passed
- `pnpm typecheck:server` — passed
- `pnpm exec eslint server/api/workouts/manual.post.ts tests/unit/server/api/workouts/manual.post.test.ts` — passed
- `git diff --check` / `git show --check` — passed

Fixes CW-143