### PR TITLE
fix(nutrition): atomic item mutations with optimistic concurrency (CW-79)

### DIFF
--- a/server/api/nutrition/[id]/items.patch.ts
+++ b/server/api/nutrition/[id]/items.patch.ts
@@ -1,5 +1,8 @@
 import { requireAuth } from '../../../utils/auth-guard'
-import { nutritionRepository } from '../../../utils/repositories/nutritionRepository'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../../utils/repositories/nutritionRepository'
 import { z } from 'zod/v3'
 import { metabolicService } from '../../../utils/services/metabolicService'
 import { nutritionPlanService } from '../../../utils/services/nutritionPlanService'
@@ -95,9 +98,11 @@ export default defineEventHandler(async (event) => {
   }
 
   const mealsList = ['breakfast', 'lunch', 'dinner', 'snacks']
+  const expectedUpdatedAt = nutrition.updatedAt
   const currentItems = (nutrition[mealType] as any[]) || []
   let updatedItems = [...currentItems]
   let movedFromMeal: string | null = null
+  let movedFromMealItems: any[] | null = null
 
   if (action === 'add') {
     if (!item) throw createError({ statusCode: 400, message: 'Item is required for add' })
@@ -130,11 +135,15 @@ export default defineEventHandler(async (event) => {
         const otherItems = (nutrition[m] as any[]) || []
         const otherIndex = otherItems.findIndex((i) => i.id === item.id)
         if (otherIndex !== -1) {
-          // Found it in another meal!
-          // We need to remove it from there and add it to the target mealType
-          const [foundItem] = otherItems.splice(otherIndex, 1)
-          nutrition = await nutritionRepository.update(nutrition.id, { [m]: otherItems })
+          // Found it in another meal! Remove it from there (in memory only) and
+          // add it to the target mealType. Both changes are committed together
+          // in the single atomic write below, so a cross-meal move can never
+          // leave the item removed from the source meal without also being
+          // added to the target meal (or vice versa).
+          const remainingOtherItems = [...otherItems]
+          const [foundItem] = remainingOtherItems.splice(otherIndex, 1)
           movedFromMeal = m
+          movedFromMealItems = remainingOtherItems
 
           // Update the local list and set the index
           index = updatedItems.length
@@ -188,14 +197,20 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // Update record
-  const updatedNutrition = await nutritionRepository.update(nutrition.id, {
-    [mealType]: updatedItems
-  })
+  // Build every field this mutation touches into a single payload: the meal
+  // array(s) and the recalculated totals. Recalculating totals from the
+  // in-memory merged state (rather than re-reading from the DB after a first
+  // write) lets the whole mutation land in one atomic statement.
+  const mealChanges: Record<string, any[]> = { [mealType]: updatedItems }
+  if (movedFromMeal && movedFromMealItems && movedFromMeal !== mealType) {
+    mealChanges[movedFromMeal] = movedFromMealItems
+  }
 
-  const totals = recalculateNutritionTotals(updatedNutrition)
+  const mergedForTotals = { ...nutrition, ...mealChanges }
+  const totals = recalculateNutritionTotals(mergedForTotals)
 
-  await nutritionRepository.update(updatedNutrition.id, {
+  const result = await nutritionRepository.updateWithVersionCheck(nutrition.id, expectedUpdatedAt, {
+    ...mealChanges,
     calories: totals.calories,
     protein: totals.protein,
     carbs: totals.carbs,
@@ -204,6 +219,15 @@ export default defineEventHandler(async (event) => {
     sugar: totals.sugar,
     waterMl: totals.waterMl
   })
+
+  if (result === CONCURRENT_UPDATE_CONFLICT) {
+    throw createError({
+      statusCode: 409,
+      message: 'This nutrition entry was updated elsewhere. Please refresh and try again.'
+    })
+  }
+
+  const updatedNutrition = result
 
   // REACTIVE: Trigger fueling plan update for the entry date
   try {

--- a/server/api/nutrition/[id]/log.post.ts
+++ b/server/api/nutrition/[id]/log.post.ts
@@ -1,5 +1,8 @@
 import { requireAuth } from '../../../utils/auth-guard'
-import { nutritionRepository } from '../../../utils/repositories/nutritionRepository'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../../utils/repositories/nutritionRepository'
 import { generateStructuredAnalysis } from '../../../utils/gemini'
 import { z } from 'zod/v3'
 import { getUserTimezone, getStartOfLocalDateUTC } from '../../../utils/date'
@@ -262,14 +265,41 @@ export default defineEventHandler(async (event) => {
         })
       })
 
-      targetNutrition = await nutritionRepository.create({
-        userId,
-        date: targetDate,
-        ...meals,
-        waterMl: 0
-      })
+      // Compute totals from the in-memory meal state up front so the new row
+      // is created with correct totals in a single write (no separate
+      // follow-up totals write that a concurrent request could race with).
+      const totals = recalculateNutritionTotals(meals)
+
+      try {
+        targetNutrition = await nutritionRepository.create({
+          userId,
+          date: targetDate,
+          ...meals,
+          calories: totals.calories,
+          protein: totals.protein,
+          carbs: totals.carbs,
+          fat: totals.fat,
+          fiber: totals.fiber,
+          sugar: totals.sugar,
+          waterMl: totals.waterMl
+        })
+      } catch (err: any) {
+        // Another request created the row for this date between our read and
+        // this create (unique userId+date constraint violation).
+        if (err?.code === 'P2002') {
+          throw createError({
+            statusCode: 409,
+            message: `Nutrition entry for ${targetDateStr} was created elsewhere. Please retry.`
+          })
+        }
+        throw err
+      }
     } else {
-      // Update existing
+      // Update existing. Merge the meal-array changes and the recalculated
+      // totals into a single payload so the whole mutation lands in one
+      // atomic, version-checked write instead of a separate meal write
+      // followed by a separate totals write.
+      const expectedUpdatedAt = targetNutrition.updatedAt
       const updates: any = {}
       items.forEach((item: any) => {
         const targetMeal = item.mealType || mealType || 'snacks'
@@ -285,7 +315,32 @@ export default defineEventHandler(async (event) => {
         })
       })
 
-      targetNutrition = await nutritionRepository.update(targetNutrition.id, updates)
+      const mergedForTotals = { ...targetNutrition, ...updates }
+      const totals = recalculateNutritionTotals(mergedForTotals)
+
+      const result = await nutritionRepository.updateWithVersionCheck(
+        targetNutrition.id,
+        expectedUpdatedAt,
+        {
+          ...updates,
+          calories: totals.calories,
+          protein: totals.protein,
+          carbs: totals.carbs,
+          fat: totals.fat,
+          fiber: totals.fiber,
+          sugar: totals.sugar,
+          waterMl: totals.waterMl
+        }
+      )
+
+      if (result === CONCURRENT_UPDATE_CONFLICT) {
+        throw createError({
+          statusCode: 409,
+          message: `Nutrition entry for ${targetDateStr} was updated elsewhere. Please retry.`
+        })
+      }
+
+      targetNutrition = result
     }
 
     const addedFluidMl = Math.max(0, Math.round(grouped.hydrationMl))
@@ -329,19 +384,6 @@ export default defineEventHandler(async (event) => {
         intraWorkout
       })
     }
-
-    // Recalculate totals for this record
-    const totals = recalculateNutritionTotals(targetNutrition)
-
-    await nutritionRepository.update(targetNutrition.id, {
-      calories: totals.calories,
-      protein: totals.protein,
-      carbs: totals.carbs,
-      fat: totals.fat,
-      fiber: totals.fiber,
-      sugar: totals.sugar,
-      waterMl: totals.waterMl
-    })
 
     // REACTIVE: Trigger fueling plan update for the log date
     try {

--- a/server/api/nutrition/hydration-quick-add.post.ts
+++ b/server/api/nutrition/hydration-quick-add.post.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod/v3'
 import { requireAuth } from '../../utils/auth-guard'
 import { parseCalendarDate } from '../../utils/date'
-import { nutritionRepository } from '../../utils/repositories/nutritionRepository'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../utils/repositories/nutritionRepository'
 import { normalizeFluidFields, recalculateNutritionTotals } from '../../utils/nutrition/totals'
 
 const quickAddSchema = z.object({
@@ -69,27 +72,58 @@ export default defineEventHandler(async (event) => {
     source
   })
 
-  let nutrition = await nutritionRepository.getByDate(userId, date)
+  const nutrition = await nutritionRepository.getByDate(userId, date)
+
+  let updatedNutrition: Awaited<ReturnType<typeof nutritionRepository.create>>
 
   if (!nutrition) {
-    nutrition = await nutritionRepository.create({
-      userId,
-      date,
-      waterMl: body.volumeMl,
-      snacks: [hydrationItem]
-    })
+    const snacks = [hydrationItem]
+    const totals = recalculateNutritionTotals({ snacks })
+    try {
+      updatedNutrition = await nutritionRepository.create({
+        userId,
+        date,
+        waterMl: totals.waterMl,
+        snacks
+      })
+    } catch (err: any) {
+      // Another request created the row for this date between our read and
+      // this create (unique userId+date constraint violation).
+      if (err?.code === 'P2002') {
+        throw createError({
+          statusCode: 409,
+          message: 'A hydration entry was added elsewhere for this date. Please retry.'
+        })
+      }
+      throw err
+    }
   } else {
+    // Merge the new snack entry and the recalculated waterMl total into a
+    // single, version-checked write so a concurrent quick-add can never be
+    // silently dropped by a lost-update race.
+    const expectedUpdatedAt = nutrition.updatedAt
     const currentSnacks = Array.isArray(nutrition.snacks) ? nutrition.snacks : []
-    nutrition = await nutritionRepository.update(nutrition.id, {
-      snacks: [...currentSnacks, hydrationItem],
-      waterMl: Math.max(0, Number(nutrition.waterMl || 0) + body.volumeMl)
-    })
-  }
+    const snacks = [...currentSnacks, hydrationItem]
+    const totals = recalculateNutritionTotals({ ...nutrition, snacks })
 
-  const totals = recalculateNutritionTotals(nutrition as Record<string, any>)
-  const updatedNutrition = await nutritionRepository.update(nutrition.id, {
-    waterMl: totals.waterMl
-  })
+    const result = await nutritionRepository.updateWithVersionCheck(
+      nutrition.id,
+      expectedUpdatedAt,
+      {
+        snacks,
+        waterMl: totals.waterMl
+      }
+    )
+
+    if (result === CONCURRENT_UPDATE_CONFLICT) {
+      throw createError({
+        statusCode: 409,
+        message: 'This nutrition entry was updated elsewhere. Please retry.'
+      })
+    }
+
+    updatedNutrition = result
+  }
 
   return {
     success: true,

--- a/server/utils/repositories/nutritionRepository.ts
+++ b/server/utils/repositories/nutritionRepository.ts
@@ -1,5 +1,8 @@
 import { prisma } from '../db'
-import type { Prisma } from '@prisma/client'
+import { Prisma } from '@prisma/client'
+
+/** Sentinel returned by `updateWithVersionCheck` when the row changed since it was read. */
+export const CONCURRENT_UPDATE_CONFLICT = Symbol('CONCURRENT_UPDATE_CONFLICT')
 
 export const nutritionRepository = {
   /**
@@ -154,6 +157,42 @@ export const nutritionRepository = {
       where: { id },
       data
     })
+  },
+
+  /**
+   * Update a nutrition entry with an optimistic concurrency check.
+   *
+   * The caller must pass the `updatedAt` value it originally read the row with.
+   * The write is executed inside a transaction and its `where` clause includes
+   * that `updatedAt`, so if another request modified the row in between, zero
+   * rows match and Prisma raises `P2025` ("record not found"). We translate that
+   * into a `CONCURRENT_UPDATE_CONFLICT` sentinel instead of throwing, so callers
+   * can surface a clear 409 rather than silently losing the concurrent write.
+   *
+   * All item mutations (add/update/delete/move) should merge every field they
+   * intend to change — meal arrays and recalculated totals alike — into a
+   * single `data` payload passed here, so the entire mutation lands in one
+   * atomic statement instead of a sequence of separate reads/writes that a
+   * concurrent request could interleave with.
+   */
+  async updateWithVersionCheck(
+    id: string,
+    expectedUpdatedAt: Date,
+    data: Prisma.NutritionUpdateInput
+  ) {
+    try {
+      return await prisma.$transaction(async (tx) => {
+        return tx.nutrition.update({
+          where: { id, updatedAt: expectedUpdatedAt },
+          data
+        })
+      })
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+        return CONCURRENT_UPDATE_CONFLICT
+      }
+      throw error
+    }
   },
 
   /**

--- a/tests/unit/server/api/nutrition/hydration-quick-add.post.test.ts
+++ b/tests/unit/server/api/nutrition/hydration-quick-add.post.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../../../../server/utils/repositories/nutritionRepository'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/repositories/nutritionRepository', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../../../server/utils/repositories/nutritionRepository')
+    >()
+  return {
+    ...actual,
+    nutritionRepository: {
+      getByDate: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateWithVersionCheck: vi.fn()
+    }
+  }
+})
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/nutrition/hydration-quick-add.post')
+  return mod.default
+}
+
+describe('POST /api/nutrition/hydration-quick-add', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+  })
+
+  it('merges the new snack and the recalculated waterMl into a single version-checked write', async () => {
+    const existing = {
+      id: 'n1',
+      updatedAt: new Date('2026-07-21T10:00:00Z'),
+      waterMl: 200,
+      snacks: [{ id: 'existing', name: 'Water', water_ml: 200, calories: 0 }]
+    }
+    vi.mocked(nutritionRepository.getByDate).mockResolvedValue(existing as any)
+    vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue({
+      id: 'n1',
+      waterMl: 500
+    } as any)
+
+    const handler = await getHandler()
+    const result = await handler({
+      context: {},
+      body: { date: '2026-07-21', volumeMl: 300 }
+    } as any)
+
+    expect(nutritionRepository.update).not.toHaveBeenCalled()
+    expect(nutritionRepository.updateWithVersionCheck).toHaveBeenCalledTimes(1)
+    const [id, updatedAt, data] = vi.mocked(nutritionRepository.updateWithVersionCheck).mock
+      .calls[0]!
+    expect(id).toBe('n1')
+    expect(updatedAt).toBe(existing.updatedAt)
+    expect(data.snacks).toHaveLength(2)
+    expect((result as any).totalWaterMl).toBe(500)
+  })
+
+  it('returns a 409 conflict instead of silently dropping a concurrent quick-add', async () => {
+    const existing = {
+      id: 'n1',
+      updatedAt: new Date('2026-07-21T10:00:00Z'),
+      waterMl: 200,
+      snacks: []
+    }
+    vi.mocked(nutritionRepository.getByDate).mockResolvedValue(existing as any)
+    vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue(
+      CONCURRENT_UPDATE_CONFLICT
+    )
+
+    const handler = await getHandler()
+    await expect(
+      handler({
+        context: {},
+        body: { date: '2026-07-21', volumeMl: 300 }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+})

--- a/tests/unit/server/api/nutrition/items.patch.test.ts
+++ b/tests/unit/server/api/nutrition/items.patch.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../../../../server/utils/repositories/nutritionRepository'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('getRouterParam', (event: any, name: string) => event.params?.[name])
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/repositories/nutritionRepository', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../../../server/utils/repositories/nutritionRepository')
+    >()
+  return {
+    ...actual,
+    nutritionRepository: {
+      getByDate: vi.fn(),
+      getById: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateWithVersionCheck: vi.fn()
+    }
+  }
+})
+
+vi.mock('../../../../../server/utils/services/metabolicService', () => ({
+  metabolicService: { calculateFuelingPlanForDate: vi.fn().mockResolvedValue({ plan: {} }) }
+}))
+
+vi.mock('../../../../../server/utils/services/nutritionPlanService', () => ({
+  nutritionPlanService: { reconcileLoggedMealsForDate: vi.fn() }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/nutrition/[id]/items.patch')
+  return mod.default
+}
+
+const baseNutrition = () => ({
+  id: 'n1',
+  date: new Date('2026-07-21T00:00:00Z'),
+  updatedAt: new Date('2026-07-21T10:00:00Z'),
+  breakfast: [{ id: 'item-1', name: 'Eggs', calories: 100, protein: 10, carbs: 1, fat: 5 }],
+  lunch: [],
+  dinner: [],
+  snacks: []
+})
+
+describe('PATCH /api/nutrition/:id/items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+  })
+
+  describe('cross-meal move (action: update)', () => {
+    it('commits the source-meal removal and target-meal addition as a single atomic write', async () => {
+      const nutrition = baseNutrition()
+      vi.mocked(nutritionRepository.getById).mockResolvedValue(nutrition as any)
+      vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue({
+        ...nutrition,
+        breakfast: [],
+        lunch: [{ id: 'item-1', name: 'Eggs', calories: 100, protein: 10, carbs: 1, fat: 5 }]
+      } as any)
+
+      const handler = await getHandler()
+      await handler({
+        params: { id: 'n1' },
+        body: {
+          action: 'update',
+          mealType: 'lunch',
+          item: { id: 'item-1', name: 'Eggs', calories: 100, protein: 10, carbs: 1, fat: 5 }
+        }
+      } as any)
+
+      // The old, buggy implementation issued a separate write to clear the
+      // source meal before writing the target meal. That plain `update` path
+      // must never be used for this mutation any more.
+      expect(nutritionRepository.update).not.toHaveBeenCalled()
+
+      // Exactly one write should have happened, and it must contain BOTH the
+      // source meal (now without the item) and the target meal (now with the
+      // item) in the same payload — so a failure of this single call can
+      // never leave the item in neither meal.
+      expect(nutritionRepository.updateWithVersionCheck).toHaveBeenCalledTimes(1)
+      const [, , data] = vi.mocked(nutritionRepository.updateWithVersionCheck).mock.calls[0]!
+      expect(data.breakfast).toEqual([])
+      expect(data.lunch).toEqual([expect.objectContaining({ id: 'item-1', name: 'Eggs' })])
+    })
+
+    it('never leaves the item lost when the single write fails', async () => {
+      const nutrition = baseNutrition()
+      vi.mocked(nutritionRepository.getById).mockResolvedValue(nutrition as any)
+      vi.mocked(nutritionRepository.updateWithVersionCheck).mockRejectedValue(
+        new Error('database unavailable')
+      )
+
+      const handler = await getHandler()
+      await expect(
+        handler({
+          params: { id: 'n1' },
+          body: {
+            action: 'update',
+            mealType: 'lunch',
+            item: { id: 'item-1', name: 'Eggs', calories: 100, protein: 10, carbs: 1, fat: 5 }
+          }
+        } as any)
+      ).rejects.toThrow('database unavailable')
+
+      // Only the single atomic write was attempted (and it failed) — there is
+      // no earlier "remove from source" write that could have already
+      // succeeded while this one failed, which is exactly the lost-update bug
+      // being fixed.
+      expect(nutritionRepository.update).not.toHaveBeenCalled()
+      expect(nutritionRepository.updateWithVersionCheck).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('optimistic concurrency', () => {
+    it('returns a 409 conflict instead of silently overwriting a concurrent change', async () => {
+      const nutrition = baseNutrition()
+      vi.mocked(nutritionRepository.getById).mockResolvedValue(nutrition as any)
+      vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue(
+        CONCURRENT_UPDATE_CONFLICT
+      )
+
+      const handler = await getHandler()
+      await expect(
+        handler({
+          params: { id: 'n1' },
+          body: {
+            action: 'add',
+            mealType: 'snacks',
+            item: { name: 'Banana', calories: 90, protein: 1, carbs: 23, fat: 0 }
+          }
+        } as any)
+      ).rejects.toMatchObject({ statusCode: 409 })
+
+      // The version check was passed the `updatedAt` that was actually read,
+      // proving the check is against the row's real state, not a stale value.
+      expect(nutritionRepository.updateWithVersionCheck).toHaveBeenCalledWith(
+        'n1',
+        nutrition.updatedAt,
+        expect.any(Object)
+      )
+    })
+  })
+})

--- a/tests/unit/server/api/nutrition/log.post.test.ts
+++ b/tests/unit/server/api/nutrition/log.post.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import {
+  CONCURRENT_UPDATE_CONFLICT,
+  nutritionRepository
+} from '../../../../../server/utils/repositories/nutritionRepository'
+import { generateStructuredAnalysis } from '../../../../../server/utils/gemini'
+import { getUserNutritionSettings } from '../../../../../server/utils/nutrition/settings'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('getRouterParam', (event: any, name: string) => event.params?.[name])
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/repositories/nutritionRepository', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../../../../server/utils/repositories/nutritionRepository')
+    >()
+  return {
+    ...actual,
+    nutritionRepository: {
+      getByDate: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateWithVersionCheck: vi.fn()
+    }
+  }
+})
+
+vi.mock('../../../../../server/utils/gemini', () => ({
+  generateStructuredAnalysis: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn(async () => 'UTC'),
+  getStartOfLocalDateUTC: vi.fn((_: string, dateStr: string) => new Date(`${dateStr}T00:00:00Z`))
+}))
+
+vi.mock('../../../../../server/utils/nutrition/settings', () => ({
+  getUserNutritionSettings: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/services/metabolicService', () => ({
+  metabolicService: {
+    calculateFuelingPlanForDate: vi.fn().mockResolvedValue({ plan: { windows: [] } })
+  }
+}))
+
+vi.mock('../../../../../server/utils/services/nutritionPlanService', () => ({
+  nutritionPlanService: { reconcileLoggedMealsForDate: vi.fn() }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/nutrition/[id]/log.post')
+  return mod.default
+}
+
+describe('POST /api/nutrition/:id/log', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    vi.mocked(getUserNutritionSettings).mockResolvedValue({ mealPattern: [] } as any)
+    vi.mocked(generateStructuredAnalysis).mockResolvedValue({
+      items: [
+        {
+          name: 'Banana',
+          calories: 90,
+          protein: 1,
+          carbs: 23,
+          fat: 0,
+          logged_at: '2026-07-21T12:00:00.000Z',
+          mealType: 'lunch'
+        }
+      ]
+    } as any)
+  })
+
+  it('merges the meal-array change and recalculated totals into a single version-checked write', async () => {
+    const existing = {
+      id: 'n1',
+      date: new Date('2026-07-21T00:00:00Z'),
+      updatedAt: new Date('2026-07-21T10:00:00Z'),
+      breakfast: [],
+      lunch: [],
+      dinner: [],
+      snacks: []
+    }
+    vi.mocked(nutritionRepository.getByDate).mockResolvedValue(existing as any)
+    vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue({
+      ...existing,
+      lunch: [{ id: 'x', name: 'Banana' }]
+    } as any)
+
+    const handler = await getHandler()
+    await handler({
+      params: { id: '2026-07-21' },
+      body: { query: 'ate a banana', mealType: 'lunch' }
+    } as any)
+
+    expect(nutritionRepository.update).not.toHaveBeenCalled()
+    expect(nutritionRepository.updateWithVersionCheck).toHaveBeenCalledTimes(1)
+    const [id, updatedAt, data] = vi.mocked(nutritionRepository.updateWithVersionCheck).mock
+      .calls[0]!
+    expect(id).toBe('n1')
+    expect(updatedAt).toBe(existing.updatedAt)
+    expect(data.lunch).toHaveLength(1)
+    expect(typeof data.calories).toBe('number')
+  })
+
+  it('returns a 409 conflict instead of silently dropping a concurrent log entry', async () => {
+    const existing = {
+      id: 'n1',
+      date: new Date('2026-07-21T00:00:00Z'),
+      updatedAt: new Date('2026-07-21T10:00:00Z'),
+      breakfast: [],
+      lunch: [],
+      dinner: [],
+      snacks: []
+    }
+    vi.mocked(nutritionRepository.getByDate).mockResolvedValue(existing as any)
+    vi.mocked(nutritionRepository.updateWithVersionCheck).mockResolvedValue(
+      CONCURRENT_UPDATE_CONFLICT
+    )
+
+    const handler = await getHandler()
+    await expect(
+      handler({
+        params: { id: '2026-07-21' },
+        body: { query: 'ate a banana', mealType: 'lunch' }
+      } as any)
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+})


### PR DESCRIPTION
Fixes CW-79

## Summary

- `PATCH /api/nutrition/[id]/items` (`action: 'update'`) handled cross-meal moves non-atomically: it wrote the source meal without the item first, then wrote the target meal separately. If the second write failed, the item was permanently lost between the two writes. It now computes both changes in memory and commits them in a single atomic write.
- All three item-mutation endpoints (`items.patch.ts`, `log.post.ts`, `hydration-quick-add.post.ts`) performed read-modify-write on the JSON meal arrays with no transaction or concurrency control, so two concurrent requests could silently overwrite each other's changes (lost update).
- Added `nutritionRepository.updateWithVersionCheck(id, expectedUpdatedAt, data)`: wraps the write in `prisma.$transaction` and constrains the `where` clause to `{ id, updatedAt: expectedUpdatedAt }` (Prisma's extended where-unique-input support). If the row changed since it was read, zero rows match, Prisma raises `P2025`, and this is translated into a `CONCURRENT_UPDATE_CONFLICT` sentinel instead of silently succeeding with stale data.
- Each endpoint now merges its meal-array change and recalculated totals into one payload and issues a single `updateWithVersionCheck` call; on conflict it throws a `409` with a clear message. Unique-constraint races on create (`P2002`) are also surfaced as `409` instead of an unhandled `500`.

## Verification

```
pnpm vitest run tests/unit/server/api/nutrition/index.post.test.ts
```
```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Also ran the full nutrition suite (including new tests covering the cross-meal-move atomicity and the 409 conflict path for all three endpoints) and the full server unit suite:

```
pnpm vitest run tests/unit/server/api/nutrition/
 Test Files  7 passed (7)
      Tests  31 passed (31)

pnpm vitest run tests/unit/server
 Test Files  242 passed (242)
      Tests  1244 passed (1244)

pnpm typecheck
(exit 0, no errors)
```

## Test plan
- [x] `pnpm vitest run tests/unit/server/api/nutrition/index.post.test.ts` passes
- [x] New tests: cross-meal move is a single atomic write and cannot lose the item on failure
- [x] New tests: concurrent update returns 409 instead of silently dropping data (all three endpoints)
- [x] `pnpm typecheck` passes
- [x] Full server unit suite passes (1244 tests)