### PR TITLE
fix(nutrition): add test coverage for critical fueling alert (CW-66)

### DIFF
--- a/tests/unit/server/utils/services/metabolicService.test.ts
+++ b/tests/unit/server/utils/services/metabolicService.test.ts
@@ -4,6 +4,7 @@ import { prisma } from '../../../../../server/utils/db'
 import { nutritionRepository } from '../../../../../server/utils/repositories/nutritionRepository'
 import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
 import { plannedWorkoutRepository } from '../../../../../server/utils/repositories/plannedWorkoutRepository'
+import { auditLogRepository } from '../../../../../server/utils/repositories/auditLogRepository'
 import { getUserNutritionSettings } from '../../../../../server/utils/nutrition/settings'
 import { formatUserTime } from '../../../../../server/utils/date'
 import { bodyMetricResolver } from '../../../../../server/utils/services/bodyMetricResolver'
@@ -19,7 +20,16 @@ vi.mock('../../../../../server/utils/db', () => ({
     },
     athleteJourneyEvent: {
       findMany: vi.fn()
+    },
+    auditLog: {
+      findMany: vi.fn()
     }
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/auditLogRepository', () => ({
+  auditLogRepository: {
+    log: vi.fn()
   }
 }))
 
@@ -277,6 +287,90 @@ describe('metabolicService smoke coverage', () => {
           'Europe/Budapest'
         )
       ).toBe('Pre-Workout Breakfast')
+    })
+  })
+
+  describe('checkCriticalAlerts', () => {
+    const hardMorningWorkout = {
+      id: 'w-hard-1',
+      title: 'Threshold Intervals',
+      startTime: '2026-02-13T07:00:00.000Z',
+      intensityFactor: 0.9,
+      durationSec: 60 * 60
+    }
+
+    beforeEach(() => {
+      vi.mocked(nutritionRepository.getByDate).mockResolvedValue({ id: 'nutrition-1' } as any)
+      vi.mocked(prisma.auditLog.findMany).mockResolvedValue([] as any)
+      // Morning by default (7:00 local < 10:00 cutoff)
+      vi.mocked(formatUserTime).mockReturnValue('7:0')
+    })
+
+    it('logs a CRITICAL_FUELING_ALERT when starting glycogen is critically low before a hard morning workout', async () => {
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([hardMorningWorkout] as any)
+
+      await metabolicService.checkCriticalAlerts(userId, 15, date)
+
+      expect(auditLogRepository.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId,
+          action: 'CRITICAL_FUELING_ALERT',
+          resourceType: 'Nutrition',
+          resourceId: 'nutrition-1',
+          metadata: expect.objectContaining({
+            startingGlycogen: 15,
+            workoutId: 'w-hard-1',
+            workoutTitle: 'Threshold Intervals'
+          })
+        })
+      )
+    })
+
+    it('does not log an alert when starting glycogen is not critically low', async () => {
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([hardMorningWorkout] as any)
+
+      await metabolicService.checkCriticalAlerts(userId, 45, date)
+
+      expect(workoutRepository.getForUser).not.toHaveBeenCalled()
+      expect(auditLogRepository.log).not.toHaveBeenCalled()
+    })
+
+    it('does not log an alert when there is no hard morning workout', async () => {
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+        { ...hardMorningWorkout, intensityFactor: 0.5 }
+      ] as any)
+
+      await metabolicService.checkCriticalAlerts(userId, 10, date)
+
+      expect(auditLogRepository.log).not.toHaveBeenCalled()
+    })
+
+    it('does not log an alert for a hard workout later in the day', async () => {
+      // Afternoon local time (>= 10:00 cutoff)
+      vi.mocked(formatUserTime).mockReturnValue('15:0')
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([hardMorningWorkout] as any)
+
+      await metabolicService.checkCriticalAlerts(userId, 10, date)
+
+      expect(auditLogRepository.log).not.toHaveBeenCalled()
+    })
+
+    it('does not throw and returns cleanly when no workouts exist for the day', async () => {
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([] as any)
+
+      await expect(metabolicService.checkCriticalAlerts(userId, 5, date)).resolves.toBeUndefined()
+      expect(auditLogRepository.log).not.toHaveBeenCalled()
+    })
+
+    it('de-dupes and does not re-log an alert already recorded for the same date', async () => {
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([hardMorningWorkout] as any)
+      vi.mocked(prisma.auditLog.findMany).mockResolvedValue([
+        { metadata: { date: date.toISOString().split('T')[0] } }
+      ] as any)
+
+      await metabolicService.checkCriticalAlerts(userId, 12, date)
+
+      expect(auditLogRepository.log).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Fixes CW-66

## Summary
CW-66 reported that `metabolicService.checkCriticalAlerts()` had its body deleted in commit `54ef94d2` (replaced with a `// ... logic remains same` stub), creating a silent dead path for the low-starting-glycogen-before-a-hard-morning-workout audit alert.

**Investigation finding: the logic bug was already fixed.** A later refactor, commit `09dcd22c0` ("Add partner campaigns and harden coaching invites, quotas, and roster access.", 2026-07-14), re-implemented `checkCriticalAlerts` in full — it detects `startingGlycogen < 20` before a hard morning workout (intensity >= 0.85, duration >= 45min, local start hour < 10), de-dupes against recent audit log entries for the same date, and writes a `CRITICAL_FUELING_ALERT` audit log entry via `auditLogRepository.log(...)`. The call site in `finalizeDay()` (around line 862) correctly awaits it. Confirmed via `git blame` — current implementation at `server/utils/services/metabolicService.ts:1570-1631` is entirely attributed to `09dcd22c0`, not the stub commit.

What was still missing per the ticket's acceptance criteria: **unit test coverage**. This PR adds it — no production code changes.

### Test coverage added (`tests/unit/server/utils/services/metabolicService.test.ts`)
- Alert logged when `startingGlycogen < 20` before a hard morning workout
- No alert when glycogen is not critically low
- No alert when the workout isn't hard enough
- No alert when the hard workout isn't in the morning
- No alert/throw when there are no workouts for the day (clean return)
- De-dupe: no repeat alert for a date already logged

## Verification
```
pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts
# Test Files  1 passed (1)
# Tests  18 passed (18)

pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts
# Test Files  1 passed (1)
# Tests  15 passed (15)

pnpm typecheck
# exit 0, no errors
```