### PR TITLE
fix(ai): format prompt weights by preference (CW-195)

### DIFF
--- a/server/utils/services/chatContextService.ts
+++ b/server/utils/services/chatContextService.ts
@@ -8,7 +8,11 @@ import { generateTrainingContext, formatTrainingContextForPrompt } from '../trai
 import { getInjuryLabel } from '../../utils/wellness'
 import { filterGoalsForContext } from '../goal-context'
 import { getUserAiSettings } from '../ai-user-settings'
-import { formatPromptDistance, formatPromptHeight } from '../ai-prompt-format'
+import {
+  formatPromptDistance,
+  formatPromptHeight,
+  formatPromptWeight
+} from '../ai-prompt-format'
 
 type BuildAthleteContextOptions = {
   includeDomainToolInstructions?: boolean
@@ -317,8 +321,7 @@ export async function buildAthleteContext(
     if (userProfile.maxHr) metrics.push(`Global Max HR: ${userProfile.maxHr} bpm`)
     if (userProfile.restingHr) metrics.push(`Global Resting HR: ${userProfile.restingHr} bpm`)
     if (userProfile.weight) {
-      const weightUnit = userProfile.weightUnits === 'Pounds' ? 'lbs' : 'kg'
-      metrics.push(`Weight: ${userProfile.weight.toFixed(2)}${weightUnit}`)
+      metrics.push(`Weight: ${formatPromptWeight(userProfile.weight, userProfile.weightUnits)}`)
     }
     if (userProfile.height) {
       metrics.push(`Height: ${formatPromptHeight(userProfile.height, userProfile.heightUnits)}`)

--- a/server/utils/services/wellness-analysis.ts
+++ b/server/utils/services/wellness-analysis.ts
@@ -6,7 +6,7 @@ import { auditLogRepository } from '../repositories/auditLogRepository'
 import { getUserLocalDate, getUserTimezone } from '../date'
 import { triggerDailyCheckinIfNeeded } from './checkin-service'
 import { checkQuota } from '../quotas/engine'
-import { formatPromptTemperature } from '../ai-prompt-format'
+import { formatPromptTemperature, formatPromptWeight } from '../ai-prompt-format'
 import {
   getMoodLabel,
   getStressLabel,
@@ -141,7 +141,7 @@ export async function analyzeWellness(wellnessId: string, userId: string) {
     const [user, aiSettings, wellnessEvents] = await Promise.all([
       prisma.user.findUnique({
         where: { id: userId },
-        select: { language: true, temperatureUnits: true }
+        select: { language: true, temperatureUnits: true, weightUnits: true }
       }),
       getUserAiSettings(userId),
       getWellnessEventOverlaysForUser(userId, {
@@ -301,7 +301,7 @@ export async function analyzeWellness(wellnessId: string, userId: string) {
 
                 * Injury: ${wellness.injury || 'None'} (${getInjuryLabel(wellness.injury)})
 
-              - Vitals: SpO2 ${wellness.spO2}%, Weight ${wellness.weight}kg
+              - Vitals: SpO2 ${wellness.spO2}%, Weight ${formatPromptWeight(wellness.weight, user?.weightUnits)}
 
         ${sleepDetails}
 

--- a/tests/unit/server/utils/services/wellness-analysis.test.ts
+++ b/tests/unit/server/utils/services/wellness-analysis.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { prismaWellnessFindUnique, prismaWellnessUpdate, prismaUserFindUnique, checkQuotaMock } =
-  vi.hoisted(() => ({
-    prismaWellnessFindUnique: vi.fn(),
-    prismaWellnessUpdate: vi.fn(),
-    prismaUserFindUnique: vi.fn(),
-    checkQuotaMock: vi.fn()
-  }))
+const {
+  prismaWellnessFindUnique,
+  prismaWellnessUpdate,
+  prismaUserFindUnique,
+  checkQuotaMock,
+  generateStructuredAnalysisMock
+} = vi.hoisted(() => ({
+  prismaWellnessFindUnique: vi.fn(),
+  prismaWellnessUpdate: vi.fn(),
+  prismaUserFindUnique: vi.fn(),
+  checkQuotaMock: vi.fn(),
+  generateStructuredAnalysisMock: vi.fn()
+}))
 
 vi.mock('../../../../../../server/utils/db', () => ({
   prisma: {
@@ -16,7 +22,17 @@ vi.mock('../../../../../../server/utils/db', () => ({
     },
     user: {
       findUnique: prismaUserFindUnique
-    }
+    },
+    goal: { findMany: vi.fn().mockResolvedValue([]) },
+    plannedWorkout: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null)
+    },
+    trainingAvailability: { findMany: vi.fn().mockResolvedValue([]) },
+    weeklyTrainingPlan: { findFirst: vi.fn().mockResolvedValue(null) },
+    integration: { findUnique: vi.fn().mockResolvedValue(null) },
+    calendarNote: { findMany: vi.fn().mockResolvedValue([]) },
+    athleteJourneyEvent: { findMany: vi.fn().mockResolvedValue([]) }
   }
 }))
 
@@ -31,15 +47,45 @@ vi.mock('../../../../../server/utils/ai-user-settings', () => ({
   })
 }))
 
-vi.mock('../../../../../server/utils/date', () => ({
-  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
-  getUserLocalDate: vi.fn(() => new Date('2026-03-10T00:00:00.000Z'))
-}))
+vi.mock('../../../../../server/utils/date', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../server/utils/date')>(
+    '../../../../../server/utils/date'
+  )
+
+  return {
+    ...actual,
+    getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+    getUserLocalDate: vi.fn(() => new Date('2026-03-10T00:00:00.000Z'))
+  }
+})
 
 vi.mock('../../../../../server/utils/repositories/wellnessRepository', () => ({
   wellnessRepository: {
     getForUser: vi.fn().mockResolvedValue([])
   }
+}))
+
+vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: {
+    getByUserId: vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/workoutRepository', () => ({
+  workoutRepository: {
+    getForUser: vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/nutritionRepository', () => ({
+  nutritionRepository: {
+    getForUser: vi.fn().mockResolvedValue([])
+  }
+}))
+
+vi.mock('../../../../../server/utils/training-metrics', () => ({
+  generateTrainingContext: vi.fn().mockResolvedValue({}),
+  formatTrainingContextForPrompt: vi.fn().mockReturnValue('Mocked Training Context')
 }))
 
 vi.mock('../../../../../server/utils/services/wellnessEventService', () => ({
@@ -53,7 +99,22 @@ vi.mock('../../../../../server/utils/services/checkin-service', () => ({
 }))
 
 vi.mock('../../../../../server/utils/gemini', () => ({
-  generateStructuredAnalysis: vi.fn()
+  generateStructuredAnalysis: generateStructuredAnalysisMock
+}))
+
+vi.mock('../../../../../trigger/init', () => ({}))
+
+vi.mock('../../../../../trigger/queues', () => ({
+  userReportsQueue: {}
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  logger: {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  },
+  task: vi.fn((config) => config)
 }))
 
 describe('analyzeWellness quota enforcement', () => {
@@ -67,9 +128,25 @@ describe('analyzeWellness quota enforcement', () => {
       sleepHours: 7.5,
       recoveryScore: 80,
       readiness: 8,
+      spO2: 98,
+      weight: 70,
       rawJson: {}
     })
-    prismaUserFindUnique.mockResolvedValue({ language: 'English' })
+    prismaWellnessUpdate.mockResolvedValue({})
+    checkQuotaMock.mockResolvedValue(undefined)
+    generateStructuredAnalysisMock.mockResolvedValue({
+      executive_summary: 'Ready',
+      status: 'READY',
+      sections: [],
+      recommendations: []
+    })
+    prismaUserFindUnique.mockResolvedValue({
+      name: 'Athlete',
+      language: 'English',
+      timezone: 'UTC',
+      aiPersona: 'Supportive',
+      nutritionTrackingEnabled: false
+    })
   })
 
   it('marks wellness analysis as QUOTA_EXCEEDED when quota is exceeded', async () => {
@@ -90,6 +167,62 @@ describe('analyzeWellness quota enforcement', () => {
     })
     expect(result).toEqual({ success: false, reason: 'QUOTA_EXCEEDED' })
   })
+
+  it.each([
+    {
+      weightUnits: 'Pounds',
+      expectedWeight: '154.3 lbs',
+      unexpectedWeight: '70.00lbs'
+    },
+    {
+      weightUnits: 'Kilograms',
+      expectedWeight: '70.0 kg',
+      unexpectedWeight: '154.3 lbs'
+    }
+  ])(
+    'formats stored kilograms as $weightUnits across every fixed AI prompt',
+    async ({ weightUnits, expectedWeight, unexpectedWeight }) => {
+      prismaUserFindUnique.mockResolvedValue({
+        name: 'Athlete',
+        language: 'English',
+        timezone: 'UTC',
+        aiPersona: 'Supportive',
+        nutritionTrackingEnabled: false,
+        weight: 70,
+        weightUnits
+      })
+
+      const { buildAthleteContext } =
+        await import('../../../../../server/utils/services/chatContextService')
+      const { context } = await buildAthleteContext('user-1')
+
+      const { buildDailyCoachUserInfo } = await import('../../../../../trigger/daily-coach')
+      const { buildAnalysisPrompt: buildThreeDayNutritionPrompt } =
+        await import('../../../../../trigger/analyze-last-3-nutrition')
+      const { buildAnalysisPrompt: buildSevenDayNutritionPrompt } =
+        await import('../../../../../trigger/analyze-last-7-nutrition')
+
+      const prompts = [
+        context,
+        buildDailyCoachUserInfo({ weight: 70, weightUnits }),
+        buildThreeDayNutritionPrompt([], { weight: 70, weightUnits }, 'UTC'),
+        buildSevenDayNutritionPrompt([], { weight: 70, weightUnits }, 'UTC')
+      ]
+
+      for (const prompt of prompts) {
+        expect(prompt).toContain(expectedWeight)
+        expect(prompt).not.toContain(unexpectedWeight)
+      }
+
+      const { analyzeWellness } =
+        await import('../../../../../server/utils/services/wellness-analysis')
+      await analyzeWellness('wellness-1', 'user-1')
+
+      const wellnessPrompt = generateStructuredAnalysisMock.mock.calls.at(-1)?.[0]
+      expect(wellnessPrompt).toContain(`Weight ${expectedWeight}`)
+      expect(wellnessPrompt).not.toContain(unexpectedWeight)
+    }
+  )
 })
 
 describe('analyzeWellness skin temperature formatting', () => {

--- a/trigger/analyze-last-3-nutrition.ts
+++ b/trigger/analyze-last-3-nutrition.ts
@@ -10,6 +10,7 @@ import {
   formatDateUTC,
   getStartOfDaysAgoUTC
 } from '../server/utils/date'
+import { formatPromptWeight } from '../server/utils/ai-prompt-format'
 
 // Analysis schema for nutrition reports
 const nutritionAnalysisSchema = {
@@ -121,7 +122,7 @@ function buildNutritionSummary(nutritionDays: any[], timezone: string) {
     .join('\n\n')
 }
 
-function buildAnalysisPrompt(nutritionDays: any[], user: any, timezone: string) {
+export function buildAnalysisPrompt(nutritionDays: any[], user: any, timezone: string) {
   const dateRange =
     nutritionDays.length > 0
       ? `${formatDateUTC(nutritionDays[nutritionDays.length - 1].date)} - ${formatDateUTC(nutritionDays[0].date)}`
@@ -132,7 +133,7 @@ Preferred Language: ${user?.language || 'English'} (ALL analysis and text respon
 
 USER PROFILE:
 - FTP: ${user?.ftp || 'Unknown'} watts
-- Weight: ${user?.weight || 'Unknown'} kg
+- Weight: ${formatPromptWeight(user?.weight, user?.weightUnits)}
 - Cycling athlete - endurance training focus
 
 RECENT NUTRITION DATA (Last ${nutritionDays.length} Days):
@@ -263,7 +264,7 @@ export const analyzeLast3NutritionTask = task({
       // Fetch user profile for context
       const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { ftp: true, weight: true, maxHr: true, language: true }
+        select: { ftp: true, weight: true, weightUnits: true, maxHr: true, language: true }
       })
 
       // Build the analysis prompt

--- a/trigger/analyze-last-7-nutrition.ts
+++ b/trigger/analyze-last-7-nutrition.ts
@@ -10,6 +10,7 @@ import {
   formatDateUTC,
   getStartOfDaysAgoUTC
 } from '../server/utils/date'
+import { formatPromptWeight } from '../server/utils/ai-prompt-format'
 
 // Analysis schema for nutrition reports
 const nutritionAnalysisSchema = {
@@ -122,7 +123,7 @@ function buildNutritionSummary(nutritionDays: any[], timezone: string) {
     .join('\n\n')
 }
 
-function buildAnalysisPrompt(nutritionDays: any[], user: any, timezone: string) {
+export function buildAnalysisPrompt(nutritionDays: any[], user: any, timezone: string) {
   const dateRange =
     nutritionDays.length > 0
       ? `${formatDateUTC(nutritionDays[nutritionDays.length - 1].date)} - ${formatDateUTC(nutritionDays[0].date)}`
@@ -133,7 +134,7 @@ Preferred Language: ${user?.language || 'English'} (ALL analysis and text respon
 
 USER PROFILE:
 - FTP: ${user?.ftp || 'Unknown'} watts
-- Weight: ${user?.weight || 'Unknown'} kg
+- Weight: ${formatPromptWeight(user?.weight, user?.weightUnits)}
 - Cycling athlete - endurance training focus
 
 WEEKLY NUTRITION DATA (Last ${nutritionDays.length} Days):
@@ -271,7 +272,7 @@ export const analyzeLast7NutritionTask = task({
       // Fetch user profile for context
       const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { ftp: true, weight: true, maxHr: true, language: true }
+        select: { ftp: true, weight: true, weightUnits: true, maxHr: true, language: true }
       })
 
       // Build the analysis prompt

--- a/trigger/daily-coach.ts
+++ b/trigger/daily-coach.ts
@@ -22,7 +22,10 @@ import { isWithinPreferredEmailTime } from '../server/utils/email-schedule'
 import { getCurrentFitnessSummary } from '../server/utils/training-stress'
 import { evaluateFitbitRecoveryAlert } from '../server/utils/wellness'
 import { dispatchTask } from '../server/utils/task-dispatcher'
-import { formatPromptHeight } from '../server/utils/ai-prompt-format'
+import {
+  formatPromptHeight,
+  formatPromptWeight
+} from '../server/utils/ai-prompt-format'
 
 const suggestionSchema = {
   type: 'object',
@@ -46,6 +49,25 @@ const suggestionSchema = {
     }
   },
   required: ['action', 'reason', 'confidence']
+}
+
+export function buildDailyCoachUserInfo(
+  user: {
+    ftp?: number | null
+    weight?: number | null
+    weightUnits?: string | null
+    height?: number | null
+    heightUnits?: string | null
+    maxHr?: number | null
+  } | null
+) {
+  return `
+USER INFO:
+- FTP: ${user?.ftp || 'Unknown'} watts
+- Weight: ${formatPromptWeight(user?.weight, user?.weightUnits)}
+- Height: ${formatPromptHeight(user?.height, user?.heightUnits)}
+- Max HR: ${user?.maxHr || 'Unknown'} bpm
+`
 }
 
 export const dailyCoachTask = task({
@@ -201,13 +223,7 @@ Recent Performance: ${profile.recent_performance?.trend || 'Unknown'}
 Current Focus: ${profile.planning_context?.current_focus || 'General training'}
 `
     } else {
-      athleteContext = `
-USER INFO:
-- FTP: ${user?.ftp || 'Unknown'} watts
-- Weight: ${user?.weight || 'Unknown'} ${user?.weightUnits === 'Pounds' ? 'lbs' : 'kg'}
-- Height: ${formatPromptHeight(user?.height, user?.heightUnits)}
-- Max HR: ${user?.maxHr || 'Unknown'} bpm
-`
+      athleteContext = buildDailyCoachUserInfo(user)
     }
 
     // Add goals context


### PR DESCRIPTION
## What changed

- Reused `formatPromptWeight` in chat context, daily coach, both nutrition reports, and wellness analysis.
- Added `weightUnits` to the nutrition and wellness user-profile selects that previously omitted it.
- Extracted the existing daily-coach fallback profile prompt and exported existing nutrition prompt builders for direct regression coverage.
- Added Pounds and Kilograms regression coverage across every corrected prompt call site.

## Why

Several AI prompts either changed only the unit label or hard-coded kilograms while the stored value remained kilograms. A 70 kg athlete preferring Pounds could therefore receive values such as `70.00lbs` instead of `154.3 lbs`.

## Impact

AI prompts now consistently represent stored kilogram values in the configured weight unit without changing kilogram-preference output.

## Root cause

These call sites bypassed the shared unit-aware prompt formatter, and three profile queries did not fetch `weightUnits`.

## Checks

- `pnpm vitest run tests/unit/server/utils/services/chatContextService.test.ts tests/unit/server/utils/services/wellness-analysis.test.ts` — 2 files passed, 6 tests passed
- `pnpm typecheck:server` — passed
- Scoped ESLint across all six changed files — passed
- `git diff --check` / `git show --check` — passed

Fixes CW-195