### PR TITLE
fix(ai): add regression tests for sync-edit vs async-generation race guard (CW-22)

### DIFF
--- a/tests/unit/server/utils/ai-tools/planning.test.ts
+++ b/tests/unit/server/utils/ai-tools/planning.test.ts
@@ -554,6 +554,43 @@ describe('planningTools', () => {
         })
       )
     })
+
+    it('rejects the edit when a structure generation run is active for the workout', async () => {
+      vi.mocked(plannedWorkoutRepository.getById).mockResolvedValue({
+        id: 'pw-inflight',
+        title: 'Tempo',
+        syncStatus: 'SYNCED',
+        type: 'Ride',
+        durationSec: 3600,
+        structuredWorkout: {
+          description: 'Existing',
+          steps: [{ type: 'Active', name: 'Main' }]
+        },
+        user: { ftp: 250, lthr: 168, maxHr: 185 }
+      } as any)
+      vi.mocked(hasActiveStructureGenerationRun).mockResolvedValue(true)
+
+      const result = await tools.set_planned_workout_structure.execute(
+        {
+          workout_id: 'pw-inflight',
+          structured_workout: {
+            description: 'Updated',
+            steps: [{ type: 'Active', name: 'Main updated' }]
+          }
+        },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(hasActiveStructureGenerationRun).toHaveBeenCalledWith('pw-inflight')
+      expect(result).toEqual({
+        success: false,
+        structure_job_in_flight: true,
+        error:
+          'Structure generation or adjustment is already running for this workout. Wait for it to finish before editing structure directly.'
+      })
+      expect(writeCanonicalPlannedWorkoutStructure).not.toHaveBeenCalled()
+      expect(sportSettingsRepository.getForActivityType).not.toHaveBeenCalled()
+    })
   })
 
   describe('patch_planned_workout_structure', () => {
@@ -743,6 +780,40 @@ describe('planningTools', () => {
           })
         })
       )
+    })
+
+    it('rejects the patch when a structure generation run is active for the workout', async () => {
+      vi.mocked(plannedWorkoutRepository.getById).mockResolvedValue({
+        id: 'pw-inflight',
+        title: 'Patch test',
+        syncStatus: 'SYNCED',
+        type: 'Ride',
+        durationSec: 3600,
+        structuredWorkout: {
+          steps: [{ type: 'Warmup', name: 'Easy start' }],
+          coachInstructions: 'Old'
+        },
+        user: { ftp: 250, lthr: 168, maxHr: 185 }
+      } as any)
+      vi.mocked(hasActiveStructureGenerationRun).mockResolvedValue(true)
+
+      const result = await tools.patch_planned_workout_structure.execute(
+        {
+          workout_id: 'pw-inflight',
+          operations: [{ op: 'replace', path: 'steps.0.name', value: 'Revised warmup' }]
+        },
+        { toolCallId: '1', messages: [] }
+      )
+
+      expect(hasActiveStructureGenerationRun).toHaveBeenCalledWith('pw-inflight')
+      expect(result).toEqual({
+        success: false,
+        structure_job_in_flight: true,
+        error:
+          'Structure generation or adjustment is already running for this workout. Wait for it to finish before editing structure directly.'
+      })
+      expect(writeCanonicalPlannedWorkoutStructure).not.toHaveBeenCalled()
+      expect(plannedWorkoutRepository.update).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Fixes CW-22

## Summary
- Investigated CW-22 (sync structure edits silently clobbered by a late-completing async generation task) against current `develop`. The guard already exists: `set_planned_workout_structure` and `patch_planned_workout_structure` in `server/utils/ai-tools/planning.ts` already call `hasActiveStructureGenerationRun(workout_id)` (from `server/utils/structure-generation-run.ts`) before applying an edit, and return `{ success: false, structure_job_in_flight: true, error: '...' }` when a generation run is active — added by commit `06a767792` ("feat(workouts): track structure generation runs and guard publishing"), already merged into `develop`. No code change was needed in `planning.ts`.
- The remaining gap was test coverage: no unit test verified this rejection path. Added two tests in `tests/unit/server/utils/ai-tools/planning.test.ts` — one for `set_planned_workout_structure`, one for `patch_planned_workout_structure` — asserting the tool rejects with the in-flight error and does not call `writeCanonicalPlannedWorkoutStructure`/`update` when `hasActiveStructureGenerationRun` returns true. Existing tests already cover the "no generation active" success path via the default `mockResolvedValue(false)` in `beforeEach`.
- No changes to `trigger/generate-structured-workout.ts` were needed.

## Verification
```
pnpm typecheck && pnpm test:unit tests/unit/server/utils/ai-tools/planning.test.ts
```
- `pnpm typecheck`: passed with no errors.
- `pnpm test:unit tests/unit/server/utils/ai-tools/planning.test.ts`: 27 passed (27), including the 2 new race-condition tests.