### PR TITLE
fix(cron): isolate per-user dispatch failures in batch jobs (CW-153)

### DIFF
--- a/tests/unit/trigger/finalize-daily-nutrition.test.ts
+++ b/tests/unit/trigger/finalize-daily-nutrition.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { userFindMany, dispatchTask, loggerError, loggerWarn, loggerLog } = vi.hoisted(() => ({
+  userFindMany: vi.fn(),
+  dispatchTask: vi.fn(),
+  loggerError: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerLog: vi.fn()
+}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    user: {
+      findMany: userFindMany
+    }
+  }
+}))
+
+vi.mock('../../../server/utils/task-dispatcher', () => ({
+  dispatchTask
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn(),
+  getUserLocalDate: vi.fn()
+}))
+
+vi.mock('../../../server/utils/services/metabolicService', () => ({
+  metabolicService: {
+    finalizeDay: vi.fn()
+  }
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  logger: {
+    log: loggerLog,
+    warn: loggerWarn,
+    error: loggerError
+  },
+  task: vi.fn().mockImplementation((config) => ({
+    run: config.run,
+    id: config.id
+  })),
+  schedules: {
+    task: vi.fn().mockImplementation((config) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+}))
+
+describe('finalizeDailyNutritionCron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('continues dispatching after a mid-batch failure and reports partial counts', async () => {
+    userFindMany.mockResolvedValue([{ id: 'user-1' }, { id: 'user-2' }, { id: 'user-3' }])
+    dispatchTask
+      .mockResolvedValueOnce({ id: 'run-1' })
+      .mockRejectedValueOnce(new Error('dispatch failed'))
+      .mockResolvedValueOnce({ id: 'run-3' })
+
+    const { finalizeDailyNutritionCron } = await import('../../../trigger/finalize-daily-nutrition')
+    const result = await finalizeDailyNutritionCron.run()
+
+    expect(dispatchTask).toHaveBeenCalledTimes(3)
+    expect(dispatchTask).toHaveBeenNthCalledWith(1, 'finalize-daily-nutrition', {
+      userId: 'user-1'
+    })
+    expect(dispatchTask).toHaveBeenNthCalledWith(2, 'finalize-daily-nutrition', {
+      userId: 'user-2'
+    })
+    expect(dispatchTask).toHaveBeenNthCalledWith(3, 'finalize-daily-nutrition', {
+      userId: 'user-3'
+    })
+    expect(loggerError).toHaveBeenCalledWith(
+      'Failed to dispatch finalize-daily-nutrition',
+      expect.objectContaining({ userId: 'user-2' })
+    )
+    expect(result).toEqual({
+      success: false,
+      count: 3,
+      dispatchedCount: 2,
+      failedCount: 1
+    })
+  })
+})

--- a/tests/unit/trigger/trial-ending-reminder.test.ts
+++ b/tests/unit/trigger/trial-ending-reminder.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { userFindMany, llmUsageGroupBy, dispatchTask, loggerError, loggerWarn, loggerLog } =
+  vi.hoisted(() => ({
+    userFindMany: vi.fn(),
+    llmUsageGroupBy: vi.fn(),
+    dispatchTask: vi.fn(),
+    loggerError: vi.fn(),
+    loggerWarn: vi.fn(),
+    loggerLog: vi.fn()
+  }))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    user: {
+      findMany: userFindMany
+    },
+    llmUsage: {
+      groupBy: llmUsageGroupBy
+    }
+  }
+}))
+
+vi.mock('../../../server/utils/task-dispatcher', () => ({
+  dispatchTask
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  formatUserDate: vi.fn(() => 'Friday, January 1')
+}))
+
+vi.mock('../../../server/utils/quotas/registry', () => ({
+  QUOTA_REGISTRY: {
+    SUPPORTER: {
+      daily_checkin: { limit: 1 },
+      activity_recommendation: { limit: 2 },
+      workout_analysis: { limit: 3 },
+      chat: { limit: 4 }
+    }
+  }
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  logger: {
+    log: loggerLog,
+    warn: loggerWarn,
+    error: loggerError
+  },
+  schedules: {
+    task: vi.fn().mockImplementation((config) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+}))
+
+function trialUser(id: string, trialEndsAt: Date) {
+  return {
+    id,
+    name: `User ${id}`,
+    email: `${id}@example.com`,
+    timezone: 'UTC',
+    trialEndsAt
+  }
+}
+
+describe('trialEndingReminderCron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    llmUsageGroupBy.mockResolvedValue([])
+  })
+
+  it('continues dispatching after a mid-loop failure and reports partial counts', async () => {
+    const trialEndsAt = new Date()
+    trialEndsAt.setUTCDate(trialEndsAt.getUTCDate() + 2)
+    trialEndsAt.setUTCHours(12, 0, 0, 0)
+
+    userFindMany.mockResolvedValue([
+      trialUser('user-1', trialEndsAt),
+      trialUser('user-2', trialEndsAt),
+      trialUser('user-3', trialEndsAt)
+    ])
+
+    dispatchTask
+      .mockResolvedValueOnce({ id: 'run-1' })
+      .mockRejectedValueOnce(new Error('dispatch failed'))
+      .mockResolvedValueOnce({ id: 'run-3' })
+
+    const { trialEndingReminderCron } = await import('../../../trigger/trial-ending-reminder')
+    const result = await trialEndingReminderCron.run()
+
+    expect(dispatchTask).toHaveBeenCalledTimes(3)
+    expect(dispatchTask.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ userId: 'user-1', templateKey: 'TrialEndingSoon' })
+    )
+    expect(dispatchTask.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ userId: 'user-2', templateKey: 'TrialEndingSoon' })
+    )
+    expect(dispatchTask.mock.calls[2][1]).toEqual(
+      expect.objectContaining({ userId: 'user-3', templateKey: 'TrialEndingSoon' })
+    )
+    expect(loggerError).toHaveBeenCalledWith(
+      'Failed to dispatch trial ending reminder',
+      expect.objectContaining({ userId: 'user-2' })
+    )
+    expect(result).toEqual({
+      success: false,
+      count: 3,
+      dispatchedCount: 2,
+      failedCount: 1,
+      skippedCount: 0
+    })
+  })
+})

