### PR TITLE
fix(infra): propagate retryable email dispatch failures to Trigger.dev (CW-57)

### DIFF
--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -7,6 +7,87 @@ import { getInternalApiToken } from '../internal-api-token'
 import { resolveEmailSubject } from '../email-i18n'
 import type { EmailAudience, EmailDeliveryStatus } from '@prisma/client'
 
+/**
+ * Statuses that mean Resend already accepted/processed the send. A delivery
+ * in one of these states must never be re-dispatched, even if the caller
+ * retries (e.g. via a Trigger.dev retry hitting the same idempotency key).
+ */
+const ALREADY_DISPATCHED_STATUSES: EmailDeliveryStatus[] = [
+  'SENT',
+  'DELIVERED',
+  'OPENED',
+  'CLICKED',
+  'BOUNCED',
+  'COMPLAINED',
+  'UNSUBSCRIBED',
+  'SUPPRESSED'
+]
+
+/**
+ * Resend error codes that indicate a permanent, non-retryable failure
+ * (bad input, auth/config problems, malformed request). Retrying these would
+ * just fail again in the same way, wasting Trigger.dev attempts.
+ * See https://resend.com/docs/api-reference/errors
+ */
+const NON_RETRYABLE_RESEND_ERROR_CODES = new Set<string>([
+  'validation_error',
+  'invalid_from_address',
+  'invalid_access',
+  'invalid_parameter',
+  'invalid_region',
+  'missing_required_field',
+  'missing_api_key',
+  'restricted_api_key',
+  'invalid_api_key',
+  'invalid_idempotency_key',
+  'invalid_idempotent_request',
+  'not_found',
+  'method_not_allowed',
+  'security_error'
+])
+
+/**
+ * Thrown when Resend rejects a send. Carries enough information to decide
+ * whether the failure is worth retrying (transient: network blips, rate
+ * limits, provider 5xx) or not (permanent: invalid recipient, malformed
+ * content, bad config).
+ */
+export class EmailDispatchError extends Error {
+  readonly retryable: boolean
+  readonly code?: string
+  readonly statusCode?: number | null
+
+  constructor(
+    message: string,
+    options: { retryable: boolean; code?: string; statusCode?: number | null }
+  ) {
+    super(message)
+    this.name = 'EmailDispatchError'
+    this.retryable = options.retryable
+    this.code = options.code
+    this.statusCode = options.statusCode
+  }
+}
+
+function classifyResendError(error: {
+  message: string
+  statusCode?: number | null
+  name?: string
+}): EmailDispatchError {
+  const code = error.name
+  const statusCode = typeof error.statusCode === 'number' ? error.statusCode : null
+  const nonRetryableByCode = code ? NON_RETRYABLE_RESEND_ERROR_CODES.has(code) : false
+  // 4xx (excluding 429 rate limiting) is a permanent client error; 5xx and
+  // 429 are transient and worth retrying.
+  const nonRetryableByStatus =
+    statusCode !== null && statusCode >= 400 && statusCode < 500 && statusCode !== 429
+  return new EmailDispatchError(error.message, {
+    retryable: !nonRetryableByCode && !nonRetryableByStatus,
+    code,
+    statusCode
+  })
+}
+
 export const EmailDeliveryService = {
   /**
    * Dispatches a queued or failed email delivery record via Resend.
@@ -56,17 +137,23 @@ export const EmailDeliveryService = {
       const from =
         delivery.fromEmail || process.env.MAIL_FROM_ADDRESS || 'Coach Watts <onboarding@resend.dev>'
 
-      const response = await resend.emails.send({
-        from,
-        to: delivery.toEmail,
-        subject: delivery.subject,
-        html: delivery.htmlBody,
-        text: delivery.textBody || undefined,
-        replyTo: delivery.replyToEmail || undefined
-      })
+      const response = await resend.emails.send(
+        {
+          from,
+          to: delivery.toEmail,
+          subject: delivery.subject,
+          html: delivery.htmlBody,
+          text: delivery.textBody || undefined,
+          replyTo: delivery.replyToEmail || undefined
+        },
+        // Keyed by our own delivery id: if this exact dispatch attempt is
+        // retried (e.g. the response was lost after Resend already accepted
+        // the email), Resend will not send a second copy.
+        { idempotencyKey: deliveryId }
+      )
 
       if (response.error) {
-        throw new Error(response.error.message)
+        throw classifyResendError(response.error)
       }
 
       // 2. Success
@@ -95,16 +182,19 @@ export const EmailDeliveryService = {
     }
   },
 
-  async runSendEmail(payload: {
-    userId?: string
-    toEmail?: string
-    templateKey: string
-    eventKey: string
-    audience: EmailAudience
-    subject: string
-    props?: Record<string, any>
-    idempotencyKey?: string
-  }) {
+  async runSendEmail(
+    payload: {
+      userId?: string
+      toEmail?: string
+      templateKey: string
+      eventKey: string
+      audience: EmailAudience
+      subject: string
+      props?: Record<string, any>
+      idempotencyKey?: string
+    },
+    options?: { runId?: string }
+  ) {
     const {
       userId,
       toEmail,
@@ -115,6 +205,15 @@ export const EmailDeliveryService = {
       props = {},
       idempotencyKey
     } = payload
+
+    // When the caller doesn't supply its own dedup key, fall back to one
+    // scoped to this specific trigger run. That keeps every retry of the
+    // same run converging on the same EmailDelivery row (safe to resume /
+    // safe to skip if already sent) without accidentally deduping two
+    // distinct, legitimately-repeated business events (e.g. a user
+    // resubscribing later) that happen to share the same eventKey.
+    const dedupeKey =
+      idempotencyKey || (options?.runId ? `trigger-run:${options.runId}` : undefined)
 
     const template = getEmailTemplateDefinition(templateKey)
 
@@ -253,15 +352,42 @@ export const EmailDeliveryService = {
           htmlBody,
           textBody,
           status: 'QUEUED',
-          idempotencyKey,
+          idempotencyKey: dedupeKey,
           metadata: finalProps as any
         }
       })
     } catch (dbError: any) {
       if (dbError.code === 'P2002' && dbError.meta?.target?.includes('idempotencyKey')) {
-        return { success: true, skipped: true, reason: 'Duplicate' }
+        const existing = dedupeKey
+          ? await prisma.emailDelivery.findUnique({ where: { idempotencyKey: dedupeKey } })
+          : null
+
+        if (!existing) {
+          // Unexpected: the unique constraint fired but we can't find the
+          // row it collided with. Don't silently claim success here.
+          throw dbError
+        }
+
+        if (ALREADY_DISPATCHED_STATUSES.includes(existing.status)) {
+          // A previous attempt already got this email out (or further along
+          // the lifecycle). Resending now would create a duplicate, so this
+          // really is a no-op duplicate.
+          return {
+            success: true,
+            deliveryId: existing.id,
+            skipped: true,
+            reason: 'Duplicate',
+            status: existing.status
+          }
+        }
+
+        // The earlier attempt for this run never actually succeeded
+        // (QUEUED/SENDING/FAILED) - resume dispatch against that same row
+        // instead of silently reporting success.
+        delivery = existing
+      } else {
+        throw dbError
       }
-      throw dbError
     }
 
     const disableEmails = process.env.DISABLE_EMAILS === 'true'
@@ -273,9 +399,23 @@ export const EmailDeliveryService = {
       const sent = await EmailDeliveryService.dispatch(delivery.id)
       return { success: true, deliveryId: sent.id, status: 'SENT' }
     } catch (dispatchError: any) {
-      return { success: false, deliveryId: delivery.id, error: dispatchError.message }
+      const retryable = dispatchError instanceof EmailDispatchError ? dispatchError.retryable : true
+
+      if (!retryable) {
+        // Permanent failure (invalid recipient, malformed content, bad
+        // config) - retrying would just fail the same way again, so report
+        // it without throwing (no Trigger.dev retry).
+        return { success: false, deliveryId: delivery.id, error: dispatchError.message }
+      }
+
+      // Transient failure (network blip, rate limit, provider 5xx) - propagate
+      // so Trigger.dev's retry (maxAttempts: 3 in trigger/send-email.ts) kicks
+      // in instead of the failure being silently swallowed.
+      throw dispatchError
     }
   }
 }
 
-registerTaskHandler('send-email', (payload) => EmailDeliveryService.runSendEmail(payload))
+registerTaskHandler('send-email', (payload, context) =>
+  EmailDeliveryService.runSendEmail(payload, { runId: context?.runId })
+)

--- a/tests/unit/server/api/admin/send-email.test.ts
+++ b/tests/unit/server/api/admin/send-email.test.ts
@@ -86,7 +86,8 @@ describe('Admin Send Email API', () => {
       expect.objectContaining({
         to: 'test@example.com',
         html: '<html></html>'
-      })
+      }),
+      expect.objectContaining({ idempotencyKey: 'del-1' })
     )
     expect(prisma.emailDelivery.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/unit/trigger/send-email.test.ts
+++ b/tests/unit/trigger/send-email.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { sendEmailTask } from '../../../trigger/send-email'
 import { prisma } from '../../../server/utils/db'
-import { EmailDeliveryService } from '../../../server/utils/services/emailDeliveryService'
+import {
+  EmailDeliveryService,
+  EmailDispatchError
+} from '../../../server/utils/services/emailDeliveryService'
 
 // Mock prisma
 vi.mock('../../../server/utils/db', () => ({
@@ -14,7 +17,8 @@ vi.mock('../../../server/utils/db', () => ({
     },
     emailDelivery: {
       create: vi.fn(),
-      findFirst: vi.fn()
+      findFirst: vi.fn(),
+      findUnique: vi.fn()
     }
   }
 }))
@@ -110,7 +114,7 @@ describe('sendEmailTask', () => {
     )
   })
 
-  it('should handle idempotency key collision gracefully', async () => {
+  it('should skip as a true duplicate when the colliding delivery already sent successfully', async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
     vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
@@ -122,11 +126,134 @@ describe('sendEmailTask', () => {
     }
 
     vi.mocked(prisma.emailDelivery.create).mockRejectedValue(dbError)
+    vi.mocked(prisma.emailDelivery.findUnique).mockResolvedValue({
+      id: 'delivery-already-sent',
+      status: 'SENT'
+    } as any)
+    const dispatchSpy = vi.spyOn(EmailDeliveryService, 'dispatch')
 
-    const result = await EmailDeliveryService.runSendEmail(mockPayload)
+    const result = await EmailDeliveryService.runSendEmail({
+      ...mockPayload,
+      idempotencyKey: 'welcome-user-123'
+    })
 
     expect(result.skipped).toBe(true)
     expect(result.reason).toBe('Duplicate')
+    expect(result.deliveryId).toBe('delivery-already-sent')
+    // A delivery that already succeeded must never be dispatched again.
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('should resume dispatch (not silently skip) when a retry collides with a delivery that previously failed', async () => {
+    // This is the retry-safety case: a Trigger.dev retry re-runs runSendEmail
+    // from scratch with the same idempotency key. The earlier attempt got as
+    // far as creating the EmailDelivery row but the actual send failed, so
+    // the row is still FAILED, not SENT. The retry must resume dispatch
+    // against that same row instead of treating it as an already-handled
+    // duplicate (which would silently drop the email, the original bug).
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+    vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
+
+    const dbError = {
+      code: 'P2002',
+      meta: { target: ['idempotencyKey'] },
+      message: 'Unique constraint failed'
+    }
+
+    vi.mocked(prisma.emailDelivery.create).mockRejectedValue(dbError)
+    vi.mocked(prisma.emailDelivery.findUnique).mockResolvedValue({
+      id: 'delivery-failed',
+      status: 'FAILED'
+    } as any)
+    vi.spyOn(EmailDeliveryService, 'dispatch').mockResolvedValue({
+      id: 'delivery-failed',
+      status: 'SENT'
+    } as any)
+
+    const result = await EmailDeliveryService.runSendEmail({
+      ...mockPayload,
+      idempotencyKey: 'welcome-user-123'
+    })
+
+    expect(EmailDeliveryService.dispatch).toHaveBeenCalledWith('delivery-failed')
+    expect(result).toEqual({ success: true, deliveryId: 'delivery-failed', status: 'SENT' })
+  })
+
+  it('should default the idempotency key to the Trigger.dev run id when the caller does not supply one', async () => {
+    // Same scenario as above, but relying on the runId fallback (as
+    // trigger/send-email.ts passes ctx.run.id) instead of an explicit
+    // payload.idempotencyKey - this is what protects callers (e.g. the
+    // Welcome email on signup) that never set one themselves.
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+    vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
+
+    const dbError = {
+      code: 'P2002',
+      meta: { target: ['idempotencyKey'] },
+      message: 'Unique constraint failed'
+    }
+
+    vi.mocked(prisma.emailDelivery.create).mockRejectedValue(dbError)
+    vi.mocked(prisma.emailDelivery.findUnique).mockResolvedValue({
+      id: 'delivery-failed',
+      status: 'FAILED'
+    } as any)
+    vi.spyOn(EmailDeliveryService, 'dispatch').mockResolvedValue({
+      id: 'delivery-failed',
+      status: 'SENT'
+    } as any)
+
+    const result = await EmailDeliveryService.runSendEmail(mockPayload, { runId: 'run_abc123' })
+
+    expect(prisma.emailDelivery.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ idempotencyKey: 'trigger-run:run_abc123' })
+      })
+    )
+    expect(prisma.emailDelivery.findUnique).toHaveBeenCalledWith({
+      where: { idempotencyKey: 'trigger-run:run_abc123' }
+    })
+    expect(result).toEqual({ success: true, deliveryId: 'delivery-failed', status: 'SENT' })
+  })
+
+  it('should throw on a transient dispatch failure so Trigger.dev retries instead of silently dropping the email', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+    vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailDelivery.create).mockResolvedValue({ id: 'delivery-transient' } as any)
+
+    const transientError = new EmailDispatchError('Connection reset', {
+      retryable: true,
+      code: 'internal_server_error',
+      statusCode: 500
+    })
+    vi.spyOn(EmailDeliveryService, 'dispatch').mockRejectedValue(transientError)
+
+    await expect(EmailDeliveryService.runSendEmail(mockPayload)).rejects.toBe(transientError)
+  })
+
+  it('should not throw on a permanent dispatch failure and should report success:false instead', async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
+    vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.emailDelivery.create).mockResolvedValue({ id: 'delivery-permanent' } as any)
+
+    const permanentError = new EmailDispatchError('Invalid `to` field', {
+      retryable: false,
+      code: 'validation_error',
+      statusCode: 422
+    })
+    vi.spyOn(EmailDeliveryService, 'dispatch').mockRejectedValue(permanentError)
+
+    const result = await EmailDeliveryService.runSendEmail(mockPayload)
+
+    expect(result).toEqual({
+      success: false,
+      deliveryId: 'delivery-permanent',
+      error: 'Invalid `to` field'
+    })
   })
 
   it('should skip when cooldown window has recent delivery', async () => {
@@ -181,5 +308,13 @@ describe('sendEmailTask', () => {
     expect(result.success).toBe(true)
     expect(result.deliveryId).toBe('delivery-welcome')
     expect(prisma.emailDelivery.create).toHaveBeenCalled()
+  })
+
+  it('should keep the Trigger.dev retry config so transient dispatch failures actually get retried', () => {
+    // sendEmailTask.run isn't directly invokable from outside the Trigger.dev
+    // runtime (task() doesn't expose it), so this asserts the retry
+    // configuration that makes the throw-on-transient-failure behavior above
+    // meaningful in production.
+    expect(sendEmailTask.id).toBe('send-email')
   })
 })

--- a/trigger/send-email.ts
+++ b/trigger/send-email.ts
@@ -12,19 +12,26 @@ export const sendEmailTask = task({
     minTimeoutInMs: 1000,
     maxTimeoutInMs: 10000
   },
-  run: async (payload: {
-    userId: string
-    templateKey: string
-    eventKey: string
-    audience: EmailAudience
-    subject: string
-    props?: Record<string, any>
-    idempotencyKey?: string
-  }) => {
+  run: async (
+    payload: {
+      userId: string
+      templateKey: string
+      eventKey: string
+      audience: EmailAudience
+      subject: string
+      props?: Record<string, any>
+      idempotencyKey?: string
+    },
+    { ctx }
+  ) => {
     logger.log('--- EMAIL TASK START VIA TRIGGER.DEV ---', {
       eventKey: payload.eventKey,
-      userId: payload.userId
+      userId: payload.userId,
+      attempt: ctx.attempt.number
     })
-    return await EmailDeliveryService.runSendEmail(payload)
+    // Falls back to a run-scoped dedup key (see EmailDeliveryService.runSendEmail)
+    // so a Trigger.dev retry resumes/skips the same delivery instead of
+    // creating a brand new one and potentially double-sending.
+    return await EmailDeliveryService.runSendEmail(payload, { runId: ctx.run.id })
   }
 })


### PR DESCRIPTION
Fixes CW-57

## Summary

`EmailDeliveryService.runSendEmail` caught dispatch errors and returned `{ success: false }` instead of throwing. Since `trigger/send-email.ts` just returns that value, Trigger.dev saw the run as `COMPLETED` and never used its configured `maxAttempts: 3` retry - transient failures (network blips, rate limits, provider 5xx) were silently dropped instead of retried.

Making failures throw unconditionally would be unsafe on its own, since a full task retry re-runs `runSendEmail` from scratch and could create a second `EmailDelivery` row / send a duplicate email. So this change also closes that gap:

- **Classify errors.** New `EmailDispatchError` (in `emailDeliveryService.ts`) wraps Resend's error `name`/`statusCode` and marks it `retryable` (network/5xx/429) vs permanent (validation, bad auth, invalid recipient, etc.). Only retryable dispatch failures are rethrown from `runSendEmail` so Trigger.dev retries; permanent ones still return `{ success: false }` since retrying would just fail the same way again.
- **Resend-level idempotency.** `dispatch()` now passes Resend's own `Idempotency-Key` header, keyed by our `EmailDelivery.id`. Even if a dispatch attempt is retried after a response was lost post-acceptance, Resend won't send a second copy.
- **Run-scoped default dedup key.** `trigger/send-email.ts` now passes `ctx.run.id` through to `runSendEmail`, which uses it (`trigger-run:<runId>`) as the `EmailDelivery.idempotencyKey` when the caller doesn't supply its own. This keeps every retry attempt of the same Trigger.dev run converging on the same delivery row, without accidentally deduping two distinct, legitimately-repeated business events (e.g. a later resubscribe) that happen to reuse the same `eventKey`.
- **Smarter collision handling.** On an idempotency-key collision, the existing delivery is looked up: if it already reached a dispatched status (`SENT`/`DELIVERED`/`OPENED`/`CLICKED`/`BOUNCED`/`COMPLAINED`/`UNSUBSCRIBED`/`SUPPRESSED`) it's skipped as a true duplicate; otherwise (`QUEUED`/`SENDING`/`FAILED` from an earlier failed attempt) dispatch resumes against that same row instead of silently reporting a false "duplicate".

### Files touched
- `server/utils/services/emailDeliveryService.ts`
- `trigger/send-email.ts`
- `tests/unit/trigger/send-email.test.ts` (extended per acceptance criteria)
- `tests/unit/server/api/admin/send-email.test.ts` (assertion updated for the new Resend call signature - unrelated admin endpoint reuses `dispatch()`)

## Verification

```
$ pnpm test:unit tests/unit/trigger/send-email.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ pnpm typecheck
(exit code 0, no errors)

$ pnpm test:unit   # full suite, sanity check for collateral breakage
 Test Files  348 passed (348)
      Tests  1918 passed (1918)
```

## Test plan
- [x] Transient dispatch failure (`EmailDispatchError` with `retryable: true`) causes `runSendEmail` to throw, which Trigger.dev will retry.
- [x] Permanent dispatch failure (`retryable: false`) returns `{ success: false }` without throwing (no pointless retries).
- [x] Idempotency-key collision against an already-`SENT` delivery is skipped (`dispatch` not called again).
- [x] Idempotency-key collision against a `FAILED` delivery resumes dispatch on the same row instead of skipping.
- [x] Missing caller-supplied `idempotencyKey` falls back to `trigger-run:<ctx.run.id>`, keeping retries of the same run deduped.