### PR TITLE
fix(chat): add idempotency test coverage for structure tools (CW-23)

### DIFF
--- a/tests/unit/server/utils/chat/turns.test.ts
+++ b/tests/unit/server/utils/chat/turns.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildToolIdempotencyKey,
+  hashToolArgs,
+  isMutatingChatTool
+} from '../../../../../server/utils/chat/turns'
+
+describe('isMutatingChatTool - structure tools (CW-23)', () => {
+  it('classifies all planned-workout/plan structure tools as mutating', () => {
+    expect(isMutatingChatTool('generate_planned_workout_structure')).toBe(true)
+    expect(isMutatingChatTool('adjust_planned_workout')).toBe(true)
+    expect(isMutatingChatTool('set_planned_workout_structure')).toBe(true)
+    expect(isMutatingChatTool('modify_training_plan_structure')).toBe(true)
+  })
+
+  it('does not misclassify unrelated read tools as mutating', () => {
+    expect(isMutatingChatTool('get_planned_workout_structure')).toBe(false)
+    expect(isMutatingChatTool('get_workout_details')).toBe(false)
+  })
+})
+
+describe('structure tool idempotency keys (CW-23)', () => {
+  it.each([
+    'generate_planned_workout_structure',
+    'adjust_planned_workout',
+    'set_planned_workout_structure'
+  ])('produces the same idempotency key for repeated identical %s calls', (toolName) => {
+    const args = { workoutId: 'w-1', steps: [{ durationSec: 300 }, { durationSec: 60 }] }
+
+    const firstCallHash = hashToolArgs(args)
+    const secondCallHash = hashToolArgs(args)
+    expect(secondCallHash).toBe(firstCallHash)
+
+    const firstKey = buildToolIdempotencyKey('lineage-1', toolName, firstCallHash)
+    const secondKey = buildToolIdempotencyKey('lineage-1', toolName, secondCallHash)
+
+    // Same lineage + same tool + same args must dedup to a single cached execution.
+    expect(secondKey).toBe(firstKey)
+  })
+
+  it('produces a different key when the structure args actually change', () => {
+    const toolName = 'set_planned_workout_structure'
+    const keyForArgsA = buildToolIdempotencyKey(
+      'lineage-1',
+      toolName,
+      hashToolArgs({ workoutId: 'w-1', steps: [{ durationSec: 300 }] })
+    )
+    const keyForArgsB = buildToolIdempotencyKey(
+      'lineage-1',
+      toolName,
+      hashToolArgs({ workoutId: 'w-1', steps: [{ durationSec: 600 }] })
+    )
+
+    expect(keyForArgsB).not.toBe(keyForArgsA)
+  })
+
+  it('produces a different key for a different lineage even with identical args', () => {
+    const toolName = 'generate_planned_workout_structure'
+    const argsHash = hashToolArgs({ workoutId: 'w-1' })
+
+    const keyLineageA = buildToolIdempotencyKey('lineage-a', toolName, argsHash)
+    const keyLineageB = buildToolIdempotencyKey('lineage-b', toolName, argsHash)
+
+    expect(keyLineageA).not.toBe(keyLineageB)
+  })
+})


### PR DESCRIPTION
Fixes CW-23

- Verified `isMutatingChatTool` in `server/utils/chat/turns.ts` already classifies all three tools named in CW-23 (`generate_planned_workout_structure`, `adjust_planned_workout`, `set_planned_workout_structure`) as mutating, plus a fourth (`modify_training_plan_structure`) — all shipped earlier under CW-145 (commit 688173462). No production code change was needed.
- The ticket's designated test path `tests/unit/server/utils/chat/turns.test.ts` did not exist (a co-located `server/utils/chat/turns.test.ts` from CW-145 already covered classification, but the ticket's specified verification command pointed at a path that didn't exist and failed with "No test files found").
- Added `tests/unit/server/utils/chat/turns.test.ts` asserting: the four structure tools classify as mutating, unrelated read tools do not, and `buildToolIdempotencyKey`/`hashToolArgs` produce identical keys for repeated identical calls (same lineage + tool + args) and different keys when args or lineage differ — directly exercising the dedup/idempotency behavior described in the ticket's acceptance criteria.

## Verification
- `pnpm typecheck` — passed (exit 0)
- `pnpm test:unit tests/unit/server/utils/chat/turns.test.ts` — 1 test file, 7 tests passed