### PR TITLE
Configure Watt Mind Sentry for web production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,10 +86,10 @@ CW_WORKER_QUEUE_WEBHOOK_CONCURRENCY=5
 
 # Sentry (disabled in local dev by default — set SENTRY_ENABLED=true to opt in)
 # SENTRY_ENABLED=true
-SENTRY_DSN="https://27c2bc691e512298040726bf5de7608a@o4508727277256704.ingest.de.sentry.io/4510667866243152"
+SENTRY_DSN="your-sentry-dsn"
 SENTRY_AUTH_TOKEN="your-sentry-auth-token"
-SENTRY_ORG="your-sentry-org"
-SENTRY_PROJECT="your-sentry-project"
+SENTRY_ORG="watt-mind"
+SENTRY_PROJECT="coach-watts-web"
 
 # Rate Limiting
 WEBHOOK_RATE_LIMIT_MAX=100

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,8 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=watt-mind
+            SENTRY_PROJECT=coach-watts-web
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN --mount=type=cache,id=pnpm-v3,target=/pnpm/store pnpm install --frozen-lockf
 FROM base AS builder
 ARG COMMIT_SHA
 ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN}
+ENV SENTRY_ORG=${SENTRY_ORG}
+ENV SENTRY_PROJECT=${SENTRY_PROJECT}
+# Nuxt evaluates its Sentry module configuration during `pnpm build`.
+ENV NODE_ENV=production
 ENV CHAT_TURN_RUNNER_ENABLED=false
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/SENTRY-ISSUES.md
+++ b/SENTRY-ISSUES.md
@@ -1,26 +1,22 @@
 # Sentry Issue Tracking
 
