### PR TITLE
fix(infra): fail closed on transient Trigger.dev run-status errors (CW-43)

### DIFF
--- a/server/utils/integration-sync-guard.ts
+++ b/server/utils/integration-sync-guard.ts
@@ -51,12 +51,24 @@ export async function isProviderActivelySyncing(
     return false
   }
 
-  const [providerRunning, batchRunning] = await Promise.all([
-    isTaskRunningForUser(taskId, userId),
-    isTaskRunningForUser('ingest-all', userId)
-  ])
+  try {
+    const [providerRunning, batchRunning] = await Promise.all([
+      isTaskRunningForUser(taskId, userId),
+      isTaskRunningForUser('ingest-all', userId)
+    ])
 
-  return providerRunning || batchRunning
+    return providerRunning || batchRunning
+  } catch (error) {
+    // Couldn't confirm run status (isTaskRunningForUser already retried and
+    // gave up) — a transient Trigger.dev/Redis blip. Fail closed: treat the
+    // integration as actively syncing so we neither clear its SYNCING
+    // status nor let a duplicate sync be dispatched.
+    console.warn(
+      `[SyncGuard] Unable to determine sync status for provider "${provider}"; assuming active`,
+      error
+    )
+    return true
+  }
 }
 
 export async function resolveProviderSyncBlock(
@@ -82,7 +94,16 @@ export async function resolveProviderSyncBlock(
 }
 
 export async function resolveSyncAllBlock(userId: string): Promise<SyncBlockResult> {
-  const batchRunning = await isTaskRunningForUser('ingest-all', userId)
+  let batchRunning: boolean
+  try {
+    batchRunning = await isTaskRunningForUser('ingest-all', userId)
+  } catch (error) {
+    // Same fail-closed reasoning as isProviderActivelySyncing above: an
+    // unconfirmed run status must not be treated as "safe to dispatch".
+    console.warn('[SyncGuard] Unable to determine ingest-all run status; assuming active', error)
+    batchRunning = true
+  }
+
   if (batchRunning) {
     const syncingIntegration = await prisma.integration.findFirst({
       where: { userId, syncStatus: 'SYNCING' },

--- a/server/utils/task-dispatcher.ts
+++ b/server/utils/task-dispatcher.ts
@@ -548,15 +548,53 @@ export async function getTaskStatus(
   }
 }
 
+const TASK_RUNNING_CHECK_MAX_ATTEMPTS = 3
+const TASK_RUNNING_CHECK_RETRY_DELAY_MS = 250
+
+/**
+ * Reports whether a task is currently running for a user.
+ *
+ * This backs sync/dispatch guards (see integration-sync-guard.ts), so a
+ * transient Trigger.dev/Redis API error must never be reported as "not
+ * running" here: a caller that saw `false` would treat it as safe to
+ * dispatch and could enqueue a duplicate task during an API blip. We retry a
+ * few times with a short backoff, and if we still can't get a confident
+ * answer we throw so the caller fails closed (treats "couldn't determine"
+ * as "don't dispatch") instead of silently proceeding.
+ */
 export async function isTaskRunningForUser(
   taskIdentifier: string,
   userId: string
 ): Promise<boolean> {
-  const runsForUser = await listTaskRunsForUser(userId, 100)
-  return runsForUser.some(
-    (run) =>
-      run.taskIdentifier === taskIdentifier &&
-      ACTIVE_RUN_STATUSES.has(run.status) &&
-      (!run.id.startsWith('run_') || isRunFresh(run))
+  let lastError: unknown
+  for (let attempt = 1; attempt <= TASK_RUNNING_CHECK_MAX_ATTEMPTS; attempt++) {
+    try {
+      const runsForUser = await listTaskRunsForUser(userId, 100)
+      return runsForUser.some(
+        (run) =>
+          run.taskIdentifier === taskIdentifier &&
+          ACTIVE_RUN_STATUSES.has(run.status) &&
+          (!run.id.startsWith('run_') || isRunFresh(run))
+      )
+    } catch (error) {
+      lastError = error
+      if (attempt < TASK_RUNNING_CHECK_MAX_ATTEMPTS) {
+        console.warn(
+          `[TaskDispatcher] isTaskRunningForUser check failed for "${taskIdentifier}" ` +
+            `(attempt ${attempt}/${TASK_RUNNING_CHECK_MAX_ATTEMPTS}), retrying`,
+          error
+        )
+        await new Promise((resolve) =>
+          setTimeout(resolve, TASK_RUNNING_CHECK_RETRY_DELAY_MS * attempt)
+        )
+      }
+    }
+  }
+
+  throw new Error(
+    `Unable to determine run status for task "${taskIdentifier}" after ` +
+      `${TASK_RUNNING_CHECK_MAX_ATTEMPTS} attempts: ` +
+      `${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    { cause: lastError }
   )
 }

--- a/tests/unit/server/utils/integration-sync-guard.test.ts
+++ b/tests/unit/server/utils/integration-sync-guard.test.ts
@@ -103,6 +103,48 @@ describe('integration-sync-guard', () => {
     expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'provider' })
   })
 
+  it('fails closed and blocks provider sync when the run-status check errors (transient API failure)', async () => {
+    isTaskRunningMock.mockRejectedValue(new Error('Trigger.dev API request failed'))
+
+    const { resolveProviderSyncBlock } =
+      await import('../../../../server/utils/integration-sync-guard')
+
+    const result = await resolveProviderSyncBlock('user-1', {
+      id: 'integration-oura',
+      provider: 'oura',
+      syncStatus: 'SYNCING'
+    })
+
+    expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'provider' })
+    expect(prismaMock.integration.update).not.toHaveBeenCalled()
+  })
+
+  it('fails closed and blocks sync-all when the ingest-all run-status check errors (transient API failure)', async () => {
+    isTaskRunningMock.mockRejectedValue(new Error('Trigger.dev API request failed'))
+    prismaMock.integration.findFirst.mockResolvedValue({ provider: 'oura' })
+
+    const { resolveSyncAllBlock } = await import('../../../../server/utils/integration-sync-guard')
+
+    const result = await resolveSyncAllBlock('user-1')
+
+    expect(result).toEqual({ blocked: true, provider: 'oura', reason: 'ingest-all' })
+    expect(prismaMock.integration.update).not.toHaveBeenCalled()
+  })
+
+  it('does not fail closed when the run-status check cleanly reports nothing running', async () => {
+    isTaskRunningMock.mockResolvedValue(false)
+    prismaMock.integration.findMany.mockResolvedValue([
+      { id: 'integration-oura', provider: 'oura', syncStatus: 'SYNCING' }
+    ])
+
+    const { resolveSyncAllBlock } = await import('../../../../server/utils/integration-sync-guard')
+
+    const result = await resolveSyncAllBlock('user-1')
+
+    expect(result).toEqual({ blocked: false })
+    expect(prismaMock.integration.update).toHaveBeenCalledTimes(1)
+  })
+
   it('formats sync-in-progress messages for batch and provider blocks', async () => {
     const { formatSyncInProgressMessage } =
       await import('../../../../server/utils/integration-sync-guard')

--- a/tests/unit/server/utils/task-dispatcher.test.ts
+++ b/tests/unit/server/utils/task-dispatcher.test.ts
@@ -5,6 +5,7 @@ import {
   dispatchTask,
   getTaskDriver,
   getTaskStatus,
+  isTaskRunningForUser,
   listTaskRunsForUser,
   parseTaskRunId
 } from '../../../../server/utils/task-dispatcher'
@@ -36,7 +37,8 @@ vi.mock('../../../../server/utils/task-registry', () => ({
 }))
 
 vi.mock('../../../../server/utils/trigger-check', () => ({
-  safeTriggerTask: vi.fn()
+  safeTriggerTask: vi.fn(),
+  isRunFresh: vi.fn().mockReturnValue(true)
 }))
 
 function redisJob(overrides: Record<string, unknown> = {}) {
@@ -62,6 +64,7 @@ describe('Task Dispatcher Framework', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.mocked(hasTaskHandler).mockImplementation((taskId) => taskId !== 'trigger-only-task')
+    vi.mocked(triggerCheck.isRunFresh).mockReturnValue(true)
     process.env = { ...originalEnv }
   })
 
@@ -203,6 +206,46 @@ describe('Task Dispatcher Framework', () => {
         isRunning: false,
         status: 'NOT_FOUND'
       })
+    })
+  })
+
+  describe('isTaskRunningForUser() resilience', () => {
+    it('retries a transient run-status error and returns the confirmed result', async () => {
+      process.env.TASK_QUEUE_DRIVER = 'trigger'
+      vi.mocked(runs.list)
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 'run_1',
+              taskIdentifier: 'ingest-strava',
+              status: 'EXECUTING',
+              createdAt: new Date(),
+              tags: ['user:u1']
+            }
+          ]
+        } as any)
+
+      await expect(isTaskRunningForUser('ingest-strava', 'u1')).resolves.toBe(true)
+      expect(runs.list).toHaveBeenCalledTimes(2)
+    })
+
+    it('fails closed by throwing once every retry attempt errors, instead of reporting "not running"', async () => {
+      process.env.TASK_QUEUE_DRIVER = 'trigger'
+      vi.mocked(runs.list).mockRejectedValue(new Error('Request contains an invalid argument.'))
+
+      await expect(isTaskRunningForUser('ingest-strava', 'u1')).rejects.toThrow(
+        /Unable to determine run status/
+      )
+      expect(runs.list).toHaveBeenCalledTimes(3)
+    })
+
+    it('resolves false once the API confirms cleanly that nothing is running', async () => {
+      process.env.TASK_QUEUE_DRIVER = 'trigger'
+      vi.mocked(runs.list).mockResolvedValueOnce({ data: [] } as any)
+
+      await expect(isTaskRunningForUser('ingest-strava', 'u1')).resolves.toBe(false)
+      expect(runs.list).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
Fixes CW-43

## Summary

`isTaskRunningForUser` in `server/utils/task-dispatcher.ts` had no retry or error handling around the underlying Trigger.dev/Redis run-status query. Under the `trigger` driver (the production default when `TRIGGER_SECRET_KEY` is set), a transient Trigger.dev API error while listing runs threw straight up through the sync guards in `server/utils/integration-sync-guard.ts` with no catch, and the deduplication chain in `trigger/ingest-all.ts` had a log line implying "check failed" was already handled gracefully, when it actually wasn't — an uncaught exception there aborted before any duplicate dispatch could happen, but the sync-guard callers (used by `server/api/integrations/sync.post.ts`) had no such implicit protection and would surface as an unhandled 500 rather than a controlled "sync in progress" response.

### Fix

- `isTaskRunningForUser` now retries up to 3 times with a short backoff (250ms, 500ms) before giving up, and throws a clear error if it still can't confirm run status — it never silently reports "not running" for an unconfirmed state.
- `integration-sync-guard.ts`'s `isProviderActivelySyncing` and `resolveSyncAllBlock` now catch that error and treat it the same as "task is running" (fail closed), so a transient API error blocks a duplicate dispatch/stale-status clear instead of being treated as safe to proceed.
- Extended `tests/unit/server/utils/integration-sync-guard.test.ts` with cases for: transient API error → guard does not allow a duplicate dispatch and does not clear stale status; clean "no task running" response → guard still allows dispatch/clears stale status as before.
- Extended `tests/unit/server/utils/task-dispatcher.test.ts` with direct coverage of `isTaskRunningForUser`'s retry-then-succeed and retry-then-fail-closed paths.

Only the owned paths (`server/utils/task-dispatcher.ts`, `server/utils/integration-sync-guard.ts`) plus their corresponding test files were touched.

## Verification

```
pnpm test:unit tests/unit/server/utils/integration-sync-guard.test.ts
# Test Files  1 passed (1)
#      Tests  9 passed (9)

pnpm test:unit tests/unit/server/utils/task-dispatcher.test.ts
# Test Files  1 passed (1)
#      Tests  15 passed (15)

pnpm typecheck
# EXIT_CODE=0, no errors
```