### PR TITLE
fix(security): reject foreign eventIds on goals PATCH (CW-148)

### DIFF
--- a/server/api/goals/[id].patch.ts
+++ b/server/api/goals/[id].patch.ts
@@ -98,12 +98,32 @@ export default defineEventHandler(async (event) => {
   const { eventData, eventId, eventIds, ...goalData } = body
   const data: any = { ...goalData }
 
-  if (eventIds && Array.isArray(eventIds)) {
-    data.events = {
-      set: eventIds.map((id) => ({ id }))
+  const requestedEventIds: string[] | null =
+    eventIds && Array.isArray(eventIds) ? eventIds : eventId ? [eventId] : null
+
+  if (requestedEventIds) {
+    // Prevent IDOR: only the caller's events may be linked to their goal
+    const uniqueEventIds = [...new Set(requestedEventIds)]
+    if (uniqueEventIds.length > 0) {
+      const ownedEvents = await prisma.event.findMany({
+        where: {
+          id: { in: uniqueEventIds },
+          userId
+        },
+        select: { id: true }
+      })
+
+      if (ownedEvents.length !== uniqueEventIds.length) {
+        throw createError({
+          statusCode: 403,
+          message: 'Not authorized to link one or more events'
+        })
+      }
     }
-  } else if (eventId) {
-    data.events = { set: [{ id: eventId }] }
+
+    data.events = {
+      set: requestedEventIds.map((id) => ({ id }))
+    }
   }
 
   if (eventData) {

--- a/tests/unit/server/api/goals/id.patch.test.ts
+++ b/tests/unit/server/api/goals/id.patch.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    goal: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    },
+    event: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn()
+    }
+  }
+}))
+
+const getHandler = async () => (await import('../../../../../server/api/goals/[id].patch')).default
+
+const ownedGoal = {
+  id: 'goal-1',
+  userId: 'attacker-1',
+  events: []
+}
+
+describe('PATCH /api/goals/:id event IDOR', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'attacker-1' } as any)
+    vi.mocked(prisma.goal.findUnique).mockResolvedValue(ownedGoal as any)
+  })
+
+  it('rejects foreign eventIds and never updates the goal', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([])
+
+    await expect(
+      handler({
+        context: { params: { id: 'goal-1' } },
+        body: { eventIds: ['victim-event-1'] }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.event.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['victim-event-1'] },
+        userId: 'attacker-1'
+      },
+      select: { id: true }
+    })
+    expect(prisma.goal.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects when eventIds mixes owned and foreign ids', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([{ id: 'owned-event-1' }] as any)
+
+    await expect(
+      handler({
+        context: { params: { id: 'goal-1' } },
+        body: { eventIds: ['owned-event-1', 'victim-event-1'] }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.goal.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects a foreign eventId and never updates the goal', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([])
+
+    await expect(
+      handler({
+        context: { params: { id: 'goal-1' } },
+        body: { eventId: 'victim-event-1' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.event.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['victim-event-1'] },
+        userId: 'attacker-1'
+      },
+      select: { id: true }
+    })
+    expect(prisma.goal.update).not.toHaveBeenCalled()
+  })
+
+  it('links owned eventIds after ownership verification', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: 'owned-event-1' },
+      { id: 'owned-event-2' }
+    ] as any)
+    vi.mocked(prisma.goal.update).mockResolvedValue({
+      id: 'goal-1',
+      userId: 'attacker-1'
+    } as any)
+
+    await expect(
+      handler({
+        context: { params: { id: 'goal-1' } },
+        body: { eventIds: ['owned-event-1', 'owned-event-2'] }
+      } as any)
+    ).resolves.toMatchObject({
+      success: true,
+      goal: { id: 'goal-1' }
+    })
+
+    expect(prisma.goal.update).toHaveBeenCalledWith({
+      where: { id: 'goal-1' },
+      data: expect.objectContaining({
+        events: {
+          set: [{ id: 'owned-event-1' }, { id: 'owned-event-2' }]
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`PATCH /api/goals/[id]` ownership-checked the goal but linked arbitrary `eventIds`, allowing cross-user private event association and later leakage via `GET /api/goals`.

## Changes
- Ownership-check every event before `events.set`
- Reject foreign/missing event IDs with 403 and skip the goal update
- Unit tests for foreign, mixed, and owned event linking

## Linear
https://linear.app/watt-mind/issue/CW-148/goals-patch-can-attach-another-users-private-events-idor-data-leak

## Test plan
- [x] `pnpm vitest run tests/unit/server/api/goals` (4/4 passed)
- [ ] Confirm create-path (`POST /api/goals`) is tracked separately if same gap remains

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

