### PR TITLE
fix(coaching): hard-reset identity stores on Act As entry (CW-146)

### DIFF
--- a/app/pages/coaching/athletes/[id]/index.vue
+++ b/app/pages/coaching/athletes/[id]/index.vue
@@ -915,7 +915,6 @@
     if (!athlete.value) return
     const name = athlete.value.name || athlete.value.email || 'Athlete'
     coachingStore.startActingAs(athlete.value.id, name)
-    void router.push('/dashboard')
   }
 
   async function confirmRemoveAthlete() {

--- a/app/pages/coaching/athletes/index.vue
+++ b/app/pages/coaching/athletes/index.vue
@@ -615,7 +615,6 @@
     if (!athlete?.id) return
     const name = athlete.name || athlete.email || 'Athlete'
     coachingStore.startActingAs(athlete.id, name)
-    void router.push('/dashboard')
   }
 
   function extractInviteCode(raw: string) {

--- a/app/pages/coaching/teams/[id].vue
+++ b/app/pages/coaching/teams/[id].vue
@@ -930,7 +930,6 @@
     if (!athlete?.id || athlete?.canViewDetails === false || athlete?.isMasked) return
     const name = athlete.name || athlete.email || 'Athlete'
     coachingStore.startActingAs(athlete.id, name)
-    void router.push('/dashboard')
   }
 
   async function removeMember(userId: string, displayName?: string) {

--- a/app/stores/coaching.ts
+++ b/app/stores/coaching.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 
 const ACT_AS_COOKIE_NAME = 'coach_wattz_act_as_user'
+const ACT_AS_DASHBOARD_PATH = '/dashboard'
 
 function persistActAsCookie(userId: string | null) {
   if (!import.meta.client) return
@@ -11,6 +12,21 @@ function persistActAsCookie(userId: string | null) {
   }
 
   document.cookie = `${ACT_AS_COOKIE_NAME}=${encodeURIComponent(userId)}; path=/; SameSite=Lax`
+}
+
+/**
+ * Hard-navigate so identity-scoped Pinia caches (user, profile, entitlements)
+ * are wiped and re-fetched under the new act-as (or restored coach) identity.
+ */
+function hardResetForIdentityChange(path?: string) {
+  if (!import.meta.client) return
+
+  if (path) {
+    window.location.assign(path)
+    return
+  }
+
+  window.location.reload()
 }
 
 export const useCoachingStore = defineStore('coaching', () => {
@@ -37,6 +53,8 @@ export const useCoachingStore = defineStore('coaching', () => {
       localStorage.setItem('coaching_act_as_id', userId)
       localStorage.setItem('coaching_act_as_name', userName)
       persistActAsCookie(userId)
+      // Mirror stopActingAs: full navigation clears stale coach identity UI
+      hardResetForIdentityChange(ACT_AS_DASHBOARD_PATH)
     }
   }
 
@@ -52,10 +70,8 @@ export const useCoachingStore = defineStore('coaching', () => {
 
   function stopActingAs() {
     clearActingAs()
-    if (import.meta.client) {
-      // Force reload to clear all states and re-fetch session
-      window.location.reload()
-    }
+    // Force reload to clear all states and re-fetch session
+    hardResetForIdentityChange()
   }
 
   return {

--- a/tests/unit/app/stores/coaching.test.ts
+++ b/tests/unit/app/stores/coaching.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment nuxt
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCoachingStore } from '../../../../app/stores/coaching'
+
+describe('useCoachingStore Pinia Store', () => {
+  let assignSpy: ReturnType<typeof vi.fn>
+  let reloadSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    localStorage.clear()
+    document.cookie = 'coach_wattz_act_as_user=; path=/; max-age=0; SameSite=Lax'
+
+    assignSpy = vi.fn()
+    reloadSpy = vi.fn()
+    vi.stubGlobal('location', {
+      ...window.location,
+      assign: assignSpy,
+      reload: reloadSpy
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('initializes with empty act-as state', () => {
+    const store = useCoachingStore()
+    expect(store.actingAsUserId).toBeNull()
+    expect(store.actingAsUserName).toBeNull()
+    expect(store.isCoachingMode).toBe(false)
+  })
+
+  it('startActingAs persists identity and hard-navigates to dashboard', () => {
+    const store = useCoachingStore()
+    store.startActingAs('athlete-123', 'Ada Athlete')
+
+    expect(store.actingAsUserId).toBe('athlete-123')
+    expect(store.actingAsUserName).toBe('Ada Athlete')
+    expect(store.isCoachingMode).toBe(true)
+    expect(localStorage.getItem('coaching_act_as_id')).toBe('athlete-123')
+    expect(localStorage.getItem('coaching_act_as_name')).toBe('Ada Athlete')
+    expect(document.cookie).toContain('coach_wattz_act_as_user=athlete-123')
+    expect(assignSpy).toHaveBeenCalledWith('/dashboard')
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('stopActingAs clears identity and reloads to restore coach session', () => {
+    const store = useCoachingStore()
+    store.startActingAs('athlete-123', 'Ada Athlete')
+    assignSpy.mockClear()
+
+    store.stopActingAs()
+
+    expect(store.actingAsUserId).toBeNull()
+    expect(store.actingAsUserName).toBeNull()
+    expect(store.isCoachingMode).toBe(false)
+    expect(localStorage.getItem('coaching_act_as_id')).toBeNull()
+    expect(localStorage.getItem('coaching_act_as_name')).toBeNull()
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it('clearActingAs clears persistence without navigating', () => {
+    const store = useCoachingStore()
+    store.startActingAs('athlete-123', 'Ada Athlete')
+    assignSpy.mockClear()
+
+    store.clearActingAs()
+
+    expect(store.actingAsUserId).toBeNull()
+    expect(localStorage.getItem('coaching_act_as_id')).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Entering Act As only set the coaching cookie and soft-navigated to `/dashboard`, leaving coach `userStore` / profile / entitlement caches in place. Server-scoped API data was correct via `x-act-as-user`, but the UI still showed coach identity/tier.

## Changes
- Centralize Act As entry in `coachingStore.startActingAs` with a hard navigation to `/dashboard` (mirrors `stopActingAs`)
- Remove redundant soft `router.push` from athletes/team Act As entry points
- Add unit coverage for persist + hard navigate / exit reload

## Linear
https://linear.app/watt-mind/issue/CW-146/act-as-athlete-does-not-reset-identity-scoped-stores-coach-tierprofile

## Test plan
- [x] `pnpm test:unit tests/unit/app/stores/coaching.test.ts` (4/4)
- [x] `pnpm typecheck`
- [ ] Manual: coach Pro acting as FREE athlete → dashboard shows athlete name/tier

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

