### PR TITLE
fix(ai): stop recommend_workout defaulting sport type to Ride (CW-21)

### DIFF
--- a/server/utils/ai-tools/recommendations.ts
+++ b/server/utils/ai-tools/recommendations.ts
@@ -9,6 +9,11 @@ import {
   dismissRecommendation
 } from '../recommendation-actions'
 
+function normalizeSportType(type: string | null | undefined): string | undefined {
+  if (!type) return undefined
+  return type === 'Gym' ? 'WeightTraining' : type
+}
+
 function formatActivityRecommendation(rec: {
   id: string
   recommendation: string
@@ -33,7 +38,7 @@ function formatActivityRecommendation(rec: {
       source: 'activity_recommendation' as const,
       recommendation_id: rec.id,
       title: planned.title,
-      type: planned.type || 'Ride',
+      type: normalizeSportType(planned.type),
       duration_minutes: planned.durationSec ? Math.round(planned.durationSec / 60) : undefined,
       tss: planned.tss ?? undefined,
       description: planned.description || rec.recommendation,
@@ -49,7 +54,9 @@ function formatActivityRecommendation(rec: {
       source: 'activity_recommendation' as const,
       recommendation_id: rec.id,
       title: modifications.new_title || 'Suggested workout',
-      type: analysis.suggested_type || analysis.workout_type || undefined,
+      type: normalizeSportType(
+        modifications.new_type || analysis.suggested_type || analysis.workout_type
+      ),
       duration_minutes:
         typeof modifications.new_duration_min === 'number'
           ? modifications.new_duration_min

--- a/tests/unit/server/utils/ai-tools/recommendations.test.ts
+++ b/tests/unit/server/utils/ai-tools/recommendations.test.ts
@@ -83,6 +83,109 @@ describe('recommendationTools', () => {
     )
   })
 
+  it('does not default the sport type to Ride when the planned workout has no type set', async () => {
+    vi.mocked(activityRecommendationRepository.findToday).mockResolvedValue({
+      id: 'act-rec-2',
+      recommendation: 'proceed',
+      confidence: 0.8,
+      reasoning: 'Readiness is good.',
+      status: 'COMPLETED',
+      analysisJson: null,
+      plannedWorkout: {
+        id: 'pw-2',
+        title: 'Untyped session',
+        type: null,
+        durationSec: 1800,
+        tss: 30,
+        description: null
+      }
+    } as any)
+
+    const result = await tools.recommend_workout.execute(
+      { day_of_week: 3 },
+      { toolCallId: 'tool-1', messages: [] }
+    )
+
+    expect(result.recommendation).toEqual(
+      expect.objectContaining({
+        source: 'activity_recommendation',
+        title: 'Untyped session',
+        type: undefined,
+        planned_workout_id: 'pw-2'
+      })
+    )
+  })
+
+  it('derives the sport type from the suggested_modifications.new_type field for a running suggestion', async () => {
+    vi.mocked(activityRecommendationRepository.findToday).mockResolvedValue({
+      id: 'act-rec-3',
+      recommendation: 'modify',
+      confidence: 0.7,
+      reasoning: 'Fatigue detected, suggest an easier run instead.',
+      status: 'COMPLETED',
+      plannedWorkout: null,
+      analysisJson: {
+        suggested_modifications: {
+          action: 'modify',
+          new_title: 'Recovery Run',
+          new_type: 'Run',
+          new_tss: 25,
+          new_duration_min: 40,
+          zone_adjustments: 'Zone 1-2 only',
+          description: 'Easy recovery run.'
+        }
+      }
+    } as any)
+
+    const result = await tools.recommend_workout.execute(
+      { day_of_week: 4 },
+      { toolCallId: 'tool-1', messages: [] }
+    )
+
+    expect(result.recommendation).toEqual(
+      expect.objectContaining({
+        source: 'activity_recommendation',
+        title: 'Recovery Run',
+        type: 'Run'
+      })
+    )
+  })
+
+  it('maps a Gym suggestion to the WeightTraining sport type instead of defaulting to Ride', async () => {
+    vi.mocked(activityRecommendationRepository.findToday).mockResolvedValue({
+      id: 'act-rec-4',
+      recommendation: 'modify',
+      confidence: 0.7,
+      reasoning: 'Suggest strength training instead.',
+      status: 'COMPLETED',
+      plannedWorkout: null,
+      analysisJson: {
+        suggested_modifications: {
+          action: 'modify',
+          new_title: 'Strength Session',
+          new_type: 'Gym',
+          new_tss: 20,
+          new_duration_min: 45,
+          zone_adjustments: '',
+          description: 'Strength training session.'
+        }
+      }
+    } as any)
+
+    const result = await tools.recommend_workout.execute(
+      { day_of_week: 6 },
+      { toolCallId: 'tool-1', messages: [] }
+    )
+
+    expect(result.recommendation).toEqual(
+      expect.objectContaining({
+        source: 'activity_recommendation',
+        title: 'Strength Session',
+        type: 'WeightTraining'
+      })
+    )
+  })
+
   describe('get_recommendation_details', () => {
     it('should return details when found', async () => {
       const mockRec = { id: 'rec1', userId, status: 'ACTIVE' }


### PR DESCRIPTION
Fixes CW-21

- `formatActivityRecommendation` in `server/utils/ai-tools/recommendations.ts` no longer hardcodes `type: planned.type || 'Ride'`; when a planned workout has no type it now returns `undefined` instead of silently claiming cycling.
- The `suggested_modifications` branch was reading `analysis.suggested_type` / `analysis.workout_type`, fields that don't exist in the LLM analysis schema (`trigger/recommend-today-activity.ts` defines `new_type` under `suggested_modifications`, enum `Ride | Run | Gym | Swim | Rest`). It now reads `modifications.new_type` (with the same `Gym -> WeightTraining` mapping used in `recommendation-actions.ts`), so a Run/Gym/Swim suggestion is actually surfaced by the tool instead of always coming back `undefined` and later defaulting to `Ride` downstream (e.g. `planned-workout-service.ts`'s `body.type || workout?.type || 'Ride'` fallback).
- Added unit tests: no planned type (no Ride default), `new_type: 'Run'`, and `new_type: 'Gym'` -> `WeightTraining`.

Note: the literal hardcoded "Zone 2 Endurance Ride" stub referenced in the ticket description was already replaced with a dynamic lookup (`activityRecommendationRepository.findToday` / `recommendationRepository.list`) in an earlier refactor. The residual bug causing the reported symptom (recommendations always resolving to cycling) was this sport-type field mismatch/hardcoded fallback, which this PR fixes.

## Verification
```
pnpm typecheck                                                      # exit 0, no errors
pnpm test:unit tests/unit/server/utils/ai-tools/recommendations.test.ts   # 1 file, 9 tests passed
```