### PR TITLE
fix(security): sanitize WELLNESS/REPORT/ATHLETE_PROFILE share payloads (CW-147)

### DIFF
--- a/server/api/share/[token].get.ts
+++ b/server/api/share/[token].get.ts
@@ -1,7 +1,13 @@
 import { workoutRepository } from '../../utils/repositories/workoutRepository'
 import { nutritionRepository } from '../../utils/repositories/nutritionRepository'
 import { attachStreamToWorkout } from '../../utils/repositories/workoutStreamRepository'
-import { sanitizeSharedNutrition, sanitizeSharedPlannedWorkout } from '../../utils/share-response'
+import {
+  sanitizeSharedNutrition,
+  sanitizeSharedPlannedWorkout,
+  sanitizeSharedWellness,
+  sanitizeSharedReport,
+  sanitizeSharedTrainingPlan
+} from '../../utils/share-response'
 
 defineRouteMeta({
   openAPI: {
@@ -84,9 +90,10 @@ export default defineEventHandler(async (event) => {
   let data: any = null
 
   if (shareToken.resourceType === 'REPORT') {
-    data = await prisma.report.findUnique({
+    const report = await prisma.report.findUnique({
       where: { id: shareToken.resourceId }
     })
+    data = report ? sanitizeSharedReport(report) : null
   } else if (shareToken.resourceType === 'WORKOUT') {
     const workoutRecord = await workoutRepository.getById(shareToken.resourceId, shareToken.userId)
     data = workoutRecord ? await attachStreamToWorkout(workoutRecord) : null
@@ -94,9 +101,10 @@ export default defineEventHandler(async (event) => {
     const nutrition = await nutritionRepository.getByIdInternal(shareToken.resourceId)
     data = nutrition ? sanitizeSharedNutrition(nutrition) : null
   } else if (shareToken.resourceType === 'ATHLETE_PROFILE') {
-    data = await prisma.report.findUnique({
+    const profile = await prisma.report.findUnique({
       where: { id: shareToken.resourceId }
     })
+    data = profile ? sanitizeSharedReport(profile) : null
   } else if (shareToken.resourceType === 'PLANNED_WORKOUT') {
     const plannedWorkout = await prisma.plannedWorkout.findUnique({
       where: { id: shareToken.resourceId },
@@ -120,7 +128,7 @@ export default defineEventHandler(async (event) => {
       ? sanitizeSharedPlannedWorkout(plannedWorkout, shareToken.accessMode)
       : null
   } else if (shareToken.resourceType === 'TRAINING_PLAN') {
-    data = await prisma.trainingPlan.findUnique({
+    const plan = await prisma.trainingPlan.findUnique({
       where: { id: shareToken.resourceId },
       include: {
         goal: true,
@@ -140,10 +148,10 @@ export default defineEventHandler(async (event) => {
       }
     })
 
-    if (data && data.blocks) {
+    if (plan?.blocks) {
       const workoutIds: string[] = []
 
-      data.blocks.forEach((block: any) => {
+      plan.blocks.forEach((block: any) => {
         block.weeks.forEach((week: any) => {
           week.workouts.forEach((workout: any) => {
             workoutIds.push(workout.id)
@@ -160,7 +168,7 @@ export default defineEventHandler(async (event) => {
 
       const tokenMap = new Map(existingTokens.map((t) => [t.resourceId, t.token]))
 
-      data.blocks.forEach((block: any) => {
+      plan.blocks.forEach((block: any) => {
         block.weeks.forEach((week: any) => {
           week.workouts.forEach((workout: any) => {
             const token = tokenMap.get(workout.id)
@@ -171,10 +179,13 @@ export default defineEventHandler(async (event) => {
         })
       })
     }
+
+    data = plan ? sanitizeSharedTrainingPlan(plan) : null
   } else if (shareToken.resourceType === 'WELLNESS') {
-    data = await prisma.wellness.findUnique({
+    const wellness = await prisma.wellness.findUnique({
       where: { id: shareToken.resourceId }
     })
+    data = wellness ? sanitizeSharedWellness(wellness) : null
   }
 
   if (!data) {

--- a/server/utils/share-response.ts
+++ b/server/utils/share-response.ts
@@ -1,5 +1,18 @@
 import { resolveShareTokenAccessMode } from './public-plans'
 
+function pickFields<T extends Record<string, unknown>>(
+  source: T,
+  keys: readonly (keyof T & string)[]
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (key in source) {
+      result[key] = source[key]
+    }
+  }
+  return result
+}
+
 export function sanitizeSharedNutrition(nutrition: Record<string, unknown>) {
   const {
     userId: _userId,
@@ -38,5 +51,148 @@ export function sanitizeSharedPlannedWorkout(
   return {
     ...preview,
     previewMode: true
+  }
+}
+
+/** Fields safe for unauthenticated WELLNESS share pages (metrics + AI summary). */
+export function sanitizeSharedWellness(wellness: Record<string, unknown>) {
+  const {
+    userId: _userId,
+    rawJson: _rawJson,
+    comments: _comments,
+    history: _history,
+    lastSource: _lastSource,
+    feedback: _feedback,
+    feedbackText: _feedbackText,
+    customMetrics: _customMetrics,
+    aiAnalysis: _aiAnalysis,
+    aiAnalysisStatus: _aiAnalysisStatus,
+    aiAnalyzedAt: _aiAnalyzedAt,
+    // Clinical / sensitive biometrics not shown on the public share page
+    bloodGlucose: _bloodGlucose,
+    diastolic: _diastolic,
+    systolic: _systolic,
+    injury: _injury,
+    menstrualPhase: _menstrualPhase,
+    lactate: _lactate,
+    abdomen: _abdomen,
+    bodyFat: _bodyFat,
+    hydration: _hydration,
+    hydrationVolume: _hydrationVolume,
+    skinTemp: _skinTemp,
+    tags: _tags,
+    ...safe
+  } = wellness
+
+  return safe
+}
+
+const SHARED_REPORT_FIELDS = [
+  'id',
+  'type',
+  'status',
+  'createdAt',
+  'updatedAt',
+  'dateRangeStart',
+  'dateRangeEnd',
+  'analysisJson',
+  'markdown',
+  'suggestions',
+  'overallScore',
+  'trainingLoadScore',
+  'recoveryScore',
+  'progressScore',
+  'consistencyScore',
+  'trainingLoadExplanation',
+  'recoveryBalanceExplanation',
+  'progressTrendExplanation',
+  'adaptationReadinessExplanation',
+  'injuryRiskExplanation'
+] as const
+
+/** Allowlisted REPORT / ATHLETE_PROFILE payload for public share links. */
+export function sanitizeSharedReport(report: Record<string, unknown>) {
+  return pickFields(report, SHARED_REPORT_FIELDS)
+}
+
+const SHARED_PLAN_WORKOUT_FIELDS = [
+  'id',
+  'date',
+  'dayIndex',
+  'weekIndex',
+  'title',
+  'description',
+  'type',
+  'category',
+  'durationSec',
+  'distanceMeters',
+  'tss',
+  'workIntensity',
+  'completed',
+  'completionStatus',
+  'structuredWorkout',
+  'targetArea',
+  'fuelingStrategy',
+  'startTime',
+  'trainingWeekId',
+  'shareToken'
+] as const
+
+function sanitizeSharedPlanWorkout(workout: Record<string, unknown>) {
+  return pickFields(workout, SHARED_PLAN_WORKOUT_FIELDS)
+}
+
+function sanitizeSharedPlanGoal(goal: unknown) {
+  if (!goal || typeof goal !== 'object') return null
+  const { title } = goal as Record<string, unknown>
+  return title === undefined ? null : { title }
+}
+
+/**
+ * Sanitize TRAINING_PLAN rows returned by GET /api/share/[token].
+ * Primary UI uses /api/public/plans/access/[token]; this path still must not
+ * leak userId, private notes, or sync/internal workout fields.
+ */
+export function sanitizeSharedTrainingPlan(plan: Record<string, unknown>) {
+  const {
+    userId: _userId,
+    teamId: _teamId,
+    folderId: _folderId,
+    coachNotes: _coachNotes,
+    athleteNotes: _athleteNotes,
+    customInstructions: _customInstructions,
+    fromTemplateId: _fromTemplateId,
+    hasBeenSavedAsTemplate: _hasBeenSavedAsTemplate,
+    goal,
+    blocks,
+    ...rest
+  } = plan
+
+  const sanitizedBlocks = Array.isArray(blocks)
+    ? blocks.map((block) => {
+        if (!block || typeof block !== 'object') return block
+        const blockRecord = block as Record<string, unknown>
+        const weeks = Array.isArray(blockRecord.weeks)
+          ? blockRecord.weeks.map((week) => {
+              if (!week || typeof week !== 'object') return week
+              const weekRecord = week as Record<string, unknown>
+              const workouts = Array.isArray(weekRecord.workouts)
+                ? weekRecord.workouts.map((workout) =>
+                    workout && typeof workout === 'object'
+                      ? sanitizeSharedPlanWorkout(workout as Record<string, unknown>)
+                      : workout
+                  )
+                : weekRecord.workouts
+              return { ...weekRecord, workouts }
+            })
+          : blockRecord.weeks
+        return { ...blockRecord, weeks }
+      })
+    : blocks
+
+  return {
+    ...rest,
+    goal: sanitizeSharedPlanGoal(goal),
+    blocks: sanitizedBlocks
   }
 }

--- a/tests/unit/server/api/share/share-response-sanitize.test.ts
+++ b/tests/unit/server/api/share/share-response-sanitize.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sanitizeSharedWellness,
+  sanitizeSharedReport,
+  sanitizeSharedTrainingPlan
+} from '../../../../../server/utils/share-response'
+
+describe('share response sanitizers (CW-147)', () => {
+  it('strips wellness internal/PII and clinical fields', () => {
+    const result = sanitizeSharedWellness({
+      id: 'wellness-1',
+      userId: 'user-1',
+      date: '2026-07-28',
+      recoveryScore: 82,
+      readiness: 8,
+      hrv: 65,
+      sleepHours: 7.5,
+      aiAnalysisJson: { executive_summary: 'Recovered well' },
+      rawJson: { secret: true },
+      comments: 'private coach note',
+      history: [{ source: 'oura' }],
+      lastSource: 'oura',
+      feedback: 'thumbs_up',
+      feedbackText: 'private feedback',
+      customMetrics: { privateKey: 1 },
+      aiAnalysis: 'raw analysis text',
+      aiAnalysisStatus: 'COMPLETED',
+      aiAnalyzedAt: '2026-07-28T12:00:00.000Z',
+      bloodGlucose: 95,
+      diastolic: 80,
+      systolic: 120,
+      injury: 'knee',
+      menstrualPhase: 'follicular',
+      lactate: 1.2,
+      abdomen: 80,
+      bodyFat: 12,
+      hydration: 'dehydrated',
+      hydrationVolume: 500,
+      skinTemp: 36.5,
+      tags: 'Alcohol,Sick'
+    })
+
+    expect(result).toEqual({
+      id: 'wellness-1',
+      date: '2026-07-28',
+      recoveryScore: 82,
+      readiness: 8,
+      hrv: 65,
+      sleepHours: 7.5,
+      aiAnalysisJson: { executive_summary: 'Recovered well' }
+    })
+
+    for (const denied of [
+      'userId',
+      'rawJson',
+      'comments',
+      'history',
+      'feedbackText',
+      'bloodGlucose',
+      'injury',
+      'menstrualPhase',
+      'customMetrics',
+      'tags'
+    ]) {
+      expect(result).not.toHaveProperty(denied)
+    }
+  })
+
+  it('allowlists REPORT / ATHLETE_PROFILE fields and drops private ones', () => {
+    const analysisJson = {
+      title: 'Athlete Profile',
+      executive_summary: 'Strong aerobic base'
+    }
+
+    const result = sanitizeSharedReport({
+      id: 'report-1',
+      userId: 'user-1',
+      type: 'ATHLETE_PROFILE',
+      status: 'COMPLETED',
+      createdAt: '2026-07-28T10:00:00.000Z',
+      updatedAt: '2026-07-28T11:00:00.000Z',
+      dateRangeStart: '2026-07-01T00:00:00.000Z',
+      dateRangeEnd: '2026-07-28T00:00:00.000Z',
+      analysisJson,
+      markdown: '# Profile',
+      suggestions: [{ text: 'Sleep more' }],
+      overallScore: 78,
+      trainingLoadScore: 70,
+      recoveryScore: 80,
+      progressScore: 75,
+      consistencyScore: 82,
+      trainingLoadExplanation: 'Balanced',
+      recoveryBalanceExplanation: 'Good',
+      progressTrendExplanation: 'Up',
+      adaptationReadinessExplanation: 'Ready',
+      injuryRiskExplanation: 'Low',
+      feedback: 'thumbs_up',
+      feedbackText: 'private coach feedback',
+      modelVersion: 'gpt-secret',
+      latex: '\\documentclass{article}',
+      pdfUrl: 'https://internal.example/report.pdf',
+      templateId: 'template-1'
+    })
+
+    expect(result).toEqual({
+      id: 'report-1',
+      type: 'ATHLETE_PROFILE',
+      status: 'COMPLETED',
+      createdAt: '2026-07-28T10:00:00.000Z',
+      updatedAt: '2026-07-28T11:00:00.000Z',
+      dateRangeStart: '2026-07-01T00:00:00.000Z',
+      dateRangeEnd: '2026-07-28T00:00:00.000Z',
+      analysisJson,
+      markdown: '# Profile',
+      suggestions: [{ text: 'Sleep more' }],
+      overallScore: 78,
+      trainingLoadScore: 70,
+      recoveryScore: 80,
+      progressScore: 75,
+      consistencyScore: 82,
+      trainingLoadExplanation: 'Balanced',
+      recoveryBalanceExplanation: 'Good',
+      progressTrendExplanation: 'Up',
+      adaptationReadinessExplanation: 'Ready',
+      injuryRiskExplanation: 'Low'
+    })
+
+    for (const denied of [
+      'userId',
+      'feedback',
+      'feedbackText',
+      'modelVersion',
+      'latex',
+      'pdfUrl',
+      'templateId'
+    ]) {
+      expect(result).not.toHaveProperty(denied)
+    }
+  })
+
+  it('sanitizes TRAINING_PLAN share payload and nested workouts', () => {
+    const result = sanitizeSharedTrainingPlan({
+      id: 'plan-1',
+      userId: 'user-1',
+      teamId: 'team-1',
+      folderId: 'folder-1',
+      name: 'Base Build',
+      description: '12-week base',
+      startDate: '2026-08-01T00:00:00.000Z',
+      coachNotes: 'private coach notes',
+      athleteNotes: 'private athlete notes',
+      customInstructions: 'do not leak',
+      fromTemplateId: 'template-9',
+      hasBeenSavedAsTemplate: true,
+      goal: {
+        id: 'goal-1',
+        userId: 'user-1',
+        title: 'Marathon',
+        notes: 'secret goal notes'
+      },
+      blocks: [
+        {
+          id: 'block-1',
+          name: 'Block A',
+          order: 1,
+          weeks: [
+            {
+              id: 'week-1',
+              weekNumber: 1,
+              workouts: [
+                {
+                  id: 'workout-1',
+                  userId: 'user-1',
+                  title: 'Easy Run',
+                  type: 'RUN',
+                  durationSec: 3600,
+                  rawJson: { secret: true },
+                  syncStatus: 'SYNCED',
+                  syncError: 'boom',
+                  externalId: 'ext-1',
+                  structureHash: 'hash',
+                  pendingRemoteStructuredWorkout: { steps: [] },
+                  createdFromSettingsSnapshot: { ftp: 250 },
+                  lastGenerationContext: { prompt: 'secret' },
+                  shareToken: { token: 'pw-token' }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(result).not.toHaveProperty('userId')
+    expect(result).not.toHaveProperty('teamId')
+    expect(result).not.toHaveProperty('folderId')
+    expect(result).not.toHaveProperty('coachNotes')
+    expect(result).not.toHaveProperty('athleteNotes')
+    expect(result).not.toHaveProperty('customInstructions')
+    expect(result).not.toHaveProperty('fromTemplateId')
+    expect(result).not.toHaveProperty('hasBeenSavedAsTemplate')
+
+    expect(result.name).toBe('Base Build')
+    expect(result.goal).toEqual({ title: 'Marathon' })
+
+    const workout = (result.blocks as any)[0].weeks[0].workouts[0]
+    expect(workout).toEqual({
+      id: 'workout-1',
+      title: 'Easy Run',
+      type: 'RUN',
+      durationSec: 3600,
+      shareToken: { token: 'pw-token' }
+    })
+    expect(workout).not.toHaveProperty('userId')
+    expect(workout).not.toHaveProperty('rawJson')
+    expect(workout).not.toHaveProperty('syncStatus')
+    expect(workout).not.toHaveProperty('externalId')
+    expect(workout).not.toHaveProperty('lastGenerationContext')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Public share links for WELLNESS / REPORT / ATHLETE_PROFILE (and TRAINING_PLAN) were returning full Prisma rows to unauthenticated holders, leaking `userId`, `rawJson`, comments/clinical fields, and other internals.

## Changes
- Add sanitizers for WELLNESS (denylist), REPORT/ATHLETE_PROFILE (allowlist), and TRAINING_PLAN
- Wire sanitizers into `GET /api/share/[token]`
- Unit tests asserting denied fields are absent

## Linear
https://linear.app/watt-mind/issue/CW-147/public-share-wellnessreportathlete-profile-return-unsanitized-db-rows

## Test plan
- [x] `pnpm vitest run tests/unit/server/api/share` (+ share-response utils tests) — 5 files / 16 tests passed
- [ ] Spot-check public share responses for denied fields

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

