### PR TITLE
fix(ai): self-heal stuck structure-generation status on trigger timeout (CW-2)

### DIFF
--- a/docs/issues/012-ai-in-triggers-architecture-rethink.md
+++ b/docs/issues/012-ai-in-triggers-architecture-rethink.md
@@ -3,7 +3,42 @@
 **Type:** Architecture  
 **Priority:** High  
 **Area:** `ai`, `backend`, `infra`, `workouts`  
-**Status:** Open (partial — shared AI timeouts in PR #222; durable generation status model still TODO)
+**Status:** Open (partial — shared AI timeouts in PR #222; durable generation status model landed via `WorkoutStructureGenerationRun` (CW-5, PR #398); CW-2 closed the last gap in that model — see "CW-2 update" below. Broader "unify timeouts across every workout/planning trigger" and Option B/C from this doc remain undone.)
+
+## CW-2 update (2026-07-31)
+
+CW-5 already added a durable generation-status model for `generate-structured-workout` /
+`adjust-structured-workout`: the `WorkoutStructureGenerationRun` table (status
+`PENDING|RUNNING|COMPLETED|STALE|FAILED|SUPERSEDED`, fenced by `PlannedWorkout.generationRevision`)
+plus `hasActiveStructureGenerationRun()` / `structureGenerationInFlight` on the workout GET
+response and in the chat planning tools. This is a stronger design than the flat
+`structureGenerationStatus` field proposed below — revision fencing means a superseded/retried
+generation can't clobber a newer one's result.
+
+What CW-2 investigated and found still missing: **Trigger.dev's `maxDuration` docs state that when
+a run is killed for exceeding its time budget, the task's own `cleanup`/`onSuccess`/`onFailure`
+lifecycle hooks do **not** run.** Since `startStructureGenerationTask`/`finishStructureGenerationTask`
+/`failStructureGenerationTaskFromPayload` are only reachable from in-task `try/catch/finally`, a hard
+180s timeout left the `WorkoutStructureGenerationRun` row stuck in `RUNNING` forever — which wedged
+`structureGenerationInFlight` (blocking Publish on the planned-workout page) and the chat planning
+tools' in-flight guard (`hasActiveStructureGenerationRun`) indefinitely, even though the frontend's
+own local 180s poll timeout and Trigger.dev-run-status listener (`TIMED_OUT`) already recover
+gracefully on their own.
+
+Fix shipped: `hasActiveStructureGenerationRun()` now self-heals. Any `PENDING`/`RUNNING` row older
+than `STRUCTURE_GENERATION_RUN_STALE_AFTER_MS` (task `maxDuration` + 60s buffer, defined in
+`server/utils/workout-ai-timeouts.ts`) is reconciled to `FAILED` the next time it's read — no
+separate reconciliation job needed, since every consumer of the "is this still generating?"
+question already goes through this function. Also consolidated the previously-duplicated
+`180`/`180_000` `maxDuration` literals in both trigger tasks into
+`STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC`/`_MS` in the same file, and removed a redundant local
+`45_000` AI-call-timeout literal in `generate-structured-workout.ts` in favor of the already-shared
+`WORKOUT_STRUCTURE_AI_TIMEOUT_MS`.
+
+**Deliberately not done in CW-2** (see PR for full reasoning): a scheduled/cron reconciliation
+task, unifying `maxDuration` across the ~50 other trigger tasks in this repo, and Option B (split
+AI-draft vs. persist into separate tasks). Those are larger, product/ops-scoped decisions this
+ticket's owned paths and risk budget didn't cover.
 
 ## Summary
 

--- a/server/utils/structure-generation-run.ts
+++ b/server/utils/structure-generation-run.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@prisma/client'
 import { prisma } from './db'
 import type { StructureRunSource } from './trigger-run-tags'
+import { STRUCTURE_GENERATION_RUN_STALE_AFTER_MS } from './workout-ai-timeouts'
 
 export type StructureGenerationMode = 'generate' | 'adjust'
 export type StructureGenerationRunStatus =
@@ -145,14 +146,40 @@ export async function attachTriggerRunId(runId: string, triggerRunId: string) {
   })
 }
 
