### PR TITLE
fix(security): allowlist Stripe checkout/portal redirect URLs (CW-150)

### DIFF
--- a/server/api/stripe/checkout-session.post.ts
+++ b/server/api/stripe/checkout-session.post.ts
@@ -4,6 +4,7 @@ import { prisma } from '../../utils/db'
 import { stripe } from '../../utils/stripe'
 import { ensureStripeCustomerForUser } from '../../utils/stripe-customer'
 import { assertNoActiveStoreSubscription } from '../../utils/provider-subscriptions'
+import { requireStripeRedirectUrl } from '../../utils/stripe-redirect-url'
 
 const checkoutSessionSchema = z.object({
   priceId: z.string(),
@@ -48,8 +49,20 @@ export default defineEventHandler(async (event) => {
 
   const { customerId } = await ensureStripeCustomerForUser(user)
 
-  const config = useRuntimeConfig()
-  const baseUrl = config.public.siteUrl || 'http://localhost:3099'
+  let config: any
+  try {
+    config = useRuntimeConfig()
+  } catch {
+    config = {}
+  }
+  const baseUrl = config?.public?.siteUrl || 'http://localhost:3099'
+
+  const success_url = requireStripeRedirectUrl(
+    successUrl,
+    baseUrl,
+    '/settings/billing?success=true'
+  )
+  const cancel_url = requireStripeRedirectUrl(cancelUrl, baseUrl, '/settings/billing?canceled=true')
 
   // Create Stripe checkout session
   const checkoutSession = await stripe.checkout.sessions.create({
@@ -72,8 +85,8 @@ export default defineEventHandler(async (event) => {
     automatic_tax: {
       enabled: true
     },
-    success_url: successUrl || `${baseUrl}/settings/billing?success=true`,
-    cancel_url: cancelUrl || `${baseUrl}/settings/billing?canceled=true`,
+    success_url,
+    cancel_url,
     metadata: {
       userId: user.id
     }

--- a/server/api/stripe/portal-session.post.ts
+++ b/server/api/stripe/portal-session.post.ts
@@ -4,6 +4,7 @@ import { prisma } from '../../utils/db'
 import { stripe } from '../../utils/stripe'
 import { ensureStripeCustomerForUser } from '../../utils/stripe-customer'
 import { isLifetimeSubscriber, stripeBillingResetData } from '../../utils/lifetime-subscription'
+import { requireStripeRedirectUrl } from '../../utils/stripe-redirect-url'
 
 const portalSessionSchema = z.object({
   returnUrl: z.string().optional()
@@ -64,14 +65,20 @@ export default defineEventHandler(async (event) => {
     throw error
   }
 
-  const config = useRuntimeConfig()
-  const baseUrl = config.public.siteUrl || 'http://localhost:3099'
+  let config: any
+  try {
+    config = useRuntimeConfig()
+  } catch {
+    config = {}
+  }
+  const baseUrl = config?.public?.siteUrl || 'http://localhost:3099'
+  const return_url = requireStripeRedirectUrl(returnUrl, baseUrl, '/settings/billing')
 
   let portalSession
   try {
     portalSession = await stripe.billingPortal.sessions.create({
       customer: customerId,
-      return_url: returnUrl || `${baseUrl}/settings/billing`
+      return_url
     })
   } catch (error: any) {
     if (error?.type !== 'StripeInvalidRequestError' && error?.code !== 'resource_missing') {

--- a/server/utils/stripe-redirect-url.ts
+++ b/server/utils/stripe-redirect-url.ts
@@ -1,0 +1,136 @@
+import { createError } from 'h3'
+
+/**
+ * Same-origin allowlist for Stripe Checkout / Billing Portal redirect URLs.
+ *
+ * Client-supplied success/cancel/return URLs must resolve to an origin equal to
+ * `config.public.siteUrl` (or an explicit extra allowlist). Relative paths are
+ * resolved against the site origin. Cross-origin and non-http(s) URLs are rejected.
+ */
+
+export class StripeRedirectUrlError extends Error {
+  readonly statusCode = 400
+
+  constructor(message = 'Invalid redirect URL') {
+    super(message)
+    this.name = 'StripeRedirectUrlError'
+  }
+}
+
+export type StripeRedirectUrlOptions = {
+  /** Additional absolute origins allowed beyond `siteUrl` (e.g. preview hosts). */
+  allowedOrigins?: string[]
+}
+
+function siteBaseUrl(siteUrl: string): URL {
+  const raw = (siteUrl || 'http://localhost:3099').trim() || 'http://localhost:3099'
+  try {
+    return new URL(raw)
+  } catch {
+    throw new StripeRedirectUrlError('Invalid site URL configuration')
+  }
+}
+
+function allowedOriginSet(site: URL, options?: StripeRedirectUrlOptions): Set<string> {
+  const origins = new Set<string>([site.origin])
+  for (const entry of options?.allowedOrigins || []) {
+    if (!entry) continue
+    try {
+      origins.add(new URL(entry).origin)
+    } catch {
+      throw new StripeRedirectUrlError('Invalid redirect allowlist origin')
+    }
+  }
+  return origins
+}
+
+/**
+ * Validate and normalize a client-supplied redirect URL to an absolute same-origin URL.
+ */
+export function normalizeStripeRedirectUrl(
+  candidate: string,
+  siteUrl: string,
+  options?: StripeRedirectUrlOptions
+): string {
+  const trimmed = candidate.trim()
+  if (!trimmed) {
+    throw new StripeRedirectUrlError('Invalid redirect URL')
+  }
+
+  // Protocol-relative URLs (`//evil.example`) must not be treated as paths.
+  if (trimmed.startsWith('//')) {
+    throw new StripeRedirectUrlError('Invalid redirect URL')
+  }
+
+  const site = siteBaseUrl(siteUrl)
+  const allowed = allowedOriginSet(site, options)
+
+  let parsed: URL
+  if (trimmed.startsWith('/')) {
+    if (trimmed.split('/').some((segment) => segment === '..')) {
+      throw new StripeRedirectUrlError('Invalid redirect URL')
+    }
+    parsed = new URL(trimmed, site)
+  } else {
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      throw new StripeRedirectUrlError('Invalid redirect URL')
+    }
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new StripeRedirectUrlError('Invalid redirect URL')
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new StripeRedirectUrlError('Invalid redirect URL')
+  }
+
+  if (!allowed.has(parsed.origin)) {
+    throw new StripeRedirectUrlError('Redirect URL must be same-origin')
+  }
+
+  // Fragments are never sent to the server and are useless for Stripe redirects.
+  parsed.hash = ''
+  return parsed.toString()
+}
+
+/**
+ * Resolve an optional client redirect URL, falling back to a same-origin default path
+ * when the candidate is omitted or blank.
+ */
+export function resolveStripeRedirectUrl(
+  candidate: string | undefined | null,
+  siteUrl: string,
+  fallbackPath: string,
+  options?: StripeRedirectUrlOptions
+): string {
+  if (candidate == null || String(candidate).trim() === '') {
+    const path = fallbackPath.startsWith('/') ? fallbackPath : `/${fallbackPath}`
+    return normalizeStripeRedirectUrl(path, siteUrl, options)
+  }
+  return normalizeStripeRedirectUrl(String(candidate), siteUrl, options)
+}
+
+/**
+ * Same as {@link resolveStripeRedirectUrl}, but maps validation failures to HTTP 400.
+ */
+export function requireStripeRedirectUrl(
+  candidate: string | undefined | null,
+  siteUrl: string,
+  fallbackPath: string,
+  options?: StripeRedirectUrlOptions
+): string {
+  try {
+    return resolveStripeRedirectUrl(candidate, siteUrl, fallbackPath, options)
+  } catch (error) {
+    if (error instanceof StripeRedirectUrlError) {
+      throw createError({
+        statusCode: 400,
+        message: error.message
+      })
+    }
+    throw error
+  }
+}

--- a/tests/unit/server/api/stripe/checkout-session.post.test.ts
+++ b/tests/unit/server/api/stripe/checkout-session.post.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { prisma } from '../../../../../server/utils/db'
+import { stripe } from '../../../../../server/utils/stripe'
+import { ensureStripeCustomerForUser } from '../../../../../server/utils/stripe-customer'
+import { assertNoActiveStoreSubscription } from '../../../../../server/utils/provider-subscriptions'
+
+/** Matches handler fallback + tests/unit/setup.ts default. */
+const SITE = 'http://localhost:3099'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/stripe', () => ({
+  stripe: {
+    checkout: {
+      sessions: {
+        create: vi.fn()
+      }
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/stripe-customer', () => ({
+  ensureStripeCustomerForUser: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/provider-subscriptions', () => ({
+  assertNoActiveStoreSubscription: vi.fn()
+}))
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/stripe/checkout-session.post')).default
+
+describe('POST /api/stripe/checkout-session redirect allowlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Athlete',
+      stripeCustomerId: 'cus_1'
+    } as any)
+    vi.mocked(assertNoActiveStoreSubscription).mockResolvedValue(undefined as any)
+    vi.mocked(ensureStripeCustomerForUser).mockResolvedValue({ customerId: 'cus_1' } as any)
+    vi.mocked(stripe.checkout.sessions.create).mockResolvedValue({
+      id: 'cs_test_1',
+      url: 'https://checkout.stripe.com/pay/cs_test_1'
+    } as any)
+  })
+
+  it('rejects cross-origin successUrl with 400 and never calls Stripe', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        body: {
+          priceId: 'price_1',
+          successUrl: 'https://evil.example/phish',
+          cancelUrl: `${SITE}/settings/billing?canceled=true`
+        }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringMatching(/same-origin|Invalid redirect/i)
+    })
+
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects cross-origin cancelUrl with 400', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        body: {
+          priceId: 'price_1',
+          successUrl: `${SITE}/settings/billing?success=true`,
+          cancelUrl: 'https://evil.example/phish'
+        }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 400 })
+
+    expect(stripe.checkout.sessions.create).not.toHaveBeenCalled()
+  })
+
+  it('uses default same-origin URLs when omitted', async () => {
+    const handler = await getHandler()
+
+    await handler({
+      body: { priceId: 'price_1' }
+    } as any)
+
+    expect(stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: `${SITE}/settings/billing?success=true`,
+        cancel_url: `${SITE}/settings/billing?canceled=true`
+      })
+    )
+  })
+
+  it('accepts same-origin absolute redirect URLs', async () => {
+    const handler = await getHandler()
+
+    await handler({
+      body: {
+        priceId: 'price_1',
+        successUrl: `${SITE}/settings/billing?success=true`,
+        cancelUrl: `${SITE}/pricing?canceled=true`
+      }
+    } as any)
+
+    expect(stripe.checkout.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: `${SITE}/settings/billing?success=true`,
+        cancel_url: `${SITE}/pricing?canceled=true`
+      })
+    )
+  })
+})