-Live tracker for **this repo** ([Sentry dashboard](https://newpush-y4.sentry.io/issues/?project=coach-watts&query=is%3Aunresolved)). Last synced from Sentry: **2026-07-24**.
+## Current web project (agents — read this first)
 
-## Which Sentry project (agents — read this first)
+| Field                 | Value                                                                                                                      |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Organization**      | `watt-mind` (EU)                                                                                                           |
+| **Project**           | `coach-watts-web`                                                                                                          |
+| **Dashboard**         | https://watt-mind.sentry.io/issues/?project=4511817881157712                                                               |
+| **Env vars**          | `SENTRY_ORG=watt-mind`, `SENTRY_PROJECT=coach-watts-web` (see `.env`)                                                      |
+| **Linear automation** | Native Sentry → Linear alert configuration, filtered to event environment `production` and targeting the Coach Watts team. |
 
-| Field            | Value                                                                          |
-| ---------------- | ------------------------------------------------------------------------------ |
-| **Organization** | `newpush-y4`                                                                   |
-| **Project**      | `coach-watts`                                                                  |
-| **Region URL**   | `https://de.sentry.io`                                                         |
-| **Dashboard**    | https://newpush-y4.sentry.io/issues/?project=coach-watts&query=is%3Aunresolved |
-| **Env vars**     | `SENTRY_ORG=newpush-y4`, `SENTRY_PROJECT=coach-watts` (see `.env`)             |
+Use `watt-mind` / `coach-watts-web` for new investigation and issue capture. **Do not use** `coach-watts-app` for this repository: it is the mobile companion application with its own DSN and issue stream.
 
-When using the Sentry MCP (`search_issues`, `search_events`, `get_sentry_resource`, `update_issue`), **always** pass:
+## Legacy Newpush archive
 
-- `organizationSlug: "newpush-y4"`
-- `regionUrl: "https://de.sentry.io"`
-- `projectSlug: "coach-watts"` (or filter with `project:coach-watts`)
+The sections below are an historical record of the former `newpush-y4` / `coach-watts` project, last synchronized on **2026-07-24**. Keep their links and issue IDs intact; they do not describe the active web deployment after the Watt Mind migration.
 
-**Do not use** `watt-mind` / `coach-watts-app` — that is the **mobile companion app** (separate codebase). Issue IDs there look like `COACH-WATTS-APP-*`. This web/backend app uses `COACH-WATTS-*` (no `-APP`).
-
-Also out of scope for this tracker: `newpush-y4` / `platform` (e.g. [PLATFORM-CA](https://newpush-y4.sentry.io/issues/PLATFORM-CA)).
+For the archive only, use `organizationSlug: "newpush-y4"`, `regionUrl: "https://de.sentry.io"`, and `projectSlug: "coach-watts"`. The `newpush-y4` / `platform` project (for example [PLATFORM-CA](https://newpush-y4.sentry.io/issues/PLATFORM-CA)) remains out of scope.
 
 Related docs:
 
@@ -29,7 +25,7 @@ Related docs:
 - [docs/issues/196-sentry-no-cefsharp-scanner-filter.md](./docs/issues/196-sentry-no-cefsharp-scanner-filter.md) — COACH-WATTS-117 noise filter
 - [docs/issues/323-sentry-chunk-load-deploy-noise.md](./docs/issues/323-sentry-chunk-load-deploy-noise.md) — chunk-load cluster (C / 9 / 1ER)
 
-## Active — Unresolved in Sentry
+## Legacy — Unresolved in Sentry
 
 Sorted by recency. These still need a fix, deploy verification, or ongoing monitoring.
 

--- a/app/pages/debug/sentry.vue
+++ b/app/pages/debug/sentry.vue
@@ -143,7 +143,7 @@
       <template #footer>
         <p class="text-xs text-gray-400">
           Check your Sentry dashboard at: <br />
-          <code class="text-blue-400">https://newpush-y4.sentry.io/projects/coach-watts/</code>
+          <code class="text-blue-400">https://watt-mind.sentry.io/projects/coach-watts-web/</code>
         </p>
       </template>
     </UCard>

--- a/docs/04-guides/support.md
+++ b/docs/04-guides/support.md
@@ -51,8 +51,8 @@ When the developer accepts your fix plan (e.g., using `/support resolve <ticket_
 
 ## 3. Sentry Issues
 
-**Project for this repo:** org `newpush-y4`, project `coach-watts`, region `https://de.sentry.io`.
-Do **not** pull from `watt-mind` / `coach-watts-app` (mobile companion). See [SENTRY-ISSUES.md](../../SENTRY-ISSUES.md) → _Which Sentry project_.
+**Project for this repo:** org `watt-mind`, project `coach-watts-web`, region `https://de.sentry.io`.
+Do **not** pull from `watt-mind` / `coach-watts-app` (mobile companion). See [SENTRY-ISSUES.md](../../SENTRY-ISSUES.md) → _Current web project_.
 
 When a bug is also tracked in Sentry (see [SENTRY-ISSUES.md](../../SENTRY-ISSUES.md)), **resolve it in Sentry in the same session** once it is handled:
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -135,7 +135,7 @@ Historical documents, incident reports, and past status updates.
 
 ### Bug Fix Reports
 
-- [**Sentry Issue Tracking**](../SENTRY-ISSUES.md) - Living document for org `newpush-y4` / project `coach-watts` (not mobile `watt-mind`). **Resolve handled issues in Sentry** when fixing or triaging (see Maintenance Guidelines).
+- [**Sentry Issue Tracking**](../SENTRY-ISSUES.md) - Current web project is org `watt-mind` / project `coach-watts-web` (not the mobile `coach-watts-app` project). **Resolve handled issues in Sentry** when fixing or triaging (see Maintenance Guidelines).
 - [**Account Query Error**](./05-archive/bug-fixes/account-query-error.md)
 - [**Chat Tool Calling Fixes**](./05-archive/bug-fixes/chat-tool-calling-fixes.md)
 - [**Strava Training Load Fix**](./05-archive/bug-fixes/strava-training-load-fix.md)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -458,8 +458,8 @@ export default defineNuxtConfig({
 
   sentry: {
     enabled: sentryEnabled,
-    org: 'newpush-y4',
-    project: 'coach-watts',
+    org: process.env.SENTRY_ORG || 'watt-mind',
+    project: process.env.SENTRY_PROJECT || 'coach-watts-web',
     sourceMapsUploadOptions: {
       enabled: !!process.env.SENTRY_AUTH_TOKEN,
       telemetry: false


### PR DESCRIPTION
## Summary
- migrate the Coach Watts web configuration from Newpush to Watt Mind / `coach-watts-web`
- enable Sentry during the production Docker build and pass the required build metadata
- refresh the web Sentry inventory, debug link, and operational docs

## Excluded
- Trigger.dev configuration is intentionally unchanged because Trigger.dev is being sunsetted.

## Deployment follow-up
Before the release PR reaches `master`, configure `SENTRY_DSN` and `NUXT_PUBLIC_SENTRY_DSN` in Dokploy production for the web and worker services.

## Validation
- Git diff whitespace check
- workflow YAML parsing
- repository pre-commit lint/format hooks