### PR TITLE
perf(fit): avoid ArrayBuffer copy in parseFitFile (CW-218)

### DIFF
--- a/server/utils/fit.ts
+++ b/server/utils/fit.ts
@@ -23,6 +23,33 @@ export interface FitData {
 }
 
 /**
+ * Produce an ArrayBuffer for fit-file-parser without an unnecessary full copy.
+ *
+ * fit-file-parser only skips its internal copy when given an ArrayBuffer; for
+ * Buffer/Uint8Array inputs it allocates a new ArrayBuffer and copies every byte.
+ * Large FIT downloads typically own their underlying ArrayBuffer
+ * (byteOffset === 0 and byteLength === buffer.byteLength), so we can pass that
+ * through with zero extra allocation.
+ *
+ * Node's small-buffer pool (and other TypedArray views) may expose a larger
+ * underlying ArrayBuffer with a non-zero byteOffset. In that case a slice copy
+ * is required so the parser — which wraps the whole ArrayBuffer — does not read
+ * adjacent unrelated bytes. That copy is intentionally kept as ArrayBuffer
+ * (not Buffer) so fit-file-parser does not copy a second time.
+ */
+export function toFitParserArrayBuffer(buffer: Buffer): ArrayBuffer {
+  const { buffer: arrayBuffer, byteOffset, byteLength } = buffer
+  if (
+    byteOffset === 0 &&
+    byteLength === arrayBuffer.byteLength &&
+    arrayBuffer instanceof ArrayBuffer
+  ) {
+    return arrayBuffer
+  }
+  return arrayBuffer.slice(byteOffset, byteOffset + byteLength)
+}
+
+/**
  * Parse a FIT file buffer into a structured object
  */
 export function parseFitFile(buffer: Buffer): Promise<FitData> {
@@ -36,9 +63,10 @@ export function parseFitFile(buffer: Buffer): Promise<FitData> {
       mode: 'list'
     })
 
-    const cleanBuffer = Buffer.isBuffer(buffer)
-      ? buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
-      : buffer
+    // Prefer the Buffer's underlying ArrayBuffer when it already owns the full
+    // byte range (no slice). Only copy when the Buffer is a view into a larger
+    // slab — see toFitParserArrayBuffer.
+    const cleanBuffer = toFitParserArrayBuffer(buffer)
 
     fitParser.parse(cleanBuffer as any, (error: any, data: any) => {
       if (error) {

--- a/server/utils/fit.ts
+++ b/server/utils/fit.ts
@@ -46,7 +46,7 @@ export function toFitParserArrayBuffer(buffer: Buffer): ArrayBuffer {
   ) {
     return arrayBuffer
   }
-  return arrayBuffer.slice(byteOffset, byteOffset + byteLength)
+  return arrayBuffer.slice(byteOffset, byteOffset + byteLength) as ArrayBuffer
 }
 
 /**

--- a/tests/unit/server/utils/fit.test.ts
+++ b/tests/unit/server/utils/fit.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { parseFitFile, toFitParserArrayBuffer } from '../../../../server/utils/fit'
+
+const { parseMock, FitParserMock } = vi.hoisted(() => {
+  const parseMock = vi.fn((_content: ArrayBuffer, callback: (error: any, data: any) => void) => {
+    callback(undefined, {
+      protocolVersion: 1,
+      profileVersion: 1,
+      activity: {},
+      sessions: [],
+      laps: [],
+      records: [],
+      events: [],
+      device_infos: []
+    })
+  })
+  class FitParserMock {
+    parse = parseMock
+  }
+  return { parseMock, FitParserMock }
+})
+
+vi.mock('fit-file-parser', () => ({
+  default: FitParserMock
+}))
+
+describe('toFitParserArrayBuffer', () => {
+  it('returns the underlying ArrayBuffer without copying when Buffer owns it fully', () => {
+    const owned = Buffer.allocUnsafe(64 * 1024)
+    owned.fill(0xab)
+
+    const result = toFitParserArrayBuffer(owned)
+
+    expect(result).toBe(owned.buffer)
+    expect(result.byteLength).toBe(owned.byteLength)
+  })
+
+  it('slices a copy when Buffer is a view into a larger ArrayBuffer', () => {
+    const slab = new ArrayBuffer(32)
+    const view = Buffer.from(slab, 8, 16)
+    view.fill(0xcd)
+
+    const result = toFitParserArrayBuffer(view)
+
+    expect(result).not.toBe(slab)
+    expect(result.byteLength).toBe(16)
+    expect(new Uint8Array(result).every((b) => b === 0xcd)).toBe(true)
+  })
+})
+
+describe('parseFitFile', () => {
+  beforeEach(() => {
+    parseMock.mockClear()
+  })
+
+  it('passes the owned ArrayBuffer through without an intermediate slice copy', async () => {
+    const owned = Buffer.allocUnsafe(128 * 1024)
+    owned.fill(0x11)
+
+    await parseFitFile(owned)
+
+    expect(parseMock).toHaveBeenCalledTimes(1)
+    const passed = parseMock.mock.calls[0]?.[0]
+    expect(passed).toBe(owned.buffer)
+    expect(passed).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('passes a correctly sized ArrayBuffer copy for pooled/offset Buffer views', async () => {
+    const slab = new ArrayBuffer(48)
+    new Uint8Array(slab).fill(0x00)
+    const view = Buffer.from(slab, 4, 20)
+    view.fill(0x22)
+
+    await parseFitFile(view)
+
+    expect(parseMock).toHaveBeenCalledTimes(1)
+    const passed = parseMock.mock.calls[0]?.[0] as ArrayBuffer
+    expect(passed).toBeInstanceOf(ArrayBuffer)
+    expect(passed).not.toBe(slab)
+    expect(passed.byteLength).toBe(20)
+    expect(new Uint8Array(passed).every((b) => b === 0x22)).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`parseFitFile` unconditionally `slice()`'d the Buffer's underlying ArrayBuffer, doubling peak memory for large FIT parses (follow-up from CW-215 worker OOM work).

## Changes
- Pass through the owned ArrayBuffer when the Buffer already owns the full backing store
- Slice only for pooled/offset views (documented)
- Unit tests for owned vs offset views

## Linear
https://linear.app/watt-mind/issue/CW-218/avoid-arraybuffer-copy-in-parsefitfile-during-fit-ingestion

## Test plan
- [x] `pnpm test tests/unit/server/utils --run` (162 files / 953 tests passed)
- [ ] Confirm large FIT ingest memory behavior in worker after deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

