### PR TITLE
fix(security): revoke deactivated OAuth/API-key access (CW-149)

### DIFF
--- a/server/api/oauth/userinfo.get.ts
+++ b/server/api/oauth/userinfo.get.ts
@@ -1,4 +1,5 @@
 import { oauthRepository } from '../../utils/repositories/oauthRepository'
+import { prisma } from '../../utils/db'
 
 defineRouteMeta({
   openAPI: {
@@ -43,6 +44,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const user = token.user
+
+  if (user.deactivatedAt) {
+    throw createError({ statusCode: 403, message: 'Account deactivated' })
+  }
 
   // Update last used info
   await prisma.oAuthToken.update({

--- a/server/utils/coaching.ts
+++ b/server/utils/coaching.ts
@@ -1,9 +1,18 @@
 import type { H3Event } from 'h3'
-import { getHeader } from 'h3'
+import { createError, getHeader } from 'h3'
 import { getServerSession } from './session'
 import { oauthRepository } from './repositories/oauthRepository'
 import { validateApiKey } from './auth-api-key'
 import { prisma } from './db'
+
+function ensureActiveUser(user: { deactivatedAt?: Date | string | null } | null | undefined) {
+  if (user?.deactivatedAt) {
+    throw createError({
+      statusCode: 403,
+      message: 'Account deactivated'
+    })
+  }
+}
 
 /**
  * Validates an OAuth Bearer token and returns the associated user.
@@ -54,18 +63,21 @@ export async function getEffectiveUserId(event: H3Event): Promise<string> {
   // 1. Try centralized session (handles Acting As and Impersonation)
   const session = await getServerSession(event)
   if (session?.user?.id) {
+    ensureActiveUser(session.user)
     return session.user.id
   }
 
   // 2. Try API key
   const user = await validateApiKey(event)
   if (user) {
+    ensureActiveUser(user)
     return user.id
   }
 
   // 3. Try OAuth Bearer Token
   const oauthUser = await validateOAuthToken(event)
   if (oauthUser) {
+    ensureActiveUser(oauthUser)
     return oauthUser.id
   }
 

--- a/server/utils/services/accountDeactivationService.ts
+++ b/server/utils/services/accountDeactivationService.ts
@@ -59,7 +59,17 @@ export async function deactivateAccount(options: DeactivateAccountOptions) {
     }
   })
 
+  // Invalidate all credential material so pre-existing tokens/keys cannot be reused.
   await prisma.session.deleteMany({
+    where: { userId }
+  })
+  await prisma.oAuthToken.deleteMany({
+    where: { userId }
+  })
+  await prisma.oAuthAuthCode.deleteMany({
+    where: { userId }
+  })
+  await prisma.apiKey.deleteMany({
     where: { userId }
   })
 

--- a/tests/unit/server/api/oauth/authorize.nuxt.test.ts
+++ b/tests/unit/server/api/oauth/authorize.nuxt.test.ts
@@ -114,6 +114,29 @@ describe('POST /api/oauth/authorize', () => {
     })
   })
 
+  it('rejects deactivated users with 403 before issuing consent', async () => {
+    getEffectiveUserId.mockRejectedValue(
+      Object.assign(new Error('Account deactivated'), { statusCode: 403 })
+    )
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        body: {
+          client_id: 'client-1',
+          redirect_uri: 'https://example.com/callback',
+          action: 'approve'
+        }
+      })
+    ).rejects.toMatchObject({
+      message: 'Account deactivated',
+      statusCode: 403
+    })
+
+    expect(findUnique).not.toHaveBeenCalled()
+    expect(createAuthCode).not.toHaveBeenCalled()
+  })
+
   it('throws 400 when required fields are missing', async () => {
     const handler = await getHandler()
 

--- a/tests/unit/server/api/oauth/userinfo.test.ts
+++ b/tests/unit/server/api/oauth/userinfo.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', vi.fn())
+vi.stubGlobal('getHeader', (event: any, name: string) => {
+  const headers = event?.headers || event?.node?.req?.headers || {}
+  return headers[name] || headers[name.toLowerCase()]
+})
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  // @ts-expect-error test helper property
+  error.statusCode = err.statusCode
+  return error
+})
+
+const getAccessToken = vi.fn()
+const oAuthTokenUpdate = vi.fn().mockResolvedValue({})
+
+vi.mock('../../../../../server/utils/repositories/oauthRepository', () => ({
+  oauthRepository: {
+    getAccessToken: (...args: unknown[]) => getAccessToken(...args)
+  }
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    oAuthToken: {
+      update: (...args: unknown[]) => oAuthTokenUpdate(...args)
+    }
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/oauth/userinfo.get')
+  return mod.default
+}
+
+describe('GET /api/oauth/userinfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects a pre-existing bearer token after account deactivation with 403', async () => {
+    getAccessToken.mockResolvedValue({
+      id: 'token-1',
+      scopes: ['profile:read'],
+      accessTokenExpiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 'user-1',
+        name: 'Deactivated User',
+        email: 'deactivated@example.com',
+        image: null,
+        ftp: 250,
+        weight: 70,
+        deactivatedAt: new Date('2026-07-01T00:00:00.000Z')
+      }
+    })
+
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        headers: { Authorization: 'Bearer stale-access-token' },
+        node: { req: { socket: { remoteAddress: '127.0.0.1' } } }
+      } as any)
+    ).rejects.toMatchObject({
+      message: 'Account deactivated',
+      statusCode: 403
+    })
+
+    expect(oAuthTokenUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns profile fields for an active user bearer token', async () => {
+    getAccessToken.mockResolvedValue({
+      id: 'token-1',
+      scopes: ['openid'],
+      accessTokenExpiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 'user-1',
+        name: 'Active User',
+        email: 'active@example.com',
+        image: null,
+        deactivatedAt: null
+      }
+    })
+
+    const handler = await getHandler()
+    const result = await handler({
+      headers: { Authorization: 'Bearer active-access-token' },
+      node: { req: { socket: { remoteAddress: '127.0.0.1' } } }
+    } as any)
+
+    expect(result).toMatchObject({
+      sub: 'user-1',
+      name: 'Active User',
+      email: 'active@example.com'
+    })
+    expect(oAuthTokenUpdate).toHaveBeenCalled()
+  })
+
+  it('rejects missing Authorization header with 401', async () => {
+    const handler = await getHandler()
+
+    await expect(handler({ headers: {} } as any)).rejects.toMatchObject({
+      message: 'Missing or invalid Authorization header',
+      statusCode: 401
+    })
+  })
+})

--- a/tests/unit/server/utils/auth-account-deactivation.test.ts
+++ b/tests/unit/server/utils/auth-account-deactivation.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const findUnique = vi.fn()
+const userUpdate = vi.fn()
+const sessionDeleteMany = vi.fn()
+const oAuthTokenDeleteMany = vi.fn()
+const oAuthAuthCodeDeleteMany = vi.fn()
+const apiKeyDeleteMany = vi.fn()
+const logAction = vi.fn()
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => findUnique(...args),
+      update: (...args: unknown[]) => userUpdate(...args)
+    },
+    session: {
+      deleteMany: (...args: unknown[]) => sessionDeleteMany(...args)
+    },
+    oAuthToken: {
+      deleteMany: (...args: unknown[]) => oAuthTokenDeleteMany(...args)
+    },
+    oAuthAuthCode: {
+      deleteMany: (...args: unknown[]) => oAuthAuthCodeDeleteMany(...args)
+    },
+    apiKey: {
+      deleteMany: (...args: unknown[]) => apiKeyDeleteMany(...args)
+    }
+  }
+}))
+
+vi.mock('../../../../server/utils/audit', () => ({
+  logAction: (...args: unknown[]) => logAction(...args)
+}))
+
+vi.mock('h3', () => ({
+  createError: (err: { statusCode: number; statusMessage: string }) => {
+    const error = new Error(err.statusMessage)
+    ;(error as any).statusCode = err.statusCode
+    return error
+  }
+}))
+
+describe('deactivateAccount credential revocation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      deactivatedAt: null
+    })
+    userUpdate.mockResolvedValue({})
+    sessionDeleteMany.mockResolvedValue({ count: 1 })
+    oAuthTokenDeleteMany.mockResolvedValue({ count: 2 })
+    oAuthAuthCodeDeleteMany.mockResolvedValue({ count: 1 })
+    apiKeyDeleteMany.mockResolvedValue({ count: 1 })
+    logAction.mockResolvedValue(undefined)
+  })
+
+  it('revokes sessions, OAuth tokens/auth codes, and API keys on deactivation', async () => {
+    const { deactivateAccount } =
+      await import('../../../../server/utils/services/accountDeactivationService')
+
+    const result = await deactivateAccount({
+      userId: 'user-1',
+      actor: { id: 'admin-1', email: 'admin@example.com' },
+      reason: 'Abuse'
+    })
+
+    expect(userUpdate).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: {
+        deactivatedAt: expect.any(Date),
+        deactivationReason: 'Abuse'
+      }
+    })
+    expect(sessionDeleteMany).toHaveBeenCalledWith({ where: { userId: 'user-1' } })
+    expect(oAuthTokenDeleteMany).toHaveBeenCalledWith({ where: { userId: 'user-1' } })
+    expect(oAuthAuthCodeDeleteMany).toHaveBeenCalledWith({ where: { userId: 'user-1' } })
+    expect(apiKeyDeleteMany).toHaveBeenCalledWith({ where: { userId: 'user-1' } })
+    expect(result).toMatchObject({
+      success: true,
+      message: 'Account deactivated'
+    })
+  })
+
+  it('does not revoke credentials again when already deactivated', async () => {
+    const deactivatedAt = new Date('2026-07-01T00:00:00.000Z')
+    findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      deactivatedAt
+    })
+
+    const { deactivateAccount } =
+      await import('../../../../server/utils/services/accountDeactivationService')
+
+    const result = await deactivateAccount({
+      userId: 'user-1',
+      actor: { id: 'admin-1' }
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      alreadyDeactivated: true,
+      deactivatedAt
+    })
+    expect(userUpdate).not.toHaveBeenCalled()
+    expect(oAuthTokenDeleteMany).not.toHaveBeenCalled()
+    expect(apiKeyDeleteMany).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/server/utils/auth-getEffectiveUserId.test.ts
+++ b/tests/unit/server/utils/auth-getEffectiveUserId.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getServerSession = vi.fn()
+const validateApiKey = vi.fn()
+const getAccessToken = vi.fn()
+const oAuthTokenUpdate = vi.fn().mockResolvedValue({})
+
+vi.mock('../../../../server/utils/session', () => ({
+  getServerSession: (...args: unknown[]) => getServerSession(...args)
+}))
+
+vi.mock('../../../../server/utils/auth-api-key', () => ({
+  validateApiKey: (...args: unknown[]) => validateApiKey(...args)
+}))
+
+vi.mock('../../../../server/utils/repositories/oauthRepository', () => ({
+  oauthRepository: {
+    getAccessToken: (...args: unknown[]) => getAccessToken(...args)
+  }
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    oAuthToken: {
+      update: (...args: unknown[]) => oAuthTokenUpdate(...args)
+    }
+  }
+}))
+
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<typeof import('h3')>('h3')
+  return {
+    ...actual,
+    createError: (err: { statusCode: number; message: string }) => {
+      const error = new Error(err.message)
+      ;(error as any).statusCode = err.statusCode
+      return error
+    },
+    getHeader: (event: any, name: string) => {
+      const headers = event?.node?.req?.headers || event?.headers || {}
+      return headers[name.toLowerCase()] || headers[name]
+    }
+  }
+})
+
+describe('getEffectiveUserId deactivated account rejection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSession.mockResolvedValue(null)
+    validateApiKey.mockResolvedValue(null)
+    getAccessToken.mockResolvedValue(null)
+  })
+
+  it('rejects a pre-existing OAuth bearer token for a deactivated user with 403', async () => {
+    const { getEffectiveUserId } = await import('../../../../server/utils/coaching')
+
+    getAccessToken.mockResolvedValue({
+      id: 'token-1',
+      accessTokenExpiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 'user-1',
+        deactivatedAt: new Date('2026-07-01T00:00:00.000Z')
+      }
+    })
+
+    const event = {
+      node: {
+        req: {
+          headers: { authorization: 'Bearer stale-access-token' },
+          socket: { remoteAddress: '127.0.0.1' }
+        }
+      }
+    }
+
+    await expect(getEffectiveUserId(event as any)).rejects.toMatchObject({
+      message: 'Account deactivated',
+      statusCode: 403
+    })
+  })
+
+  it('rejects an API key belonging to a deactivated user with 403', async () => {
+    const { getEffectiveUserId } = await import('../../../../server/utils/coaching')
+
+    validateApiKey.mockResolvedValue({
+      id: 'user-1',
+      deactivatedAt: new Date('2026-07-01T00:00:00.000Z')
+    })
+
+    await expect(getEffectiveUserId({} as any)).rejects.toMatchObject({
+      message: 'Account deactivated',
+      statusCode: 403
+    })
+  })
+
+  it('rejects a session whose effective user is deactivated with 403', async () => {
+    const { getEffectiveUserId } = await import('../../../../server/utils/coaching')
+
+    getServerSession.mockResolvedValue({
+      user: {
+        id: 'athlete-1',
+        deactivatedAt: new Date('2026-07-01T00:00:00.000Z')
+      }
+    })
+
+    await expect(getEffectiveUserId({} as any)).rejects.toMatchObject({
+      message: 'Account deactivated',
+      statusCode: 403
+    })
+  })
+
+  it('returns the user id for an active OAuth bearer token', async () => {
+    const { getEffectiveUserId } = await import('../../../../server/utils/coaching')
+
+    getAccessToken.mockResolvedValue({
+      id: 'token-1',
+      accessTokenExpiresAt: new Date(Date.now() + 60_000),
+      user: {
+        id: 'user-1',
+        deactivatedAt: null
+      }
+    })
+
+    const event = {
+      node: {
+        req: {
+          headers: { authorization: 'Bearer active-access-token' },
+          socket: { remoteAddress: '127.0.0.1' }
+        }
+      }
+    }
+
+    await expect(getEffectiveUserId(event as any)).resolves.toBe('user-1')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Account deactivation deleted sessions but left `OAuthToken` / `ApiKey` rows usable on paths that call `getEffectiveUserId` (or custom bearer lookup) instead of `requireAuth`/`ensureActiveUser`.

## Changes
- On deactivation, also delete `OAuthToken`, `OAuthAuthCode`, and `ApiKey` rows
- `getEffectiveUserId` rejects deactivated users (403) for session / API key / OAuth
- `oauth/userinfo` rejects deactivated bearer users (403); authorize covered via `getEffectiveUserId`
- Unit tests for deactivation + pre-existing bearer → 403

## Linear
https://linear.app/watt-mind/issue/CW-149/deactivated-users-retain-oauthapi-key-access-on-geteffectiveuserid

## Test plan
- [x] `pnpm vitest run tests/unit/server` (221 files / 1125 tests)
- [ ] Confirm oauth refresh residual risk is acceptable or follow up separately

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

