### PR TITLE
fix(nutrition): retry QUOTA_EXCEEDED nutrition analyses (CW-77)

### DIFF
--- a/server/utils/repositories/nutritionRepository.ts
+++ b/server/utils/repositories/nutritionRepository.ts
@@ -123,7 +123,8 @@ export const nutritionRepository = {
           { aiAnalysisStatus: null },
           { aiAnalysisStatus: 'NOT_STARTED' },
           { aiAnalysisStatus: 'PENDING' },
-          { aiAnalysisStatus: 'FAILED' }
+          { aiAnalysisStatus: 'FAILED' },
+          { aiAnalysisStatus: 'QUOTA_EXCEEDED' }
         ]
       },
       select: {

--- a/tests/unit/server/utils/repositories/nutritionRepository.test.ts
+++ b/tests/unit/server/utils/repositories/nutritionRepository.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { nutritionRepository } from '../../../../../server/utils/repositories/nutritionRepository'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    nutrition: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      upsert: vi.fn()
+    }
+  }
+}))
+
+describe('nutritionRepository', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getPendingAnalysis', () => {
+    it('includes QUOTA_EXCEEDED alongside the other pending statuses so rate-limited records are re-processed', async () => {
+      vi.mocked(prisma.nutrition.findMany).mockResolvedValue([])
+
+      await nutritionRepository.getPendingAnalysis(userId)
+
+      expect(prisma.nutrition.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId,
+            OR: expect.arrayContaining([
+              { aiAnalysisStatus: null },
+              { aiAnalysisStatus: 'NOT_STARTED' },
+              { aiAnalysisStatus: 'PENDING' },
+              { aiAnalysisStatus: 'FAILED' },
+              { aiAnalysisStatus: 'QUOTA_EXCEEDED' }
+            ])
+          })
+        })
+      )
+    })
+
+    it('scopes to an end date when provided', async () => {
+      vi.mocked(prisma.nutrition.findMany).mockResolvedValue([])
+      const endDate = new Date('2026-01-01')
+
+      await nutritionRepository.getPendingAnalysis(userId, endDate)
+
+      expect(prisma.nutrition.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId,
+            date: { lte: endDate }
+          })
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes CW-77

## Summary
- `nutritionRepository.getPendingAnalysis()` only matched `null`/`NOT_STARTED`/`PENDING`/`FAILED` statuses, so records marked `QUOTA_EXCEEDED` after a 429 from the quota engine were permanently stranded and never picked up again by the manual bulk re-analysis endpoint (`POST /api/nutrition/analyze-all`). Added `QUOTA_EXCEEDED` to the status `OR` filter.
- No backoff logic was added: this query is only consumed by the manual, user-initiated "re-analyze all" endpoint (batched at 10 records per click), not an automatic/cron loop, so there's no risk of hammering the AI provider on a tight retry cadence.

### Already fixed (verified, no change needed)
The ticket's other defect — `data_completeness` schema `required: ['status', 'confidence', 'reasoning']` vs. the declared `reasoningText` property — was already resolved on `develop` by commit `0c5e04583` ("fix(worker): restore Redis queue proxy and harden Gemini task schemas"). Current code on this branch already has `required: ['status', 'confidence', 'reasoningText']` matching the property name, so `trigger/analyze-nutrition.ts` was left untouched.

## Test plan
- [x] Added `tests/unit/server/utils/repositories/nutritionRepository.test.ts` covering `getPendingAnalysis` status filter (including `QUOTA_EXCEEDED`) and `endDate` scoping — passes.
- [x] `pnpm typecheck` passes cleanly.

## Verification
```
$ pnpm vitest run tests/unit/server/utils/repositories/nutritionRepository.test.ts tests/unit/server/utils/repositories/workoutRepository.test.ts
 Test Files  2 passed (2)
      Tests  7 passed (7)

$ pnpm typecheck
EXIT_CODE=0
```