### PR TITLE
fix(security): scope issue comment mutations (CW-141)

### DIFF
--- a/server/api/admin/issues/[id]/comments/[commentId]/acknowledge.post.ts
+++ b/server/api/admin/issues/[id]/comments/[commentId]/acknowledge.post.ts
@@ -1,8 +1,8 @@
-import { getServerSession } from '../../../../../../utils/session'
+import { requireAdmin } from '../../../../../../utils/auth-guard'
 import { issuesRepository } from '../../../../../../utils/repositories/issuesRepository'
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
+  const session = await requireAdmin(event)
   if (!session?.user?.id) {
     throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
   }
@@ -14,22 +14,25 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Missing issueId or commentId' })
   }
 
-  // Verify the comment exists and belongs to the issue
-  const issue = await issuesRepository.getById(issueId)
+  const issue = await issuesRepository.getById(issueId, undefined, true)
   if (!issue) {
     throw createError({ statusCode: 404, statusMessage: 'Issue not found' })
   }
 
-  const comment = issue.comments.find(c => c.id === commentId)
+  const comment = issue.comments.find((c) => c.id === commentId)
   if (!comment) {
-    // If user is admin, they might see NOTES which are filtered out in getById for regular users.
-    // However, issuesRepository.getById filters comments if userId is provided.
-    // Here we are inside an API, so we should check if the user is authorized.
-    // For now, if getById didn't return it, it might be a NOTE or not exist.
     throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
   }
 
-  const updatedComment = await issuesRepository.acknowledgeComment(commentId, session.user.id)
+  const updatedComment = await issuesRepository.acknowledgeComment(
+    issueId,
+    commentId,
+    session.user.id
+  )
+
+  if (!updatedComment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
 
   return updatedComment
 })

--- a/server/api/admin/issues/[id]/comments/[commentId]/reaction.post.ts
+++ b/server/api/admin/issues/[id]/comments/[commentId]/reaction.post.ts
@@ -25,11 +25,26 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Invalid emoji' })
   }
 
+  const issue = await issuesRepository.getById(issueId, undefined, true)
+  if (!issue) {
+    throw createError({ statusCode: 404, statusMessage: 'Issue not found' })
+  }
+
+  const comment = issue.comments.find((comment) => comment.id === commentId)
+  if (!comment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
+
   const updatedComment = await issuesRepository.toggleReaction(
+    issueId,
     commentId,
     session.user.id,
     result.data.emoji
   )
+
+  if (!updatedComment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
 
   return updatedComment
 })

--- a/server/api/issues/[id]/comments/[commentId]/acknowledge.post.ts
+++ b/server/api/issues/[id]/comments/[commentId]/acknowledge.post.ts
@@ -14,22 +14,30 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Missing issueId or commentId' })
   }
 
-  // Verify the comment exists and belongs to the issue
-  const issue = await issuesRepository.getById(issueId)
+  const isAdmin = Boolean(session.user.isAdmin)
+  const issue = await issuesRepository.getById(
+    issueId,
+    isAdmin ? undefined : session.user.id,
+    isAdmin
+  )
   if (!issue) {
     throw createError({ statusCode: 404, statusMessage: 'Issue not found' })
   }
 
-  const comment = issue.comments.find(c => c.id === commentId)
+  const comment = issue.comments.find((c) => c.id === commentId)
   if (!comment) {
-    // If user is admin, they might see NOTES which are filtered out in getById for regular users.
-    // However, issuesRepository.getById filters comments if userId is provided.
-    // Here we are inside an API, so we should check if the user is authorized.
-    // For now, if getById didn't return it, it might be a NOTE or not exist.
     throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
   }
 
-  const updatedComment = await issuesRepository.acknowledgeComment(commentId, session.user.id)
+  const updatedComment = await issuesRepository.acknowledgeComment(
+    issueId,
+    commentId,
+    session.user.id
+  )
+
+  if (!updatedComment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
 
   return updatedComment
 })

