### PR TITLE
perf(tests): default vitest env to node, threads pool

### DIFF
--- a/tests/unit/app/chartjs-annotation.test.ts
+++ b/tests/unit/app/chartjs-annotation.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
 import { Chart as ChartJS } from 'chart.js'
 import {

--- a/tests/unit/app/chat-domain-tool-card.test.ts
+++ b/tests/unit/app/chat-domain-tool-card.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import ChatDomainToolCard from '../../../app/components/chat/ChatDomainToolCard.vue'

--- a/tests/unit/app/chat-message-content.test.ts
+++ b/tests/unit/app/chat-message-content.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import ChatMessageContent from '../../../app/components/chat/ChatMessageContent.vue'

--- a/tests/unit/app/chat-planned-workout-card.test.ts
+++ b/tests/unit/app/chat-planned-workout-card.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts
+++ b/tests/unit/app/components/chat/ChatPlannedWorkoutCard.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/tests/unit/app/dashboard-hydration-quick-card.test.ts
+++ b/tests/unit/app/dashboard-hydration-quick-card.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import DashboardHydrationQuickCard from '../../../app/components/dashboard/HydrationQuickCard.vue'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,7 +31,8 @@ export default defineVitestConfig({
     }
   },
   test: {
-    environment: 'happy-dom',
+    environment: 'node',
+    pool: 'threads',
     globals: true,
     hookTimeout: 180_000,
     testTimeout: 30_000,


### PR DESCRIPTION
## Summary
- `vitest.config.ts` set `environment: 'happy-dom'` globally, so every one of the 306 unit test files paid the cost of a DOM environment even though only ~17 files (Vue `mount()` calls or files opted into the `nuxt` environment) actually need one.
- Switched the default `environment` to `node` and `pool` to `threads` (lower per-file worker startup cost than the default `forks`).
- Added `// @vitest-environment happy-dom` to the 6 files that `mount()` real Vue components via `@vue/test-utils` and were relying on the old global default. The 11 files already declaring `// @vitest-environment nuxt` are untouched.

## Result
3 back-to-back full `vitest run` runs before/after, same machine:
- Before: ~85-89s wall clock
- After: ~54-67s wall clock (≈30-35% faster)

Same 347/348 test files and 1908/1913 tests pass before and after — the 5 failures in `wellness-analysis.test.ts` are pre-existing and unrelated (root-caused and filed as CW-259).

Fixes CW-260

## Test plan
- [x] `pnpm vitest run` — same pass/fail counts as before the change, run 3x for stability
- [x] Grepped all test files without an explicit `@vitest-environment` override for DOM API usage (`mount(`, `@vue/test-utils`, `document.`, `window.`, `localStorage`, `matchMedia`, `IntersectionObserver`, etc.) to confirm none were missed