### PR TITLE
fix(security): reject foreign eventIds on goals POST (CW-219)

### DIFF
--- a/server/api/goals/index.post.ts
+++ b/server/api/goals/index.post.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v3'
 import { requireAuth } from '../../utils/auth-guard'
+import { prisma } from '../../utils/db'
 
 defineRouteMeta({
   // ... (omitting openAPI for brevity)
@@ -140,6 +141,26 @@ export default defineEventHandler(async (event) => {
     if (data.eventId) {
       if (!eventsToConnect.some((e) => e.id === data.eventId)) {
         eventsToConnect.push({ id: data.eventId })
+      }
+    }
+
+    // Prevent IDOR: only the caller's events may be linked to their goal
+    const uniqueExistingEventIds = [...new Set(eventsToConnect.map((e) => e.id))]
+    if (uniqueExistingEventIds.length > 0) {
+      const ownedEvents = await prisma.event.findMany({
+        where: {
+          id: { in: uniqueExistingEventIds },
+          userId: user.id
+        },
+        select: { id: true }
+      })
+
+      if (ownedEvents.length !== uniqueExistingEventIds.length) {
+        throw createError({
+          statusCode: 403,
+          statusMessage: 'Not authorized to link one or more events',
+          message: 'Not authorized to link one or more events'
+        })
       }
     }
 

--- a/tests/unit/server/api/goals/index.post.test.ts
+++ b/tests/unit/server/api/goals/index.post.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  ;(error as any).statusMessage = err.statusMessage || err.message
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    goal: {
+      create: vi.fn()
+    },
+    event: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+      create: vi.fn()
+    }
+  }
+}))
+
+const getHandler = async () => (await import('../../../../../server/api/goals/index.post')).default
+
+describe('POST /api/goals event IDOR', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'attacker-1' } as any)
+  })
+
+  it('rejects foreign eventIds and never creates the goal', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([])
+
+    await expect(
+      handler({
+        body: {
+          type: 'EVENT',
+          title: 'Stolen race',
+          eventIds: ['victim-event-1']
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      statusMessage: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.event.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['victim-event-1'] },
+        userId: 'attacker-1'
+      },
+      select: { id: true }
+    })
+    expect(prisma.goal.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects when eventIds mixes owned and foreign ids', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([{ id: 'owned-event-1' }] as any)
+
+    await expect(
+      handler({
+        body: {
+          type: 'EVENT',
+          title: 'Mixed events',
+          eventIds: ['owned-event-1', 'victim-event-1']
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      statusMessage: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.goal.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects a foreign eventId and never creates the goal', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([])
+
+    await expect(
+      handler({
+        body: {
+          type: 'EVENT',
+          title: 'Stolen race',
+          eventId: 'victim-event-1'
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      statusMessage: 'Not authorized to link one or more events'
+    })
+
+    expect(prisma.event.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['victim-event-1'] },
+        userId: 'attacker-1'
+      },
+      select: { id: true }
+    })
+    expect(prisma.goal.create).not.toHaveBeenCalled()
+  })
+
+  it('links owned eventIds after ownership verification', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.event.findMany).mockResolvedValue([
+      { id: 'owned-event-1' },
+      { id: 'owned-event-2' }
+    ] as any)
+    vi.mocked(prisma.goal.create).mockResolvedValue({
+      id: 'goal-1',
+      title: 'My race'
+    } as any)
+
+    await expect(
+      handler({
+        body: {
+          type: 'EVENT',
+          title: 'My race',
+          targetDate: '2026-09-01T00:00:00.000Z',
+          eventIds: ['owned-event-1', 'owned-event-2']
+        }
+      } as any)
+    ).resolves.toMatchObject({
+      success: true,
+      goal: { id: 'goal-1', title: 'My race' }
+    })
+
+    expect(prisma.event.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['owned-event-1', 'owned-event-2'] },
+        userId: 'attacker-1'
+      },
+      select: { id: true }
+    })
+    expect(prisma.goal.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'attacker-1',
+        title: 'My race',
+        events: {
+          connect: [{ id: 'owned-event-1' }, { id: 'owned-event-2' }]
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to CW-148: `POST /api/goals` still connected arbitrary `eventIds` without ownership checks, allowing the same cross-user private event association / leak via `GET /api/goals`.

## Changes
- Ownership-check `eventIds`/`eventId` before `goal.create`
- Reject foreign/missing event IDs with 403
- Unit tests for foreign, mixed, and owned event linking on POST

## Linear
https://linear.app/watt-mind/issue/CW-219/goals-post-can-attach-another-users-private-events-idor-residual-from

## Test plan
- [x] `pnpm vitest run tests/unit/server/api/goals` (4/4)
- [ ] Merge alongside CW-148 (#375) so PATCH + POST are both covered

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

