### PR TITLE
fix(oura): stop retry storms on invalid refresh tokens (CW-212)

### DIFF
--- a/server/utils/oura.ts
+++ b/server/utils/oura.ts
@@ -1,4 +1,6 @@
 import type { Integration } from '@prisma/client'
+import { prisma } from './db'
+import { IntegrationAuthError, IntegrationProviderError } from './integration-errors'
 
 interface OuraTokenResponse {
   access_token: string
@@ -8,14 +10,71 @@ interface OuraTokenResponse {
   token_type: string
 }
 
+interface OuraTokenErrorPayload {
+  status?: number
+  error?: string
+  error_description?: string
+  message?: string
+}
+
+const OURA_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000
+const OURA_TOKEN_TRANSACTION_TIMEOUT_MS = 20_000
+const OURA_RECONNECT_MESSAGE = 'Oura authorization expired or was revoked. Please reconnect Oura.'
+
+const OURA_UNRECOVERABLE_REFRESH_ERRORS = new Set([
+  'invalid_request',
+  'invalid_grant',
+  'invalid_client',
+  'unauthorized_client',
+  'unsupported_grant_type'
+])
+
+function parseOuraTokenErrorPayload(errorText: string): OuraTokenErrorPayload {
+  try {
+    return JSON.parse(errorText) as OuraTokenErrorPayload
+  } catch {
+    return {}
+  }
+}
+
+function extractOuraRefreshErrorCode(payload: OuraTokenErrorPayload): string | undefined {
+  if (typeof payload.error === 'string' && payload.error.trim()) {
+    return payload.error.trim()
+  }
+  return undefined
+}
+
+function isUnrecoverableOuraRefreshFailure(
+  status: number,
+  payload: OuraTokenErrorPayload
+): boolean {
+  if (status === 401) return true
+  if (status !== 400) return false
+
+  const errorCode = extractOuraRefreshErrorCode(payload)?.toLowerCase()
+  if (!errorCode) {
+    // Oura often returns bare invalid_request / "Invalid request" for revoked tokens.
+    return true
+  }
+  return OURA_UNRECOVERABLE_REFRESH_ERRORS.has(errorCode)
+}
+
+function throwOuraAuthRevoked(integrationId: string, statusCode?: number): never {
+  throw new IntegrationAuthError({
+    provider: 'oura',
+    integrationId,
+    code: 'AUTH_REVOKED',
+    statusCode,
+    message: OURA_RECONNECT_MESSAGE
+  })
+}
+
 /**
- * Refreshes an expired Oura access token using the refresh token
+ * Refreshes an expired Oura access token using the refresh token.
+ * Serializes concurrent refreshes for one integration via a DB row lock so webhook
+ * fan-out (Promise.all of multiple endpoints) cannot stampede Oura with duplicate refreshes.
  */
 export async function refreshOuraToken(integration: Integration): Promise<Integration> {
-  if (!integration.refreshToken) {
-    throw new Error('No refresh token available for Oura integration')
-  }
-
   const clientId = process.env.OURA_CLIENT_ID
   const clientSecret = process.env.OURA_CLIENT_SECRET
 
@@ -23,42 +82,124 @@ export async function refreshOuraToken(integration: Integration): Promise<Integr
     throw new Error('OURA credentials not configured')
   }
 
-  console.log('Refreshing Oura token for integration:', integration.id)
+  const result = await prisma.$transaction(
+    async (transaction) => {
+      await transaction.$queryRaw`SELECT "id" FROM "Integration" WHERE "id" = ${integration.id} FOR UPDATE`
 
-  const response = await fetch('https://api.ouraring.com/oauth/token', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      const latest = await transaction.integration.findUnique({
+        where: { id: integration.id }
+      })
+      if (!latest) {
+        throw new Error('Oura integration no longer exists')
+      }
+
+      // A caller that waited for the lock must reuse credentials written by the winner.
+      if (
+        latest.accessToken !== integration.accessToken ||
+        latest.refreshToken !== integration.refreshToken
+      ) {
+        return { integration: latest }
+      }
+
+      if (latest.syncStatus === 'FAILED' && latest.errorMessage === OURA_RECONNECT_MESSAGE) {
+        return { authRevoked: true as const, statusCode: 400 }
+      }
+
+      if (!latest.refreshToken) {
+        throw new IntegrationAuthError({
+          provider: 'oura',
+          integrationId: integration.id,
+          code: 'AUTH_MISSING',
+          message: 'No refresh token available for Oura integration'
+        })
+      }
+
+      console.log('Refreshing Oura token for integration:', integration.id)
+
+      const response = await fetch('https://api.ouraring.com/oauth/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: latest.refreshToken,
+          client_id: clientId,
+          client_secret: clientSecret
+        }).toString()
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        const payload = parseOuraTokenErrorPayload(errorText)
+        const errorCode = extractOuraRefreshErrorCode(payload)
+
+        // Log diagnostics without request/response secrets (tokens never appear here).
+        console.error('Oura token refresh failed:', {
+          integrationId: integration.id,
+          status: response.status,
+          error: errorCode || undefined,
+          errorDescription:
+            typeof payload.error_description === 'string' ? payload.error_description : undefined
+        })
+
+        if (isUnrecoverableOuraRefreshFailure(response.status, payload)) {
+          try {
+            await transaction.integration.update({
+              where: { id: integration.id },
+              data: {
+                syncStatus: 'FAILED',
+                errorMessage: OURA_RECONNECT_MESSAGE
+              }
+            })
+          } catch (updateError) {
+            console.error('[Oura] Failed to mark integration as reconnect required', {
+              integrationId: integration.id,
+              updateError
+            })
+          }
+
+          // Commit FAILED status before surfacing the auth error to callers.
+          return { authRevoked: true as const, statusCode: response.status }
+        }
+
+        if (response.status >= 500) {
+          throw new IntegrationProviderError({
+            provider: 'oura',
+            integrationId: integration.id,
+            statusCode: response.status,
+            message: `Oura token refresh unavailable: ${response.status} ${response.statusText}`
+          })
+        }
+
+        throw new Error(
+          `Failed to refresh Oura token: ${response.status} ${response.statusText}${
+            errorCode ? ` (${errorCode})` : ''
+          }`
+        )
+      }
+
+      const tokenData: OuraTokenResponse = await response.json()
+      const expiresAt = new Date(Date.now() + tokenData.expires_in * 1000)
+
+      const updated = await transaction.integration.update({
+        where: { id: integration.id },
+        data: {
+          accessToken: tokenData.access_token,
+          refreshToken: tokenData.refresh_token,
+          expiresAt
+        }
+      })
+      return { integration: updated }
     },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: integration.refreshToken,
-      client_id: clientId,
-      client_secret: clientSecret
-    }).toString()
-  })
+    { maxWait: OURA_TOKEN_TRANSACTION_TIMEOUT_MS, timeout: OURA_TOKEN_TRANSACTION_TIMEOUT_MS }
+  )
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    console.error('Oura token refresh failed:', errorText)
-    throw new Error(`Failed to refresh Oura token: ${response.status} ${response.statusText}`)
+  if ('authRevoked' in result) {
+    throwOuraAuthRevoked(integration.id, result.statusCode)
   }
 