--- a/trigger/finalize-daily-nutrition.ts
+++ b/trigger/finalize-daily-nutrition.ts
@@ -38,18 +38,47 @@ export const finalizeDailyNutritionCron = schedules.task({
 
     logger.log('Finalizing daily nutrition for users', { count: users.length })
 
+    let dispatchedCount = 0
+    let failedCount = 0
     const batchSize = 25
     for (let i = 0; i < users.length; i += batchSize) {
       const batch = users.slice(i, i + batchSize)
-      await Promise.all(
-        batch.map((u) =>
-          dispatchTask('finalize-daily-nutrition', {
-            userId: u.id
-          })
-        )
+      const results = await Promise.all(
+        batch.map(async (u) => {
+          try {
+            await dispatchTask('finalize-daily-nutrition', {
+              userId: u.id
+            })
+            return true
+          } catch (error) {
+            logger.error('Failed to dispatch finalize-daily-nutrition', {
+              userId: u.id,
+              error
+            })
+            return false
+          }
+        })
       )
+
+      for (const ok of results) {
+        if (ok) dispatchedCount++
+        else failedCount++
+      }
     }
 
-    return { success: true, count: users.length }
+    if (failedCount > 0) {
+      logger.warn('Finalize daily nutrition cron completed with partial failures', {
+        count: users.length,
+        dispatchedCount,
+        failedCount
+      })
+    }
+
+    return {
+      success: failedCount === 0,
+      count: users.length,
+      dispatchedCount,
+      failedCount
+    }
   }
 })

--- a/trigger/trial-ending-reminder.ts
+++ b/trigger/trial-ending-reminder.ts
@@ -80,29 +80,60 @@ export const trialEndingReminderCron = schedules.task({
       windowEnd: windowEnd.toISOString()
     })
 
+    let dispatchedCount = 0
+    let failedCount = 0
+    let skippedCount = 0
+
     for (const user of users) {
-      if (!user.trialEndsAt) continue
+      if (!user.trialEndsAt) {
+        skippedCount++
+        continue
+      }
 
-      const trialEndKey = user.trialEndsAt.toISOString().slice(0, 10)
-      const usageHighlights = await getWeeklyUsageSummary(user.id)
+      try {
+        const trialEndKey = user.trialEndsAt.toISOString().slice(0, 10)
+        const usageHighlights = await getWeeklyUsageSummary(user.id)
 
-      await dispatchTask('send-email', {
-        userId: user.id,
-        templateKey: 'TrialEndingSoon',
-        eventKey: `TRIAL_ENDING_${trialEndKey}`,
-        idempotencyKey: `trial-ending:${user.id}:${trialEndKey}`,
-        audience: 'ENGAGEMENT',
-        subject: 'Your Coach Watts performance trial ends soon',
-        props: {
-          name: user.name || 'Athlete',
-          trialEndsAt: formatUserDate(user.trialEndsAt, user.timezone || 'UTC', 'EEEE, MMMM d'),
-          usageHighlights,
-          supporterHighlights: formatSupporterHighlights(),
-          pricingUrl: `${process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'}/settings/billing`
-        }
+        await dispatchTask('send-email', {
+          userId: user.id,
+          templateKey: 'TrialEndingSoon',
+          eventKey: `TRIAL_ENDING_${trialEndKey}`,
+          idempotencyKey: `trial-ending:${user.id}:${trialEndKey}`,
+          audience: 'ENGAGEMENT',
+          subject: 'Your Coach Watts performance trial ends soon',
+          props: {
+            name: user.name || 'Athlete',
+            trialEndsAt: formatUserDate(user.trialEndsAt, user.timezone || 'UTC', 'EEEE, MMMM d'),
+            usageHighlights,
+            supporterHighlights: formatSupporterHighlights(),
+            pricingUrl: `${process.env.NUXT_PUBLIC_SITE_URL || 'https://coachwatts.com'}/settings/billing`
+          }
+        })
+        dispatchedCount++
+      } catch (error) {
+        failedCount++
+        logger.error('Failed to dispatch trial ending reminder', {
+          userId: user.id,
+          error
+        })
+      }
+    }
+
+    if (failedCount > 0) {
+      logger.warn('Trial ending reminder cron completed with partial failures', {
+        count: users.length,
+        dispatchedCount,
+        failedCount,
+        skippedCount
       })
     }
 
-    return { success: true, count: users.length }
+    return {
+      success: failedCount === 0,
+      count: users.length,
+      dispatchedCount,
+      failedCount,
+      skippedCount
+    }
   }
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`finalize-daily-nutrition` and `trial-ending-reminder` aborted the rest of a cron batch when one `dispatchTask` failed.

## Changes
- Per-user try/catch around dispatch in both crons
- Return `dispatchedCount` / `failedCount` for partial failure reporting
- Unit tests: failing 2nd user still dispatches 3rd+

## Linear
https://linear.app/watt-mind/issue/CW-153/cron-batch-tasks-abort-remaining-users-when-one-dispatchtask-fails

## Test plan
- [x] Owned unit tests (2/2)
- [ ] Confirm monitoring treats partial-failure `success: false` + counts correctly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

