### PR TITLE
fix(chat): detect strength blocks[].steps as renderable structure (CW-19)

### DIFF
--- a/app/components/chat/ChatMessageContent.vue
+++ b/app/components/chat/ChatMessageContent.vue
@@ -7,7 +7,7 @@
   import ChatDomainToolCard from '~/components/chat/ChatDomainToolCard.vue'
   import ChatPlannedWorkoutCard from '~/components/chat/ChatPlannedWorkoutCard.vue'
   import ChatTicketToolCard from '~/components/chat/ChatTicketToolCard.vue'
-  import { hasStructuredWorkoutPreviewData } from '~/utils/structuredWorkout'
+  import { hasRenderableStructure } from '~/utils/workout-structure'
 
   const props = withDefaults(
     defineProps<{
@@ -125,7 +125,7 @@
   const hasPlannedWorkoutStructure = (response: any) => {
     if (!response || typeof response !== 'object') return false
     const structure = response.structuredWorkout || response.structured_workout
-    return hasStructuredWorkoutPreviewData(structure)
+    return hasRenderableStructure(structure)
   }
 
   const shouldRenderPlannedWorkoutCard = (part: any) => {

--- a/app/components/chat/ChatPlannedWorkoutCard.vue
+++ b/app/components/chat/ChatPlannedWorkoutCard.vue
@@ -2,7 +2,7 @@
   import { computed, onUnmounted, ref, watch } from 'vue'
   import MiniWorkoutChart from '~/components/workouts/MiniWorkoutChart.vue'
   import WorkoutMessagesTimeline from '~/components/workouts/WorkoutMessagesTimeline.vue'
-  import { hasStructuredWorkoutPreviewData } from '~/utils/structuredWorkout'
+  import { hasRenderableStructure } from '~/utils/workout-structure'
 
   const props = defineProps<{
     toolName: string
@@ -170,7 +170,7 @@
   })
 
   const hasVisualization = computed(() => {
-    return hasStructuredWorkoutPreviewData(plannedWorkout.value)
+    return hasRenderableStructure(plannedWorkout.value)
   })
 
   const chartPreference = computed<'power' | 'hr' | 'pace'>(() => {

--- a/app/utils/workout-structure.ts
+++ b/app/utils/workout-structure.ts
@@ -1,0 +1,44 @@
+import { getStructuredWorkoutObject } from '~/utils/structuredWorkout'
+
+function hasNonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0
+}
+
+/**
+ * Canonical strength/WeightTraining structure groups exercise steps inside
+ * `blocks`. A block only counts as renderable if it actually carries at
+ * least one exercise step — an empty `blocks` entry (e.g. `{ steps: [] }`)
+ * should not be treated as structured data.
+ */
+function hasRenderableBlocks(blocks: unknown): boolean {
+  if (!Array.isArray(blocks) || blocks.length === 0) return false
+
+  return blocks.some(
+    (block) =>
+      block &&
+      typeof block === 'object' &&
+      Array.isArray((block as any).steps) &&
+      (block as any).steps.length > 0
+  )
+}
+
+/**
+ * Determines whether a (possibly wrapped) structured workout payload
+ * contains renderable structure: top-level `steps` (endurance workouts),
+ * `exercises` (legacy strength shape), or `blocks[].steps` (canonical
+ * strength/WeightTraining structure).
+ *
+ * This is the shared detection helper used by chat components so that
+ * WeightTraining workouts with valid `blocks` are recognized as structured
+ * instead of getting stuck on a "Waiting for structured workout" state.
+ */
+export function hasRenderableStructure(value: any): boolean {
+  const structuredWorkout = getStructuredWorkoutObject(value)
+  if (!structuredWorkout || typeof structuredWorkout !== 'object') return false
+
+  if (hasNonEmptyArray((structuredWorkout as any).steps)) return true
+  if (hasNonEmptyArray((structuredWorkout as any).exercises)) return true
+  if (hasRenderableBlocks((structuredWorkout as any).blocks)) return true
+
+  return false
+}

--- a/tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts
+++ b/tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts
@@ -1,0 +1,143 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ChatPlannedWorkoutCard from '../../../../../app/components/chat/ChatPlannedWorkoutCard.vue'
+import { hasRenderableStructure } from '../../../../../app/utils/workout-structure'
+
+vi.mock('../../../../../app/composables/useFormat', () => ({
+  useFormat: () => ({
+    formatDateUTC: (date: string | Date) => String(date)
+  })
+}))
+
+const strengthBlocksWithSteps = [
+  {
+    id: 'block-1',
+    type: 'single_exercise',
+    title: 'Squats',
+    steps: [
+      {
+        id: 'step-1',
+        name: 'Back Squat',
+        prescriptionMode: 'reps',
+        loadMode: 'absolute',
+        setRows: [{ id: 'set-1', index: 0, value: '5' }]
+      }
+    ]
+  }
+]
+
+const strengthBlocksWithoutSteps = [
+  { id: 'block-1', type: 'single_exercise', title: 'Squats', steps: [] }
+]
+
+describe('hasRenderableStructure', () => {
+  it('detects endurance steps as renderable structure', () => {
+    expect(hasRenderableStructure({ steps: [{ type: 'Active', durationSeconds: 600 }] })).toBe(true)
+  })
+
+  it('detects legacy exercises arrays as renderable structure', () => {
+    expect(hasRenderableStructure({ exercises: [{ id: 'squat', name: 'Back Squat' }] })).toBe(true)
+  })
+
+  it('detects strength blocks[].steps as renderable structure', () => {
+    expect(hasRenderableStructure({ blocks: strengthBlocksWithSteps })).toBe(true)
+  })
+
+  it('rejects blocks that carry no exercise steps', () => {
+    expect(hasRenderableStructure({ blocks: strengthBlocksWithoutSteps })).toBe(false)
+  })
+
+  it('rejects payloads with no steps, exercises, or blocks', () => {
+    expect(hasRenderableStructure({ description: 'Text-only guidance' })).toBe(false)
+    expect(hasRenderableStructure(null)).toBe(false)
+  })
+
+  it('unwraps a nested structuredWorkout field', () => {
+    expect(
+      hasRenderableStructure({
+        structuredWorkout: { blocks: strengthBlocksWithSteps }
+      })
+    ).toBe(true)
+  })
+})
+
+const fetchMock = vi.fn()
+
+const mountCard = (response: any, args: Record<string, any> = {}) =>
+  mount(ChatPlannedWorkoutCard, {
+    props: {
+      toolName: 'create_planned_workout',
+      response,
+      args
+    },
+    global: {
+      stubs: {
+        MiniWorkoutChart: { template: '<div data-test="mini-chart" />' },
+        WorkoutMessagesTimeline: true,
+        UBadge: { template: '<span><slot /></span>' },
+        UButton: { template: '<button><slot /></button>' },
+        UIcon: { template: '<i />' },
+        UAlert: { template: '<div><slot /></div>' }
+      }
+    }
+  })
+
+describe('ChatPlannedWorkoutCard strength structure detection', () => {
+  beforeEach(() => {
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    fetchMock.mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a strength workout with blocks as structured instead of "Waiting for structured workout"', async () => {
+    fetchMock.mockResolvedValue({
+      workout: {
+        id: 'workout-1',
+        title: 'Strength Day',
+        type: 'WeightTraining',
+        syncStatus: 'SYNCED',
+        structuredWorkout: { blocks: strengthBlocksWithSteps }
+      }
+    })
+
+    const wrapper = mountCard(
+      { workout_id: 'workout-1' },
+      { generate_structure: true, date: '2026-08-01', title: 'Strength Day' }
+    )
+
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Waiting for structured workout')
+    expect(wrapper.find('[data-test="mini-chart"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('keeps the waiting state for strength workouts whose blocks have no steps yet', async () => {
+    fetchMock.mockResolvedValue({
+      workout: {
+        id: 'workout-1',
+        title: 'Strength Day',
+        type: 'WeightTraining',
+        syncStatus: 'SYNCED',
+        structuredWorkout: { blocks: strengthBlocksWithoutSteps }
+      }
+    })
+
+    const wrapper = mountCard(
+      { workout_id: 'workout-1' },
+      { generate_structure: true, date: '2026-08-01', title: 'Strength Day' }
+    )
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Waiting for structured workout')
+    expect(wrapper.find('[data-test="mini-chart"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
Fixes CW-19

- Add a shared `hasRenderableStructure()` helper in `app/utils/workout-structure.ts` that checks `steps`, `exercises`, and canonical strength `blocks[].steps` (mirrors the server-side `hasRenderableStrengthBlocks` semantics, requiring at least one block with a non-empty `steps` array).
- Use the helper in `ChatPlannedWorkoutCard.vue` (`hasVisualization`) and `ChatMessageContent.vue` (`hasPlannedWorkoutStructure`) instead of the looser blocks-length-only check, so WeightTraining workouts with valid `blocks` render as structured in chat instead of staying stuck on "Waiting for structured workout".
- Added unit tests covering the helper directly (steps/exercises/blocks[].steps detection, nested `structuredWorkout` unwrapping, rejection of empty blocks) and both component states (structured strength workout vs. one still waiting on blocks with no steps).

## Verification
```
pnpm typecheck && pnpm test:unit tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts
```
- `pnpm typecheck`: exit 0, no errors.
- `pnpm test:unit tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts`: 1 test file passed, 8 tests passed.