### PR TITLE
fix(nutrition): scope hydration double-count suppression per drink segment (CW-69)

### DIFF
--- a/server/utils/nutrition/hydration.ts
+++ b/server/utils/nutrition/hydration.ts
@@ -120,6 +120,21 @@ function inferContainerMl(container: string): number {
   return 0
 }
 
+const EXPLICIT_VOLUME_PATTERN =
+  /(\d+(?:\.\d+)?)\s*(ml|milliliters?|millilitres?|l|liters?|litres?|oz|fl\s?oz)\b/gi
+
+// A leading count is common ("2 bottles", "three glasses") and was previously dropped, so a
+// round of drinks logged as one phrase counted as a single container.
+const CONTAINER_PATTERN =
+  /\b(\d+|one|two|three|four|five|six)?\s*(large|medium|small)?\s*(bottles?|glass(?:es)?|cups?|flasks?)\b/gi
+
+// Separators that mark genuinely distinct drink entries rather than one drink described
+// twice, e.g. "500ml + a glass of water" is two separate drinks. Explicit-volume vs.
+// container-estimate double counting ("a 500ml bottle of water") is only a risk *within*
+// one of these segments/clauses, so double-count suppression is scoped per segment instead
+// of across the whole message.
+const DRINK_SEPARATOR_PATTERN = /\s*(?:\+|,|;|\n|\band\b|\bthen\b)\s*/
+
 export function extractFluidIntakeMl(text: string): number {
   if (!text || typeof text !== 'string') return 0
   const lower = text.toLowerCase()
@@ -127,33 +142,34 @@ export function extractFluidIntakeMl(text: string): number {
   if (!hasFluidKeyword) return 0
 
   let totalMl = 0
-  let hasExplicitVolume = false
-  const explicitVolumePattern =
-    /(\d+(?:\.\d+)?)\s*(ml|milliliters?|millilitres?|l|liters?|litres?|oz|fl\s?oz)\b/gi
-  for (const match of Array.from(lower.matchAll(explicitVolumePattern))) {
-    const value = Number(match[1] || 0)
-    const unit = (match[2] || '').toLowerCase()
-    if (!value) continue
-    hasExplicitVolume = true
-    if (unit === 'ml' || unit.startsWith('millil')) totalMl += value
-    else if (unit === 'l' || unit.startsWith('liter') || unit.startsWith('litre'))
-      totalMl += value * 1000
-    else totalMl += value * OUNCE_TO_ML
-  }
+  for (const segment of lower.split(DRINK_SEPARATOR_PATTERN)) {
+    if (!segment) continue
 
-  // If the user already gave an explicit volume ("500ml bottle"), don't also add a
-  // container estimate (which would double count).
-  if (!hasExplicitVolume) {
-    // A leading count is common ("2 bottles", "three glasses") and was previously dropped, so a
-    // round of drinks logged as one phrase counted as a single container.
-    const containerPattern =
-      /\b(\d+|one|two|three|four|five|six)?\s*(large|medium|small)?\s*(bottles?|glass(?:es)?|cups?|flasks?)\b/gi
-    for (const match of Array.from(lower.matchAll(containerPattern))) {
-      const descriptor = `${match[2] || ''} ${match[3] || ''}`.trim()
-      const perContainerMl = inferContainerMl(descriptor)
-      if (!perContainerMl) continue
-      totalMl += perContainerMl * parseCount(match[1])
+    let segmentMl = 0
+    let hasExplicitVolume = false
+    for (const match of Array.from(segment.matchAll(EXPLICIT_VOLUME_PATTERN))) {
+      const value = Number(match[1] || 0)
+      const unit = (match[2] || '').toLowerCase()
+      if (!value) continue
+      hasExplicitVolume = true
+      if (unit === 'ml' || unit.startsWith('millil')) segmentMl += value
+      else if (unit === 'l' || unit.startsWith('liter') || unit.startsWith('litre'))
+        segmentMl += value * 1000
+      else segmentMl += value * OUNCE_TO_ML
     }
+
+    // If this segment already gave an explicit volume ("500ml bottle"), don't also add a
+    // container estimate for the same drink (which would double count).
+    if (!hasExplicitVolume) {
+      for (const match of Array.from(segment.matchAll(CONTAINER_PATTERN))) {
+        const descriptor = `${match[2] || ''} ${match[3] || ''}`.trim()
+        const perContainerMl = inferContainerMl(descriptor)
+        if (!perContainerMl) continue
+        segmentMl += perContainerMl * parseCount(match[1])
+      }
+    }
+
+    totalMl += segmentMl
   }
 
   return Math.round(totalMl)

--- a/tests/unit/server/utils/nutrition-tools.test.ts
+++ b/tests/unit/server/utils/nutrition-tools.test.ts
@@ -6,6 +6,7 @@ import { metabolicService } from '../../../../server/utils/services/metabolicSer
 import { mealRecommendationService } from '../../../../server/utils/services/mealRecommendationService'
 import { nutritionPlanService } from '../../../../server/utils/services/nutritionPlanService'
 import { getUserNutritionSettings } from '../../../../server/utils/nutrition/settings'
+import { extractFluidIntakeMl } from '../../../../server/utils/nutrition/hydration'
 
 vi.mock('../../../../server/utils/db', () => ({
   prisma: {
@@ -360,5 +361,19 @@ describe('nutrition chat tools', () => {
       ]
     })
     expect(result.totals.water_ml).toBe(750)
+  })
+})
+
+describe('extractFluidIntakeMl container vs. explicit volume double-counting (CW-69)', () => {
+  it('does not add a container estimate on top of an explicit volume for the same drink', () => {
+    expect(extractFluidIntakeMl('a 500ml bottle of water')).toBe(500)
+  })
+
+  it('falls back to a container estimate when no explicit volume is given', () => {
+    expect(extractFluidIntakeMl('a bottle of water')).toBe(500)
+  })
+
+  it('sums independent entries instead of suppressing the second one', () => {
+    expect(extractFluidIntakeMl('500ml + a glass of water')).toBe(750)
   })
 })


### PR DESCRIPTION
Fixes CW-69

## Summary
`extractFluidIntakeMl` in `server/utils/nutrition/hydration.ts` used a single message-wide `hasExplicitVolume` flag to decide whether to skip the container-keyword estimate pass. That correctly prevented "a 500ml bottle of water" from double counting to 1000ml, but it also incorrectly suppressed the container estimate for any *other*, independent drink mentioned in the same message — e.g. "500ml + a glass of water" collapsed to 500ml instead of the correct 750ml (500ml + 250ml glass).

Fix: split the input on separators that indicate genuinely distinct drink entries (`+`, `,`, `;`, newlines, "and", "then") and scope the explicit-volume-vs-container-estimate double-count suppression to each segment independently, rather than to the whole message. This keeps single-drink descriptions ("a 500ml bottle of water") from double counting while still summing independent entries correctly.

## Changes
- `server/utils/nutrition/hydration.ts`: per-segment double-count suppression in `extractFluidIntakeMl`
- `tests/unit/server/utils/nutrition-tools.test.ts`: added the three CW-69 acceptance-criteria cases

## Verification
```
pnpm vitest run tests/unit/server/utils/nutrition-tools.test.ts
# Test Files  1 passed (1)
# Tests  11 passed (11)
```

Also ran the pre-existing hydration unit tests (`tests/unit/server/utils/nutrition/hydration-advice.test.ts`) to confirm no regressions — all 11 pass, 22/22 total across both files. `pnpm typecheck` passes clean.