### PR TITLE
fix(performance): chunk and lean-select workoutStreamV2 queries (CW-224)

### DIFF
--- a/server/api/scores/athlete-profile.get.ts
+++ b/server/api/scores/athlete-profile.get.ts
@@ -41,7 +41,13 @@ async function ensurePersonalBestsBackfilled(userId: string) {
     }
   })
 
-  const workoutsWithStreams = await attachStreamsToWorkouts(workouts)
+  // pbDetectionService.detectPBs only reads streams.time/watts/distance off each
+  // workout (peak power + fastest-distance-segment detection) -- the mandatory
+  // baseline (time/heartrate/watts/velocity/lat/lng/hrZoneTimes/powerZoneTimes)
+  // already covers time/watts, so only `distance` needs to be requested here.
+  // This avoids pulling every per-second stream array (and JSON blob) for a
+  // user's entire workout history, which was the CW-224 slow query.
+  const workoutsWithStreams = await attachStreamsToWorkouts(workouts, { fields: ['distance'] })
 
   for (const workout of workoutsWithStreams) {
     if (!workout.streams) continue

--- a/server/utils/data-management/collector.ts
+++ b/server/utils/data-management/collector.ts
@@ -92,6 +92,11 @@ export class UserUniverseCollector {
       }
     })
 
