### PR TITLE
feat(deploy): staging deployment from develop branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - develop
   workflow_dispatch:
 
 concurrency:
@@ -32,7 +33,8 @@ jobs:
     # secrets do not fall back to another environment by name, so renaming this
     # from `preview` requires provisioning the secret on the new environment
     # before merge, or this job fails at the "Trigger Dokploy Deployment" step.
-    environment: production
+    # `develop` deploys to `staging` (coach-dev), `master` deploys to `production`.
+    environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
     permissions:
       contents: read
       packages: write
@@ -65,7 +67,7 @@ jobs:
           tags: |
             type=sha,format=long
             type=ref,event=branch
-            latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
@@ -128,6 +130,7 @@ jobs:
           title: 'Deploy Status - ${{ github.repository }}'
           description: |
             **Deploy:** ${{ job.status }}
+            **Environment:** ${{ github.ref == 'refs/heads/master' && 'production' || 'staging' }}
             **Branch:** ${{ github.ref_name }}
             **Commit:** [${{ github.sha }}](${{ github.event.head_commit.url }})
           color: ${{ job.status == 'success' && '0x28a745' || '0xdc3545' }}


### PR DESCRIPTION
## Summary
- Build and push a `:develop`-tagged image on pushes to `develop` (in addition to the existing `master` production path).
- The literal `latest` tag is now `type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}` so a develop push can no longer clobber the production image tag.
- The `build-and-deploy` job's GitHub Environment is now selected by branch: `production` for `master`, `staging` for `develop` — each carries its own `DOKPLOY_WEBHOOK_URL` secret, so a develop push redeploys the new `coach-dev` Dokploy stack instead of production.

## Context
Coach Watts previously only deployed from `master`. This adds a parallel staging deployment (`testing.coachwatts.com`) tracking `develop`, backed by its own Dokploy Postgres DB, so QA can happen against develop before it's promoted to master — mirroring the pattern already used by `cashsaas`/`legalease` in this org.

Companion infra (already provisioned, outside this repo):
- Dokploy `staging` environment + `coach-dev-db` Postgres under the "Coach Watts" project.
- Dokploy Stack `Coach Watts Dev` (app-dev/worker-dev/cache-dev), pulling `ghcr.io/watt-mind/coach:develop`.
- Cloudflare DNS: `testing.coachwatts.com` → `185.112.158.168` (DNS-only, matching the existing Traefik/Let's Encrypt setup).
- `staging` GitHub Environment already existed (leftover from the disabled Trigger.dev path) — added `DOKPLOY_WEBHOOK_URL` to it.

## Known follow-ups (not blocking this PR)
- OAuth apps (Google/Strava/Whoop/etc.) need `testing.coachwatts.com` added as an authorized redirect URI, or those login/connect flows will fail on staging.
- Stripe keys were deliberately left out of the dev stack rather than reuse live secret keys — billing QA needs test-mode keys added separately.
- The dev stack currently points at the same GCS bucket as production (`coach-wattz-assets-prod-eu`) for file uploads — worth splitting to a dedicated dev bucket later.
- Shared OAuth apps mean webhook-based integrations (e.g. Strava) can only have one active callback URL registered, so those webhooks won't reach staging.

## Test plan
- [ ] Merge to `develop` and confirm the workflow run pushes `ghcr.io/watt-mind/coach:develop` and successfully calls the staging Dokploy webhook (first run will fail before this PR merges, since the image tag doesn't exist yet — expected).
- [ ] Confirm `coach-dev` stack deploys and `https://testing.coachwatts.com` serves the app.
- [ ] Confirm a subsequent push to `master` still deploys production correctly (tag `latest` still applies only there).