### PR TITLE
fix(workouts): preserve requested local date (CW-204)

### DIFF
--- a/server/api/workouts/by-date.get.ts
+++ b/server/api/workouts/by-date.get.ts
@@ -1,6 +1,6 @@
 import { requireAuth } from '../../utils/auth-guard'
 import { prisma } from '../../utils/db'
-import { getUserTimezone, getStartOfDayUTC, getEndOfDayUTC } from '../../utils/date'
+import { getUserTimezone, getStartOfLocalDateUTC, getEndOfLocalDateUTC } from '../../utils/date'
 
 defineRouteMeta({
   openAPI: {
@@ -60,11 +60,9 @@ export default defineEventHandler(async (event) => {
     const userId = user.id
     const timezone = await getUserTimezone(userId)
 
-    // Parse the date parameter (YYYY-MM-DD)
-    const targetDate = new Date(date)
-    // Convert this "face value" date into the correct UTC range for the user's timezone
-    const startOfDay = getStartOfDayUTC(timezone, targetDate)
-    const endOfDay = getEndOfDayUTC(timezone, targetDate)
+    // Convert the requested calendar date directly into the user's UTC query range.
+    const startOfDay = getStartOfLocalDateUTC(timezone, date)
+    const endOfDay = getEndOfLocalDateUTC(timezone, date)
 
     // Fetch workouts for that day that are not duplicates
     const workouts = await workoutRepository.getForUser(userId, {

--- a/tests/unit/server/api/workouts/by-date.test.ts
+++ b/tests/unit/server/api/workouts/by-date.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import { getUserTimezone } from '../../../../../server/utils/date'
+
+const workoutRepositoryMock = {
+  getForUser: vi.fn()
+}
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('getQuery', (event: any) => event.query || {})
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('workoutRepository', workoutRepositoryMock)
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {}
+}))
+
+vi.mock('../../../../../server/utils/date', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../server/utils/date')>(
+    '../../../../../server/utils/date'
+  )
+
+  return {
+    ...actual,
+    getUserTimezone: vi.fn()
+  }
+})
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/workouts/by-date.get')).default
+
+describe('GET /api/workouts/by-date', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    workoutRepositoryMock.getForUser.mockResolvedValue([])
+  })
+
+  it('queries the requested Los Angeles calendar day instead of the previous day', async () => {
+    const handler = await getHandler()
+    vi.mocked(getUserTimezone).mockResolvedValue('America/Los_Angeles')
+
+    await handler({ query: { date: '2026-03-15' } } as any)
+
+    expect(workoutRepositoryMock.getForUser).toHaveBeenCalledWith('user-1', {
+      startDate: new Date('2026-03-15T07:00:00.000Z'),
+      endDate: new Date('2026-03-16T06:59:59.999Z'),
+      orderBy: { date: 'asc' }
+    })
+  })
+
+  it('keeps the requested calendar day correct for Tokyo', async () => {
+    const handler = await getHandler()
+    vi.mocked(getUserTimezone).mockResolvedValue('Asia/Tokyo')
+
+    await handler({ query: { date: '2026-03-15' } } as any)
+
+    expect(workoutRepositoryMock.getForUser).toHaveBeenCalledWith('user-1', {
+      startDate: new Date('2026-03-14T15:00:00.000Z'),
+      endDate: new Date('2026-03-15T14:59:59.999Z'),
+      orderBy: { date: 'asc' }
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Replaced instant-based day-boundary conversion with the existing calendar-date helpers.
- Pass the raw `YYYY-MM-DD` query value directly to `getStartOfLocalDateUTC` and `getEndOfLocalDateUTC`.
- Added regression coverage for `America/Los_Angeles` and `Asia/Tokyo`.

## Why

The endpoint parsed a date-only query as UTC midnight before converting it into the athlete timezone. For negative UTC offsets, that instant falls on the prior local calendar day.

## Impact

Workout-by-date queries now cover the requested athlete-local calendar date in timezones behind UTC while preserving correct behavior in timezones ahead of UTC.

## Root cause

The route passed a date-only value through helpers whose contract expects an absolute `Date` instant instead of using the helpers designed for calendar-date strings.

## Checks

- `pnpm vitest run tests/unit/server/api/workouts/by-date.test.ts` — 1 file passed, 2 tests passed
- `pnpm typecheck:server` — passed
- `pnpm exec eslint server/api/workouts/by-date.get.ts tests/unit/server/api/workouts/by-date.test.ts` — passed
- `git diff --check` / `git show --check` — passed

Fixes CW-204