### PR TITLE
fix(coaching): require write scope for mutations (CW-142)

### DIFF
--- a/server/api/coaching/athletes/[id]/planned-workouts/[workoutId].delete.ts
+++ b/server/api/coaching/athletes/[id]/planned-workouts/[workoutId].delete.ts
@@ -11,6 +11,6 @@ const paramsSchema = z.object({
 export default defineEventHandler(async (event) => {
   await requireAuth(event)
   const { id: athleteId, workoutId } = await getValidatedRouterParams(event, paramsSchema.parse)
-  await requireCoachAccessToAthlete(event, athleteId)
+  await requireCoachAccessToAthlete(event, athleteId, ['coaching:write'])
   return await deletePlannedWorkoutForUser(athleteId, workoutId)
 })

--- a/server/api/coaching/athletes/[id]/planned-workouts/[workoutId].patch.ts
+++ b/server/api/coaching/athletes/[id]/planned-workouts/[workoutId].patch.ts
@@ -11,7 +11,7 @@ const paramsSchema = z.object({
 export default defineEventHandler(async (event) => {
   await requireAuth(event)
   const { id: athleteId, workoutId } = await getValidatedRouterParams(event, paramsSchema.parse)
-  await requireCoachAccessToAthlete(event, athleteId)
+  await requireCoachAccessToAthlete(event, athleteId, ['coaching:write'])
   const body = await readBody(event)
   return await updatePlannedWorkoutForUser(athleteId, workoutId, body)
 })

--- a/server/api/coaching/athletes/[id]/planned-workouts/[workoutId]/move.post.ts
+++ b/server/api/coaching/athletes/[id]/planned-workouts/[workoutId]/move.post.ts
@@ -15,7 +15,7 @@ const bodySchema = z.object({
 export default defineEventHandler(async (event) => {
   await requireAuth(event)
   const { id: athleteId, workoutId } = await getValidatedRouterParams(event, paramsSchema.parse)
-  await requireCoachAccessToAthlete(event, athleteId)
+  await requireCoachAccessToAthlete(event, athleteId, ['coaching:write'])
   const body = await readBody(event)
   const parsed = bodySchema.parse(body)
   return await movePlannedWorkoutForUser(athleteId, workoutId, parsed.targetDate)

--- a/server/api/coaching/athletes/[id]/planned-workouts/index.post.ts
+++ b/server/api/coaching/athletes/[id]/planned-workouts/index.post.ts
@@ -10,7 +10,7 @@ const paramsSchema = z.object({
 export default defineEventHandler(async (event) => {
   await requireAuth(event)
   const { id: athleteId } = await getValidatedRouterParams(event, paramsSchema.parse)
-  await requireCoachAccessToAthlete(event, athleteId)
+  await requireCoachAccessToAthlete(event, athleteId, ['coaching:write'])
   const body = await readBody(event)
   return await createPlannedWorkoutForUser(athleteId, body)
 })

--- a/server/api/library/plans/[id]/apply.post.ts
+++ b/server/api/library/plans/[id]/apply.post.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/v3'
-import { getServerSession } from '../../../../utils/session'
+import { requireAuth } from '../../../../utils/auth-guard'
 import { prisma } from '../../../../utils/db'
 import { requireCoachAccessToAthlete } from '../../../../utils/coaching-auth'
 import {
@@ -22,10 +22,7 @@ function normalizeStartDate(value: string) {
 }
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
-  if (!session?.user?.id) {
-    throw createError({ statusCode: 401, message: 'Unauthorized' })
-  }
+  const coach = await requireAuth(event, ['coaching:write'])
 
   const planId = getRouterParam(event, 'id')
   if (!planId) {
@@ -33,11 +30,11 @@ export default defineEventHandler(async (event) => {
   }
 
   const body = applyPlanSchema.parse(await readBody(event))
-  const coachId = session.user.id
+  const coachId = coach.id
   const targetUserId = body.athleteId || coachId
 
   if (targetUserId !== coachId) {
-    await requireCoachAccessToAthlete(event, targetUserId)
+    await requireCoachAccessToAthlete(event, targetUserId, ['coaching:write'])
   }
 
   const template = await prisma.trainingPlan.findFirst({

--- a/server/utils/coaching-auth.ts
+++ b/server/utils/coaching-auth.ts
@@ -2,8 +2,12 @@ import type { H3Event } from 'h3'
 import { requireAuth } from './auth-guard'
 import { coachingRepository } from './repositories/coachingRepository'
 
-export async function requireCoachAccessToAthlete(event: H3Event, athleteId: string) {
-  const coach = await requireAuth(event, ['coaching:read'])
+export async function requireCoachAccessToAthlete(
+  event: H3Event,
+  athleteId: string,
+  requiredScopes: string[] = ['coaching:read']
+) {
+  const coach = await requireAuth(event, requiredScopes)
   const isCoaching = await coachingRepository.checkRelationship(coach.id, athleteId)
 
   if (!isCoaching) {

--- a/tests/unit/server/utils/coaching-auth.test.ts
+++ b/tests/unit/server/utils/coaching-auth.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const requireAuthMock = vi.fn()
+const checkRelationshipMock = vi.fn()
+
+vi.stubGlobal('defineEventHandler', (handler: any) => handler)
+vi.stubGlobal('getValidatedRouterParams', async () => ({
+  id: 'athlete-1',
+  workoutId: 'workout-1'
+}))
+
+vi.stubGlobal('createError', (input: { statusCode: number; message: string }) => {
+  return Object.assign(new Error(input.message), { statusCode: input.statusCode })
+})
+
+vi.mock('../../../../server/utils/auth-guard', () => ({
+  requireAuth: requireAuthMock
+}))
+
+vi.mock('../../../../server/utils/repositories/coachingRepository', () => ({
+  coachingRepository: {
+    checkRelationship: checkRelationshipMock
+  }
+}))
+
+vi.mock('../../../../server/utils/planned-workout-service', () => ({
+  createPlannedWorkoutForUser: vi.fn(),
+  deletePlannedWorkoutForUser: vi.fn(),
+  movePlannedWorkoutForUser: vi.fn(),
+  updatePlannedWorkoutForUser: vi.fn()
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {}
+}))
+
+const mutationLoaders = [
+  {
+    name: 'planned-workout create',
+    load: () => import('../../../../server/api/coaching/athletes/[id]/planned-workouts/index.post')
+  },
+  {
+    name: 'planned-workout update',
+    load: () =>
+      import('../../../../server/api/coaching/athletes/[id]/planned-workouts/[workoutId].patch')
+  },
+  {
+    name: 'planned-workout delete',
+    load: () =>
+      import('../../../../server/api/coaching/athletes/[id]/planned-workouts/[workoutId].delete')
+  },
+  {
+    name: 'planned-workout move',
+    load: () =>
+      import('../../../../server/api/coaching/athletes/[id]/planned-workouts/[workoutId]/move.post')
+  },
+  {
+    name: 'training-plan apply',
+    load: () => import('../../../../server/api/library/plans/[id]/apply.post')
+  }
+]
+
+describe('requireCoachAccessToAthlete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkRelationshipMock.mockResolvedValue(true)
+  })
+
+  it.each(mutationLoaders)('rejects a read-only OAuth token on $name', async ({ load }) => {
+    requireAuthMock.mockImplementation(async (_event, requiredScopes?: string[]) => {
+      const tokenScopes = ['coaching:read']
+      if (requiredScopes?.some((scope) => !tokenScopes.includes(scope))) {
+        throw Object.assign(new Error('Insufficient permissions'), { statusCode: 403 })
+      }
+      return { id: 'coach-1' }
+    })
+
+    const event = {} as any
+    const { default: handler } = await load()
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 403 })
+    expect(requireAuthMock).toHaveBeenCalledWith(event, ['coaching:write'])
+    expect(checkRelationshipMock).not.toHaveBeenCalled()
+  })
+
+  it('uses coaching:read by default for read routes', async () => {
+    requireAuthMock.mockResolvedValue({ id: 'coach-1' })
+
+    const { requireCoachAccessToAthlete } = await import('../../../../server/utils/coaching-auth')
+
+    await requireCoachAccessToAthlete({} as any, 'athlete-1')
+
+    expect(requireAuthMock).toHaveBeenCalledWith({}, ['coaching:read'])
+    expect(checkRelationshipMock).toHaveBeenCalledWith('coach-1', 'athlete-1')
+  })
+
+  it('keeps session-cookie coaches authorized for mutations', async () => {
+    requireAuthMock.mockResolvedValue({ id: 'coach-1' })
+
+    const { requireCoachAccessToAthlete } = await import('../../../../server/utils/coaching-auth')
+
+    await expect(
+      requireCoachAccessToAthlete({} as any, 'athlete-1', ['coaching:write'])
+    ).resolves.toMatchObject({ id: 'coach-1' })
+    expect(requireAuthMock).toHaveBeenCalledWith({}, ['coaching:write'])
+    expect(checkRelationshipMock).toHaveBeenCalledWith('coach-1', 'athlete-1')
+  })
+})


### PR DESCRIPTION
## What changed

- Extended `requireCoachAccessToAthlete` to accept required OAuth scopes while retaining `coaching:read` as the default for read routes.
- Required `coaching:write` for planned-workout create, update, delete, and move operations.
- Required `coaching:write` for training-plan application, including OAuth authentication at the route boundary.
- Added regression coverage for every affected mutation, the read-scope default, and session-cookie coach access.

## Why

Read-only OAuth tokens could pass the shared coach relationship guard and mutate an athlete's planned-workout calendar.

## Impact

Third-party OAuth clients must now hold `coaching:write` to change coached-athlete workouts or apply a plan. Existing session-cookie coach flows continue to work, and GET callers retain read-scope behavior.

## Root cause

The shared coach authorization helper hardcoded `coaching:read`, and mutating routes used it without a way to request a stronger scope.

## Checks

- `pnpm vitest run tests/unit/server` — 206 files passed, 1,026 tests passed
- `pnpm typecheck` — passed
- ESLint on all changed TypeScript files — passed
- `git diff --check` — passed

Fixes CW-142
