### PR TITLE
fix(chat): treat structure tools as mutating in chat guard (CW-145)

### DIFF
--- a/server/utils/chat/turn-executor.test.ts
+++ b/server/utils/chat/turn-executor.test.ts
@@ -675,6 +675,28 @@ describe('write repair prompt helpers', () => {
     ).toBe(false)
   })
 
+  it('treats structure mutations as successful writes for empty-response retry guards', () => {
+    const setStructure = [
+      {
+        toolName: 'set_planned_workout_structure',
+        args: { plannedWorkoutId: 'pw-1', structure: { steps: [] } },
+        result: { message: 'Workout structure updated.', success: true }
+      }
+    ]
+    const modifyPlanStructure = [
+      {
+        toolName: 'modify_training_plan_structure',
+        args: { planId: 'plan-1', blocks: [] },
+        result: { message: 'Training plan structure updated.', success: true }
+      }
+    ]
+
+    expect(hasSuccessfulMutatingToolResult(setStructure)).toBe(true)
+    expect(shouldRetryEmptyToolResponse(0, setStructure)).toBe(false)
+    expect(hasSuccessfulMutatingToolResult(modifyPlanStructure)).toBe(true)
+    expect(shouldRetryEmptyToolResponse(0, modifyPlanStructure)).toBe(false)
+  })
+
   it('retries a successful read once but returns no fallback when every tool failed', () => {
     expect(
       shouldRetryEmptyToolResponse(0, [

--- a/server/utils/chat/turns.test.ts
+++ b/server/utils/chat/turns.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { isMutatingChatTool } from './turns'
+
+describe('isMutatingChatTool', () => {
+  it('classifies structure write tools as mutating', () => {
+    expect(isMutatingChatTool('set_planned_workout_structure')).toBe(true)
+    expect(isMutatingChatTool('modify_training_plan_structure')).toBe(true)
+    expect(isMutatingChatTool('generate_planned_workout_structure')).toBe(true)
+    expect(isMutatingChatTool('adjust_planned_workout')).toBe(true)
+  })
+
+  it('keeps existing mutating tools classified as mutating', () => {
+    expect(isMutatingChatTool('create_planned_workout')).toBe(true)
+    expect(isMutatingChatTool('log_nutrition_meal')).toBe(true)
+    expect(isMutatingChatTool('log_hydration_intake')).toBe(true)
+    expect(isMutatingChatTool('lock_meal_to_plan')).toBe(true)
+    expect(isMutatingChatTool('record_wellness_event')).toBe(true)
+    expect(isMutatingChatTool('ticket_update')).toBe(true)
+    expect(isMutatingChatTool('patch_planned_workout_structure')).toBe(true)
+  })
+
+  it('does not classify read tools as mutating', () => {
+    expect(isMutatingChatTool('get_workout_details')).toBe(false)
+    expect(isMutatingChatTool('get_recent_workouts')).toBe(false)
+  })
+})

--- a/server/utils/chat/turns.ts
+++ b/server/utils/chat/turns.ts
@@ -117,6 +117,8 @@ export function isMutatingChatTool(toolName: string) {
     toolName === 'lock_meal_to_plan' ||
     toolName === 'generate_planned_workout_structure' ||
     toolName === 'adjust_planned_workout' ||
+    toolName === 'set_planned_workout_structure' ||
+    toolName === 'modify_training_plan_structure' ||
     toolName.startsWith('create_') ||
     toolName.startsWith('record_') ||
     toolName.startsWith('update_') ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`isMutatingChatTool()` omitted `set_planned_workout_structure` and `modify_training_plan_structure`, so empty-response retry / heartbeat recovery / cross-lineage dedup could replay successful structure mutations.

## Changes
- Add both tools to the mutating allowlist in `server/utils/chat/turns.ts`
- Add focused unit coverage + empty-response retry regression coverage

## Linear
https://linear.app/watt-mind/issue/CW-145/chat-mutation-guard-misses-set-planned-workout-structure-and-modify

## Test plan
- [x] `pnpm vitest run server/utils/chat tests/unit/server/utils/chat` (12 files / 147 tests passed)
- [ ] Confirm no regression for already-listed mutating tools

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

