### PR TITLE
fix(wellness): honor fitness startDate/endDate query range (CW-46)

### DIFF
--- a/app/pages/fitness/index.vue
+++ b/app/pages/fitness/index.vue
@@ -602,12 +602,37 @@
     { label: 'Poor (<6h)', value: 'poor' }
   ]
 
-  // Fetch all wellness data
+  const { formatDateUTC, getUserLocalDate } = useFormat()
+
+  function getSelectedPeriodRange() {
+    const endDate = getUserLocalDate()
+    let startDate: Date
+
+    if (selectedPeriod.value === 'YTD') {
+      startDate = new Date(Date.UTC(endDate.getUTCFullYear(), 0, 1))
+    } else {
+      const days =
+        typeof selectedPeriod.value === 'string'
+          ? parseInt(selectedPeriod.value)
+          : selectedPeriod.value
+      startDate = new Date(endDate)
+      startDate.setUTCDate(endDate.getUTCDate() - (days || 30))
+    }
+
+    return { startDate, endDate }
+  }
+
+  // Fetch wellness for the selected period (API accepts startDate/endDate)
   async function fetchWellness() {
     loading.value = true
     try {
-      // Fetch up to 180 days to support YTD and historical trends
-      const wellness = await $fetch<any, string & {}>('/api/wellness', { query: { limit: 180 } })
+      const { startDate, endDate } = getSelectedPeriodRange()
+      const wellness = await $fetch<any, string & {}>('/api/wellness', {
+        query: {
+          startDate: startDate.toISOString(),
+          endDate: endDate.toISOString()
+        }
+      })
 
       allWellness.value = wellness
     } catch (error) {
@@ -622,29 +647,15 @@
     }
   }
 