+    // This is a full-fidelity GDPR/migration export, so we deliberately keep
+    // the default (no `fields` option) full-column fetch here -- every stream
+    // column, including the JSON blobs, must round-trip intact. The CW-224
+    // slow-query fix still applies via findManyByWorkoutIds' internal
+    // chunking of large IN(...) clauses.
     const workoutsWithStreams = await attachStreamsToWorkouts(workouts)
 
     const fitFiles = await this.prisma.fitFile.findMany({

--- a/server/utils/report-engine.ts
+++ b/server/utils/report-engine.ts
@@ -79,6 +79,17 @@ export async function fetchReportContext(userId: string, inputConfig: any) {
             orderBy: source.orderBy || { date: 'desc' },
             includeDuplicates: false
           })
+          // Deliberately left at the default (full-column) fetch: the
+          // downstream buildWorkoutSummary()/buildWorkoutAnalysisFactsV2()
+          // pipeline reads most stream fields (heartrate, watts, cadence,
+          // velocity, latlng, altitude, grade, temp, torque,
+          // leftRightBalance, hrv, respiration, targetPower, zone times),
+          // and report templates are user-editable DB content that could in
+          // principle reference any field on the raw workout data passed
+          // into the prompt context -- so trimming columns here isn't safe
+          // to do with confidence. The CW-224 slow-query fix still applies
+          // via findManyByWorkoutIds' internal chunking of large IN(...)
+          // clauses.
           data = await attachStreamsToWorkouts(data)
 
           // Apply additional filters (e.g., by sport type)

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -123,13 +123,132 @@ export async function attachStreamToWorkout<T extends { id: string }>(
 }
 
 export async function attachStreamsToWorkouts<T extends { id: string }>(
-  workouts: T[]
+  workouts: T[],
+  options?: FindManyByWorkoutIdsOptions
 ): Promise<Array<T & { streams: NormalizedStream | null }>> {
-  const streamMap = await workoutStreamRepository.findManyByWorkoutIds(workouts.map((w) => w.id))
+  const streamMap = await workoutStreamRepository.findManyByWorkoutIds(
+    workouts.map((w) => w.id),
+    options
+  )
   return workouts.map((workout) => ({
     ...workout,
     streams: streamMap.get(workout.id) ?? null
   }))
+}
+
+/**
+ * Optional, non-mandatory NormalizedStream fields that a caller of
+ * findManyByWorkoutIds/attachStreamsToWorkouts can opt into fetching on top of
+ * the mandatory baseline (see REQUIRED_V2_SELECT/REQUIRED_V1_SELECT below).
+ */
+export type WorkoutStreamOptionalField =
+  | 'distance'
+  | 'cadence'
+  | 'altitude'
+  | 'grade'
+  | 'moving'
+  | 'temp'
+  | 'torque'
+  | 'leftRightBalance'
+  | 'hrv'
+  | 'respiration'
+  | 'targetPower'
+  | 'avgPacePerKm'
+  | 'paceVariability'
+  | 'lapSplits'
+  | 'paceZones'
+  | 'pacingStrategy'
+  | 'surges'
+  | 'extrasMeta'
+
+export interface FindManyByWorkoutIdsOptions {
+  /**
+   * Extra columns to fetch beyond the mandatory baseline. When omitted
+   * (undefined), every column is fetched -- this is the original/default
+   * behavior and should be kept for callers that need full-fidelity stream
+   * data (e.g. the GDPR/migration data export in data-management/collector.ts).
+   *
+   * When provided (including an empty array), only the mandatory baseline
+   * fields plus whatever is listed here are fetched, which is dramatically
+   * cheaper for hot paths that read a handful of scalar fields (or none) off
+   * potentially hundreds of workouts' streams at once.
+   */
+  fields?: readonly WorkoutStreamOptionalField[]
+}
+
+/**
+ * Columns always fetched from WorkoutStreamV2 once a caller opts into a lean
+ * `fields` selection. `time`/`heartrate`/`watts`/`velocity`/`lat`/`lng`/
+ * `hrZoneTimes`/`powerZoneTimes` are required because hasUsableStreamData()
+ * inspects them to decide whether a V2 row counts as "usable" stream data
+ * (falling back to the legacy V1 table otherwise) -- dropping any of them
+ * would silently change that determination for every caller, not just the
+ * one requesting a lean select. `id`/`workoutId`/`createdAt`/`updatedAt` are
+ * cheap identity/bookkeeping columns kept for parity with NormalizedStream.
+ */
+const REQUIRED_V2_SELECT = {
+  id: true,
+  workoutId: true,
+  createdAt: true,
+  updatedAt: true,
+  time: true,
+  heartrate: true,
+  watts: true,
+  velocity: true,
+  lat: true,
+  lng: true,
+  hrZoneTimes: true,
+  powerZoneTimes: true
+} as const
+
+/** Same rationale as REQUIRED_V2_SELECT, but for the legacy V1 fallback table (single `latlng` Json column instead of split lat/lng arrays). */
+const REQUIRED_V1_SELECT = {
+  id: true,
+  workoutId: true,
+  createdAt: true,
+  updatedAt: true,
+  time: true,
+  heartrate: true,
+  watts: true,
+  velocity: true,
+  latlng: true,
+  hrZoneTimes: true,
+  powerZoneTimes: true
+} as const
+
+function buildV2Select(
+  fields: readonly WorkoutStreamOptionalField[] | undefined
+): Record<string, true> | undefined {
+  if (fields === undefined) return undefined
+  const select: Record<string, true> = { ...REQUIRED_V2_SELECT }
+  for (const field of fields) select[field] = true
+  return select
+}
+
+function buildV1Select(
+  fields: readonly WorkoutStreamOptionalField[] | undefined
+): Record<string, true> | undefined {
+  if (fields === undefined) return undefined
+  const select: Record<string, true> = { ...REQUIRED_V1_SELECT }
+  for (const field of fields) select[field] = true
+  return select
+}
+
+/**
+ * Max number of workout IDs per `IN (...)` clause. A Sentry-reported slow
+ * query captured 623 workout IDs in a single IN clause; batching keeps each
+ * round trip's result set (and the DB's work per query) bounded regardless
+ * of how many workouts a caller asks for at once.
+ */
+const WORKOUT_ID_CHUNK_SIZE = 200
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+  if (items.length <= size) return [items as T[]]
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size) as T[])
+  }
+  return chunks
 }
 
 export const workoutStreamRepository = {
@@ -153,13 +272,27 @@ export const workoutStreamRepository = {
     return stream !== null
   },
 
-  async findManyByWorkoutIds(workoutIds: string[]): Promise<Map<string, NormalizedStream>> {
+  async findManyByWorkoutIds(
+    workoutIds: string[],
+    options?: FindManyByWorkoutIdsOptions
+  ): Promise<Map<string, NormalizedStream>> {
     const result = new Map<string, NormalizedStream>()
     if (workoutIds.length === 0) return result
 
-    const v2Records: any[] = await (prisma as any).workoutStreamV2
-      .findMany({ where: { workoutId: { in: workoutIds } } })
-      .catch(() => [])
+    const fields = options?.fields
+    const v2Select = buildV2Select(fields)
+
+    const v2Chunks = await Promise.all(
+      chunkArray(workoutIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+        (prisma as any).workoutStreamV2
+          .findMany({
+            where: { workoutId: { in: chunk } },
+            ...(v2Select ? { select: v2Select } : {})
+          })
+          .catch(() => [])
+      )
+    )
+    const v2Records: any[] = v2Chunks.flat()
 
     const missingIds: string[] = []
     for (const r of v2Records) {
@@ -177,9 +310,18 @@ export const workoutStreamRepository = {
     }
 
     if (missingIds.length > 0) {
-      const v1Records = await prisma.workoutStream
-        .findMany({ where: { workoutId: { in: missingIds } } })
-        .catch(() => [])
+      const v1Select = buildV1Select(fields) as any
+      const v1Chunks = await Promise.all(
+        chunkArray(missingIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+          prisma.workoutStream
+            .findMany({
+              where: { workoutId: { in: chunk } },
+              ...(v1Select ? { select: v1Select } : {})
+            })
+            .catch(() => [])
+        )
+      )
+      const v1Records = v1Chunks.flat()
       for (const r of v1Records) {
         const normalized = toNormalizedFromV1(r)
         if (hasUsableStreamData(normalized)) {

--- a/server/utils/services/intervalsService.ts
+++ b/server/utils/services/intervalsService.ts
@@ -1404,8 +1404,12 @@ export const IntervalsService = {
 
     if (!workoutToDelete) return
 
+    // deduplicationService.calculateCompletenessScore only checks whether
+    // `streams` is truthy (never reads a specific field), so we don't need
+    // any of the optional stream columns here -- just the mandatory baseline
+    // that findManyByWorkoutIds always fetches to determine "usable" streams.
     const duplicatesWithStreams = workoutToDelete.duplicates.length
-      ? await attachStreamsToWorkouts(workoutToDelete.duplicates)
+      ? await attachStreamsToWorkouts(workoutToDelete.duplicates, { fields: [] })
       : []
 
     await prisma.$transaction(async (tx) => {

--- a/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
@@ -6,9 +6,11 @@ import {
   splitLatlngPoints,
   workoutStreamRepository
 } from '../../../../../server/utils/repositories/workoutStreamRepository'
+import { prisma } from '../../../../../server/utils/db'
 
 const workoutStreamV2 = {
-  upsert: vi.fn()
+  upsert: vi.fn(),
+  findMany: vi.fn()
 }
 
 vi.mock('../../../../../server/utils/db', () => ({
@@ -126,6 +128,140 @@ describe('workoutStreamRepository', () => {
           })
         })
       )
+    })
+  })
+
+  describe('findManyByWorkoutIds', () => {
+    beforeEach(() => {
+      workoutStreamV2.findMany.mockResolvedValue([])
+      vi.mocked(prisma.workoutStream.findMany).mockResolvedValue([] as any)
+    })
+
+    it('fetches every column when no `fields` option is given (default/full behavior)', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([
+        { workoutId: 'workout-1', time: [0, 1], watts: [100, 110], lat: [], lng: [] }
+      ])
+
+      await workoutStreamRepository.findManyByWorkoutIds(['workout-1'])
+
+      expect(workoutStreamV2.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { workoutId: { in: ['workout-1'] } }
+        })
+      )
+      // No `select` key at all -- Prisma returns every column.
+      const call = workoutStreamV2.findMany.mock.calls[0]![0]
+      expect(call.select).toBeUndefined()
+    })
+
+    it('passes an explicit `select` limited to the mandatory baseline plus requested fields', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([
+        {
+          workoutId: 'workout-1',
+          time: [0, 1],
+          heartrate: [90, 95],
+          watts: [100, 110],
+          velocity: [1, 2],
+          lat: [],
+          lng: [],
+          hrZoneTimes: null,
+          powerZoneTimes: null,
+          distance: [0, 10]
+        }
+      ])
+
+      await workoutStreamRepository.findManyByWorkoutIds(['workout-1'], { fields: ['distance'] })
+
+      expect(workoutStreamV2.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { workoutId: { in: ['workout-1'] } },
+          select: expect.objectContaining({
+            // mandatory baseline required by hasUsableStreamData()
+            time: true,
+            heartrate: true,
+            watts: true,
+            velocity: true,
+            lat: true,
+            lng: true,
+            hrZoneTimes: true,
+            powerZoneTimes: true,
+            // explicitly requested extra field
+            distance: true
+          })
+        })
+      )
+
+      // Fields never requested (and not part of the mandatory baseline)
+      // must not be present in the select at all.
+      const call = workoutStreamV2.findMany.mock.calls[0]![0]
+      expect(call.select.cadence).toBeUndefined()
+      expect(call.select.lapSplits).toBeUndefined()
+      expect(call.select.extrasMeta).toBeUndefined()
+    })
+
+    it('still fetches the mandatory baseline when `fields` is an empty array (existence-only callers)', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([
+        { workoutId: 'workout-1', time: [0, 1], watts: [50], lat: [], lng: [] }
+      ])
+
+      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-1'], {
+        fields: []
+      })
+
+      const call = workoutStreamV2.findMany.mock.calls[0]![0]
+      expect(call.select).toEqual(
+        expect.objectContaining({
+          time: true,
+          heartrate: true,
+          watts: true,
+          velocity: true,
+          lat: true,
+          lng: true,
+          hrZoneTimes: true,
+          powerZoneTimes: true
+        })
+      )
+      expect(streams.get('workout-1')).toBeTruthy()
+    })
+
+    it('splits a large IN(...) clause into chunks of at most 200 IDs', async () => {
+      const workoutIds = Array.from({ length: 450 }, (_, i) => `workout-${i}`)
+
+      await workoutStreamRepository.findManyByWorkoutIds(workoutIds)
+
+      expect(workoutStreamV2.findMany).toHaveBeenCalledTimes(3)
+      const callSizes = workoutStreamV2.findMany.mock.calls.map(
+        (call: any[]) => call[0].where.workoutId.in.length
+      )
+      expect(callSizes).toEqual([200, 200, 50])
+    })
+
+    it('falls back to the legacy V1 table (with the same lean select) for workouts missing a V2 row', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([])
+      vi.mocked(prisma.workoutStream.findMany).mockResolvedValue([
+        { workoutId: 'workout-legacy', time: [0, 1], watts: [120], latlng: [] }
+      ] as any)
+
+      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-legacy'], {
+        fields: ['distance']
+      })
+
+      expect(prisma.workoutStream.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { workoutId: { in: ['workout-legacy'] } },
+          select: expect.objectContaining({
+            time: true,
+            heartrate: true,
+            watts: true,
+            velocity: true,
+            latlng: true,
+            hrZoneTimes: true,
+            powerZoneTimes: true,
+            distance: true
+          })
+        })
+      )
+      expect(streams.get('workout-legacy')).toBeTruthy()
     })
   })
 })

