### PR TITLE
fix(orchestrate): key full-sync progress SSE by user.id (CW-8)

### DIFF
--- a/server/api/orchestrate/progress.get.ts
+++ b/server/api/orchestrate/progress.get.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, setHeader } from 'h3'
-import { getServerSession } from '../../utils/session'
+import { requireAuth } from '../../utils/auth-guard'
 import { activeSyncs } from './full-sync.post'
 
 defineRouteMeta({
@@ -22,16 +22,9 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
-  const session = await getServerSession(event)
-
-  if (!session?.user?.email) {
-    throw createError({
-      statusCode: 401,
-      message: 'Unauthorized'
-    })
-  }
-
-  const userId = session.user.email
+  // Use the same user.id key as full-sync.post.ts stores in activeSyncs
+  const user = await requireAuth(event)
+  const userId = user.id
 
   // Set SSE headers
   setHeader(event, 'Content-Type', 'text/event-stream')
@@ -49,7 +42,7 @@ export default defineEventHandler(async (event) => {
         controller.enqueue(encoder.encode(message))
       }
 
-      // Get sync state if it exists
+      // Get sync state if it exists (keyed by user.id, matching full-sync)
       const syncState = activeSyncs.get(userId)
 
       if (syncState) {

--- a/tests/unit/server/api/orchestrate/progress.get.test.ts
+++ b/tests/unit/server/api/orchestrate/progress.get.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+
+const activeSyncs = new Map<
+  string,
+  {
+    userId: string
+    states: Record<string, unknown>
+    startTime: Date
+    subscribers: Set<(data: unknown) => void>
+  }
+>()
+
+const setHeaderMock = vi.fn()
+
+vi.stubGlobal('defineRouteMeta', () => {})
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: any) => fn,
+  setHeader: (...args: unknown[]) => setHeaderMock(...args),
+  createError: (err: { message: string; statusCode?: number }) => {
+    const error = new Error(err.message)
+    ;(error as any).statusCode = err.statusCode
+    return error
+  }
+}))
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/api/orchestrate/full-sync.post', () => ({
+  activeSyncs
+}))
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/orchestrate/progress.get')).default
+
+function createMockEvent() {
+  const closeHandlers: Array<() => void> = []
+  return {
+    node: {
+      req: {
+        on: (eventName: string, handler: () => void) => {
+          if (eventName === 'close') closeHandlers.push(handler)
+        }
+      }
+    },
+    _closeHandlers: closeHandlers
+  }
+}
+
+async function readFirstSseEvent(stream: ReadableStream): Promise<unknown> {
+  const reader = stream.getReader()
+  const { value } = await reader.read()
+  await reader.cancel()
+
+  const text = new TextDecoder().decode(value)
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '))
+  if (!dataLine) throw new Error(`No SSE data line in: ${text}`)
+  return JSON.parse(dataLine.slice('data: '.length))
+}
+
+describe('GET /api/orchestrate/progress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activeSyncs.clear()
+    vi.mocked(requireAuth).mockResolvedValue({
+      id: 'user-id-123',
+      email: 'athlete@example.com'
+    } as any)
+  })
+
+  it('looks up activeSyncs by user.id (not email) and emits init', async () => {
+    const startTime = new Date('2026-07-29T12:00:00.000Z')
+    activeSyncs.set('user-id-123', {
+      userId: 'user-id-123',
+      states: {
+        'task-a': { taskId: 'task-a', status: 'running' }
+      },
+      startTime,
+      subscribers: new Set()
+    })
+    // Email key must NOT match — this is the CW-8 regression
+    activeSyncs.set('athlete@example.com', {
+      userId: 'wrong',
+      states: {},
+      startTime,
+      subscribers: new Set()
+    })
+
+    const handler = await getHandler()
+    const event = createMockEvent()
+    const stream = (await handler(event as any)) as ReadableStream
+    const payload = await readFirstSseEvent(stream)
+
+    expect(payload).toMatchObject({
+      type: 'init',
+      states: {
+        'task-a': { taskId: 'task-a', status: 'running' }
+      }
+    })
+    expect(requireAuth).toHaveBeenCalledWith(event)
+  })
+
+  it('returns no_sync when no entry exists for user.id', async () => {
+    // Only email-keyed entry present (pre-fix bug shape)
+    activeSyncs.set('athlete@example.com', {
+      userId: 'athlete@example.com',
+      states: { 'task-a': { taskId: 'task-a', status: 'running' } },
+      startTime: new Date(),
+      subscribers: new Set()
+    })
+
+    const handler = await getHandler()
+    const stream = (await handler(createMockEvent() as any)) as ReadableStream
+    const payload = await readFirstSseEvent(stream)
+
+    expect(payload).toEqual({
+      type: 'no_sync',
+      message: 'No active sync in progress'
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Full-sync progress was stored in `activeSyncs` by `user.id`, but the progress SSE endpoint looked up by `session.user.email`, so clients almost always saw `no_sync` during an active sync.

## Changes
- Standardize progress lookup on `user.id` via `requireAuth`
- Add unit coverage for the key mismatch / happy path

## Linear
https://linear.app/watt-mind/issue/CW-8/orchestrate-progress-sse-uses-wrong-user-key

## Test plan
- [x] `vitest run tests/unit/server/api/orchestrate/progress.get.test.ts` (2/2)
- [x] `pnpm typecheck`
- [ ] Manual: start full sync and confirm SSE progress events

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

