### PR TITLE
fix(admin): require admin middleware on subscriptions page (CW-48)

### DIFF
--- a/app/pages/admin/subscriptions.vue
+++ b/app/pages/admin/subscriptions.vue
@@ -15,10 +15,8 @@
 
   definePageMeta({
     layout: 'admin',
-    middleware: ['auth']
+    middleware: ['auth', 'admin']
   })
-
-  // Ensure only admin can access (though middleware 'admin' likely handles this, duplicating check is safe)
   const { data: stats, pending, error } = await useFetch('/api/admin/subscriptions')
 
   useHead({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`/admin/subscriptions` only used `auth` middleware, so authenticated non-admins could reach the admin page shell before API rejection.

## Changes
- Set `middleware: ['auth', 'admin']` on `app/pages/admin/subscriptions.vue`

## Linear
https://linear.app/watt-mind/issue/CW-48/admin-subscriptions-missing-admin-middleware

## Test plan
- [x] `pnpm typecheck`
- [ ] Manual: non-admin redirected away from `/admin/subscriptions`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5788f8d9-2dff-45cf-b193-1a0af861ec9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