--- a/tests/unit/server/api/stripe/portal-session.post.test.ts
+++ b/tests/unit/server/api/stripe/portal-session.post.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { prisma } from '../../../../../server/utils/db'
+import { stripe } from '../../../../../server/utils/stripe'
+import { ensureStripeCustomerForUser } from '../../../../../server/utils/stripe-customer'
+import { isLifetimeSubscriber } from '../../../../../server/utils/lifetime-subscription'
+
+/** Matches handler fallback + tests/unit/setup.ts default. */
+const SITE = 'http://localhost:3099'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/stripe', () => ({
+  stripe: {
+    billingPortal: {
+      sessions: {
+        create: vi.fn()
+      }
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/stripe-customer', () => ({
+  ensureStripeCustomerForUser: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/lifetime-subscription', () => ({
+  isLifetimeSubscriber: vi.fn(),
+  stripeBillingResetData: vi.fn(() => ({}))
+}))
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/stripe/portal-session.post')).default
+
+describe('POST /api/stripe/portal-session redirect allowlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      email: 'a@example.com',
+      name: 'Athlete',
+      stripeCustomerId: 'cus_1',
+      subscriptionStatus: 'active'
+    } as any)
+    vi.mocked(isLifetimeSubscriber).mockReturnValue(false)
+    vi.mocked(ensureStripeCustomerForUser).mockResolvedValue({ customerId: 'cus_1' } as any)
+    vi.mocked(stripe.billingPortal.sessions.create).mockResolvedValue({
+      url: 'https://billing.stripe.com/session/test'
+    } as any)
+  })
+
+  it('rejects cross-origin returnUrl with 400 and never calls Stripe', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        body: { returnUrl: 'https://evil.example/phish' }
+      } as any)
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringMatching(/same-origin|Invalid redirect/i)
+    })
+
+    expect(stripe.billingPortal.sessions.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects protocol-relative returnUrl with 400', async () => {
+    const handler = await getHandler()
+
+    await expect(
+      handler({
+        body: { returnUrl: '//evil.example/phish' }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 400 })
+
+    expect(stripe.billingPortal.sessions.create).not.toHaveBeenCalled()
+  })
+
+  it('uses the default same-origin return URL when omitted', async () => {
+    const handler = await getHandler()
+
+    await handler({ body: {} } as any)
+
+    expect(stripe.billingPortal.sessions.create).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      return_url: `${SITE}/settings/billing`
+    })
+  })
+
+  it('accepts a same-origin absolute returnUrl', async () => {
+    const handler = await getHandler()
+
+    await handler({
+      body: { returnUrl: `${SITE}/settings/billing?from=portal` }
+    } as any)
+
+    expect(stripe.billingPortal.sessions.create).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      return_url: `${SITE}/settings/billing?from=portal`
+    })
+  })
+})

