### PR TITLE
fix(integrations): idempotency key + concurrency guard for recommend-today-activity (CW-55)

### DIFF
--- a/trigger/ingest-all.ts
+++ b/trigger/ingest-all.ts
@@ -8,7 +8,11 @@ import { auditLogRepository } from '../server/utils/repositories/auditLogReposit
 import { nutritionRepository } from '../server/utils/repositories/nutritionRepository'
 import type { IngestionResult } from './types'
 import { enqueueAutomaticWorkoutAnalysesForUser } from '../server/utils/workout-analysis-enqueue'
-import { dispatchTask, dispatchTaskAndWait } from '../server/utils/task-dispatcher'
+import {
+  dispatchTask,
+  dispatchTaskAndWait,
+  isTaskRunningForUser
+} from '../server/utils/task-dispatcher'
 
 export const ingestAllTask = task({
   id: 'ingest-all',
@@ -437,28 +441,44 @@ export const ingestAllTask = task({
       try {
         const aiSettings = await getUserAiSettings(userId)
         if (aiSettings.aiAutoAnalyzeReadiness) {
-          logger.log('🤖 [Auto-Analyze] Wellness updated: Triggering daily recommendation...')
-
-          await dispatchTask(
+          const recommendationAlreadyRunning = await isTaskRunningForUser(
             'recommend-today-activity',
-            {
-              userId,
-              date: new Date(),
-              source: 'AUTOMATIC'
-            },
-            {
-              concurrencyKey: userId,
-              tags: [`user:${userId}`]
-            }
+            userId
           )
 
-          // Log the action
-          await auditLogRepository.log({
-            userId,
-            action: 'AUTO_ANALYZE_READINESS',
-            resourceType: 'ActivityRecommendation',
-            metadata: { date: new Date().toISOString(), source: 'ingest-all' }
-          })
+          if (recommendationAlreadyRunning) {
+            logger.log(
+              '⏭️ Skipping daily recommendation: already running for user (concurrency guard)',
+              { userId }
+            )
+          } else {
+            logger.log('🤖 [Auto-Analyze] Wellness updated: Triggering daily recommendation...')
+
+            const recommendationDate = new Date()
+            const recommendationDateKey = recommendationDate.toISOString().slice(0, 10)
+
+            await dispatchTask(
+              'recommend-today-activity',
+              {
+                userId,
+                date: recommendationDate,
+                source: 'AUTOMATIC'
+              },
+              {
+                id: `recommend-today-activity:${userId}:${recommendationDateKey}`,
+                concurrencyKey: userId,
+                tags: [`user:${userId}`]
+              }
+            )
+
+            // Log the action
+            await auditLogRepository.log({
+              userId,
+              action: 'AUTO_ANALYZE_READINESS',
+              resourceType: 'ActivityRecommendation',
+              metadata: { date: recommendationDate.toISOString(), source: 'ingest-all' }
+            })
+          }
         }
       } catch (err) {
         logger.error('❌ [Auto-Analyze] Failed to trigger daily recommendation', { err })


### PR DESCRIPTION
Fixes CW-55

## Summary
`trigger/ingest-all.ts` was enqueuing `recommend-today-activity` (the daily "auto-analyze readiness" chain step) with no idempotency key and no concurrency guard. Overlapping or repeated provider syncs for the same user (e.g. multiple webhook deliveries or overlapping manual + automatic syncs) could spawn duplicate recommendation runs for the same user/date.

Changes in `trigger/ingest-all.ts`:
- Added an `isTaskRunningForUser('recommend-today-activity', userId)` concurrency guard (the same helper already used by `triggerWorkoutDeduplicationIfEnabled` and `integration-sync-guard.ts` in this codebase) before dispatching. If a run is already active for the user, the dispatch and audit log are skipped and a log line is emitted instead.
- Added an idempotency key on the `dispatchTask` call: `` `recommend-today-activity:${userId}:${recommendationDateKey}` ``, following the same `task-name:entity-id:extra` convention used elsewhere in the codebase (e.g. `structure-${mode}:${plannedWorkoutId}:rev-${generationRevision}` in `server/utils/structure-generation-run.ts`, and the `daily-recommendation:${userId}:${recommendationDateKey}` key already used for the email dispatch inside `trigger/recommend-today-activity.ts`).

No other files were touched.

## Verification
`pnpm typecheck` — exit code 0, no TS errors (only pre-existing, unrelated `vue-email`/Nuxt-version warnings in the output).