-  const tokenData: OuraTokenResponse = await response.json()
-  const expiresAt = new Date(Date.now() + tokenData.expires_in * 1000)
-  const { prisma } = await import('./db')
-
-  // Update the integration in the database
-  const updatedIntegration = await prisma.integration.update({
-    where: { id: integration.id },
-    data: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt
-    }
-  })
-
-  return updatedIntegration
+  return result.integration
 }
 
 /**
@@ -70,19 +211,29 @@ function isTokenExpired(integration: Integration): boolean {
   }
 
   const now = new Date()
-  const expiryWithBuffer = new Date(integration.expiresAt.getTime() - 5 * 60 * 1000) // 5 minutes buffer
+  const expiryWithBuffer = new Date(integration.expiresAt.getTime() - OURA_TOKEN_REFRESH_BUFFER_MS)
   return now >= expiryWithBuffer
 }
 
 /**
- * Ensures the integration has a valid access token, refreshing if necessary
+ * Ensures the integration has a valid access token, refreshing if necessary.
+ * Re-reads the DB first so parallel webhook fetchers can reuse a just-rotated token.
  */
-async function ensureValidToken(integration: Integration): Promise<Integration> {
-  if (isTokenExpired(integration)) {
+export async function ensureValidOuraToken(integration: Integration): Promise<Integration> {
+  const latest = await prisma.integration.findUnique({
+    where: { id: integration.id }
+  })
+  if (!latest) return integration
+
+  if (isTokenExpired(latest)) {
     console.log('Oura token expired or expiring soon, refreshing...')
-    return await refreshOuraToken(integration)
+    return await refreshOuraToken(latest)
   }
-  return integration
+  return latest
+}
+
+async function ensureValidToken(integration: Integration): Promise<Integration> {
+  return ensureValidOuraToken(integration)
 }
 
 // --- Data Fetching ---

--- a/tests/unit/server/utils/oura-auth.test.ts
+++ b/tests/unit/server/utils/oura-auth.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ensureValidOuraToken, refreshOuraToken } from '../../../../server/utils/oura'
+import {
+  IntegrationAuthError,
+  IntegrationProviderError
+} from '../../../../server/utils/integration-errors'
+
+const { prismaIntegrationFindUnique, prismaIntegrationUpdate, prismaQueryRaw, prismaTransaction } =
+  vi.hoisted(() => ({
+    prismaIntegrationFindUnique: vi.fn(),
+    prismaIntegrationUpdate: vi.fn(),
+    prismaQueryRaw: vi.fn(),
+    prismaTransaction: vi.fn()
+  }))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    $transaction: prismaTransaction,
+    integration: {
+      findUnique: prismaIntegrationFindUnique,
+      update: prismaIntegrationUpdate
+    }
+  }
+}))
+
+beforeEach(() => {
+  prismaIntegrationFindUnique.mockReset()
+  prismaIntegrationUpdate.mockReset()
+  prismaQueryRaw.mockReset()
+  prismaTransaction.mockReset()
+  prismaQueryRaw.mockResolvedValue([])
+  prismaTransaction.mockImplementation(async (callback: (transaction: unknown) => unknown) =>
+    callback({
+      $queryRaw: prismaQueryRaw,
+      integration: {
+        findUnique: prismaIntegrationFindUnique,
+        update: prismaIntegrationUpdate
+      }
+    })
+  )
+  vi.restoreAllMocks()
+  process.env.OURA_CLIENT_ID = 'test-client-id'
+  process.env.OURA_CLIENT_SECRET = 'test-client-secret'
+})
+
+describe('Oura token refresh auth failures', () => {
+  it('marks the integration for reconnection on invalid_request 400 and throws IntegrationAuthError', async () => {
+    const integration = {
+      id: 'integration-invalid-refresh',
+      accessToken: 'expired-token',
+      refreshToken: 'invalid-refresh-token',
+      expiresAt: new Date(Date.now() - 1000),
+      syncStatus: 'SUCCESS',
+      errorMessage: null
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: async () =>
+          JSON.stringify({
+            status: 400,
+            error: 'invalid_request',
+            error_description: 'Invalid request'
+          })
+      }) as any
+    )
+
+    const error = await refreshOuraToken(integration).catch((err) => err)
+    expect(error).toBeInstanceOf(IntegrationAuthError)
+    expect(error).toMatchObject({
+      name: 'IntegrationAuthError',
+      code: 'AUTH_REVOKED',
+      provider: 'oura',
+      integrationId: integration.id,
+      statusCode: 400,
+      message: 'Oura authorization expired or was revoked. Please reconnect Oura.',
+      retryable: false
+    })
+
+    expect(prismaIntegrationUpdate).toHaveBeenCalledWith({
+      where: { id: integration.id },
+      data: {
+        syncStatus: 'FAILED',
+        errorMessage: 'Oura authorization expired or was revoked. Please reconnect Oura.'
+      }
+    })
+
+    const logged = errorSpy.mock.calls.find((call) => call[0] === 'Oura token refresh failed:')
+    expect(logged?.[1]).toMatchObject({
+      integrationId: integration.id,
+      status: 400,
+      error: 'invalid_request',
+      errorDescription: 'Invalid request'
+    })
+    expect(JSON.stringify(logged?.[1])).not.toContain('invalid-refresh-token')
+    expect(JSON.stringify(logged?.[1])).not.toContain('test-client-secret')
+  })
+
+  it('classifies invalid_grant 400 as an unrecoverable auth failure', async () => {
+    const integration = {
+      id: 'integration-invalid-grant',
+      accessToken: 'expired-token',
+      refreshToken: 'revoked-refresh-token',
+      expiresAt: new Date(Date.now() - 1000)
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: async () => JSON.stringify({ error: 'invalid_grant' })
+      }) as any
+    )
+
+    await expect(refreshOuraToken(integration)).rejects.toBeInstanceOf(IntegrationAuthError)
+    expect(prismaIntegrationUpdate).toHaveBeenCalledWith({
+      where: { id: integration.id },
+      data: {
+        syncStatus: 'FAILED',
+        errorMessage: 'Oura authorization expired or was revoked. Please reconnect Oura.'
+      }
+    })
+  })
+
+  it('does not call Oura again when the integration already requires reconnection', async () => {
+    const integration = {
+      id: 'integration-already-failed',
+      accessToken: 'expired-token',
+      refreshToken: 'invalid-refresh-token',
+      expiresAt: new Date(Date.now() - 1000),
+      syncStatus: 'FAILED',
+      errorMessage: 'Oura authorization expired or was revoked. Please reconnect Oura.'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock as any)
+
+    await expect(refreshOuraToken(integration)).rejects.toBeInstanceOf(IntegrationAuthError)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('surfaces provider unavailable errors for Oura 5xx refresh failures without marking reconnect', async () => {
+    const integration = {
+      id: 'integration-oura-5xx',
+      accessToken: 'expired-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() - 1000)
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: async () => 'upstream down'
+      }) as any
+    )
+
+    await expect(refreshOuraToken(integration)).rejects.toBeInstanceOf(IntegrationProviderError)
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('Oura concurrent refresh callers', () => {
+  it('serializes concurrent refreshes and reuses the rotated credentials', async () => {
+    const expiredIntegration = {
+      id: 'integration-concurrent-refresh',
+      accessToken: 'expired-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: new Date(Date.now() - 1000)
+    } as any
+    let storedIntegration = expiredIntegration
+    let transactionQueue = Promise.resolve()
+
+    prismaIntegrationFindUnique.mockImplementation(async () => storedIntegration)
+    prismaIntegrationUpdate.mockImplementation(async ({ data }) => {
+      storedIntegration = { ...storedIntegration, ...data }
+      return storedIntegration
+    })
+    prismaTransaction.mockImplementation((callback: (transaction: unknown) => Promise<unknown>) => {
+      const result = transactionQueue.then(() =>
+        callback({
+          $queryRaw: prismaQueryRaw,
+          integration: {
+            findUnique: prismaIntegrationFindUnique,
+            update: prismaIntegrationUpdate
+          }
+        })
+      )
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        access_token: 'fresh-token',
+        refresh_token: 'fresh-refresh-token',
+        expires_in: 86_400,
+        scope: 'email personal daily',
+        token_type: 'bearer'
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock as any)
+
+    const [first, second] = await Promise.all([
+      refreshOuraToken(expiredIntegration),
+      refreshOuraToken(expiredIntegration)
+    ])
+
+    expect(first.accessToken).toBe('fresh-token')
+    expect(second.accessToken).toBe('fresh-token')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(prismaIntegrationUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses credentials refreshed by another caller without marking the integration failed', async () => {
+    const staleIntegration = {
+      id: 'integration-stale-refresh',
+      accessToken: 'expired-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: new Date(Date.now() - 1000)
+    } as any
+    const refreshedIntegration = {
+      ...staleIntegration,
+      accessToken: 'fresh-token',
+      refreshToken: 'fresh-refresh-token',
+      expiresAt: new Date(Date.now() + 86_400_000)
+    }
+    prismaIntegrationFindUnique.mockResolvedValue(refreshedIntegration)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock as any)
+
+    await expect(refreshOuraToken(staleIntegration)).resolves.toBe(refreshedIntegration)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('re-reads fresh credentials for callers holding a stale integration object', async () => {
+    const staleIntegration = {
+      id: 'integration-ensure-stale',
+      accessToken: 'expired-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: new Date(Date.now() - 1000)
+    } as any
+    const refreshedIntegration = {
+      ...staleIntegration,
+      accessToken: 'fresh-token',
+      refreshToken: 'fresh-refresh-token',
+      expiresAt: new Date(Date.now() + 86_400_000)
+    }
+    prismaIntegrationFindUnique.mockResolvedValue(refreshedIntegration)
+
+    await expect(ensureValidOuraToken(staleIntegration)).resolves.toBe(refreshedIntegration)
+    expect(prismaTransaction).not.toHaveBeenCalled()
+  })
+
+  it('only one concurrent invalid refresh marks FAILED and all callers get IntegrationAuthError', async () => {
+    const expiredIntegration = {
+      id: 'integration-concurrent-invalid',
+      accessToken: 'expired-token',
+      refreshToken: 'invalid-refresh-token',
+      expiresAt: new Date(Date.now() - 1000),
+      syncStatus: 'SUCCESS',
+      errorMessage: null
+    } as any
+    let storedIntegration = { ...expiredIntegration }
+    let transactionQueue = Promise.resolve()
+
+    prismaIntegrationFindUnique.mockImplementation(async () => storedIntegration)
+    prismaIntegrationUpdate.mockImplementation(async ({ data }) => {
+      storedIntegration = { ...storedIntegration, ...data }
+      return storedIntegration
+    })
+    prismaTransaction.mockImplementation((callback: (transaction: unknown) => Promise<unknown>) => {
+      const result = transactionQueue.then(() =>
+        callback({
+          $queryRaw: prismaQueryRaw,
+          integration: {
+            findUnique: prismaIntegrationFindUnique,
+            update: prismaIntegrationUpdate
+          }
+        })
+      )
+      transactionQueue = result.then(
+        () => undefined,
+        () => undefined
+      )
+      return result
+    })
+
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () =>
+        JSON.stringify({
+          status: 400,
+          error: 'invalid_request',
+          error_description: 'Invalid request'
+        })
+    })
+    vi.stubGlobal('fetch', fetchMock as any)
+
+    const results = await Promise.allSettled([
+      refreshOuraToken(expiredIntegration),
+      refreshOuraToken(expiredIntegration),
+      refreshOuraToken(expiredIntegration)
+    ])
+
+    expect(results.every((r) => r.status === 'rejected')).toBe(true)
+    for (const result of results) {
+      expect(result.status).toBe('rejected')
+      if (result.status === 'rejected') {
+        expect(result.reason).toBeInstanceOf(IntegrationAuthError)
+        expect(String(result.reason.message)).not.toContain('invalid-refresh-token')
+      }
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(prismaIntegrationUpdate).toHaveBeenCalledTimes(1)
+    expect(storedIntegration.syncStatus).toBe('FAILED')
+  })
+})

--- a/trigger/ingest-oura.ts
+++ b/trigger/ingest-oura.ts
@@ -16,6 +16,7 @@ import { workoutRepository } from '../server/utils/repositories/workoutRepositor
 import { wellnessRepository } from '../server/utils/repositories/wellnessRepository'
 import { normalizeTSS } from '../server/utils/normalize-tss'
 import { calculateWorkoutStress } from '../server/utils/calculate-workout-stress'
+import { buildAuthFailureResult } from '../server/utils/ingestion-failure'
 import type { IngestionResult } from './types'
 import { registerTaskHandler } from '../server/utils/task-registry'
 
@@ -52,9 +53,6 @@ export async function runIngestOura(payload: IngestOuraPayload): Promise<Ingesti
     where: { id: integration.id },
     data: { syncStatus: 'SYNCING' }
   })
-
-  let syncSucceeded = false
-  let syncErrorMessage: string | null = null
 
   try {
     const start = new Date(startDate)
@@ -158,7 +156,10 @@ export async function runIngestOura(payload: IngestOuraPayload): Promise<Ingesti
     let workoutUpsertCount = 0
 
     if (OURA_WORKOUTS_ENABLED) {
-      const workouts = await fetchOuraWorkouts(integration, start, end)
+      // Re-fetch integration so subsequent requests use any token rotated during wellness fetch.
+      const latestIntegration =
+        (await prisma.integration.findUnique({ where: { id: integration.id } })) || integration
+      const workouts = await fetchOuraWorkouts(latestIntegration, start, end)
       logger.log(`[Oura Ingest] Fetched ${workouts.length} workout records`)
 
       for (const workout of workouts) {
@@ -193,7 +194,14 @@ export async function runIngestOura(payload: IngestOuraPayload): Promise<Ingesti
       logger.log('[Oura Ingest] Workouts Disabled - Skipping')
     }
 
-    syncSucceeded = true
+    await prisma.integration.update({
+      where: { id: integration.id },
+      data: {
+        syncStatus: 'SUCCESS',
+        lastSyncAt: new Date(),
+        errorMessage: null
+      }
+    })
 
     return {
       success: true,
@@ -207,18 +215,27 @@ export async function runIngestOura(payload: IngestOuraPayload): Promise<Ingesti
       endDate
     }
   } catch (error) {
+    const authFailure = buildAuthFailureResult(error, { userId, startDate, endDate })
+    if (authFailure) {
+      logger.warn('[Oura Ingest] Authorization expired or revoked', {
+        integrationId: integration.id,
+        message: authFailure.message,
+        code: authFailure.error?.code,
+        statusCode: authFailure.error?.statusCode
+      })
+      // refreshOuraToken already marked the integration FAILED with a reconnect message.
+      return authFailure
+    }
+
     logger.error('[Oura Ingest] Error ingesting data', { error })
-    syncErrorMessage = error instanceof Error ? error.message : 'Unknown error'
-    throw error
-  } finally {
     await prisma.integration.update({
       where: { id: integration.id },
       data: {
-        syncStatus: syncSucceeded ? 'SUCCESS' : 'FAILED',
-        lastSyncAt: syncSucceeded ? new Date() : undefined,
-        errorMessage: syncSucceeded ? null : syncErrorMessage
+        syncStatus: 'FAILED',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error'
       }
     })
+    throw error
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Oura update webhooks hammered token refresh on HTTP 400 `invalid_request`, with concurrent refresh attempts for the same integration and noisy unrecoverable failures.

## Changes
- Serialize refresh with DB locking so concurrent callers share one provider call
- Classify invalid/revoked refresh failures as non-retryable auth errors
- Mark integration for reconnection and fail once with safe diagnostics (no tokens)
- Regression tests for invalid refresh + concurrent callers

## Linear
https://linear.app/watt-mind/issue/CW-212/handle-oura-oauth-token-refresh-rejection-without-repeated-failed

## Test plan
- [x] `pnpm exec vitest run server/utils/oura.test.ts tests/unit/server/utils/oura-auth.test.ts` (9/9)
- [ ] Confirm reconnect UX surfaces FAILED syncStatus in staging

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