--- a/tests/unit/server/api/stripe/stripe-redirect-url.test.ts
+++ b/tests/unit/server/api/stripe/stripe-redirect-url.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeStripeRedirectUrl,
+  resolveStripeRedirectUrl,
+  StripeRedirectUrlError
+} from '../../../../../server/utils/stripe-redirect-url'
+
+const SITE = 'https://app.coachwatts.com'
+
+describe('stripe-redirect-url', () => {
+  describe('normalizeStripeRedirectUrl', () => {
+    it('accepts same-origin absolute URLs', () => {
+      expect(normalizeStripeRedirectUrl(`${SITE}/settings/billing?success=true`, SITE)).toBe(
+        `${SITE}/settings/billing?success=true`
+      )
+    })
+
+    it('resolves relative paths against siteUrl', () => {
+      expect(normalizeStripeRedirectUrl('/settings/billing?canceled=true', SITE)).toBe(
+        `${SITE}/settings/billing?canceled=true`
+      )
+    })
+
+    it('strips fragments', () => {
+      expect(normalizeStripeRedirectUrl(`${SITE}/billing#section`, SITE)).toBe(`${SITE}/billing`)
+    })
+
+    it('rejects cross-origin absolute URLs', () => {
+      expect(() => normalizeStripeRedirectUrl('https://evil.example/phish', SITE)).toThrow(
+        StripeRedirectUrlError
+      )
+      try {
+        normalizeStripeRedirectUrl('https://evil.example/phish', SITE)
+      } catch (error: any) {
+        expect(error.statusCode).toBe(400)
+        expect(error.message).toMatch(/same-origin/i)
+      }
+    })
+
+    it('rejects protocol-relative URLs', () => {
+      expect(() => normalizeStripeRedirectUrl('//evil.example/phish', SITE)).toThrow(
+        StripeRedirectUrlError
+      )
+    })
+
+    it('rejects non-http schemes', () => {
+      expect(() => normalizeStripeRedirectUrl('javascript:alert(1)', SITE)).toThrow(
+        StripeRedirectUrlError
+      )
+    })
+
+    it('rejects path traversal segments', () => {
+      expect(() => normalizeStripeRedirectUrl('/ok/../evil', SITE)).toThrow(StripeRedirectUrlError)
+    })
+
+    it('rejects URLs with credentials', () => {
+      expect(() =>
+        normalizeStripeRedirectUrl(`https://user:pass@app.coachwatts.com/billing`, SITE)
+      ).toThrow(StripeRedirectUrlError)
+    })
+
+    it('accepts an explicit allowlist origin', () => {
+      expect(
+        normalizeStripeRedirectUrl('https://preview.example/billing', SITE, {
+          allowedOrigins: ['https://preview.example']
+        })
+      ).toBe('https://preview.example/billing')
+    })
+  })
+
+  describe('resolveStripeRedirectUrl', () => {
+    it('uses the fallback path when omitted', () => {
+      expect(resolveStripeRedirectUrl(undefined, SITE, '/settings/billing')).toBe(
+        `${SITE}/settings/billing`
+      )
+      expect(resolveStripeRedirectUrl(null, SITE, '/settings/billing?success=true')).toBe(
+        `${SITE}/settings/billing?success=true`
+      )
+      expect(resolveStripeRedirectUrl('   ', SITE, '/settings/billing')).toBe(
+        `${SITE}/settings/billing`
+      )
+    })
+
+    it('normalizes a provided same-origin URL', () => {
+      expect(
+        resolveStripeRedirectUrl(`${SITE}/pricing?canceled=true`, SITE, '/settings/billing')
+      ).toBe(`${SITE}/pricing?canceled=true`)
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Stripe checkout/portal endpoints accepted unconstrained client `successUrl`/`cancelUrl`/`returnUrl` values and forwarded them to Stripe (post-payment open redirect / phishing).

## Changes
- Shared same-origin redirect validator against `config.public.siteUrl`
- Reject cross-origin URLs with 400; keep defaults when omitted
- Unit coverage for checkout + portal redirect rejection/normalization

## Linear
https://linear.app/watt-mind/issue/CW-150/stripe-checkoutportal-accept-unvalidated-client-redirect-urls-open

## Test plan
- [x] `pnpm vitest run tests/unit/server/api/stripe` (19/19)
- [ ] Confirm checkout/portal still works with omitted URLs in staging

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

