### PR TITLE
chore: document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,3 +49,18 @@ This project has Trigger.dev agent skills in `.claude/skills/`. Before writing o
 ## Scope
 
 This repository is Coach Watts product development only. Do not reference internal corporate teams, internal financial namespaces, or client engagements in code, commits, PR descriptions, or issue comments here.
+
+## Cursor Cloud specific instructions
+
+The Cloud VM snapshot already has: Node 24 (via nvm), pnpm deps, a local `.env`, and locally-installed PostgreSQL 16 + Redis 7. The startup update script runs `pnpm install` (which regenerates Prisma Client via `postinstall`). Everything below is what an agent still needs to do/know per session.
+
+- Node: the project requires Node `>=24.11 <25`. The VM's default `/exec-daemon/node` is v22, so `~/.bashrc` prepends the nvm Node 24 bin to `PATH`. Always run commands through a login shell (e.g. `bash -lc '…'`) so `node --version` reports 24.x; a non-login shell may fall back to v22.
+- Services are NOT auto-started (no systemd). Start them at the beginning of each session:
+  - Postgres: `sudo pg_ctlcluster 16 main start` (cluster `16 main`, listens on `localhost:5432`).
+  - Redis: `sudo redis-server /etc/redis/redis.conf --daemonize yes` (password `dragonfly`, port 6379). Check with `redis-cli -a dragonfly ping`.
+- Local `.env` (gitignored) differs from `.env.example`: Postgres runs on the standard port `5432` (not 5439) with role/db `watts`/`watts` (password `password`), so `DATABASE_URL=postgresql://watts:password@localhost:5432/watts`. The dev server runs on `http://localhost:3099`.
+- Apply DB migrations with `npx prisma migrate deploy` (or `npx prisma migrate dev`). The DB already has migrations applied in the snapshot; re-running deploy is a no-op.
+- Login without Google OAuth: `.env` sets `AUTH_BYPASS_USER=dev@coachwatts.test`, so hitting any protected page auto-creates a session for that seeded admin user (see `server/plugins/auth-bypass.ts`). Recreate the user if the DB is reset with `npx tsx scripts/seed-dev-user.ts`.
+- Prisma 7 uses a driver adapter — construct `PrismaClient` with `new PrismaPg(new pg.Pool(...))` (see `server/utils/db.ts`); `new PrismaClient()` alone throws. Standalone scripts must do the same.
+- Commands (`pnpm dev`, `build`, `typecheck`, `test`, `lint`, etc.) are defined in `package.json`. Note: `pnpm lint` and `pnpm typecheck` need generated Nuxt types first — run `pnpm exec nuxt prepare` once (CI does this) or start `pnpm dev` before them.
+- AI features (chat, analysis) need a real `GEMINI_API_KEY`; external integrations (Strava/Whoop/etc.) and Stripe use placeholder credentials in local dev and won't complete real OAuth/payment flows.

--- a/scripts/seed-dev-user.ts
+++ b/scripts/seed-dev-user.ts
@@ -1,0 +1,35 @@
+import 'dotenv/config'
+import { PrismaClient } from '@prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import pg from 'pg'
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) })
+
+async function main() {
+  const email = process.env.AUTH_BYPASS_USER || 'dev@coachwatts.test'
+  const user = await prisma.user.upsert({
+    where: { email },
+    update: {},
+    create: {
+      email,
+      name: process.env.AUTH_BYPASS_NAME || 'Dev Athlete',
+      emailVerified: new Date(),
+      isAdmin: true,
+      ftp: 250,
+      maxHr: 190,
+      weight: 72,
+      uiLanguage: 'en',
+      timezone: 'UTC'
+    }
+  })
+  console.log('Seeded dev user:', { id: user.id, email: user.email, isAdmin: user.isAdmin })
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cursor Cloud development environment for Coach Watts (Nuxt 4 + Prisma 7 + Postgres + Redis). No product code changes.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious, durable startup caveats for future cloud agents (Node 24 via nvm/`~/.bashrc` PATH prepend, starting the locally-installed Postgres 16 / Redis 7 since there is no systemd, the local `.env` differences vs `.env.example` — Postgres on `5432`/`watts`, dev server on `3099`, applying migrations, and the `AUTH_BYPASS_USER` dev login).
- Adds `scripts/seed-dev-user.ts` to (re)create the `dev@coachwatts.test` admin user used by the local auth-bypass login (uses the Prisma `pg` driver adapter, matching `server/utils/db.ts`).

## Environment verified

- `pnpm install` (Node 24.18.1) + `prisma generate` + `prisma migrate deploy` — OK
- `pnpm lint` — 0 errors (warnings only)
- `pnpm test:unit` — 316 files, 1753 tests passing
- `pnpm dev` — serving on `http://localhost:3099`
- End-to-end hello-world: authenticated via auth-bypass and updated the athlete FTP through `PATCH /api/profile` (HTTP 200), persisted 250 → 265 in Postgres.

## Notes

- The startup update script is `pnpm install` (regenerates Prisma Client via `postinstall`). Service startup and migrations are intentionally left out of the update script and documented in `AGENTS.md` instead.
- `.env` is gitignored and not committed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-467d3cfc-1813-425e-8764-ebc66c7ad488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467d3cfc-1813-425e-8764-ebc66c7ad488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

