### PR TITLE
fix(chat): sanitize tool-approval-response for AI SDK prompt schema (CW-209)

### DIFF
--- a/server/api/chat/messages.post.ts
+++ b/server/api/chat/messages.post.ts
@@ -12,6 +12,7 @@ import {
   resolveApprovalOriginLineageId,
   buildCanonicalApprovalResponse
 } from '../../utils/chat/approval-continuation'
+import { sanitizeChatMessagesForToolApprovals } from './sanitize-tool-approval'
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event, ['chat:write'])
@@ -32,7 +33,9 @@ export default defineEventHandler(async (event) => {
 
   const body = await readBody(event)
   const { roomId, messages, files, replyMessage } = body
-  const clientMessages = Array.isArray(messages) ? messages : []
+  const clientMessages = sanitizeChatMessagesForToolApprovals(
+    Array.isArray(messages) ? messages : []
+  )
   const truncatedMessages = clientMessages.slice(-25)
 
   const lastMessage = truncatedMessages?.[truncatedMessages.length - 1]

--- a/server/api/chat/sanitize-tool-approval.ts
+++ b/server/api/chat/sanitize-tool-approval.ts
@@ -1,0 +1,186 @@
+/**
+ * Vercel AI SDK ModelMessage schema requires tool-approval-response parts to be:
+ *   { type: 'tool-approval-response', approvalId: string, approved: boolean, reason?: string }
+ *
+ * Client/UI payloads often send `toolCallId` instead of `approvalId`, stringy `approved`
+ * values, or non-string `reason` objects. Those fail `standardizePrompt` with
+ * AI_TypeValidationError ("expected \"tool-approval-response\"").
+ */
+
+function getMessageParts(message: any): any[] {
+  if (Array.isArray(message?.parts)) return message.parts
+  if (Array.isArray(message?.content)) return message.content
+  return []
+}
+
+function withMessageParts(message: any, parts: any[]) {
+  if (Array.isArray(message?.parts)) {
+    return { ...message, parts }
+  }
+  if (Array.isArray(message?.content)) {
+    return { ...message, content: parts }
+  }
+  return { ...message, parts }
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function asOptionalReason(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function coerceApproved(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value
+  if (value === 'true' || value === 1 || value === '1') return true
+  if (value === 'false' || value === 0 || value === '0') return false
+  if (value == null) return null
+  return !!value
+}
+
+/**
+ * Normalize a single tool-approval-response content/part item.
+ * Returns null when the part cannot be made schema-valid and should be dropped.
+ */
+export function sanitizeToolApprovalResponsePart(part: any): Record<string, any> | null {
+  if (!part || part.type !== 'tool-approval-response') return part
+
+  const approvalId =
+    asNonEmptyString(part.approvalId) ||
+    asNonEmptyString(part.toolCallId) ||
+    asNonEmptyString(part.approval?.id)
+
+  const approved = coerceApproved(part.approved)
+  if (!approvalId || approved == null) {
+    return null
+  }
+
+  const reason = asOptionalReason(part.reason) ?? asOptionalReason(part.result)
+  const sanitized: Record<string, any> = {
+    type: 'tool-approval-response',
+    approvalId,
+    approved
+  }
+
+  // Keep toolCallId for our continuation matchers; SDK ModelMessage schema ignores extras
+  // on some paths, and UI history still keys off it.
+  const toolCallId = asNonEmptyString(part.toolCallId) || approvalId
+  sanitized.toolCallId = toolCallId
+
+  if (reason !== undefined) {
+    sanitized.reason = reason
+  }
+
+  if (typeof part.providerExecuted === 'boolean') {
+    sanitized.providerExecuted = part.providerExecuted
+  }
+
+  return sanitized
+}
+
+function sanitizeAssistantToolApprovalPart(part: any): any {
+  if (!part?.type?.startsWith?.('tool-') || !part.approval) return part
+
+  const approvalId =
+    asNonEmptyString(part.approval.id) ||
+    asNonEmptyString(part.approvalId) ||
+    asNonEmptyString(part.toolCallId)
+
+  if (!approvalId) {
+    // Approval object without an id leaks into convertToModelMessages as a
+    // tool-approval-response missing approvalId, which crashes standardizePrompt.
+    const { approval: _approval, ...rest } = part
+    if (rest.state === 'approval-responded' || rest.state === 'approval-requested') {
+      return { ...rest, state: 'input-available' }
+    }
+    return rest
+  }
+
+  const approved =
+    part.approval.approved == null
+      ? undefined
+      : (coerceApproved(part.approval.approved) ?? undefined)
+  const reason = asOptionalReason(part.approval.reason)
+
+  const approval: Record<string, any> = {
+    ...part.approval,
+    id: approvalId
+  }
+
+  if (approved !== undefined) {
+    approval.approved = approved
+  }
+
+  if (reason !== undefined) {
+    approval.reason = reason
+  } else if ('reason' in approval && typeof approval.reason !== 'string') {
+    delete approval.reason
+  }
+
+  return {
+    ...part,
+    approvalId: asNonEmptyString(part.approvalId) || approvalId,
+    toolCallId: asNonEmptyString(part.toolCallId) || approvalId,
+    approval
+  }
+}
+
+/**
+ * Sanitize UI/chat messages so tool approval responses conform to the AI SDK schema
+ * before persistence or convertToModelMessages / standardizePrompt.
+ */
+export function sanitizeChatMessagesForToolApprovals(messages: any[]): any[] {
+  if (!Array.isArray(messages)) return []
+
+  return messages.map((message) => {
+    if (!message || typeof message !== 'object') return message
+
+    const parts = getMessageParts(message)
+    if (parts.length === 0) return message
+
+    if (message.role === 'tool') {
+      const sanitizedParts = parts
+        .map((part) =>
+          part?.type === 'tool-approval-response' ? sanitizeToolApprovalResponsePart(part) : part
+        )
+        .filter((part) => part != null)
+
+      return withMessageParts(message, sanitizedParts)
+    }
+
+    if (message.role === 'assistant') {
+      const sanitizedParts = parts.map((part) => sanitizeAssistantToolApprovalPart(part))
+      return withMessageParts(message, sanitizedParts)
+    }
+
+    return message
+  })
+}
+
+/**
+ * Drop or repair tool-approval-response parts already present on ModelMessage[] prompts.
+ */
+export function sanitizeCoreMessagesForToolApprovals(messages: any[]): any[] {
+  if (!Array.isArray(messages)) return []
+
+  return messages
+    .map((message) => {
+      if (message?.role !== 'tool' || !Array.isArray(message.content)) return message
+
+      const content = message.content
+        .map((part: any) =>
+          part?.type === 'tool-approval-response' ? sanitizeToolApprovalResponsePart(part) : part
+        )
+        .filter((part: any) => part != null)
+
+      if (content.length === 0) return null
+
+      return { ...message, content }
+    })
+    .filter((message) => message != null)
+}

--- a/server/utils/chat/turn-executor.ts
+++ b/server/utils/chat/turn-executor.ts
@@ -28,6 +28,10 @@ import { userMemoryService } from '../services/userMemoryService'
 import { checkQuota } from '../quotas/engine'
 import { sendToUser } from '../ws-state'
 import { transformHistoryToCoreMessages } from '../ai-history'
+import {
+  sanitizeChatMessagesForToolApprovals,
+  sanitizeCoreMessagesForToolApprovals
+} from '../../api/chat/sanitize-tool-approval'
 import { normalizeCoreMessagesForGemini } from './core-message-normalizer'
 import { extractMemoryCandidatesFromConversation } from './memory-extraction'
 import { findToolNameRepair } from './tool-call-repair'
@@ -128,9 +132,10 @@ function buildMemoryEventFromToolResults(toolResults: any[]) {
 }
 
 export function normalizeMessagesForSdk(inputMessages: any[]) {
+  const sanitizedMessages = sanitizeChatMessagesForToolApprovals(inputMessages)
   const approvalResponses = new Map<string, { approved: boolean; reason?: string }>()
 
-  for (const msg of inputMessages) {
+  for (const msg of sanitizedMessages) {
     if (msg.role !== 'tool') continue
     const parts = Array.isArray(msg.parts)
       ? msg.parts
@@ -138,21 +143,23 @@ export function normalizeMessagesForSdk(inputMessages: any[]) {
         ? msg.content
         : []
     for (const part of parts) {
-      if (part?.type !== 'tool-approval-response' || !part.approvalId) continue
-      approvalResponses.set(part.approvalId, {
+      if (part?.type !== 'tool-approval-response') continue
+      const approvalId = part.approvalId || part.toolCallId
+      if (!approvalId) continue
+      approvalResponses.set(approvalId, {
         approved: !!part.approved,
-        reason: part.reason || part.result
+        reason: typeof part.reason === 'string' ? part.reason : undefined
       })
     }
   }
 
-  return inputMessages.map((msg) => {
+  return sanitizedMessages.map((msg) => {
     if (msg.role !== 'assistant' || !Array.isArray(msg.parts)) return msg
 
     const parts = msg.parts.map((part: any) => {
       if (!part?.type?.startsWith('tool-')) return part
 
-      const approvalId = part.approvalId || part.approval?.id
+      const approvalId = part.approvalId || part.approval?.id || part.toolCallId
       if (!approvalId) return part
 
       const response = approvalResponses.get(approvalId)
@@ -165,7 +172,7 @@ export function normalizeMessagesForSdk(inputMessages: any[]) {
           ...(part.approval || {}),
           id: approvalId,
           approved: response.approved,
-          reason: response.reason
+          ...(response.reason !== undefined ? { reason: response.reason } : {})
         }
       }
     })
@@ -1258,7 +1265,9 @@ export async function executeChatTurn(turnId: string, expectedRunId?: string | n
         boundedHistoryEstimatedTokens: estimateTokenCount(historyMessages)
       })
 
-      const coreMessages = await transformHistoryToCoreMessages(historyMessages)
+      const coreMessages = sanitizeCoreMessagesForToolApprovals(
+        await transformHistoryToCoreMessages(historyMessages)
+      )
       ensureTurnNotAborted()
       const normalizedMessages = normalizeCoreMessagesForGemini(coreMessages)
 

--- a/tests/unit/server/api/chat.test.ts
+++ b/tests/unit/server/api/chat.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  sanitizeChatMessagesForToolApprovals,
+  sanitizeCoreMessagesForToolApprovals,
+  sanitizeToolApprovalResponsePart
+} from '../../../../server/api/chat/sanitize-tool-approval'
+import { normalizeMessagesForSdk } from '../../../../server/utils/chat/turn-executor'
+
+describe('sanitizeToolApprovalResponsePart', () => {
+  it('maps toolCallId to approvalId and coerces approved', () => {
+    expect(
+      sanitizeToolApprovalResponsePart({
+        type: 'tool-approval-response',
+        toolCallId: 'call_1',
+        approved: 'true',
+        reason: { nested: true }
+      })
+    ).toEqual({
+      type: 'tool-approval-response',
+      approvalId: 'call_1',
+      toolCallId: 'call_1',
+      approved: true
+    })
+  })
+
+  it('drops irreparable approval responses', () => {
+    expect(
+      sanitizeToolApprovalResponsePart({
+        type: 'tool-approval-response',
+        approved: true
+      })
+    ).toBeNull()
+
+    expect(
+      sanitizeToolApprovalResponsePart({
+        type: 'tool-approval-response',
+        approvalId: 'call_1'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps valid string reasons', () => {
+    expect(
+      sanitizeToolApprovalResponsePart({
+        type: 'tool-approval-response',
+        approvalId: 'call_1',
+        approved: false,
+        reason: 'No thanks'
+      })
+    ).toMatchObject({
+      approvalId: 'call_1',
+      approved: false,
+      reason: 'No thanks'
+    })
+  })
+})
+
+describe('sanitizeChatMessagesForToolApprovals', () => {
+  it('sanitizes tool approval responses on client chat messages', () => {
+    const result = sanitizeChatMessagesForToolApprovals([
+      {
+        id: 'tool-1',
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-approval-response',
+            toolCallId: 'call_1',
+            approved: 'yes'
+          },
+          {
+            type: 'tool-approval-response',
+            approved: true
+          }
+        ]
+      }
+    ])
+
+    expect(result[0].parts).toEqual([
+      {
+        type: 'tool-approval-response',
+        approvalId: 'call_1',
+        toolCallId: 'call_1',
+        approved: true
+      }
+    ])
+  })
+
+  it('repairs assistant approval objects missing ids', () => {
+    const result = sanitizeChatMessagesForToolApprovals([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-log_meal',
+            toolCallId: 'call_1',
+            state: 'approval-responded',
+            input: { meal: 'oats' },
+            approval: { approved: 'true', reason: { bad: true } }
+          }
+        ]
+      }
+    ])
+
+    expect(result[0].parts[0]).toMatchObject({
+      toolCallId: 'call_1',
+      approval: {
+        id: 'call_1',
+        approved: true
+      }
+    })
+    expect(result[0].parts[0].approval).not.toHaveProperty('reason')
+  })
+})
+
+describe('sanitizeCoreMessagesForToolApprovals', () => {
+  it('drops invalid model-message tool-approval-response parts', () => {
+    const result = sanitizeCoreMessagesForToolApprovals([
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool-approval-response', approved: true },
+          { type: 'tool-approval-response', approvalId: 'call_1', approved: true }
+        ]
+      }
+    ])
+
+    expect(result).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-approval-response',
+            approvalId: 'call_1',
+            toolCallId: 'call_1',
+            approved: true
+          }
+        ]
+      }
+    ])
+  })
+
+  it('removes tool messages that become empty after sanitization', () => {
+    const result = sanitizeCoreMessagesForToolApprovals([
+      {
+        role: 'tool',
+        content: [{ type: 'tool-approval-response', approved: true }]
+      },
+      { role: 'user', content: 'hello' }
+    ])
+
+    expect(result).toEqual([{ role: 'user', content: 'hello' }])
+  })
+})
+
+describe('normalizeMessagesForSdk with tool approval sanitization', () => {
+  it('accepts toolCallId-only approval responses and marks the assistant call', () => {
+    const result = normalizeMessagesForSdk([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-log_meal',
+            toolCallId: 'call_1',
+            state: 'approval-requested',
+            input: { meal: 'oats' },
+            approval: { id: 'call_1' }
+          }
+        ]
+      },
+      {
+        id: 'tool-1',
+        role: 'tool',
+        parts: [
+          {
+            type: 'tool-approval-response',
+            toolCallId: 'call_1',
+            approved: 'true',
+            reason: { nested: true }
+          }
+        ]
+      }
+    ])
+
+    expect(result[0].parts[0]).toMatchObject({
+      state: 'approval-responded',
+      approval: {
+        id: 'call_1',
+        approved: true
+      }
+    })
+    expect(result[0].parts[0].approval).not.toHaveProperty('reason')
+    expect(result[1].parts).toEqual([
+      {
+        type: 'tool-approval-response',
+        approvalId: 'call_1',
+        toolCallId: 'call_1',
+        approved: true
+      }
+    ])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Chat turns crashed with `AI_TypeValidationError` / `AI_InvalidPromptError` when client messages included malformed `tool-approval-response` parts (missing/misformatted `approvalId` or `approved`).

## Changes
- Normalize/drop invalid tool-approval-response parts to the AI SDK UIMessage shape
- Wire sanitization into chat message ingress and turn-executor prompt normalization
- Add unit tests for sanitization + chat API path

## Linear
https://linear.app/watt-mind/issue/CW-209/fix-vercel-ai-sdk-ai-typevalidationerror-for-tool-approval-response-in

## Test plan
- [x] `pnpm test tests/unit/server/api/chat.test.ts` (8/8)
- [x] Related turn-executor / approval-continuation tests (30 passed)
- [ ] Spot-check a chat turn with tool approval UI in staging

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

