### PR TITLE
fix(security): sanitize health endpoint DB error responses (CW-31)

### DIFF
--- a/server/api/health.get.ts
+++ b/server/api/health.get.ts
@@ -11,7 +11,8 @@ export default defineEventHandler(async (event) => {
     dbStatus = 'connected'
   } catch (e: any) {
     dbStatus = 'disconnected'
-    error = e.message
+    console.error('[health] Database connection check failed:', e)
+    error = 'Database connection error'
     setResponseStatus(event, 503)
   }
 

--- a/tests/unit/server/api/health.test.ts
+++ b/tests/unit/server/api/health.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const queryRaw = vi.fn()
+const setResponseStatusMock = vi.fn()
+const setResponseHeaderMock = vi.fn()
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('setResponseStatus', setResponseStatusMock)
+vi.stubGlobal('setResponseHeader', setResponseHeaderMock)
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => queryRaw(...args)
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../server/api/health.get')
+  return mod.default
+}
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    queryRaw.mockReset()
+    setResponseStatusMock.mockClear()
+    setResponseHeaderMock.mockClear()
+  })
+
+  it('returns ok when the database is reachable', async () => {
+    queryRaw.mockResolvedValue([{ '?column?': 1 }])
+
+    const handler = await getHandler()
+    const result = await handler({} as any)
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      checks: {
+        database: {
+          status: 'connected'
+        }
+      }
+    })
+    expect(result.error).toBeUndefined()
+  })
+
+  it('sanitizes database errors in the 503 response and logs the full error', async () => {
+    const sensitiveError = new Error(
+      "Can't reach database server at `db.internal.example:5432` with password=supersecret"
+    )
+    queryRaw.mockRejectedValue(sensitiveError)
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const handler = await getHandler()
+    const result = await handler({} as any)
+
+    expect(result).toMatchObject({
+      status: 'error',
+      checks: {
+        database: {
+          status: 'disconnected'
+        }
+      },
+      error: 'Database connection error'
+    })
+    expect(JSON.stringify(result)).not.toContain('db.internal.example')
+    expect(JSON.stringify(result)).not.toContain('supersecret')
+    expect(JSON.stringify(result)).not.toContain(sensitiveError.message)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[health] Database connection check failed:',
+      sensitiveError
+    )
+
+    consoleErrorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Unauthenticated `GET /api/health` returned raw DB exception messages in 503 JSON, potentially leaking infrastructure details.

## Changes
- Return generic `"Database connection error"` to clients
- Log full exception server-side
- Unit tests for sanitized failure responses

## Linear
https://linear.app/watt-mind/issue/CW-31/health-endpoint-leaks-db-errors

## Test plan
- [x] `pnpm test:unit tests/unit/server/api/health.test.ts` (2/2)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

