### PR TITLE
fix(chat): retain direct-send failures for retry (CW-63)

### DIFF
--- a/app/components/chat/ChatMessageList.vue
+++ b/app/components/chat/ChatMessageList.vue
@@ -390,6 +390,8 @@
   const canShowTurnStatus = (message: any) => shouldShowAssistantStatusRow(message)
   const isQueuedUserMessage = (message: any) =>
     message?.role === 'user' && message?.metadata?.localQueueState === 'QUEUED'
+  const isFailedQueuedUserMessage = (message: any) =>
+    message?.role === 'user' && message?.metadata?.localQueueState === 'FAILED'
   const resumeTurn = (turnId?: string) => {
     if (!turnId) return
     emit('resume-turn', turnId)
@@ -903,7 +905,9 @@
                 message.role === 'user'
                   ? isQueuedUserMessage(message)
                     ? 'animate-pulse rounded-[1.75rem] rounded-tr-lg bg-amber-500/22 px-4 py-2 text-white ring-1 ring-inset ring-amber-300/35 dark:bg-amber-400/16 dark:ring-amber-200/20'
-                    : 'rounded-[1.75rem] rounded-tr-lg bg-gray-800/95 px-4 py-2 text-white dark:bg-gray-700/95 dark:text-gray-50'
+                    : isFailedQueuedUserMessage(message)
+                      ? 'rounded-[1.75rem] rounded-tr-lg bg-red-500/22 px-4 py-2 text-white ring-1 ring-inset ring-red-300/35 dark:bg-red-400/16 dark:ring-red-200/20'
+                      : 'rounded-[1.75rem] rounded-tr-lg bg-gray-800/95 px-4 py-2 text-white dark:bg-gray-700/95 dark:text-gray-50'
                   : ''
               "
             >

--- a/app/pages/chat.vue
+++ b/app/pages/chat.vue
@@ -489,6 +489,7 @@
     }, delayMs)
   }
   const sendOutgoingMessage = async (message: {
+    id: string
     text: string
     attachments: QueuedAttachment[]
   }) => {
@@ -497,6 +498,10 @@
       (chat as any).sendMessage(
         parts.length > 0
           ? {
+              // Reusing the same client-generated id across attempts lets the server
+              // recognize a retry of an already-persisted message (see
+              // server/api/chat/messages.post.ts) instead of creating a duplicate.
+              id: message.id,
               role: 'user',
               parts
             }
@@ -529,6 +534,7 @@
 
     try {
       await sendOutgoingMessage({
+        id: nextQueuedMessage.id,
         text: nextQueuedMessage.text,
         attachments: nextQueuedMessage.attachments
       })
@@ -929,14 +935,27 @@
       awaitingTurnStart.value = true
       try {
         await sendOutgoingMessage({
+          id: outgoingMessage.id,
           text: submittedText,
           attachments
         })
         input.value = ''
-      } catch (error) {
+      } catch (error: any) {
+        // The direct-send path bypassed the durable outgoing queue entirely, so a
+        // transient failure here used to just restore the composer text and leave
+        // no trace of the message anywhere else. Fall back to the same durable
+        // queue the "turn already active" branch above uses, so the message is
+        // retained, visible, and retried the same way. Reusing outgoingMessage.id
+        // (rather than generating a new one) means a retry can't duplicate a
+        // message that actually landed server-side before the client saw the error.
         awaitingTurnStart.value = false
-        input.value = submittedText
-        throw error
+        enqueueOutgoingMessage({ ...outgoingMessage, failed: true })
+        input.value = ''
+        toast.add({
+          title: 'Message failed to send',
+          description: error?.message || 'Could not send the message. It will retry when ready.',
+          color: 'error'
+        })
       }
     }
   }


### PR DESCRIPTION
Fixes CW-63

## Problem

Messages sent while no turn was active (the "direct send" path in `app/pages/chat.vue`) bypassed the durable outgoing queue entirely. If that send failed transiently, the code just restored the composer text and re-threw — no retained, retryable trace of the message anywhere, unlike a message that was queued behind an already-active turn.

## Fix

`app/pages/chat.vue`:
- On a direct-send failure, fall back to the same `enqueueOutgoingMessage` mechanism the "turn already active" branch already uses, marking the message `failed`. This persists it (sessionStorage-backed queue) and lets it ride the existing automatic retry triggers (new message arrival, terminal-turn sync, room reload) instead of vanishing.
- Threaded the client-generated message `id` through to `chat.sendMessage` for both the queued-retry and the new direct-send-fallback path, so a retry reuses the same id the server already dedupes on in `server/api/chat/messages.post.ts` (`existingMessage` lookup by `lastMessage.id`). This prevents a duplicate persisted message/turn if the original request actually landed server-side before the client observed the error (e.g. a dropped response).

`app/components/chat/ChatMessageList.vue`:
- Gave `FAILED` queued user messages a distinct (red) bubble style, reusing the exact same style pattern already used for `QUEUED` messages (just swapping the color token). Previously a failed queued message silently reverted to the normal "sent" bubble look, so the only failure signal was a toast at the moment of failure. This keeps the existing toast pattern intact while adding a persistent, in-thread visual cue.

Note for a human to fix later: this ticket's Linear title ("Admin queue status API is unauthenticated") does not match its own description/acceptance-criteria, which is entirely about chat direct-send retry. Confirmed via the description/acceptance-criteria and the matching `docs/issues/223-chat-direct-send-no-retry.md` doc — implemented against those, not the mismatched title.

## Verification
- `pnpm typecheck` — passes, no errors.
- `npx eslint app/pages/chat.vue app/components/chat/ChatMessageList.vue` — clean.
- `npx vitest run tests/unit/server/api/chat.test.ts` — 8/8 passing (existing chat API unit coverage, sanity-checked since it exercises the same message-id-based dedup path server-side that this fix now relies on).
- No existing unit/e2e test file exercises `chat.vue`'s internal queue/direct-send logic in isolation (it's a large SFC with no exported internals, and the e2e chat suite has no network-failure simulation harness), so no new test was added per the "straightforward" guidance — flagging this as a coverage gap rather than skipping silently.