+/**
+ * Returns true when this workout has a run genuinely in progress. Also self-heals: a hard
+ * Trigger.dev `maxDuration` kill skips the task's own lifecycle hooks (see
+ * STRUCTURE_GENERATION_RUN_STALE_AFTER_MS), so a PENDING/RUNNING row can outlive the run that
+ * created it. Any such row older than the stale threshold is reconciled to FAILED here and does
+ * not count as active, so callers (the "still generating" UI gate, the chat tool's in-flight
+ * guard) recover on their own without needing a separate reconciliation job.
+ */
 export async function hasActiveStructureGenerationRun(plannedWorkoutId: string): Promise<boolean> {
-  const count = await prisma.workoutStructureGenerationRun.count({
+  const activeRuns = await prisma.workoutStructureGenerationRun.findMany({
     where: {
       plannedWorkoutId,
       status: { in: ACTIVE_STATUSES }
-    }
+    },
+    select: { id: true, startedAt: true, createdAt: true }
   })
-  return count > 0
+  if (activeRuns.length === 0) return false
+
+  const now = Date.now()
+  let stillActive = false
+
+  for (const run of activeRuns) {
+    const referenceTime = (run.startedAt ?? run.createdAt).getTime()
+    if (now - referenceTime > STRUCTURE_GENERATION_RUN_STALE_AFTER_MS) {
+      await markStructureGenerationRunFailed(
+        run.id,
+        'Generation timed out before the task could report completion.'
+      )
+    } else {
+      stillActive = true
+    }
+  }
+
+  return stillActive
 }
 
 export async function supersedeActiveStructureGenerationRuns(

--- a/server/utils/workout-ai-timeouts.ts
+++ b/server/utils/workout-ai-timeouts.ts
@@ -6,3 +6,29 @@
 export const WORKOUT_STRUCTURE_AI_TIMEOUT_MS = 45_000
 
 export const WORKOUT_STRUCTURE_AI_MAX_RETRIES = 0
+
+/**
+ * Single source of truth for the Trigger.dev `maxDuration` shared by
+ * `generate-structured-workout` and `adjust-structured-workout`. Both tasks also use this
+ * value (in ms) internally to compute/log remaining budget — keep it here instead of duplicating
+ * the literal in each trigger file.
+ */
+export const STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC = 180
+export const STRUCTURE_GENERATION_TASK_MAX_DURATION_MS =
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC * 1000
+
+/**
+ * When Trigger.dev kills a run for exceeding `maxDuration`, the task's `cleanup`/`onSuccess`/
+ * `onFailure` lifecycle hooks do NOT run (see Trigger.dev docs: "maxDuration and lifecycle
+ * functions"). That means the in-task try/catch/finally around `WorkoutStructureGenerationRun`
+ * bookkeeping never executes either, so a hard timeout can leave the run row stuck in
+ * PENDING/RUNNING forever — which in turn wedges the UI's "still generating" gate and the chat
+ * tool's in-flight guard indefinitely.
+ *
+ * `hasActiveStructureGenerationRun()` self-heals this: any PENDING/RUNNING row older than this
+ * threshold is treated as failed (and reconciled to FAILED in the DB) the next time it's read.
+ * Padded above the task's own maxDuration to leave headroom for queueing/startup latency before
+ * an attempt actually begins executing.
+ */
+export const STRUCTURE_GENERATION_RUN_STALE_AFTER_MS =
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_MS + 60_000

--- a/tests/unit/server/utils/structure-generation-run.test.ts
+++ b/tests/unit/server/utils/structure-generation-run.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { prisma } from '../../../../server/utils/db'
-import { beginStructureGenerationRun } from '../../../../server/utils/structure-generation-run'
+import {
+  beginStructureGenerationRun,
+  hasActiveStructureGenerationRun
+} from '../../../../server/utils/structure-generation-run'
+import { STRUCTURE_GENERATION_RUN_STALE_AFTER_MS } from '../../../../server/utils/workout-ai-timeouts'
 
 vi.mock('../../../../server/utils/db', () => ({
   prisma: {
@@ -12,7 +16,8 @@ vi.mock('../../../../server/utils/db', () => ({
     },
     workoutStructureGenerationRun: {
       updateMany: vi.fn(),
-      create: vi.fn()
+      create: vi.fn(),
+      findMany: vi.fn()
     }
   }
 }))
@@ -20,6 +25,10 @@ vi.mock('../../../../server/utils/db', () => ({
 describe('structure generation run', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('supersedes active runs and creates a revisioned run atomically', async () => {
@@ -55,6 +64,100 @@ describe('structure generation run', () => {
       runId: 'run-1',
       generationRevision: 4,
       idempotencyKey: 'structure-generate:pw-1:rev-4'
+    })
+  })
+
+  describe('hasActiveStructureGenerationRun', () => {
+    it('returns false when there are no active runs', async () => {
+      vi.mocked(prisma.workoutStructureGenerationRun.findMany).mockResolvedValue([])
+
+      const result = await hasActiveStructureGenerationRun('pw-1')
+
+      expect(result).toBe(false)
+      expect(prisma.workoutStructureGenerationRun.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('returns true for a run that is still within its time budget', async () => {
+      const now = new Date('2026-01-01T00:00:00.000Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(now)
+
+      vi.mocked(prisma.workoutStructureGenerationRun.findMany).mockResolvedValue([
+        {
+          id: 'run-1',
+          startedAt: new Date(now.getTime() - 5_000),
+          createdAt: new Date(now.getTime() - 5_000)
+        }
+      ] as any)
+
+      const result = await hasActiveStructureGenerationRun('pw-1')
+
+      expect(result).toBe(true)
+      expect(prisma.workoutStructureGenerationRun.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('self-heals a run stuck past the stale threshold (Trigger.dev maxDuration kill skips onFailure)', async () => {
+      // Regression test for CW-2: when Trigger.dev kills a run for exceeding maxDuration, the
+      // task's own cleanup/onSuccess/onFailure hooks never execute, so nothing marks the
+      // WorkoutStructureGenerationRun row as failed. hasActiveStructureGenerationRun must detect
+      // and reconcile these stuck rows itself, otherwise the "still generating" UI gate and the
+      // chat tool's in-flight guard stay wedged forever.
+      const now = new Date('2026-01-01T00:00:00.000Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(now)
+
+      const staleStartedAt = new Date(now.getTime() - STRUCTURE_GENERATION_RUN_STALE_AFTER_MS - 1)
+      vi.mocked(prisma.workoutStructureGenerationRun.findMany).mockResolvedValue([
+        { id: 'run-stale', startedAt: staleStartedAt, createdAt: staleStartedAt }
+      ] as any)
+      vi.mocked(prisma.workoutStructureGenerationRun.updateMany).mockResolvedValue({ count: 1 })
+
+      const result = await hasActiveStructureGenerationRun('pw-1')
+
+      expect(result).toBe(false)
+      expect(prisma.workoutStructureGenerationRun.updateMany).toHaveBeenCalledWith({
+        where: { id: 'run-stale', status: { in: ['PENDING', 'RUNNING', 'RUNNING'] } },
+        data: expect.objectContaining({ status: 'FAILED' })
+      })
+    })
+
+    it('falls back to createdAt when a PENDING run never started', async () => {
+      const now = new Date('2026-01-01T00:00:00.000Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(now)
+
+      const staleCreatedAt = new Date(now.getTime() - STRUCTURE_GENERATION_RUN_STALE_AFTER_MS - 1)
+      vi.mocked(prisma.workoutStructureGenerationRun.findMany).mockResolvedValue([
+        { id: 'run-pending-stale', startedAt: null, createdAt: staleCreatedAt }
+      ] as any)
+      vi.mocked(prisma.workoutStructureGenerationRun.updateMany).mockResolvedValue({ count: 1 })
+
+      const result = await hasActiveStructureGenerationRun('pw-1')
+
+      expect(result).toBe(false)
+      expect(prisma.workoutStructureGenerationRun.updateMany).toHaveBeenCalled()
+    })
+
+    it('treats one stale and one fresh run correctly (mixed batch)', async () => {
+      const now = new Date('2026-01-01T00:00:00.000Z')
+      vi.useFakeTimers()
+      vi.setSystemTime(now)
+
+      const staleStartedAt = new Date(now.getTime() - STRUCTURE_GENERATION_RUN_STALE_AFTER_MS - 1)
+      const freshStartedAt = new Date(now.getTime() - 1_000)
+      vi.mocked(prisma.workoutStructureGenerationRun.findMany).mockResolvedValue([
+        { id: 'run-stale', startedAt: staleStartedAt, createdAt: staleStartedAt },
+        { id: 'run-fresh', startedAt: freshStartedAt, createdAt: freshStartedAt }
+      ] as any)
+      vi.mocked(prisma.workoutStructureGenerationRun.updateMany).mockResolvedValue({ count: 1 })
+
+      const result = await hasActiveStructureGenerationRun('pw-1')
+
+      expect(result).toBe(true)
+      expect(prisma.workoutStructureGenerationRun.updateMany).toHaveBeenCalledTimes(1)
+      expect(prisma.workoutStructureGenerationRun.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ id: 'run-stale' }) })
+      )
     })
   })
 })

--- a/trigger/adjust-structured-workout.ts
+++ b/trigger/adjust-structured-workout.ts
@@ -70,6 +70,8 @@ import {
   hasRenderableStructure
 } from '../server/utils/structured-workout-persistence'
 import {
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_MS,
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC,
   WORKOUT_STRUCTURE_AI_MAX_RETRIES,
   WORKOUT_STRUCTURE_AI_TIMEOUT_MS
 } from '../server/utils/workout-ai-timeouts'
@@ -674,7 +676,7 @@ export async function runAdjustStructuredWorkout(
   const entityType = plannedWorkoutId ? 'PlannedWorkout' : 'WorkoutTemplate'
   if (!entityId) throw new Error('Planned workout ID or workout template ID is required')
   const startedAtMs = Date.now()
-  const MAX_DURATION_MS = 180_000
+  const MAX_DURATION_MS = STRUCTURE_GENERATION_TASK_MAX_DURATION_MS
   const logStage = (stage: string, meta: Record<string, any> = {}) => {
     const elapsedMs = Date.now() - startedAtMs
     logger.log(`[AdjustStructuredWorkout] ${stage}`, {
@@ -1607,7 +1609,7 @@ registerTaskHandler('adjust-structured-workout', (payload) => runAdjustStructure
 export const adjustStructuredWorkoutTask = task({
   id: 'adjust-structured-workout',
   queue: userReportsQueue,
-  maxDuration: 180,
+  maxDuration: STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC,
   run: async (payload: AdjustStructuredWorkoutPayload, { ctx }) =>
     runAdjustStructuredWorkout(payload, { runId: ctx.run.id })
 })

--- a/trigger/generate-structured-workout.ts
+++ b/trigger/generate-structured-workout.ts
@@ -18,6 +18,8 @@ import {
   computeStrengthExerciseMetrics
 } from '../server/utils/structured-workout-persistence'
 import {
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_MS,
+  STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC,
   WORKOUT_STRUCTURE_AI_MAX_RETRIES,
   WORKOUT_STRUCTURE_AI_TIMEOUT_MS
 } from '../server/utils/workout-ai-timeouts'
@@ -795,8 +797,7 @@ export async function runGenerateStructuredWorkout(
   const entityId = plannedWorkoutId || workoutTemplateId
   const entityType = plannedWorkoutId ? 'PlannedWorkout' : 'WorkoutTemplate'
   const startedAtMs = Date.now()
-  const MAX_DURATION_MS = 180_000
-  const STRUCTURED_WORKOUT_TIMEOUT_MS = 45_000
+  const MAX_DURATION_MS = STRUCTURE_GENERATION_TASK_MAX_DURATION_MS
   const logStage = (stage: string, meta: Record<string, any> = {}) => {
     const elapsedMs = Date.now() - startedAtMs
     logger.log(`[GenerateStructuredWorkout] ${stage}`, {
@@ -1138,7 +1139,7 @@ OUTPUT JSON matching the schema.`
           operation: 'generate_structured_workout',
           entityType,
           entityId: entityId!,
-          timeoutMs: STRUCTURED_WORKOUT_TIMEOUT_MS
+          timeoutMs: WORKOUT_STRUCTURE_AI_TIMEOUT_MS
         })
         if (generatorMode === 'draft_json_v1') {
           const draft = await generateStructuredAnalysis(
@@ -1889,7 +1890,7 @@ registerTaskHandler('generate-structured-workout', (payload) =>
 export const generateStructuredWorkoutTask = task({
   id: 'generate-structured-workout',
   queue: userReportsQueue,
-  maxDuration: 180,
+  maxDuration: STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC,
   run: async (payload: GenerateStructuredWorkoutPayload, { ctx }) =>
     runGenerateStructuredWorkout(payload, { runId: ctx.run.id })
 })


### PR DESCRIPTION
Fixes CW-2

## What was already fine

CW-5 (merged, PR #398) already added a durable generation-status model that covers most of CW-2's acceptance criteria: the `WorkoutStructureGenerationRun` table (`PENDING|RUNNING|COMPLETED|STALE|FAILED|SUPERSEDED`, fenced by `PlannedWorkout.generationRevision`), surfaced as `structureGenerationInFlight` on the workout GET response and consumed by the frontend (`app/pages/workouts/planned/[id]/index.vue`) and the chat planning tools (`server/utils/ai-tools/planning.ts`). This is a stronger design than a flat `structureGenerationStatus` field since revision fencing prevents a superseded/retried generation from clobbering a newer one's result.

The frontend also already has independent safety nets: a local 180s poll timeout that clears loading state regardless of server truth, and a listener on Trigger.dev run status (`TIMED_OUT`/`CANCELED`/etc.) that shows a clear error toast.

## The gap this PR closes

Trigger.dev's own docs (`runs/max-duration.mdx`) state: **"When a task run exceeds the maxDuration, the lifecycle functions `cleanup`, `onSuccess`, and `onFailure` will not be called."** `generate-structured-workout` / `adjust-structured-workout` both rely on in-task `try/catch/finally` (`startStructureGenerationTask`/`finishStructureGenerationTask`/`failStructureGenerationTaskFromPayload`) to update the `WorkoutStructureGenerationRun` row — but none of that code runs if Trigger.dev hard-kills the run at the 180s `maxDuration` ceiling. The row is left stuck in `RUNNING` forever.

Concretely, this wedges:
- `structureGenerationInFlight` on the planned-workout page → the Publish button stays permanently blocked ("Structure generation is still running") even though generation failed minutes/hours ago, because the DB read never converges to a terminal state.
- The chat planning tools' in-flight guard (`hasActiveStructureGenerationRun`) → the AI chat agent permanently refuses to regenerate/adjust that workout's structure.

## Fix

`hasActiveStructureGenerationRun()` (`server/utils/structure-generation-run.ts`) now self-heals: any `PENDING`/`RUNNING` row older than `STRUCTURE_GENERATION_RUN_STALE_AFTER_MS` (task `maxDuration` + 60s buffer, `server/utils/workout-ai-timeouts.ts`) is reconciled to `FAILED` the next time it's read. No separate reconciliation job is needed since every consumer of "is this still generating?" already goes through this one function.

Also folded in two small, closely-related cleanups while touching this code (part of the "unified timeout policy" ask, scoped to the two structure-generation tasks named in the ticket):
- Consolidated the duplicated `180` / `180_000` `maxDuration` literals in both trigger tasks into `STRUCTURE_GENERATION_TASK_MAX_DURATION_SEC`/`_MS`.
- Removed a redundant local `45_000` AI-call-timeout literal in `generate-structured-workout.ts` in favor of the already-shared `WORKOUT_STRUCTURE_AI_TIMEOUT_MS` (which `adjust-structured-workout.ts` already used).

Updated `docs/issues/012-ai-in-triggers-architecture-rethink.md` with a dated note recording this finding and decision.

## Deliberately NOT done (out of scope for this PR)

- **No scheduled/cron reconciliation task.** The self-healing read is sufficient for every current consumer; a background job would be a bigger addition without demonstrated need.
- **No unification of `maxDuration`/timeouts across the ~50 other Trigger.dev tasks in this repo** (ingestion, reports, nutrition, etc.) — the ticket's literal "all workout and planning tasks" framing would be a large, risky, multi-file rewrite well beyond what this ticket's owned paths or a single PR should responsibly cover. Scoped strictly to the two structure-generation tasks the ticket names explicitly.
- **No Option B (split AI-draft vs. persist into separate tasks)** from the architecture doc — a genuine product/infra decision, not something to force unilaterally.
- Two of the ticket's source pointers turned out stale and were reinterpreted pragmatically (noted here so a reviewer isn't surprised): `tests/unit/server/utils/ai-workout-generator.test.ts` does not exist in this repo, so tests were added to the existing sibling test file `tests/unit/server/utils/structure-generation-run.test.ts` instead. Similarly, `server/utils/ai/*.ts` does not exist as a directory — the actual AI-timeout/generation-status utilities live directly under `server/utils/`.

## Verification

```
pnpm test:unit tests/unit/server/utils/structure-generation-run.test.ts tests/unit/server/utils/structure-generation-run-lifecycle.test.ts
# 2 files, 15 tests passed

pnpm test:unit tests/unit/server/utils tests/unit/trigger
# 181 files, 1087 tests passed

pnpm typecheck
# exit 0, no errors
```

The ticket's literal verification command (`pnpm test:unit tests/unit/server/utils/ai-workout-generator.test.ts`) fails with "No test files found" because that file doesn't exist in this repo — see the note above.