### PR TITLE
fix(security): scope nested plan mutations to owned plan (CW-144)

### DIFF
--- a/server/api/library/plans/[id]/architect.patch.ts
+++ b/server/api/library/plans/[id]/architect.patch.ts
@@ -86,9 +86,32 @@ export default defineEventHandler(async (event) => {
     isPublic,
     blocks: incomingBlocks
   } = validation.data
+
+  // Nested ids in the body must belong to this ownership-verified plan.
+  // Reject foreign block/week/workout ids before any mutation (IDOR guard).
+  const ownedBlockIds = new Set(plan.blocks.map((b: any) => b.id as string))
+  const ownedWeekIds = new Set(
+    plan.blocks.flatMap((b: any) => b.weeks.map((w: any) => w.id as string))
+  )
+  const ownedWorkoutIds = new Set(
+    plan.blocks.flatMap((b: any) =>
+      b.weeks.flatMap((w: any) => w.workouts.map((wo: any) => wo.id as string))
+    )
+  )
+  const isPersistedId = (value?: string) => Boolean(value && !value.startsWith('temp-'))
+
   for (const block of incomingBlocks) {
+    if (isPersistedId(block.id) && !ownedBlockIds.has(block.id!)) {
+      throw createError({ statusCode: 404, message: 'Block not found' })
+    }
     for (const week of block.weeks) {
+      if (isPersistedId(week.id) && !ownedWeekIds.has(week.id!)) {
+        throw createError({ statusCode: 404, message: 'Week not found' })
+      }
       for (const workout of week.workouts) {
+        if (isPersistedId(workout.id) && !ownedWorkoutIds.has(workout.id!)) {
+          throw createError({ statusCode: 404, message: 'Workout not found' })
+        }
         if (!workout.structuredWorkout) continue
         const canonical = adaptStructuredWorkout(workout.structuredWorkout, { source: 'TEMPLATE' })
         if (!canonical || canonical.diagnostics?.length) {
@@ -126,7 +149,7 @@ export default defineEventHandler(async (event) => {
 
     if (blocksToDelete.length > 0) {
       await tx.trainingBlock.deleteMany({
-        where: { id: { in: blocksToDelete } }
+        where: { id: { in: blocksToDelete }, trainingPlanId: id }
       })
     }
 
@@ -135,7 +158,7 @@ export default defineEventHandler(async (event) => {
       let blockId = bData.id
 
       if (blockId && !blockId.startsWith('temp-')) {
-        // Update existing block
+        // Update existing block (id already verified against this plan)
         await tx.trainingBlock.update({
           where: { id: blockId },
           data: {
@@ -170,7 +193,7 @@ export default defineEventHandler(async (event) => {
 
       if (weeksToDelete.length > 0) {
         await tx.trainingWeek.deleteMany({
-          where: { id: { in: weeksToDelete } }
+          where: { id: { in: weeksToDelete }, blockId: blockId! }
         })
       }
 
@@ -179,6 +202,7 @@ export default defineEventHandler(async (event) => {
         let weekId = wData.id
 
         if (weekId && !weekId.startsWith('temp-')) {
+          // id already verified against this plan's weeks
           await tx.trainingWeek.update({
             where: { id: weekId },
             data: {
@@ -213,7 +237,7 @@ export default defineEventHandler(async (event) => {
 
         if (workoutsToDelete.length > 0) {
           await tx.plannedWorkout.deleteMany({
-            where: { id: { in: workoutsToDelete } }
+            where: { id: { in: workoutsToDelete }, trainingWeekId: weekId! }
           })
         }
 
@@ -233,6 +257,7 @@ export default defineEventHandler(async (event) => {
           const canonicalStructure = canonicalWrite?.canonical || null
           const structureFields = canonicalWrite?.data || {}
           if (woData.id && !woData.id.startsWith('temp-')) {
+            // id already verified against this plan's workouts
             await tx.plannedWorkout.update({
               where: { id: woData.id },
               data: {

--- a/server/api/plans/[id]/blocks/reorder.put.ts
+++ b/server/api/plans/[id]/blocks/reorder.put.ts
@@ -36,10 +36,22 @@ export default defineEventHandler(async (event) => {
 
   if (!plan) throw createError({ statusCode: 404, message: 'Plan not found' })
 
+  // Nested block ids must belong to this ownership-verified plan (IDOR guard).
+  const ownedBlockIds = new Set(plan.blocks.map((b) => b.id))
+  for (const b of blocks) {
+    if (!ownedBlockIds.has(b.id)) {
+      throw createError({ statusCode: 404, message: 'Block not found' })
+    }
+  }
+
   return await prisma.$transaction(async (tx) => {
-    // 1. Update Orders
+    // 1. Update Orders (scoped to this plan)
     for (const b of blocks) {
-      await trainingBlockRepository.update(b.id, { order: b.order }, tx)
+      await trainingBlockRepository.updateMany(
+        { id: b.id, trainingPlanId: planId! },
+        { order: b.order },
+        tx
+      )
     }
 
     // 2. Fetch reordered blocks to recalculate dates

--- a/tests/unit/server/api/library/plans/architect.patch.test.ts
+++ b/tests/unit/server/api/library/plans/architect.patch.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../../server/utils/session'
+import { prisma } from '../../../../../../server/utils/db'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('getRouterParam', (event: any, name: string) => event.params?.[name])
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  ;(error as any).data = err.data
+  return error
+})
+
+vi.mock('../../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../../server/utils/db', () => ({
+  prisma: {
+    trainingPlan: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    },
+    trainingBlock: {
+      update: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    trainingWeek: {
+      update: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    plannedWorkout: {
+      update: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn()
+    },
+    $transaction: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../../shared/structured-workout-contract', () => ({
+  adaptStructuredWorkout: vi.fn((structure: any) => structure)
+}))
+
+vi.mock('../../../../../../server/utils/canonical-planned-workout-write', () => ({
+  buildTemplateStructureWriteData: vi.fn(() => null)
+}))
+
+vi.mock('../../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: {
+    getForActivityType: vi.fn().mockResolvedValue({})
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../../server/api/library/plans/[id]/architect.patch')
+  return mod.default
+}
+
+const attackerPlan = {
+  id: 'plan-attacker',
+  userId: 'attacker-1',
+  blocks: [
+    {
+      id: 'block-attacker',
+      weeks: [
+        {
+          id: 'week-attacker',
+          workouts: [{ id: 'workout-attacker' }]
+        }
+      ]
+    }
+  ]
+}
+
+const baseBlockPayload = {
+  name: 'Base',
+  type: 'BASE',
+  primaryFocus: 'endurance',
+  durationWeeks: 1,
+  order: 0,
+  weeks: [
+    {
+      weekNumber: 1,
+      volumeTargetMinutes: 300,
+      tssTarget: 200,
+      focus: null,
+      workouts: [
+        {
+          dayIndex: 0,
+          weekIndex: 1,
+          title: 'Easy',
+          description: null,
+          type: 'Ride',
+          durationSec: 3600,
+          tss: 40,
+          category: 'endurance',
+          structuredWorkout: null
+        }
+      ]
+    }
+  ]
+}
+
+describe('PATCH /api/library/plans/:id/architect IDOR', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'attacker-1' } } as any)
+    vi.mocked(prisma.trainingPlan.findUnique).mockResolvedValue(attackerPlan as any)
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(prisma))
+  })
+
+  it('rejects a foreign block id and never updates it', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        params: { id: 'plan-attacker' },
+        body: {
+          blocks: [
+            {
+              ...baseBlockPayload,
+              id: 'block-victim'
+            }
+          ]
+        }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404, message: 'Block not found' })
+
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.trainingBlock.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects a foreign week id and never updates it', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        params: { id: 'plan-attacker' },
+        body: {
+          blocks: [
+            {
+              ...baseBlockPayload,
+              id: 'block-attacker',
+              weeks: [
+                {
+                  ...baseBlockPayload.weeks[0],
+                  id: 'week-victim'
+                }
+              ]
+            }
+          ]
+        }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404, message: 'Week not found' })
+
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.trainingWeek.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects a foreign workout id and never updates it', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        params: { id: 'plan-attacker' },
+        body: {
+          blocks: [
+            {
+              ...baseBlockPayload,
+              id: 'block-attacker',
+              weeks: [
+                {
+                  ...baseBlockPayload.weeks[0],
+                  id: 'week-attacker',
+                  workouts: [
+                    {
+                      ...baseBlockPayload.weeks[0].workouts[0],
+                      id: 'workout-victim'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404, message: 'Workout not found' })
+
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(prisma.plannedWorkout.update).not.toHaveBeenCalled()
+  })
+
+  it('allows nested updates for ids that belong to the ownership-verified plan', async () => {
+    const handler = await getHandler()
+
+    const result = await handler({
+      params: { id: 'plan-attacker' },
+      body: {
+        name: 'Updated plan',
+        blocks: [
+          {
+            ...baseBlockPayload,
+            id: 'block-attacker',
+            name: 'Updated block',
+            weeks: [
+              {
+                ...baseBlockPayload.weeks[0],
+                id: 'week-attacker',
+                volumeTargetMinutes: 320,
+                workouts: [
+                  {
+                    ...baseBlockPayload.weeks[0].workouts[0],
+                    id: 'workout-attacker',
+                    title: 'Updated easy'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    } as any)
+
+    expect(result).toEqual({ success: true })
+    expect(prisma.$transaction).toHaveBeenCalled()
+    expect(prisma.trainingBlock.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'block-attacker' } })
+    )
+    expect(prisma.trainingWeek.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'week-attacker' } })
+    )
+    expect(prisma.plannedWorkout.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'workout-attacker' } })
+    )
+  })
+})

--- a/tests/unit/server/api/plans/blocks/reorder.put.test.ts
+++ b/tests/unit/server/api/plans/blocks/reorder.put.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../../server/utils/auth-guard'
+import { prisma } from '../../../../../../server/utils/db'
+import { trainingPlanRepository } from '../../../../../../server/utils/repositories/trainingPlanRepository'
+import { trainingBlockRepository } from '../../../../../../server/utils/repositories/trainingBlockRepository'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('getRouterParam', (event: any, name: string) => event.params?.[name])
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../../server/utils/db', () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    $executeRawUnsafe: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../../server/utils/repositories/trainingPlanRepository', () => ({
+  trainingPlanRepository: {
+    getById: vi.fn()
+  }
+}))
+
+vi.mock('../../../../../../server/utils/repositories/trainingBlockRepository', () => ({
+  trainingBlockRepository: {
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    list: vi.fn()
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../../server/api/plans/[id]/blocks/reorder.put')
+  return mod.default
+}
+
+describe('PUT /api/plans/:id/blocks/reorder IDOR', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'attacker-1' } as any)
+    vi.mocked(trainingPlanRepository.getById).mockResolvedValue({
+      id: 'plan-attacker',
+      userId: 'attacker-1',
+      startDate: new Date('2026-01-05T00:00:00.000Z'),
+      blocks: [
+        {
+          id: 'block-attacker-a',
+          order: 0,
+          startDate: new Date('2026-01-05T00:00:00.000Z'),
+          durationWeeks: 2,
+          weeks: []
+        },
+        {
+          id: 'block-attacker-b',
+          order: 1,
+          startDate: new Date('2026-01-19T00:00:00.000Z'),
+          durationWeeks: 2,
+          weeks: []
+        }
+      ]
+    } as any)
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn: any) => fn(prisma))
+    vi.mocked(trainingBlockRepository.list).mockResolvedValue([])
+  })
+
+  it('rejects a foreign block id and never mutates it', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        params: { id: 'plan-attacker' },
+        body: {
+          blocks: [
+            { id: 'block-attacker-a', order: 0 },
+            { id: 'block-victim', order: 1 }
+          ]
+        }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 404, message: 'Block not found' })
+
+    expect(prisma.$transaction).not.toHaveBeenCalled()
+    expect(trainingBlockRepository.updateMany).not.toHaveBeenCalled()
+    expect(trainingBlockRepository.update).not.toHaveBeenCalled()
+  })
+
+  it('reorders only blocks that belong to the ownership-verified plan', async () => {
+    vi.mocked(trainingBlockRepository.list).mockResolvedValue([
+      {
+        id: 'block-attacker-b',
+        order: 0,
+        startDate: new Date('2026-01-19T00:00:00.000Z'),
+        durationWeeks: 2,
+        weeks: []
+      },
+      {
+        id: 'block-attacker-a',
+        order: 1,
+        startDate: new Date('2026-01-05T00:00:00.000Z'),
+        durationWeeks: 2,
+        weeks: []
+      }
+    ] as any)
+
+    const handler = await getHandler()
+
+    const result = await handler({
+      params: { id: 'plan-attacker' },
+      body: {
+        blocks: [
+          { id: 'block-attacker-b', order: 0 },
+          { id: 'block-attacker-a', order: 1 }
+        ]
+      }
+    } as any)
+
+    expect(result).toEqual({ success: true })
+    expect(trainingBlockRepository.updateMany).toHaveBeenCalledWith(
+      { id: 'block-attacker-b', trainingPlanId: 'plan-attacker' },
+      { order: 0 },
+      prisma
+    )
+    expect(trainingBlockRepository.updateMany).toHaveBeenCalledWith(
+      { id: 'block-attacker-a', trainingPlanId: 'plan-attacker' },
+      { order: 1 },
+      prisma
+    )
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes an IDOR in plan architect patch and blocks reorder where nested `blockId` / `weekId` / workout IDs from the request body were mutated via bare `where: { id }` after only the parent plan was ownership-checked.

## Changes
- Reject foreign nested IDs that are not part of the ownership-verified plan tree (404)
- Scope deletes / reorder updates with parent FKs (`trainingPlanId`, etc.)
- Add unit tests for architect patch + blocks reorder IDOR cases

## Linear
https://linear.app/watt-mind/issue/CW-144/plan-architect-block-reorder-mutate-nested-ids-without-re-checking

## Test plan
- [x] `pnpm vitest run tests/unit/server/api` (59 files / 172 tests passed)
- [ ] Review IDOR rejection paths for architect + reorder

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

