### PR TITLE
fix(integrations): paginate Wahoo workout ingest (CW-54)

### DIFF
--- a/tests/unit/trigger/ingest-wahoo.test.ts
+++ b/tests/unit/trigger/ingest-wahoo.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import { fetchAllWahooWorkouts } from '../../../trigger/ingest-wahoo'
+import { fetchWahooWorkouts } from '../../../server/utils/wahoo'
+
+vi.mock('@trigger.dev/sdk/v3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@trigger.dev/sdk/v3')>()
+  return {
+    ...actual,
+    logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn() }
+  }
+})
+
+vi.mock('../../../server/utils/wahoo', () => ({
+  fetchWahooWorkouts: vi.fn(),
+  normalizeWahooWorkout: vi.fn()
+}))
+
+function makeWorkout(id: number) {
+  return { id, starts: '2026-01-01T00:00:00Z', minutes: 30 } as any
+}
+
+describe('fetchAllWahooWorkouts pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('follows pagination across multiple pages until a short page is returned', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeWorkout(i))
+    const page2 = Array.from({ length: 100 }, (_, i) => makeWorkout(100 + i))
+    const page3 = Array.from({ length: 37 }, (_, i) => makeWorkout(200 + i))
+
+    vi.mocked(fetchWahooWorkouts)
+      .mockResolvedValueOnce({ workouts: page1, total: 237 })
+      .mockResolvedValueOnce({ workouts: page2, total: 237 })
+      .mockResolvedValueOnce({ workouts: page3, total: 237 })
+
+    const result = await fetchAllWahooWorkouts({} as any)
+
+    expect(result).toHaveLength(237)
+    expect(fetchWahooWorkouts).toHaveBeenCalledTimes(3)
+    expect(fetchWahooWorkouts).toHaveBeenNthCalledWith(1, {}, 1, 100)
+    expect(fetchWahooWorkouts).toHaveBeenNthCalledWith(2, {}, 2, 100)
+    expect(fetchWahooWorkouts).toHaveBeenNthCalledWith(3, {}, 3, 100)
+  })
+
+  it('stops as soon as the reported total has been collected', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeWorkout(i))
+    const page2 = Array.from({ length: 100 }, (_, i) => makeWorkout(100 + i))
+
+    vi.mocked(fetchWahooWorkouts)
+      .mockResolvedValueOnce({ workouts: page1, total: 200 })
+      .mockResolvedValueOnce({ workouts: page2, total: 200 })
+
+    const result = await fetchAllWahooWorkouts({} as any)
+
+    expect(result).toHaveLength(200)
+    expect(fetchWahooWorkouts).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops immediately when the first page is empty', async () => {
+    vi.mocked(fetchWahooWorkouts).mockResolvedValueOnce({ workouts: [], total: 0 })
+
+    const result = await fetchAllWahooWorkouts({} as any)
+
+    expect(result).toHaveLength(0)
+    expect(fetchWahooWorkouts).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors the safety cap and does not loop forever if the API misbehaves', async () => {
+    // Simulate a misbehaving API that always returns a full page and never
+    // lets `total` be reached, so the only thing that can stop the loop is
+    // the hard cap on page count.
+    vi.mocked(fetchWahooWorkouts).mockImplementation(async (_integration, page = 1) => ({
+      workouts: Array.from({ length: 100 }, (_, i) => makeWorkout((page as number) * 1000 + i)),
+      total: Number.MAX_SAFE_INTEGER
+    }))
+
+    vi.useFakeTimers()
+    try {
+      const resultPromise = fetchAllWahooWorkouts({} as any)
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+
+      // 50 pages * 100 per page, per the safety cap.
+      expect(result).toHaveLength(5000)
+      expect(fetchWahooWorkouts).toHaveBeenCalledTimes(50)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/trigger/ingest-wahoo.ts
+++ b/trigger/ingest-wahoo.ts
@@ -9,6 +9,63 @@ import type { IngestionResult } from './types'
 import crypto from 'crypto'
 import { dispatchTask } from '../server/utils/task-dispatcher'
 
+// Wahoo Cloud API caps `per_page` well below this, but 100 is a safe, generous page size.
+const WAHOO_PAGE_SIZE = 100
+// Safety cap on the number of pages we'll fetch in one sync, in case the API misbehaves
+// (e.g. `total` never converges or pages keep returning full batches indefinitely).
+const WAHOO_MAX_PAGES = 50
+// Small delay between page requests to stay comfortably under Wahoo's rate limits.
+const WAHOO_PAGE_DELAY_MS = 250
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+type WahooWorkout = Awaited<ReturnType<typeof fetchWahooWorkouts>>['workouts'][number]
+
+/**
+ * Fetch all Wahoo workouts across pages, stopping once we've collected everything the
+ * API reports as available, the API returns a short/empty page, or we hit the safety cap.
+ */
+export async function fetchAllWahooWorkouts(
+  integration: Parameters<typeof fetchWahooWorkouts>[0]
+): Promise<WahooWorkout[]> {
+  const allWorkouts: WahooWorkout[] = []
+  let page = 1
+  let total = Infinity
+
+  while (page <= WAHOO_MAX_PAGES && allWorkouts.length < total) {
+    const result = await fetchWahooWorkouts(integration, page, WAHOO_PAGE_SIZE)
+    total = result.total
+
+    logger.log(
+      `Fetched Wahoo page ${page}: ${result.workouts.length} workouts (${allWorkouts.length + result.workouts.length}/${total} total)`
+    )
+
+    allWorkouts.push(...result.workouts)
+
+    if (result.workouts.length === 0 || result.workouts.length < WAHOO_PAGE_SIZE) {
+      // Short (or empty) page means we've reached the end, regardless of what `total` says.
+      break
+    }
+
+    page++
+
+    if (allWorkouts.length < total) {
+      await sleep(WAHOO_PAGE_DELAY_MS)
+    }
+  }
+
+  if (page > WAHOO_MAX_PAGES) {
+    logger.warn(
+      `Wahoo pagination hit the safety cap of ${WAHOO_MAX_PAGES} pages; some workouts may not have been fetched`,
+      { fetched: allWorkouts.length, total }
+    )
+  }
+
+  return allWorkouts
+}
+
 export const ingestWahooTask = task({
   id: 'ingest-wahoo',
   queue: userIngestionQueue,
@@ -42,10 +99,10 @@ export const ingestWahooTask = task({
 
     try {
       logger.log('Fetching workouts from Wahoo...')
-      // Wahoo Cloud API returns descending by default.
-      // We might need to handle pagination if there are many workouts.
-      const { workouts, total } = await fetchWahooWorkouts(integration, 1, 100)
-      logger.log(`Fetched ${workouts.length} workouts from Wahoo (Total available: ${total})`)
+      // Wahoo Cloud API returns descending by default. Paginate until we've retrieved
+      // everything the API reports as available (bounded by a safety cap).
+      const workouts = await fetchAllWahooWorkouts(integration)
+      logger.log(`Fetched ${workouts.length} total workouts from Wahoo`)
 
       const start = new Date(startDate)
       const end = new Date(endDate)


### PR DESCRIPTION
Fixes CW-54

## Summary
`trigger/ingest-wahoo.ts` previously fetched only page 1 with a hardcoded limit of 100 workouts and had no pagination logic, silently truncating history for athletes with more than 100 workouts in their requested sync window.

- Added `fetchAllWahooWorkouts()`, which paginates through the Wahoo Cloud API (`fetchWahooWorkouts` in `server/utils/wahoo.ts`, which already supports `page`/`perPage` params) until either:
  - all workouts reported by the API's `total` count have been collected,
  - a short or empty page is returned (end of data, regardless of what `total` says), or
  - a safety cap of 50 pages (5,000 workouts) is hit, to guard against a misbehaving API.
- Mirrors the existing pagination convention used by `fetchStravaActivities` in `server/utils/strava.ts` (loop until a short page signals the last page).
- Added a 250ms delay between page requests to stay comfortably under Wahoo's rate limits (Wahoo has no documented backoff convention in this codebase, so a simple fixed delay was used, similar in spirit to other providers' throttling).
- Logs a warning if the safety cap is hit so truncation is visible in task logs rather than silent.

## Verification
```
pnpm typecheck   # passed, no errors
pnpm exec eslint trigger/ingest-wahoo.ts tests/unit/trigger/ingest-wahoo.test.ts   # clean
pnpm vitest run tests/unit/trigger/   # 16 files, 104 tests passed
```

Added `tests/unit/trigger/ingest-wahoo.test.ts` covering the new pagination helper directly (mocking `fetchWahooWorkouts`):
- aggregates workouts across multiple pages until a short page is returned
- stops once the reported `total` has been collected
- stops immediately on an empty first page
- honors the safety cap when the API never signals completion