-  const { formatDateUTC, getUserLocalDate } = useFormat()
-
   // Computed properties
   const filteredWellness = computed(() => {
     let wellness = [...allWellness.value]
 
-    const todayUTC = getUserLocalDate()
-    let startDate: Date
-
-    if (selectedPeriod.value === 'YTD') {
-      startDate = new Date(Date.UTC(todayUTC.getUTCFullYear(), 0, 1))
-    } else {
-      const days =
-        typeof selectedPeriod.value === 'string'
-          ? parseInt(selectedPeriod.value)
-          : selectedPeriod.value
-      startDate = new Date(todayUTC)
-      startDate.setUTCDate(todayUTC.getUTCDate() - (days || 30))
-    }
+    const { startDate, endDate } = getSelectedPeriodRange()
 
     wellness = wellness.filter((w) => {
       const wellnessDate = new Date(w.date)
-      return wellnessDate <= todayUTC && wellnessDate >= startDate
+      return wellnessDate <= endDate && wellnessDate >= startDate
     })
 
     if (filterRecovery.value) {
@@ -1506,14 +1517,18 @@
     return opts
   }
 
-  watch([selectedPeriod, filterRecovery, filterSleep], () => {
+  watch([filterRecovery, filterSleep], () => {
     currentPage.value = 1
   })
 
-  // Load data on mount
-  onMounted(() => {
-    fetchWellness()
-  })
+  watch(
+    selectedPeriod,
+    () => {
+      currentPage.value = 1
+      fetchWellness()
+    },
+    { immediate: true }
+  )
 
   function changePage(page: number) {
     currentPage.value = page

--- a/server/api/wellness/index.get.ts
+++ b/server/api/wellness/index.get.ts
@@ -1,12 +1,100 @@
 import { requireAuth } from '../../utils/auth-guard'
+import { prisma } from '../../utils/db'
 import { wellnessRepository } from '../../utils/repositories/wellnessRepository'
+
+/** Default lookback when startDate/endDate are omitted (preserves prior API behavior). */
+const DEFAULT_RANGE_DAYS = 90
+/**
+ * Upper bound for custom ranges. Must cover Fitness "All Time" (3650 days)
+ * and YTD without silent truncation.
+ */
+const MAX_RANGE_DAYS = 3660
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function parseOptionalDate(value: unknown, field: 'startDate' | 'endDate'): Date | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid ${field}`
+    })
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid ${field}`
+    })
+  }
+  return date
+}
+
+function resolveWellnessDateRange(query: Record<string, unknown>): {
+  startDate: Date
+  endDate: Date
+} {
+  const startDate = parseOptionalDate(query.startDate, 'startDate')
+  const endDate = parseOptionalDate(query.endDate, 'endDate')
+
+  if ((startDate && !endDate) || (!startDate && endDate)) {
+    throw createError({
+      statusCode: 400,
+      message: 'Both startDate and endDate are required when specifying a custom range'
+    })
+  }
+
+  if (!startDate && !endDate) {
+    const defaultEnd = new Date()
+    const defaultStart = new Date(defaultEnd)
+    defaultStart.setUTCDate(defaultStart.getUTCDate() - DEFAULT_RANGE_DAYS)
+    return { startDate: defaultStart, endDate: defaultEnd }
+  }
+
+  // Both are defined after the checks above
+  const rangeStart = startDate as Date
+  const rangeEnd = endDate as Date
+
+  if (rangeStart > rangeEnd) {
+    throw createError({
+      statusCode: 400,
+      message: 'startDate must be on or before endDate'
+    })
+  }
+
+  const rangeMs = rangeEnd.getTime() - rangeStart.getTime()
+  if (rangeMs > MAX_RANGE_DAYS * MS_PER_DAY) {
+    throw createError({
+      statusCode: 400,
+      message: `Date range cannot exceed ${MAX_RANGE_DAYS} days`
+    })
+  }
+
+  return { startDate: rangeStart, endDate: rangeEnd }
+}
 
 defineRouteMeta({
   openAPI: {
     tags: ['Wellness'],
     summary: 'List wellness data',
-    description: 'Returns the last 90 days of wellness data for the authenticated user.',
+    description:
+      'Returns wellness data for the authenticated user. Accepts optional startDate and endDate query parameters; defaults to the last 90 days when omitted.',
     security: [{ bearerAuth: [] }],
+    inputSchema: [
+      {
+        name: 'startDate',
+        in: 'query',
+        required: false,
+        schema: { type: 'string', format: 'date-time' },
+        description: 'Range start (inclusive). Must be provided with endDate.'
+      },
+      {
+        name: 'endDate',
+        in: 'query',
+        required: false,
+        schema: { type: 'string', format: 'date-time' },
+        description: 'Range end (inclusive). Must be provided with startDate.'
+      }
+    ],
     responses: {
       200: {
         description: 'Success',
@@ -33,6 +121,7 @@ defineRouteMeta({
           }
         }
       },
+      400: { description: 'Invalid date range' },
       401: { description: 'Unauthorized' },
       403: { description: 'Forbidden' }
     }
@@ -41,12 +130,15 @@ defineRouteMeta({
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event, ['health:read'])
+  const query = getQuery(event) as Record<string, unknown>
+  const { startDate, endDate } = resolveWellnessDateRange(query)
 
   try {
     const userId = user.id
 
     const wellness = await wellnessRepository.getForUser(userId, {
-      limit: 90,
+      startDate,
+      endDate,
       orderBy: { date: 'desc' }
     })
 
@@ -78,7 +170,8 @@ export default defineEventHandler(async (event) => {
         feedbackText: usage?.feedbackText
       }
     })
-  } catch (error) {
+  } catch (error: any) {
+    if (error?.statusCode) throw error
     throw createError({
       statusCode: 500,
       message: 'Failed to fetch wellness data'

--- a/tests/unit/server/api/wellness/index.get.test.ts
+++ b/tests/unit/server/api/wellness/index.get.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prisma } from '../../../../../server/utils/db'
+import { wellnessRepository } from '../../../../../server/utils/repositories/wellnessRepository'
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('getQuery', (event: any) => event.query || {})
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    llmUsage: {
+      findMany: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/wellnessRepository', () => ({
+  wellnessRepository: {
+    getForUser: vi.fn()
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/wellness/index.get')
+  return mod.default
+}
+
+describe('GET /api/wellness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    vi.mocked(wellnessRepository.getForUser).mockResolvedValue([
+      { id: 'w-1', date: new Date('2026-07-01T00:00:00.000Z') }
+    ] as any)
+    vi.mocked(prisma.llmUsage.findMany).mockResolvedValue([] as any)
+  })
+
+  it('defaults to the last 90 days when startDate/endDate are omitted', async () => {
+    const handler = await getHandler()
+    const before = Date.now()
+
+    await handler({ query: {} } as any)
+
+    const after = Date.now()
+    expect(wellnessRepository.getForUser).toHaveBeenCalledTimes(1)
+    const [, options] = vi.mocked(wellnessRepository.getForUser).mock.calls[0]
+    expect(options.orderBy).toEqual({ date: 'desc' })
+    expect(options.limit).toBeUndefined()
+
+    const spanDays =
+      (options.endDate!.getTime() - options.startDate!.getTime()) / (24 * 60 * 60 * 1000)
+    expect(spanDays).toBe(90)
+    expect(options.endDate!.getTime()).toBeGreaterThanOrEqual(before - 1000)
+    expect(options.endDate!.getTime()).toBeLessThanOrEqual(after + 1000)
+  })
+
+  it('forwards custom startDate and endDate to the repository', async () => {
+    const handler = await getHandler()
+
+    const result = await handler({
+      query: {
+        startDate: '2026-01-01T00:00:00.000Z',
+        endDate: '2026-07-29T00:00:00.000Z'
+      }
+    } as any)
+
+    expect(wellnessRepository.getForUser).toHaveBeenCalledWith('user-1', {
+      startDate: new Date('2026-01-01T00:00:00.000Z'),
+      endDate: new Date('2026-07-29T00:00:00.000Z'),
+      orderBy: { date: 'desc' }
+    })
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'w-1',
+        llmUsageId: undefined,
+        feedback: undefined,
+        feedbackText: undefined
+      })
+    ])
+  })
+
+  it('accepts a YTD-length range without truncating to 90 days', async () => {
+    const handler = await getHandler()
+
+    await handler({
+      query: {
+        startDate: '2026-01-01T00:00:00.000Z',
+        endDate: '2026-07-29T12:00:00.000Z'
+      }
+    } as any)
+
+    const [, options] = vi.mocked(wellnessRepository.getForUser).mock.calls[0]
+    const spanDays =
+      (options.endDate!.getTime() - options.startDate!.getTime()) / (24 * 60 * 60 * 1000)
+    expect(spanDays).toBeGreaterThan(90)
+    expect(options.limit).toBeUndefined()
+  })
+
+  it('rejects invalid dates', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        query: {
+          startDate: 'not-a-date',
+          endDate: '2026-07-29'
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Invalid startDate'
+    })
+
+    expect(wellnessRepository.getForUser).not.toHaveBeenCalled()
+  })
+
+  it('rejects inverted ranges', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        query: {
+          startDate: '2026-07-29',
+          endDate: '2026-01-01'
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'startDate must be on or before endDate'
+    })
+  })
+
+  it('rejects when only one bound is provided', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        query: { startDate: '2026-01-01' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Both startDate and endDate are required when specifying a custom range'
+    })
+  })
+
+  it('rejects ranges beyond the max span', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        query: {
+          startDate: '2010-01-01T00:00:00.000Z',
+          endDate: '2026-07-29T00:00:00.000Z'
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'Date range cannot exceed 3660 days'
+    })
+  })
+
+  it('attaches llm usage feedback when present', async () => {
+    const handler = await getHandler()
+    vi.mocked(prisma.llmUsage.findMany).mockResolvedValue([
+      {
+        id: 'usage-1',
+        entityId: 'w-1',
+        feedback: 'up',
+        feedbackText: 'helpful'
+      }
+    ] as any)
+
+    const result = await handler({
+      query: {
+        startDate: '2026-01-01',
+        endDate: '2026-01-31'
+      }
+    } as any)
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'w-1',
+        llmUsageId: 'usage-1',
+        feedback: 'up',
+        feedbackText: 'helpful'
+      })
+    ])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/api/wellness` hard-capped historical wellness to 90 days and ignored client date filters, truncating Fitness YTD / custom ranges.

## Changes
- Accept optional `startDate`/`endDate`; default to last 90 calendar days only when omitted
- Reject invalid/inverted/oversized ranges; allow YTD and All Time
- Fitness page sends selected period range and refetches on change
- Unit tests for API range handling

## Linear
https://linear.app/watt-mind/issue/CW-46/fitness-index-90-day-api-cap

## Test plan
- [x] `pnpm exec vitest run tests/unit/server/api/wellness/index.get.test.ts` (8/8)
- [x] `pnpm typecheck`
- [ ] Manual: Fitness YTD / custom period shows full requested range

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

