### PR TITLE
fix(auth): block deactivated users in client/server middleware (CW-35)

### DIFF
--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,15 +1,16 @@
-export default defineNuxtRouteMiddleware(async (to, from) => {
+const DEACTIVATED_LOGIN_PATH = '/login?error=deactivated'
+
+export default defineNuxtRouteMiddleware(async (to) => {
   const config = useRuntimeConfig()
 
   if (config.public.authBypassEnabled) {
     return
   }
 
-  const { status, data, getSession } = useAuth()
+  const { status, data, getSession, signOut } = useAuth()
 
-  if (typeof data.value === 'undefined') {
-    await getSession().catch(() => null)
-  }
+  // Always refresh so session deletion / deactivatedAt from the DB is observed.
+  await getSession().catch(() => null)
 
   if (status.value === 'loading') {
     return
@@ -17,5 +18,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   if (status.value !== 'authenticated') {
     return navigateTo(`/login?callbackUrl=${encodeURIComponent(to.fullPath)}`)
+  }
+
+  const deactivatedAt = (data.value?.user as { deactivatedAt?: string | Date | null } | undefined)
+    ?.deactivatedAt
+
+  if (deactivatedAt) {
+    return signOut({
+      callbackUrl: DEACTIVATED_LOGIN_PATH
+    }) as Promise<void>
   }
 })

--- a/app/middleware/guest.ts
+++ b/app/middleware/guest.ts
@@ -1,12 +1,34 @@
-export default defineNuxtRouteMiddleware(async (to, from) => {
-  const { status, data, getSession } = useAuth()
+export default defineNuxtRouteMiddleware(async (to) => {
+  const { status, data, getSession, signOut } = useAuth()
 
-  if (typeof data.value === 'undefined') {
-    await getSession().catch(() => null)
-  }
+  await getSession().catch(() => null)
 
   if (status.value === 'loading') {
     return
+  }
+
+  const deactivatedAt = (data.value?.user as { deactivatedAt?: string | Date | null } | undefined)
+    ?.deactivatedAt
+
+  if (status.value === 'authenticated' && deactivatedAt) {
+    return signOut({
+      callbackUrl: '/login?error=deactivated'
+    }) as Promise<void>
+  }
+
+  // Surface deactivated-account messaging on the sign-in page (owned-path UX).
+  if (import.meta.client && to.query.error === 'deactivated') {
+    const toast = useToast()
+    toast.add({
+      title: 'Account deactivated',
+      description:
+        'Your account has been deactivated. Contact support if you believe this is a mistake.',
+      color: 'error'
+    })
+
+    const restQuery = { ...to.query }
+    delete restQuery.error
+    return navigateTo({ path: to.path, query: restQuery }, { replace: true })
   }
 
   // ?preview=1 keeps guest pages visible under AUTH_BYPASS_USER (local review only)

--- a/app/middleware/oauth-auth.ts
+++ b/app/middleware/oauth-auth.ts
@@ -1,9 +1,7 @@
 export default defineNuxtRouteMiddleware(async (to) => {
   const { status, data, getSession, signOut } = useAuth()
 
-  if (typeof data.value === 'undefined') {
-    await getSession().catch(() => null)
-  }
+  await getSession().catch(() => null)
 
   if (status.value === 'loading') {
     return
@@ -30,5 +28,14 @@ export default defineNuxtRouteMiddleware(async (to) => {
   // If not authenticated, redirect to the specialized OAuth login page
   if (status.value !== 'authenticated') {
     return navigateTo(`/oauth/login?callbackUrl=${encodeURIComponent(to.fullPath)}`)
+  }
+
+  const deactivatedAt = (data.value?.user as { deactivatedAt?: string | Date | null } | undefined)
+    ?.deactivatedAt
+
+  if (deactivatedAt) {
+    return signOut({
+      callbackUrl: '/login?error=deactivated'
+    }) as Promise<void>
   }
 })

--- a/app/middleware/onboarding.global.ts
+++ b/app/middleware/onboarding.global.ts
@@ -2,7 +2,7 @@ import { buildConsentGateRedirect } from '#shared/consent-redirect'
 import { sanitizeCallbackUrl } from '#shared/safe-callback-url'
 
 export default defineNuxtRouteMiddleware(async (to) => {
-  const { status, data, getSession } = useAuth()
+  const { status, data, getSession, signOut } = useAuth()
 
   if (status.value === 'loading') {
     await getSession().catch(() => null)
@@ -12,7 +12,19 @@ export default defineNuxtRouteMiddleware(async (to) => {
 
   if (status.value !== 'authenticated') return
 
-  const user = data.value?.user as { termsAcceptedAt?: string | null } | undefined
+  const user = data.value?.user as
+    | {
+        termsAcceptedAt?: string | null
+        deactivatedAt?: string | Date | null
+      }
+    | undefined
+
+  if (user?.deactivatedAt) {
+    return signOut({
+      callbackUrl: '/login?error=deactivated'
+    }) as Promise<void>
+  }
+
   const termsAccepted = !!user?.termsAcceptedAt
 
   if (!termsAccepted) {

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -279,6 +279,10 @@ export default NuxtAuthHandler({
       }
     }
   },
+  pages: {
+    signIn: '/login',
+    error: '/login'
+  },
   callbacks: {
     async signIn({ user }: any) {
       const existingUser = user?.id
@@ -291,7 +295,8 @@ export default NuxtAuthHandler({
         : null
 
       if (existingUser?.deactivatedAt) {
-        return false
+        // Redirect (string) so the login page can show a deactivated message.
+        return '/login?error=deactivated'
       }
 
       return true
@@ -304,7 +309,13 @@ export default NuxtAuthHandler({
         session.user.language = user.language || 'English'
         session.user.uiLanguage = user.uiLanguage || 'en'
         session.user.termsAcceptedAt = user.termsAcceptedAt || null
-        session.user.deactivatedAt = user.deactivatedAt || null
+        // Surface deactivatedAt so client middleware can force sign-out with a
+        // message; server middleware invalidates the cookie/DB session.
+        session.user.deactivatedAt = user.deactivatedAt
+          ? user.deactivatedAt instanceof Date
+            ? user.deactivatedAt.toISOString()
+            : user.deactivatedAt
+          : null
       }
       return session
     }

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,0 +1,76 @@
+import { createError, defineEventHandler, deleteCookie, getCookie, sendRedirect } from 'h3'
+import { prisma } from '../utils/db'
+
+const SESSION_COOKIE_NAMES = [
+  'next-auth.session-token',
+  '__Secure-next-auth.session-token'
+] as const
+
+const DEACTIVATED_LOGIN_PATH = '/login?error=deactivated'
+
+function clearSessionCookies(event: Parameters<typeof deleteCookie>[0]) {
+  for (const name of SESSION_COOKIE_NAMES) {
+    deleteCookie(event, name, { path: '/' })
+  }
+}
+
+/**
+ * Rejects deactivated accounts at the edge: invalidate DB sessions + cookies,
+ * then 401 API callers or redirect browsers to sign-in with a deactivated message.
+ */
+export default defineEventHandler(async (event) => {
+  const path = event.path || ''
+
+  if (
+    path.startsWith('/_') ||
+    path.startsWith('/api/auth') ||
+    /\.(js|css|png|jpe?g|gif|svg|ico|woff2?|ttf|map)(\?|$)/i.test(path)
+  ) {
+    return
+  }
+
+  const sessionToken =
+    getCookie(event, 'next-auth.session-token') ||
+    getCookie(event, '__Secure-next-auth.session-token')
+
+  if (!sessionToken) {
+    return
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { sessionToken },
+    select: {
+      userId: true,
+      user: {
+        select: {
+          deactivatedAt: true
+        }
+      }
+    }
+  })
+
+  if (!session?.user?.deactivatedAt) {
+    return
+  }
+
+  await prisma.session.deleteMany({
+    where: { userId: session.userId }
+  })
+
+  clearSessionCookies(event)
+
+  if (path.startsWith('/api/')) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized',
+      message: 'Account deactivated'
+    })
+  }
+
+  // Avoid redirect loops on the sign-in page itself.
+  if (path === '/login' || path.startsWith('/login?')) {
+    return
+  }
+
+  return sendRedirect(event, DEACTIVATED_LOGIN_PATH, 302)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Deactivated accounts could keep accessing authenticated routes via stale client/session middleware state.

## Changes
- Client auth/oauth/guest/onboarding middleware: refresh + require `deactivatedAt == null`, else sign out → `/login?error=deactivated`
- Server auth middleware: DB check, clear sessions/cookies, 401/redirect
- Auth handler surfaces deactivated redirect + session `deactivatedAt`

## Linear
https://linear.app/watt-mind/issue/CW-35/deactivated-users-pass-client-middleware

## Test plan
- [x] `pnpm typecheck`
- [ ] Manual: deactivate a user with an active session → forced to login with deactivated message
- [ ] Pair with CW-149 (#379) for OAuth/API-key revocation defense-in-depth

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