--- a/trigger/deduplicate-workouts.ts
+++ b/trigger/deduplicate-workouts.ts
@@ -63,7 +63,13 @@ export const deduplicateWorkoutsTask = task({
         }
       })
 
-      const workouts = await attachStreamsToWorkouts(workoutRecords)
+      // deduplicationService.findDuplicateGroups()/calculateCompletenessScore
+      // only check whether `streams` is truthy (never read a specific field),
+      // so no optional stream columns are needed here -- just the mandatory
+      // baseline findManyByWorkoutIds always fetches to determine "usable"
+      // streams. This is the CW-224 fix: this task can process a user's
+      // entire workout history (hundreds of IDs) in one call.
+      const workouts = await attachStreamsToWorkouts(workoutRecords, { fields: [] })
 
       logger.log(`Found ${workouts.length} workouts to analyze`, {
         userId: actualUserId,


### PR DESCRIPTION
Fixes CW-224

## Problem
`workoutStreamRepository.findManyByWorkoutIds()` (used by `attachStreamsToWorkouts()`) ran `workoutStreamV2.findMany({ where: { workoutId: { in: workoutIds } } })` with no `select` and no batching. A single call could pull every column -- including large per-second time-series arrays (`time`, `heartrate`, `watts`, `velocity`, `cadence`, `altitude`, `lat`/`lng`, `grade`, `moving`, `temp`, `torque`, `leftRightBalance`, `hrv`, `respiration`, `targetPower`) plus JSON metadata (`lapSplits`, `paceZones`, `pacingStrategy`, `surges`, `hrZoneTimes`, `powerZoneTimes`, `extrasMeta`) -- for potentially hundreds of workouts in one query. Sentry captured a query with 623 workout IDs in a single `IN (...)` clause, recurring 256 times in a 27-hour window (https://sentry.io/organizations/watt-mind/issues/137501617/).

## What changed
`server/utils/repositories/workoutStreamRepository.ts`:
- **Chunking**: `findManyByWorkoutIds` now splits the workout ID list into batches of 200 per `IN (...)` clause (both the WorkoutStreamV2 query and the legacy WorkoutStream/V1 fallback query), run in parallel and merged. This applies unconditionally, regardless of column selection.
- **Optional lean `select`**: added a `fields?: WorkoutStreamOptionalField[]` option on `findManyByWorkoutIds`/`attachStreamsToWorkouts`. When provided, only a mandatory baseline (`id`/`workoutId`/`createdAt`/`updatedAt` plus whatever `hasUsableStreamData()` needs to decide if a V2 row is "usable": `time`/`heartrate`/`watts`/`velocity`/`lat`+`lng`/`hrZoneTimes`/`powerZoneTimes`) plus the caller's requested fields are fetched. Omitting `fields` entirely keeps the original full-column fetch, so any caller I didn't touch is unaffected.

### Callers changed (after tracing exact field usage downstream)
- **`server/api/scores/athlete-profile.get.ts`** (`ensurePersonalBestsBackfilled`, the hot path named in the Sentry report -- loads a user's entire workout history for PB backfill): traced through to `pbDetectionService.detectPBs`, which only reads `streams.time`, `streams.watts`, and `streams.distance`. Now passes `{ fields: ['distance'] }` (time/watts are already in the mandatory baseline).
- **`server/utils/services/intervalsService.ts`** (`deleteActivity`) and **`trigger/deduplicate-workouts.ts`**: both feed into `deduplicationService.calculateCompletenessScore`/`findDuplicateGroups`, which only check `workout.streams` truthiness -- never read a specific field (verified: `mergeDuplicateGroup` re-fetches its own lean V1 `streams: { select: { id: true } }` for the actual transfer logic, independent of this map). Now pass `{ fields: [] }`.

### Callers deliberately left at full-column fetch (chunking still applies)
- **`server/utils/data-management/collector.ts`**: this is the GDPR/prod-to-local-migration data export -- it must round-trip every column faithfully, so it keeps the default (no `fields`) full select.
- **`server/utils/report-engine.ts`**: traced through `buildWorkoutSummary`/`buildWorkoutAnalysisFactsV2` (in `gemini.ts` / `workout-analysis-facts.ts`), which together read most stream fields (heartrate, watts, cadence, velocity, latlng, altitude, grade, temp, torque, leftRightBalance, hrv, respiration, targetPower, zone times) -- only `distance`/`moving`/`avgPacePerKm`/`paceVariability` and the JSON metadata blobs are unused there. Report templates are also user-editable DB content rendered through a generic `{{path}}` template engine that could in principle reference any field on the raw workout objects passed into the prompt context. Given the modest additional savings and this residual uncertainty, I left this caller on the full-column default rather than guess -- it still benefits from the chunking fix.

## Verification
- `pnpm typecheck` -- clean, exit code 0.
- New unit tests added to `tests/unit/server/utils/repositories/workoutStreamRepository.test.ts` covering: default full-select (no `select` key at all), lean select merging the mandatory baseline with requested fields, an empty `fields: []` request still fetching the mandatory baseline, ID-list chunking into batches of <= 200, and the V1 legacy fallback path using the same select mechanism.
- `pnpm vitest run tests/unit/server/utils/repositories/workoutStreamRepository.test.ts tests/unit/server/api/scores/athlete-profile.get.test.ts tests/unit/server/utils/services/intervalsService.test.ts tests/unit/server/utils/report-engine.test.ts` -- 4 files, 30 tests, all passing.
- `eslint` on all changed files -- clean.