### PR TITLE
fix(ui-ux): make notification markAsRead optimistic and reliable (CW-53)

### DIFF
--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -37,18 +37,32 @@ export const useNotificationStore = defineStore('notifications', () => {
   }
 
   const markAsRead = async (id: string) => {
+    const n = notifications.value.find((n) => n.id === id)
+    const wasUnread = !!n && !n.read
+
+    // Optimistically flip local/store state first so the badge count and
+    // read styling update immediately, before the network round-trip
+    // resolves. This also means callers that `await markAsRead(id)` before
+    // navigating still see the optimistic UI update right away, while the
+    // actual API call below is guaranteed to complete (or fail) before that
+    // await resolves - it is never left dangling/cancelled by a route change.
+    if (n && wasUnread) {
+      n.read = true
+      unreadCount.value = Math.max(0, unreadCount.value - 1)
+    }
+
     try {
       await ($fetch as any)('/api/notifications/read', {
         method: 'PATCH',
         body: { id }
       })
-      const n = notifications.value.find((n) => n.id === id)
-      if (n && !n.read) {
-        n.read = true
-        unreadCount.value = Math.max(0, unreadCount.value - 1)
-      }
     } catch (error) {
       console.error('Failed to mark notification as read:', error)
+      // Roll back the optimistic update since the server never persisted it.
+      if (n && wasUnread) {
+        n.read = false
+        unreadCount.value++
+      }
     }
   }
 

--- a/tests/unit/app/components/NotificationDropdown.test.ts
+++ b/tests/unit/app/components/NotificationDropdown.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { computed, nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import NotificationDropdown from '../../../../app/components/NotificationDropdown.vue'
+import { useNotificationStore } from '../../../../app/stores/notifications'
+
+vi.mock('@tolgee/vue', () => ({
+  useTranslate: () => ({ t: computed(() => (key: string) => key) })
+}))
+
+const { navigateToMock } = vi.hoisted(() => ({ navigateToMock: vi.fn() }))
+
+mockNuxtImport('useUserRuns', () => () => ({ refresh: vi.fn() }))
+mockNuxtImport('useFormat', () => () => ({
+  formatDate: (date: string) => date
+}))
+mockNuxtImport('navigateTo', () => navigateToMock)
+
+const NOTIFICATION = {
+  id: 'notif-1',
+  userId: 'user-1',
+  title: 'Workout synced',
+  message: 'Your workout finished syncing.',
+  link: '/workouts/planned/workout-1',
+  read: false,
+  createdAt: '2026-07-30T12:00:00.000Z'
+}
+
+function createDeferred<T = any>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function mountDropdown() {
+  const wrapper = await mountSuspended(NotificationDropdown, {
+    shallow: true,
+    global: {
+      renderStubDefaultSlot: true,
+      stubs: {
+        // The clickable notification rows live inside UPopover's named
+        // `#content` slot; the default shallow stub only renders the
+        // default slot, so this needs an explicit slot-preserving template.
+        UPopover: { template: '<div><slot /><slot name="content" /></div>' }
+      }
+    }
+  })
+
+  await flushPromises()
+  await nextTick()
+
+  return wrapper
+}
+
+describe('NotificationDropdown handleNotificationClick (CW-53)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let markReadDeferred: ReturnType<typeof createDeferred>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    navigateToMock.mockReset()
+
+    markReadDeferred = createDeferred()
+
+    fetchMock = vi.fn((url: string, options: any = {}) => {
+      if (url === '/api/notifications') {
+        return Promise.resolve({
+          notifications: [{ ...NOTIFICATION }],
+          total: 1,
+          unreadCount: 1
+        })
+      }
+      if (url === '/api/notifications/read' && options?.method === 'PATCH') {
+        return markReadDeferred.promise
+      }
+      return Promise.reject(new Error(`Unhandled fetch in test: ${url}`))
+    })
+    ;(fetchMock as any).raw = vi.fn().mockResolvedValue({ _data: null })
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('clears the unread badge immediately and only navigates after markAsRead resolves', async () => {
+    const wrapper = await mountDropdown()
+    const store = useNotificationStore()
+
+    expect(store.unreadCount).toBe(1)
+    expect(store.notifications[0]?.read).toBe(false)
+
+    const item = wrapper.find('.cursor-pointer')
+    expect(item.exists()).toBe(true)
+
+    await item.trigger('click')
+    await nextTick()
+
+    // Optimistic update: the store (and therefore the badge bound to
+    // unreadCount) updates synchronously, before the PATCH request to
+    // /api/notifications/read has resolved.
+    expect(store.unreadCount).toBe(0)
+    expect(store.notifications[0]?.read).toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/notifications/read',
+      expect.objectContaining({ method: 'PATCH', body: { id: NOTIFICATION.id } })
+    )
+
+    // Navigation must not happen before the mark-as-read call has settled.
+    expect(navigateToMock).not.toHaveBeenCalled()
+
+    markReadDeferred.resolve({})
+    await flushPromises()
+
+    expect(navigateToMock).toHaveBeenCalledWith(NOTIFICATION.link)
+  })
+
+  it('rolls back the optimistic read state when the server call fails', async () => {
+    const wrapper = await mountDropdown()
+    const store = useNotificationStore()
+
+    const item = wrapper.find('.cursor-pointer')
+    await item.trigger('click')
+    await nextTick()
+
+    expect(store.unreadCount).toBe(0)
+    expect(store.notifications[0]?.read).toBe(true)
+
+    markReadDeferred.reject(new Error('network error'))
+    await flushPromises()
+
+    // The optimistic update is rolled back since the server never
+    // persisted the read state, so the badge/unread count stay accurate.
+    expect(store.unreadCount).toBe(1)
+    expect(store.notifications[0]?.read).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes CW-53

## Summary
- `app/pages/notifications.vue` and `app/components/NotificationDropdown.vue` already `await notificationStore.markAsRead(id)` before calling `navigateTo(link)` (fixed earlier, in commit 7706435c9 "fix(app): resolve app-review bugs with error UI, i18n, and a11y improvements", 2026-07-09) — the server request is never aborted by the route change.
- What was still missing relative to the acceptance criteria: `useNotificationStore.markAsRead` only flipped local `read`/`unreadCount` state *after* the `PATCH /api/notifications/read` call resolved, so the unread badge did not update immediately on click, only after the network round-trip.
- `app/stores/notifications.ts`: `markAsRead` now optimistically marks the notification read and decrements `unreadCount` synchronously before awaiting the API call, and rolls the optimistic update back if the request fails. The API call remains awaited before callers navigate, so server-side state stays reliable.
- No changes were needed in `notifications.vue` / `NotificationDropdown.vue` beyond the store fix — both already await `markAsRead` before navigating.

Note for a human: the Linear ticket's title ("Deduplicate Auto Analyzes All Recent") does not match its own description/acceptance-criteria (which is about notification click / markAsRead sequencing). This looks like a data-entry mix-up from the original bulk import — flagging for someone to correct the title in Linear, not fixing it here.

## Verification
```
$ pnpm typecheck && pnpm test:unit tests/unit/app/components/NotificationDropdown.test.ts
...
 Test Files  1 passed (1)
      Tests  2 passed (2)
```
Both `pnpm typecheck` (nuxt typecheck --checker=vue-tsc) and the new/extended unit test suite pass cleanly.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:unit tests/unit/app/components/NotificationDropdown.test.ts`
- [x] New test: badge/unread count clears immediately (optimistically) on click, before the mark-as-read PATCH resolves, and `navigateTo` is only called after it resolves
- [x] New test: optimistic read state rolls back if the mark-as-read request fails