--- a/server/api/issues/[id]/comments/[commentId]/reaction.post.ts
+++ b/server/api/issues/[id]/comments/[commentId]/reaction.post.ts
@@ -25,11 +25,31 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Invalid emoji' })
   }
 
+  const isAdmin = Boolean(session.user.isAdmin)
+  const issue = await issuesRepository.getById(
+    issueId,
+    isAdmin ? undefined : session.user.id,
+    isAdmin
+  )
+  if (!issue) {
+    throw createError({ statusCode: 404, statusMessage: 'Issue not found' })
+  }
+
+  const comment = issue.comments.find((comment) => comment.id === commentId)
+  if (!comment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
+
   const updatedComment = await issuesRepository.toggleReaction(
+    issueId,
     commentId,
     session.user.id,
     result.data.emoji
   )
+
+  if (!updatedComment) {
+    throw createError({ statusCode: 404, statusMessage: 'Comment not found' })
+  }
 
   return updatedComment
 })

--- a/server/utils/repositories/issuesRepository.ts
+++ b/server/utils/repositories/issuesRepository.ts
@@ -18,7 +18,7 @@ export const issuesRepository = {
   /**
    * Fetch a single issue by ID.
    */
-  async getById(id: string, userId?: string) {
+  async getById(id: string, userId?: string, isAdmin = false) {
     const report = await prisma.bugReport.findUnique({
       where: { id },
       include: {
@@ -44,7 +44,9 @@ export const issuesRepository = {
           }
         },
         comments: {
-          where: userId ? { type: 'MESSAGE' } : undefined, // Only show messages to regular users
+          // Internal notes require an explicit admin context. Omitting userId alone must
+          // not turn an otherwise unrestricted lookup into an internal-comment lookup.
+          where: isAdmin ? undefined : { type: 'MESSAGE' },
           include: {
             user: {
               select: {
@@ -342,7 +344,14 @@ export const issuesRepository = {
   /**
    * Acknowledge a comment.
    */
-  async acknowledgeComment(commentId: string, userId: string) {
+  async acknowledgeComment(issueId: string, commentId: string, userId: string) {
+    const comment = await prisma.bugReportComment.findFirst({
+      where: { id: commentId, bugReportId: issueId },
+      select: { id: true }
+    })
+
+    if (!comment) return null
+
     return prisma.bugReportComment.update({
       where: { id: commentId },
       data: {
@@ -365,7 +374,7 @@ export const issuesRepository = {
   /**
    * Toggle a reaction on a comment.
    */
-  async toggleReaction(commentId: string, userId: string, emoji: string) {
+  async toggleReaction(issueId: string, commentId: string, userId: string, emoji: string) {
     console.log(
       `[issuesRepository] toggleReaction START: commentId=${commentId}, userId=${userId}, emoji=${emoji}`
     )
@@ -374,8 +383,8 @@ export const issuesRepository = {
       return null
     }
 
-    const comment = await prisma.bugReportComment.findUnique({
-      where: { id: commentId },
+    const comment = await prisma.bugReportComment.findFirst({
+      where: { id: commentId, bugReportId: issueId },
       select: { reactions: true, userId: true, acknowledgedAt: true }
     })
 

--- a/tests/unit/server/api/admin/issue-reactions.test.ts
+++ b/tests/unit/server/api/admin/issue-reactions.test.ts
@@ -18,6 +18,8 @@ vi.mock('../../../../../server/utils/auth-guard', () => ({
 
 vi.mock('../../../../../server/utils/repositories/issuesRepository', () => ({
   issuesRepository: {
+    getById: vi.fn(),
+    acknowledgeComment: vi.fn(),
     toggleIssueReaction: vi.fn(),
     toggleReaction: vi.fn()
   }
@@ -31,6 +33,12 @@ const getIssueReactionHandler = async () => {
 const getCommentReactionHandler = async () => {
   const mod =
     await import('../../../../../server/api/admin/issues/[id]/comments/[commentId]/reaction.post')
+  return mod.default
+}
+
+const getCommentAcknowledgeHandler = async () => {
+  const mod =
+    await import('../../../../../server/api/admin/issues/[id]/comments/[commentId]/acknowledge.post')
   return mod.default
 }
 
@@ -98,6 +106,10 @@ describe('Admin Issue Reactions Auth Guard', () => {
         id: 'comment-1',
         reactions: {}
       } as any)
+      vi.mocked(issuesRepository.getById).mockResolvedValue({
+        id: 'issue-1',
+        comments: [{ id: 'comment-1', type: 'NOTE' }]
+      } as any)
 
       const handler = await getCommentReactionHandler()
       const result = await handler({
@@ -106,8 +118,78 @@ describe('Admin Issue Reactions Auth Guard', () => {
       } as any)
 
       expect(requireAdmin).toHaveBeenCalled()
-      expect(issuesRepository.toggleReaction).toHaveBeenCalledWith('comment-1', 'admin-1', '🎉')
+      expect(issuesRepository.getById).toHaveBeenCalledWith('issue-1', undefined, true)
+      expect(issuesRepository.toggleReaction).toHaveBeenCalledWith(
+        'issue-1',
+        'comment-1',
+        'admin-1',
+        '🎉'
+      )
       expect(result).toEqual({ id: 'comment-1', reactions: {} })
+    })
+
+    it('rejects a comment UUID that does not belong to the issue', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue({
+        user: { id: 'admin-1', isAdmin: true }
+      } as any)
+      vi.mocked(issuesRepository.getById).mockResolvedValue({
+        id: 'issue-1',
+        comments: []
+      } as any)
+
+      const handler = await getCommentReactionHandler()
+
+      await expect(
+        handler({
+          context: { params: { id: 'issue-1', commentId: 'other-comment' } },
+          body: { emoji: '🎉' }
+        } as any)
+      ).rejects.toMatchObject({ statusCode: 404 })
+
+      expect(issuesRepository.toggleReaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('POST /api/admin/issues/[id]/comments/[commentId]/acknowledge', () => {
+    it('rejects non-admin users with 403 Forbidden', async () => {
+      vi.mocked(requireAdmin).mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { statusCode: 403 })
+      )
+      const handler = await getCommentAcknowledgeHandler()
+
+      await expect(
+        handler({
+          context: { params: { id: 'issue-1', commentId: 'comment-1' } }
+        } as any)
+      ).rejects.toThrow('Forbidden')
+    })
+
+    it('allows admins to acknowledge a comment belonging to the issue', async () => {
+      vi.mocked(requireAdmin).mockResolvedValue({
+        user: { id: 'admin-1', isAdmin: true }
+      } as any)
+      vi.mocked(issuesRepository.getById).mockResolvedValue({
+        id: 'issue-1',
+        comments: [{ id: 'comment-1', type: 'NOTE' }]
+      } as any)
+      vi.mocked(issuesRepository.acknowledgeComment).mockResolvedValue({
+        id: 'comment-1',
+        acknowledgedBy: 'admin-1'
+      } as any)
+
+      const handler = await getCommentAcknowledgeHandler()
+      const result = await handler({
+        context: { params: { id: 'issue-1', commentId: 'comment-1' } }
+      } as any)
+
+      expect(requireAdmin).toHaveBeenCalled()
+      expect(issuesRepository.getById).toHaveBeenCalledWith('issue-1', undefined, true)
+      expect(issuesRepository.acknowledgeComment).toHaveBeenCalledWith(
+        'issue-1',
+        'comment-1',
+        'admin-1'
+      )
+      expect(result).toEqual({ id: 'comment-1', acknowledgedBy: 'admin-1' })
     })
   })
 })

--- a/tests/unit/server/api/issues/comment-security.test.ts
+++ b/tests/unit/server/api/issues/comment-security.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { issuesRepository } from '../../../../../server/utils/repositories/issuesRepository'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+vi.stubGlobal('readBody', (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/repositories/issuesRepository', () => ({
+  issuesRepository: {
+    getById: vi.fn(),
+    acknowledgeComment: vi.fn(),
+    toggleReaction: vi.fn()
+  }
+}))
+
+const getReactionHandler = async () => {
+  const mod =
+    await import('../../../../../server/api/issues/[id]/comments/[commentId]/reaction.post')
+  return mod.default
+}
+
+const getAcknowledgeHandler = async () => {
+  const mod =
+    await import('../../../../../server/api/issues/[id]/comments/[commentId]/acknowledge.post')
+  return mod.default
+}
+
+describe('Issue comment ownership guards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: 'user-2', isAdmin: false }
+    } as any)
+  })
+
+  it("does not let a second user react to another user's comment", async () => {
+    vi.mocked(issuesRepository.getById).mockResolvedValue(null)
+    const handler = await getReactionHandler()
+
+    await expect(
+      handler({
+        context: { params: { id: 'issue-1', commentId: 'comment-1' } },
+        body: { emoji: '👍' }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(issuesRepository.getById).toHaveBeenCalledWith('issue-1', 'user-2', false)
+    expect(issuesRepository.toggleReaction).not.toHaveBeenCalled()
+  })
+
+  it("does not let a second user acknowledge another user's comment", async () => {
+    vi.mocked(issuesRepository.getById).mockResolvedValue(null)
+    const handler = await getAcknowledgeHandler()
+
+    await expect(
+      handler({
+        context: { params: { id: 'issue-1', commentId: 'comment-1' } }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(issuesRepository.getById).toHaveBeenCalledWith('issue-1', 'user-2', false)
+    expect(issuesRepository.acknowledgeComment).not.toHaveBeenCalled()
+  })
+
+  it('does not let a user target a hidden internal note', async () => {
+    vi.mocked(issuesRepository.getById).mockResolvedValue({
+      id: 'issue-1',
+      comments: []
+    } as any)
+    const handler = await getReactionHandler()
+
+    await expect(
+      handler({
+        context: { params: { id: 'issue-1', commentId: 'internal-note' } },
+        body: { emoji: '👀' }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(issuesRepository.toggleReaction).not.toHaveBeenCalled()
+  })
+
+  it('allows the issue owner to react to a comment on the issue', async () => {
+    vi.mocked(issuesRepository.getById).mockResolvedValue({
+      id: 'issue-1',
+      comments: [{ id: 'comment-1', type: 'MESSAGE' }]
+    } as any)
+    vi.mocked(issuesRepository.toggleReaction).mockResolvedValue({
+      id: 'comment-1',
+      reactions: { '👍': ['user-2'] }
+    } as any)
+    const handler = await getReactionHandler()
+
+    const result = await handler({
+      context: { params: { id: 'issue-1', commentId: 'comment-1' } },
+      body: { emoji: '👍' }
+    } as any)
+
+    expect(issuesRepository.toggleReaction).toHaveBeenCalledWith(
+      'issue-1',
+      'comment-1',
+      'user-2',
+      '👍'
+    )
+    expect(result).toMatchObject({ id: 'comment-1' })
+  })
+
+  it('allows an admin through the user namespace with internal-note access', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: 'admin-1', isAdmin: true }
+    } as any)
+    vi.mocked(issuesRepository.getById).mockResolvedValue({
+      id: 'issue-1',
+      comments: [{ id: 'internal-note', type: 'NOTE' }]
+    } as any)
+    vi.mocked(issuesRepository.acknowledgeComment).mockResolvedValue({
+      id: 'internal-note',
+      acknowledgedBy: 'admin-1'
+    } as any)
+    const handler = await getAcknowledgeHandler()
+
+    await handler({
+      context: { params: { id: 'issue-1', commentId: 'internal-note' } }
+    } as any)
+
+    expect(issuesRepository.getById).toHaveBeenCalledWith('issue-1', undefined, true)
+    expect(issuesRepository.acknowledgeComment).toHaveBeenCalledWith(
+      'issue-1',
+      'internal-note',
+      'admin-1'
+    )
+  })
+})

--- a/tests/unit/server/api/issues/issues-repository-security.test.ts
+++ b/tests/unit/server/api/issues/issues-repository-security.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prisma } from '../../../../../server/utils/db'
+import { issuesRepository } from '../../../../../server/utils/repositories/issuesRepository'
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    bugReport: {
+      findUnique: vi.fn()
+    },
+    bugReportComment: {
+      findFirst: vi.fn(),
+      update: vi.fn()
+    },
+    llmUsage: {
+      aggregate: vi.fn()
+    }
+  }
+}))
+
+describe('issuesRepository.getById comment visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.bugReport.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.bugReportComment.findFirst).mockResolvedValue(null)
+  })
+
+  it('filters internal notes when no user ID or admin context is supplied', async () => {
+    await issuesRepository.getById('issue-1')
+
+    expect(prisma.bugReport.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          comments: expect.objectContaining({ where: { type: 'MESSAGE' } })
+        })
+      })
+    )
+  })
+
+  it('includes internal notes only with an explicit admin context', async () => {
+    await issuesRepository.getById('issue-1', undefined, true)
+
+    expect(prisma.bugReport.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          comments: expect.objectContaining({ where: undefined })
+        })
+      })
+    )
+  })
+})
+
+describe('issuesRepository comment mutation scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.bugReportComment.findFirst).mockResolvedValue(null)
+  })
+
+  it('binds reaction lookup to both the issue and comment IDs', async () => {
+    await expect(
+      issuesRepository.toggleReaction('issue-1', 'comment-1', 'user-1', '👍')
+    ).resolves.toBeNull()
+
+    expect(prisma.bugReportComment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'comment-1', bugReportId: 'issue-1' } })
+    )
+    expect(prisma.bugReportComment.update).not.toHaveBeenCalled()
+  })
+
+  it('binds acknowledgement lookup to both the issue and comment IDs', async () => {
+    await expect(
+      issuesRepository.acknowledgeComment('issue-1', 'comment-1', 'user-1')
+    ).resolves.toBeNull()
+
+    expect(prisma.bugReportComment.findFirst).toHaveBeenCalledWith({
+      where: { id: 'comment-1', bugReportId: 'issue-1' },
+      select: { id: true }
+    })
+    expect(prisma.bugReportComment.update).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What changed

- require issue ownership (or explicit admin context) before user-namespace comment reactions and acknowledgements
- require the admin guard on both admin-namespace handlers
- bind repository comment mutations to both the issue ID and comment ID
- hide internal NOTE comments unless callers explicitly opt into admin visibility
- add regression coverage for cross-user IDOR attempts, hidden notes, admin authorization, and repository mutation scoping

## Why

Authenticated users could previously mutate comments on another user's private bug report by supplying its comment UUID. The acknowledgement path used an unrestricted issue lookup, and reaction mutations did not verify the issue relationship.

## Impact

Cross-user reaction and acknowledgement attempts now return 404 without mutating the target. Administrators retain access through an explicit admin context, including internal NOTE comments.

## Root cause

The handlers trusted the comment UUID as sufficient authorization, while `getById` treated an omitted user ID as implicit internal access and the mutation methods were not scoped to a bug report.

## Checks

- `pnpm vitest run tests/unit/server/api` — 50 files passed, 142 tests passed
- `pnpm typecheck:server` — passed
- focused ESLint for all changed TypeScript files — passed

Fixes CW-141
