### PR TITLE
fix(integrations): set SYNCING status at start of Polar ingestion (CW-42)

### DIFF
--- a/server/utils/services/polarService.ts
+++ b/server/utils/services/polarService.ts
@@ -27,6 +27,11 @@ export const polarService = {
     // Ensure valid token
     const validIntegration = await ensureValidToken(integration)
 
+    await prisma.integration.update({
+      where: { id: integration.id },
+      data: { syncStatus: 'SYNCING' }
+    })
+
     const results = {
       exercises: 0,
       sleeps: 0,
@@ -60,13 +65,13 @@ export const polarService = {
           errorMessage: null
         }
       })
-    } catch (error: any) {
+    } catch (error) {
       console.error('Polar sync error:', error)
       await prisma.integration.update({
         where: { id: integration.id },
         data: {
           syncStatus: 'FAILED',
-          errorMessage: error.message
+          errorMessage: error instanceof Error ? error.message : 'Unknown error'
         }
       })
       throw error

--- a/tests/unit/server/utils/services/polarService.test.ts
+++ b/tests/unit/server/utils/services/polarService.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { polarService } from '../../../../../server/utils/services/polarService'
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    integration: {
+      findFirst: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: prismaMock
+}))
+
+const baseIntegration = {
+  id: 'int-polar-1',
+  userId: 'user-1',
+  provider: 'polar',
+  accessToken: 'token-abc',
+  refreshToken: null,
+  expiresAt: null,
+  externalUserId: null,
+  scope: null,
+  lastSyncAt: null,
+  syncStatus: null,
+  errorMessage: null,
+  initialSyncCompleted: false,
+  ingestWorkouts: true,
+  settings: {}
+}
+
+describe('polarService.syncUser sync status lifecycle', () => {
+  beforeEach(() => {
+    prismaMock.integration.findFirst.mockReset()
+    prismaMock.integration.update.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws when the Polar integration is missing an access token', async () => {
+    prismaMock.integration.findFirst.mockResolvedValue(null)
+
+    await expect(polarService.syncUser('user-1')).rejects.toThrow('Polar integration not found')
+
+    expect(prismaMock.integration.update).not.toHaveBeenCalled()
+  })
+
+  it('marks the integration SYNCING before ingesting, then SUCCESS with lastSyncAt on completion', async () => {
+    prismaMock.integration.findFirst.mockResolvedValue({
+      ...baseIntegration,
+      settings: { ingestWellness: false }
+    })
+    prismaMock.integration.update.mockResolvedValue({})
+
+    const syncExercisesSpy = vi.spyOn(polarService, 'syncExercises').mockResolvedValue(3)
+    const syncSleepSpy = vi.spyOn(polarService, 'syncSleep').mockResolvedValue(0)
+    const syncNightlyRechargeSpy = vi
+      .spyOn(polarService, 'syncNightlyRecharge')
+      .mockResolvedValue(0)
+
+    const results = await polarService.syncUser('user-1')
+
+    expect(results).toEqual({ exercises: 3, sleeps: 0, recharges: 0 })
+
+    // First update call marks the integration as actively syncing.
+    expect(prismaMock.integration.update).toHaveBeenNthCalledWith(1, {
+      where: { id: 'int-polar-1' },
+      data: { syncStatus: 'SYNCING' }
+    })
+
+    // Final update call marks success and stamps lastSyncAt, clearing any prior error.
+    const lastCall =
+      prismaMock.integration.update.mock.calls[prismaMock.integration.update.mock.calls.length - 1]
+    expect(lastCall[0]).toEqual({
+      where: { id: 'int-polar-1' },
+      data: {
+        lastSyncAt: expect.any(Date),
+        syncStatus: 'SUCCESS',
+        errorMessage: null
+      }
+    })
+
+    expect(syncExercisesSpy).toHaveBeenCalled()
+    expect(syncSleepSpy).not.toHaveBeenCalled()
+    expect(syncNightlyRechargeSpy).not.toHaveBeenCalled()
+  })
+
+  it('marks the integration FAILED with the error message and rethrows on failure', async () => {
+    prismaMock.integration.findFirst.mockResolvedValue({
+      ...baseIntegration,
+      settings: { ingestWellness: false }
+    })
+    prismaMock.integration.update.mockResolvedValue({})
+
+    vi.spyOn(polarService, 'syncExercises').mockRejectedValue(new Error('Polar API exploded'))
+
+    await expect(polarService.syncUser('user-1')).rejects.toThrow('Polar API exploded')
+
+    expect(prismaMock.integration.update).toHaveBeenNthCalledWith(1, {
+      where: { id: 'int-polar-1' },
+      data: { syncStatus: 'SYNCING' }
+    })
+
+    expect(prismaMock.integration.update).toHaveBeenNthCalledWith(2, {
+      where: { id: 'int-polar-1' },
+      data: {
+        syncStatus: 'FAILED',
+        errorMessage: 'Polar API exploded'
+      }
+    })
+  })
+
+  it('marks the integration FAILED with a fallback message when a non-Error value is thrown', async () => {
+    prismaMock.integration.findFirst.mockResolvedValue({
+      ...baseIntegration,
+      settings: { ingestWellness: false }
+    })
+    prismaMock.integration.update.mockResolvedValue({})
+
+    vi.spyOn(polarService, 'syncExercises').mockRejectedValue('a string rejection')
+
+    await expect(polarService.syncUser('user-1')).rejects.toBe('a string rejection')
+
+    expect(prismaMock.integration.update).toHaveBeenNthCalledWith(2, {
+      where: { id: 'int-polar-1' },
+      data: {
+        syncStatus: 'FAILED',
+        errorMessage: 'Unknown error'
+      }
+    })
+  })
+})


### PR DESCRIPTION
Fixes CW-42

## Summary
Polar ingestion (`polarService.syncUser`) already updated `Integration.syncStatus`/`lastSyncAt`/`errorMessage` to `SUCCESS`/`FAILED` at the end of a sync, but never set `syncStatus` to `SYNCING` at the *start*. This meant:

- The UI sync status indicators never showed an in-progress state for Polar.
- The concurrent-sync guard (`server/utils/integration-sync-guard.ts`), which blocks duplicate ingestion runs by checking `syncStatus === 'SYNCING'`, was silently ineffective for Polar — a second sync could always be triggered while one was already running.

This mirrors the Strava (`server/utils/services/stravaService.ts`) and Garmin (`server/utils/services/garminService.ts`) lifecycle pattern: set `syncStatus: 'SYNCING'` right before the sync work begins (after token refresh), then `SUCCESS` (+ `lastSyncAt`, clearing `errorMessage`) or `FAILED` (+ `errorMessage`) in the existing try/catch.

Also hardened the error-message extraction (`error instanceof Error ? error.message : 'Unknown error'`) to match Strava's pattern and avoid crashing on non-Error throws.

## Changes
- `server/utils/services/polarService.ts`: set `syncStatus: 'SYNCING'` before starting exercise/sleep/nightly-recharge sync; safer error message extraction in the failure path.
- `tests/unit/server/utils/services/polarService.test.ts` (new): covers missing-integration error, `SYNCING` → `SUCCESS` (+ `lastSyncAt`) transition, `SYNCING` → `FAILED` (+ error message) transition, and a non-Error rejection fallback.

## Verification
- `pnpm test:unit tests/unit/server/utils/services/polarService.test.ts` → 4 passed
- `pnpm typecheck` → passes with no errors