### PR TITLE
fix(infra): import createError from h3 in canonical workout utils (CW-223)

### DIFF
--- a/server/utils/canonical-planned-workout-write.ts
+++ b/server/utils/canonical-planned-workout-write.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@prisma/client'
+import { createError } from 'h3'
 import { prisma } from './db'
 import {
   buildRemoteStructureMergeFields,

--- a/server/utils/canonical-workout-serializer.ts
+++ b/server/utils/canonical-workout-serializer.ts
@@ -1,3 +1,4 @@
+import { createError } from 'h3'
 import {
   adaptStructuredWorkout,
   type CanonicalStructuredWorkout,


### PR DESCRIPTION
Fixes CW-223

`server/utils/canonical-planned-workout-write.ts` and `server/utils/canonical-workout-serializer.ts` call `createError(...)` but relied on Nitro's HTTP-request auto-import to resolve it. Both files are also imported by Trigger.dev background tasks (`trigger/adjust-structured-workout.ts`, `trigger/generate-structured-workout.ts`, `trigger/generate-workout-messages.ts`), which run outside Nitro's auto-import scope. There, the intended 400/422 validation error was replaced by an uncaught `ReferenceError: createError is not defined` (Sentry: https://sentry.io/organizations/watt-mind/issues/137500658/).

Fix: add an explicit `import { createError } from 'h3'` to both files, matching the existing convention used elsewhere in `server/utils/` (`auth-guard.ts`, `stripe-customer.ts`, `e2e-guard.ts`, `referrals.ts`, etc).

## Verification
- Confirmed every `createError(` call site in both files (canonical-planned-workout-write.ts: lines 68, 80; canonical-workout-serializer.ts: lines 52, 54, 113, 184) and confirmed neither file imported `createError` prior to this fix.
- `pnpm typecheck` — passes cleanly (exit 0).
- `pnpm exec eslint` on both files — no issues.
- `pnpm test:unit tests/unit/server/utils/canonical-planned-workout-write.test.ts` — 3/3 tests pass (no regressions). No existing test file for canonical-workout-serializer.ts; no new tests added per ticket guidance (this is a one-line import fix).
- Pre-commit hooks (eslint --fix, prettier) ran clean on both files.