### PR TITLE
fix(billing): surface server error.data.message in useStripe (CW-152)

### DIFF
--- a/app/composables/useStripe.ts
+++ b/app/composables/useStripe.ts
@@ -1,3 +1,11 @@
+/** Prefer server body message (e.g. store-subscriber 409) over ofetch's generic status text. */
+function stripeFetchErrorMessage(
+  error: { data?: { message?: string }; message?: string } | null | undefined,
+  fallback: string
+) {
+  return error?.data?.message || error?.message || fallback
+}
+
 export function useStripe() {
   const toast = useToast()
   const fetchAny = useFetch as any
@@ -23,7 +31,7 @@ export function useStripe() {
       })
 
       if (error.value) {
-        throw new Error(error.value.message || 'Failed to create checkout session')
+        throw new Error(stripeFetchErrorMessage(error.value, 'Failed to create checkout session'))
       }
 
       if (data.value?.url) {
@@ -55,7 +63,7 @@ export function useStripe() {
       })
 
       if (error.value) {
-        throw new Error(error.value.message || 'Failed to create portal session')
+        throw new Error(stripeFetchErrorMessage(error.value, 'Failed to create portal session'))
       }
 
       if (data.value?.url) {
@@ -88,7 +96,7 @@ export function useStripe() {
       })
 
       if (error.value) {
-        throw new Error(error.value.message || `Failed to ${direction} subscription`)
+        throw new Error(stripeFetchErrorMessage(error.value, `Failed to ${direction} subscription`))
       }
 
       if (data.value?.status === 'requires_action') {

--- a/tests/unit/app/composables/useStripe.test.ts
+++ b/tests/unit/app/composables/useStripe.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useStripe } from '../../../../app/composables/useStripe'
+
+const STORE_SUBSCRIBER_409 =
+  'Your subscription is billed through the App Store. Manage or cancel it in your Apple ID subscription settings before subscribing on the web, so you are not charged twice.'
+
+const { toastAdd, mockFetch } = vi.hoisted(() => ({
+  toastAdd: vi.fn(),
+  mockFetch: vi.fn()
+}))
+
+mockNuxtImport('useToast', () => () => ({ add: toastAdd }))
+mockNuxtImport('useFetch', () => mockFetch)
+
+function fetchError(bodyMessage: string) {
+  return {
+    data: ref(null),
+    error: ref({
+      message: '[POST] "/api/stripe/checkout-session": 409 Conflict',
+      data: {
+        statusCode: 409,
+        message: bodyMessage,
+        data: { code: 'STORE_SUBSCRIPTION_ACTIVE', provider: 'APPLE' }
+      }
+    })
+  }
+}
+
+describe('useStripe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('surfaces error.data.message in checkout toast for store-subscriber 409', async () => {
+    mockFetch.mockResolvedValue(fetchError(STORE_SUBSCRIBER_409))
+
+    const { createCheckoutSession } = useStripe()
+    await createCheckoutSession('price_test')
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Checkout Failed',
+        description: STORE_SUBSCRIBER_409,
+        color: 'error'
+      })
+    )
+  })
+
+  it('surfaces error.data.message in portal toast', async () => {
+    mockFetch.mockResolvedValue({
+      data: ref(null),
+      error: ref({
+        message: '[POST] "/api/stripe/portal-session": 409 Conflict',
+        data: { message: STORE_SUBSCRIBER_409 }
+      })
+    })
+
+    const { openCustomerPortal } = useStripe()
+    await openCustomerPortal()
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Portal Access Failed',
+        description: STORE_SUBSCRIBER_409,
+        color: 'error'
+      })
+    )
+  })
+
+  it('surfaces error.data.message in changePlan toast', async () => {
+    mockFetch.mockResolvedValue({
+      data: ref(null),
+      error: ref({
+        message: '[POST] "/api/stripe/change-plan": 409 Conflict',
+        data: { message: STORE_SUBSCRIBER_409 }
+      })
+    })
+
+    const { changePlan } = useStripe()
+    const ok = await changePlan('price_test', 'upgrade')
+
+    expect(ok).toBe(false)
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Upgrade Failed',
+        description: STORE_SUBSCRIBER_409,
+        color: 'error'
+      })
+    )
+  })
+
+  it('falls back to generic message when error.data.message is absent', async () => {
+    mockFetch.mockResolvedValue({
+      data: ref(null),
+      error: ref({
+        message: '[POST] "/api/stripe/checkout-session": 500 Internal Server Error'
+      })
+    })
+
+    const { createCheckoutSession } = useStripe()
+    await createCheckoutSession('price_test')
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Checkout Failed',
+        description: '[POST] "/api/stripe/checkout-session": 500 Internal Server Error',
+        color: 'error'
+      })
+    )
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`useStripe` discarded `error.data?.message`, turning actionable store-subscriber 409s into generic “Checkout Failed” toasts.

## Changes
- Prefer `error.data?.message` for checkout, portal, and change-plan actions
- Unit coverage for message propagation

## Linear
https://linear.app/watt-mind/issue/CW-152/usestripe-discards-server-errordatamessage-actionable-billing-errors

## Test plan
- [x] `pnpm typecheck`
- [x] `vitest run tests/unit/app/composables/useStripe.test.ts` (4/4)
- [ ] Manual: trigger store-subscriber conflict and confirm toast shows server guidance

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

