### PR TITLE
fix(nutrition): unify metabolic simulation calculators (CW-75)

### DIFF
--- a/server/utils/nutrition-domain/metabolic-simulation.ts
+++ b/server/utils/nutrition-domain/metabolic-simulation.ts
@@ -169,14 +169,81 @@ export function getGramsPerMin(
   return base * (SPORT_DRAIN_WEIGHTS[sportClass] ?? 1)
 }
 
-function getDateStr(date: any): string {
+function getDateStr(date: any, timezone: string): string {
   if (date instanceof Date) {
+    // `@db.Date` columns (nutrition/workout records) arrive as a UTC-midnight instant that already
+    // encodes the intended calendar day, so the day key is read straight off it rather than
+    // reinterpreted through the timezone - doing the latter would shift it a day for any offset.
     return date.toISOString().split('T')[0]!
   }
   if (typeof date === 'string') {
     return date.split('T')[0]!
   }
-  return new Date().toISOString().split('T')[0]!
+  // No date supplied at all: this is the one spot with no calendar day to anchor to, so "today" has
+  // to be invented. It used to be read off the server's UTC clock, which disagrees with the
+  // athlete's own "today" for roughly a third of the day depending on their offset. Anchoring it to
+  // the caller's timezone instead matches how "today" is resolved everywhere else in this domain
+  // (see `getUserLocalDate` / `getDateKey`).
+  return formatInTimeZone(new Date(), timezone, 'yyyy-MM-dd')
+}
+
+/**
+ * Resolves the calendar day and its UTC day-start instant for a simulation run.
+ *
+ * Both calculators anchor every relative calculation (BMR drain, interval stepping, meal timing) to
+ * these two values, so deriving them once here is what keeps a shared date resolution from drifting
+ * back apart the way the per-function copies previously did.
+ */
+export function resolveSimulationStartTime(
+  rawDate: any,
+  timezone: string
+): { dateStr: string; dayStart: Date } {
+  const dateStr = getDateStr(rawDate, timezone)
+  const dayStart = fromZonedTime(`${dateStr}T00:00:00`, timezone)
+  return { dateStr, dayStart }
+}
+
+/**
+ * Minutes a workout lasted, resolved with one field precedence for every caller.
+ *
+ * `durationSec` is the canonical field on both the completed `Workout` and `PlannedWorkout` models;
+ * `duration`/`plannedDuration` are legacy or synthetic aliases seen on some call sites. The two
+ * calculators used to check these in different orders, which meant a workout carrying more than one
+ * of these fields could report a different length depending on which function read it.
+ */
+export function resolveWorkoutDurationMin(workout: any): number {
+  const durationSec = workout?.durationSec || workout?.duration || workout?.plannedDuration || 3600
+  return durationSec / 60
+}
+
+/**
+ * A workout's intensity (roughly an intensity factor, 0-1+), resolved with one field precedence for
+ * every caller. `workIntensity` is the canonical field on `PlannedWorkout`, `intensity` on the
+ * completed `Workout` model; `intensityFactor` is carried by some synthetic/derived workout objects.
+ * A real workout normally only has one of these populated, so the order rarely matters in practice,
+ * but the two calculators used to disagree on it, which is a mismatch waiting to happen the day a
+ * caller sends an object that has more than one set.
+ */
+export function resolveWorkoutIntensity(workout: any): number {
+  return workout?.workIntensity || workout?.intensityFactor || workout?.intensity || 0.7
+}
+
+/**
+ * The glycogen percentage a simulation should start from.
+ *
+ * An explicit starting value - including an honest zero - is evidence and is used as-is (floored at
+ * 0, since a negative tank is not meaningful). Only the absence of a value falls back to the
+ * metabolic floor. `calculateEnergyTimeline` and `calculateGlycogenState` used to apply this
+ * distinction differently: one tolerated a non-finite explicit value by silently propagating NaN
+ * through the rest of the simulation, and only one of them floored a negative value at 0.
+ */
+export function resolveStartingGlycogenPercentage(
+  explicitPercentage: number | undefined,
+  metabolicFloor: number
+): number {
+  const hasExplicit = explicitPercentage !== undefined && Number.isFinite(explicitPercentage)
+  if (hasExplicit) return Math.max(0, explicitPercentage as number)
+  return metabolicFloor * 100
 }
 
 export function parseMealDateTime(
@@ -238,14 +305,14 @@ export function calculateGlycogenState(
   const C_cap = resolveGlycogenCapacityG(settings)
 
   const metabolicFloor = settings?.metabolicFloor || 0.6
-  const baselinePct = startingPercentage !== undefined ? startingPercentage : metabolicFloor * 100
+  const baselinePct = resolveStartingGlycogenPercentage(startingPercentage, metabolicFloor)
   let currentGrams = C_cap * (baselinePct / 100)
 
   const targetCarbs = nutritionRecord.carbsGoal || 300
 
   let absorbedUntilNow = 0
   const mealTypes = ['breakfast', 'lunch', 'dinner', 'snacks']
-  const dateStr = getDateStr(nutritionRecord.date)
+  const { dateStr, dayStart } = resolveSimulationStartTime(nutritionRecord.date, timezone)
 
   mealTypes.forEach((type) => {
     if (Array.isArray(nutritionRecord[type])) {
@@ -283,7 +350,6 @@ export function calculateGlycogenState(
 
   const replenishmentPct = (actualCarbs / C_cap) * 100
 
-  const dayStart = fromZonedTime(`${dateStr}T00:00:00`, timezone)
   const minsSinceMidnight = differenceInMinutes(currentTime, dayStart)
   const dailyBmr = settings?.bmr || 1600
   const restingDailyKcal = dailyBmr * RESTING_ACTIVITY_FACTOR
@@ -303,9 +369,8 @@ export function calculateGlycogenState(
     const workoutStart = new Date(getWorkoutDate(workout, timezone))
     const isCompleted = workout.source === 'completed' || workout.completed === true
 
-    const intensity = workout.intensity || workout.workIntensity || 0.7
-    const durationMin =
-      (workout.duration || workout.durationSec || workout.plannedDuration || 3600) / 60
+    const intensity = resolveWorkoutIntensity(workout)
+    const durationMin = resolveWorkoutDurationMin(workout)
 
     const gramsPerMin =
       getGramsPerMin(intensity, getSportFuelingClass(workout.type)) * WORKOUT_DRAIN_MULTIPLIER
@@ -386,8 +451,7 @@ export function calculateEnergyTimeline(
     now?: Date
   } = {}
 ): EnergyPoint[] {
-  const dateStr = getDateStr(nutritionRecord.date)
-  const dayStart = fromZonedTime(`${dateStr}T00:00:00`, timezone)
+  const { dateStr, dayStart } = resolveSimulationStartTime(nutritionRecord.date, timezone)
   const now = options.now || new Date()
 
   const points: EnergyPoint[] = []
@@ -408,20 +472,25 @@ export function calculateEnergyTimeline(
   //
   // A day that ended empty now starts empty. That reads as an athlete digging a hole, which is the
   // signal worth showing; a chain that is actually broken supplies no starting value at all and
-  // still gets the floor.
-  const hasKnownStart =
-    options.startingGlycogenPercentage !== undefined &&
-    Number.isFinite(options.startingGlycogenPercentage)
-
-  const startingPct = hasKnownStart
-    ? Math.max(0, options.startingGlycogenPercentage as number)
-    : metabolicFloor * 100
+  // still gets the floor. `resolveStartingGlycogenPercentage` is shared with `calculateGlycogenState`
+  // so the two calculators cannot drift apart on this again.
+  const startingPct = resolveStartingGlycogenPercentage(
+    options.startingGlycogenPercentage,
+    metabolicFloor
+  )
 
   let currentGrams = C_cap * (startingPct / 100)
   let currentFluidDeficit = options.startingFluidDeficit || 0
 
   let cumulativeKcalDelta = 0
   let cumulativeCarbDelta = 0
+
+  // Carbohydrate (and its paired calories) that the gut cap held back this interval. It is not
+  // lost - it is still sitting in the gut - so it rolls into the next interval's absorption instead
+  // of vanishing, the same way the 15 minute loop below already carries every other running total
+  // forward.
+  let carriedGramsIn = 0
+  let carriedKcalIn = 0
 
   const dailyBmr = settings?.bmr || 1600
   // Both lines derive from the same daily resting figure. They used to disagree: grams came off
@@ -534,8 +603,8 @@ export function calculateEnergyTimeline(
   const workoutDrainGrams = workouts
     .filter((w: any) => w.type !== 'Rest')
     .reduce((sum: number, w: any) => {
-      const durationMin = (w.durationSec || w.duration || w.plannedDuration || 3600) / 60
-      const intensity = w.workIntensity || w.intensityFactor || w.intensity || 0.7
+      const durationMin = resolveWorkoutDurationMin(w)
+      const intensity = resolveWorkoutIntensity(w)
       return (
         sum +
         getGramsPerMin(intensity, getSportFuelingClass(w.type)) *
@@ -654,9 +723,8 @@ export function calculateEnergyTimeline(
     .filter((w) => w.type !== 'Rest')
     .map((w) => {
       const start = new Date(getWorkoutDate(w, timezone))
-      const durationSec = w.durationSec || w.duration || w.plannedDuration || 3600
-      const durationMin = durationSec / 60
-      const intensity = w.workIntensity || w.intensityFactor || w.intensity || 0.7
+      const durationMin = resolveWorkoutDurationMin(w)
+      const intensity = resolveWorkoutIntensity(w)
       const sweatRateLph =
         settings.sweatRate && settings.sweatRate > 0
           ? settings.sweatRate
@@ -792,11 +860,19 @@ export function calculateEnergyTimeline(
       // Roughly 90g/hr, the ceiling on what the gut can take up. Whatever the cap holds back has
       // not been absorbed, so its energy must be held back with it - otherwise a big meal credited
       // calories the athlete could not yet have used.
-      const cappedGramsIn = Math.min(intervalGramsIn, INTERVAL_CARB_ABSORPTION_CAP_G)
-      const absorbedRatio = intervalGramsIn > 0 ? cappedGramsIn / intervalGramsIn : 0
+      //
+      // What the cap withholds is still in the gut, not gone: it is added to what this same meal's
+      // own curve produces next interval, so a large meal is absorbed in full over several windows
+      // instead of permanently losing whatever one 15 minute slice could not take up.
+      const availableGramsIn = intervalGramsIn + carriedGramsIn
+      const availableKcalIn = intervalKcalIn + carriedKcalIn
+      const cappedGramsIn = Math.min(availableGramsIn, INTERVAL_CARB_ABSORPTION_CAP_G)
+      const absorbedRatio = availableGramsIn > 0 ? cappedGramsIn / availableGramsIn : 0
       currentGrams += cappedGramsIn
-      cumulativeKcalDelta += intervalKcalIn * absorbedRatio
+      cumulativeKcalDelta += availableKcalIn * absorbedRatio
       cumulativeCarbDelta += cappedGramsIn
+      carriedGramsIn = availableGramsIn - cappedGramsIn
+      carriedKcalIn = availableKcalIn - availableKcalIn * absorbedRatio
 
       if (isPassiveWindow && !manualFluidHours.has(hourKey)) {
         intervalFluidIn += PASSIVE_REHYDRATION_ML_PER_HOUR * (INTERVAL / 60)

--- a/server/utils/nutrition/sweat-rate.ts
+++ b/server/utils/nutrition/sweat-rate.ts
@@ -9,20 +9,26 @@ export type SweatRateBand = {
   }
 }
 
+/**
+ * Band edges are half-open (`[min, max)`), so every real-number temperature maps to exactly one
+ * band with no gap between them. The values themselves (min edges and rates) are unchanged from the
+ * original bands - only the top edges moved to meet the next band's bottom edge, closing the gaps
+ * that used to sit between e.g. 9.9 and 10, which silently fell through to the "warm" fallback band.
+ */
 export const SWEAT_RATE_LOOKUP_TABLE: SweatRateBand[] = [
   {
     temperatureMinC: -20,
-    temperatureMaxC: 9.9,
+    temperatureMaxC: 10,
     ratesLph: { low: 0.45, moderate: 0.6, high: 0.75, veryHigh: 0.9 }
   },
   {
     temperatureMinC: 10,
-    temperatureMaxC: 17.9,
+    temperatureMaxC: 18,
     ratesLph: { low: 0.55, moderate: 0.75, high: 0.95, veryHigh: 1.15 }
   },
   {
     temperatureMinC: 18,
-    temperatureMaxC: 25.9,
+    temperatureMaxC: 26,
     ratesLph: { low: 0.7, moderate: 0.95, high: 1.2, veryHigh: 1.45 }
   },
   {
@@ -40,11 +46,17 @@ function resolveIntensityBand(intensity: number): keyof SweatRateBand['ratesLph'
 }
 
 function getTempBand(temperatureC: number): SweatRateBand {
-  return (
-    SWEAT_RATE_LOOKUP_TABLE.find(
-      (band) => temperatureC >= band.temperatureMinC && temperatureC <= band.temperatureMaxC
-    ) || SWEAT_RATE_LOOKUP_TABLE[2]!
+  const match = SWEAT_RATE_LOOKUP_TABLE.find(
+    (band) => temperatureC >= band.temperatureMinC && temperatureC < band.temperatureMaxC
   )
+  if (match) return match
+
+  // Outside the tabulated range entirely (colder than -20 or at/above the top edge, 60): clamp to
+  // the nearest band rather than falling back to a fixed middle band regardless of which side of the
+  // table the value missed on.
+  const first = SWEAT_RATE_LOOKUP_TABLE[0]!
+  const last = SWEAT_RATE_LOOKUP_TABLE[SWEAT_RATE_LOOKUP_TABLE.length - 1]!
+  return temperatureC < first.temperatureMinC ? first : last
 }
 
 export function getEstimatedSweatRateLph(params: {

--- a/tests/unit/server/utils/nutrition-domain/metabolic-simulation-balance.test.ts
+++ b/tests/unit/server/utils/nutrition-domain/metabolic-simulation-balance.test.ts
@@ -67,9 +67,11 @@ describe('energy timeline carbohydrate and calorie balance', () => {
       }
     )
 
-    const last = huge[huge.length - 1]!
-    const carbsIn = last.carbBalance
-    const kcalIn = last.kcalBalance
+    // An hour in, the cap has clearly bitten: at most 90g (4 intervals x 22.5g) can have cleared
+    // the gut so far, far short of what a RAPID curve would otherwise have released for a 400g meal.
+    const oneHourIn = huge.find((p) => p.time === '08:00')!
+    const carbsIn = oneHourIn.carbBalance
+    const kcalIn = oneHourIn.kcalBalance
 
     expect(carbsIn).toBeGreaterThan(0)
     expect(carbsIn).toBeLessThan(400) // the cap withheld some of it
@@ -80,6 +82,46 @@ describe('energy timeline carbohydrate and calorie balance', () => {
     const kcalPerGram = kcalIn / carbsIn
     expect(kcalPerGram).toBeGreaterThan(3.5)
     expect(kcalPerGram).toBeLessThan(4.5)
+  })
+
+  it('defers what the gut cap held back into later intervals instead of discarding it', () => {
+    // Same oversized single meal as above. The cap can only hold back roughly 90g/hour, so a lone
+    // 400g meal logged first thing in the morning has more than enough of the day left to clear the
+    // gut in full - it should all show up by the end of the day, not just the fraction one interval
+    // could take up front.
+    const huge = timeline(
+      {
+        breakfast: [
+          {
+            name: 'Huge Meal',
+            carbs: 400,
+            calories: 1600,
+            logged_at: `${DATE}T07:00:00Z`,
+            absorptionType: 'RAPID'
+          }
+        ]
+      },
+      [],
+      {},
+      {
+        bmr: 1,
+        mealPattern: [{ name: 'Breakfast', time: '07:00' }]
+      }
+    )
+
+    const last = huge[huge.length - 1]!
+
+    // Previously: whatever a single interval's cap withheld was gone for good, so the day-end total
+    // came out well short of the 400g actually eaten. Deferred to later windows, it should recover
+    // essentially all of it well before midnight.
+    expect(last.carbBalance).toBeGreaterThanOrEqual(399)
+    expect(last.kcalBalance).toBeGreaterThanOrEqual(4 * 399)
+
+    // The running total should also never fall as it moves from one capped interval to the next -
+    // deferral means nothing already credited is later taken back.
+    for (let i = 1; i < huge.length; i++) {
+      expect(huge[i]!.carbBalance).toBeGreaterThanOrEqual(huge[i - 1]!.carbBalance)
+    }
   })
 
   it('caps absorption per interval', () => {

--- a/tests/unit/server/utils/nutrition-domain/shared-resolvers.test.ts
+++ b/tests/unit/server/utils/nutrition-domain/shared-resolvers.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import {
+  calculateEnergyTimeline,
+  calculateGlycogenState,
+  resolveSimulationStartTime,
+  resolveStartingGlycogenPercentage,
+  resolveWorkoutDurationMin,
+  resolveWorkoutIntensity
+} from '../../../../../server/utils/nutrition-domain/metabolic-simulation'
+
+const TIMEZONE = 'UTC'
+const DATE = '2026-07-22'
+
+const settings = {
+  weight: 80,
+  bmr: 1,
+  metabolicFloor: 0.6,
+  fuelState1Min: 2.5,
+  mealPattern: [{ name: 'Breakfast', time: '07:00' }]
+}
+
+describe('resolveWorkoutDurationMin', () => {
+  it('prefers durationSec, the canonical field on both workout models', () => {
+    // Before the fix, `calculateGlycogenState` checked `duration` first and `calculateEnergyTimeline`
+    // checked `durationSec` first, so a workout carrying both disagreed on its own length depending
+    // on which calculator read it.
+    const workout = { durationSec: 3600, duration: 7200, plannedDuration: 10800 }
+    expect(resolveWorkoutDurationMin(workout)).toBe(60)
+  })
+
+  it('falls back through duration and plannedDuration in order', () => {
+    expect(resolveWorkoutDurationMin({ duration: 1800 })).toBe(30)
+    expect(resolveWorkoutDurationMin({ plannedDuration: 900 })).toBe(15)
+  })
+
+  it('defaults to one hour when nothing is set', () => {
+    expect(resolveWorkoutDurationMin({})).toBe(60)
+  })
+})
+
+describe('resolveWorkoutIntensity', () => {
+  it('prefers workIntensity, the canonical field on PlannedWorkout', () => {
+    // Before the fix, `calculateGlycogenState` checked `intensity` first while
+    // `calculateEnergyTimeline` checked `workIntensity` first, so the two disagreed whenever both
+    // fields were present.
+    const workout = { workIntensity: 0.9, intensityFactor: 0.6, intensity: 0.3 }
+    expect(resolveWorkoutIntensity(workout)).toBe(0.9)
+  })
+
+  it('falls back through intensityFactor and intensity in order', () => {
+    expect(resolveWorkoutIntensity({ intensityFactor: 0.55 })).toBe(0.55)
+    expect(resolveWorkoutIntensity({ intensity: 0.72 })).toBe(0.72)
+  })
+
+  it('defaults to 0.7 when nothing is set', () => {
+    expect(resolveWorkoutIntensity({})).toBe(0.7)
+  })
+})
+
+describe('resolveStartingGlycogenPercentage', () => {
+  it('uses an explicit value as-is, including an honest zero', () => {
+    expect(resolveStartingGlycogenPercentage(0, 0.6)).toBe(0)
+    expect(resolveStartingGlycogenPercentage(42, 0.6)).toBe(42)
+  })
+
+  it('floors a negative explicit value at 0 rather than going below empty', () => {
+    expect(resolveStartingGlycogenPercentage(-15, 0.6)).toBe(0)
+  })
+
+  it('falls back to the metabolic floor when no value is supplied', () => {
+    expect(resolveStartingGlycogenPercentage(undefined, 0.6)).toBe(60)
+  })
+
+  it('falls back to the metabolic floor for a non-finite value instead of propagating NaN', () => {
+    // `calculateGlycogenState` used to accept any non-undefined value verbatim, so a NaN starting
+    // percentage silently poisoned every downstream calculation instead of falling back like
+    // `calculateEnergyTimeline` already did.
+    expect(resolveStartingGlycogenPercentage(NaN, 0.6)).toBe(60)
+  })
+})
+
+describe('resolveSimulationStartTime', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reads the calendar day straight off a Date without reinterpreting it through the timezone', () => {
+    // Nutrition/workout `date` columns are `@db.Date` and arrive as a UTC-midnight instant that
+    // already encodes the intended calendar day - reinterpreting that instant through a non-UTC
+    // timezone would shift the day key by one.
+    const { dateStr } = resolveSimulationStartTime(
+      new Date('2026-07-22T00:00:00.000Z'),
+      'America/New_York'
+    )
+    expect(dateStr).toBe('2026-07-22')
+  })
+
+  it("anchors the no-date fallback to the caller's timezone, not the server's UTC clock", () => {
+    // Previously this fallback read `new Date().toISOString()`, i.e. the UTC calendar day, even
+    // though a timezone was available and used everywhere else in the same calculation.
+    vi.useFakeTimers()
+    // 23:30 UTC on the 21st is already the 22nd in a UTC+2 zone.
+    vi.setSystemTime(new Date('2026-07-21T23:30:00.000Z'))
+
+    const { dateStr } = resolveSimulationStartTime(undefined, 'Europe/Berlin')
+    expect(dateStr).toBe('2026-07-22')
+  })
+})
+
+describe('calculateGlycogenState and calculateEnergyTimeline agree on workout field resolution', () => {
+  it('drain the same share of capacity for a workout carrying conflicting duration/intensity fields', () => {
+    // A workout object populated the way merged completed+planned records sometimes are: several
+    // duration/intensity fields set to different values. Before the shared resolvers, the two
+    // calculators picked different fields and so disagreed on how much this session cost.
+    const workout = {
+      id: 'w1',
+      title: 'Conflicting Fields Ride',
+      type: 'Ride',
+      source: 'planned',
+      date: new Date(`${DATE}T00:00:00Z`),
+      startTime: new Date(`${DATE}T09:00:00Z`),
+      durationSec: 3600,
+      duration: 7200,
+      plannedDuration: 10800,
+      workIntensity: 0.8,
+      intensityFactor: 0.5,
+      intensity: 0.3
+    }
+
+    // A zero-carb logged breakfast counts as a real (if empty) log, so neither calculator synthesizes
+    // an assumed meal on top of it - the only thing moving the tank in this scenario is the workout.
+    const nutritionRecord = {
+      date: DATE,
+      carbsGoal: 500,
+      breakfast: [{ name: 'Water', carbs: 0, calories: 0, logged_at: `${DATE}T07:00:00Z` }],
+      lunch: [],
+      dinner: [],
+      snacks: []
+    }
+
+    const state = calculateGlycogenState(
+      nutritionRecord,
+      [workout],
+      settings,
+      TIMEZONE,
+      new Date(`${DATE}T11:00:00Z`),
+      80
+    )
+
+    const points = calculateEnergyTimeline(
+      nutritionRecord,
+      [workout],
+      settings,
+      TIMEZONE,
+      undefined,
+      {
+        startingGlycogenPercentage: 80,
+        startingFluidDeficit: 0,
+        now: new Date(`${DATE}T11:00:00Z`)
+      }
+    )
+
+    const timelinePoint = points.find((p) => p.time === '11:00')!
+
+    // Both calculators resolved `durationSec: 3600` (1 hour, fully elapsed by 11:00) and
+    // `workIntensity: 0.8`, so they should land on the same tank level within rounding.
+    expect(Math.abs(state.percentage - timelinePoint.level)).toBeLessThanOrEqual(1)
+  })
+})

--- a/tests/unit/server/utils/nutrition/sweat-rate.test.ts
+++ b/tests/unit/server/utils/nutrition/sweat-rate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SWEAT_RATE_LOOKUP_TABLE,
+  getEstimatedSweatRateLph
+} from '../../../../../server/utils/nutrition/sweat-rate'
+
+describe('sweat rate temperature bands', () => {
+  it('has no gap between consecutive bands', () => {
+    const sorted = [...SWEAT_RATE_LOOKUP_TABLE].sort(
+      (a, b) => a.temperatureMinC - b.temperatureMinC
+    )
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i]!.temperatureMinC).toBe(sorted[i - 1]!.temperatureMaxC)
+    }
+  })
+
+  it('never falls through to a fixed fallback band for a value inside a gap', () => {
+    // 9.95 sat strictly between the old bands' edges (9.9 and 10), so `find` returned nothing and
+    // the lookup silently fell back to the "warm" (18-25.9) band regardless of the real temperature.
+    const cold = getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 9.95 })
+    const warm = getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 20 })
+
+    expect(cold).not.toBe(warm)
+    // 9.95 belongs to the coldest band (-20 to 10), whose "high" rate is 0.75 l/h.
+    expect(cold).toBeCloseTo(0.75, 6)
+  })
+
+  it('assigns every half-degree from -20 to 60 to exactly one band', () => {
+    for (let t = -20; t <= 60; t += 0.5) {
+      const matches = SWEAT_RATE_LOOKUP_TABLE.filter(
+        (band) => t >= band.temperatureMinC && t < band.temperatureMaxC
+      )
+      // 60 itself sits at the closed top edge, outside every half-open band; everything else must
+      // match exactly one.
+      if (t < 60) {
+        expect(matches.length).toBe(1)
+      } else {
+        expect(matches.length).toBe(0)
+      }
+    }
+  })
+
+  it('keeps the boundary values themselves anchored to the warmer band (half-open [min, max))', () => {
+    expect(getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 10 })).toBeCloseTo(0.95, 6)
+    expect(getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 18 })).toBeCloseTo(1.2, 6)
+    expect(getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 26 })).toBeCloseTo(1.45, 6)
+  })
+
+  it('clamps out-of-table temperatures to the nearest band instead of a fixed default', () => {
+    const belowRange = getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: -40 })
+    const coldestBandHigh = 0.75
+    expect(belowRange).toBeCloseTo(coldestBandHigh, 6)
+
+    const aboveRange = getEstimatedSweatRateLph({ intensity: 0.9, temperatureC: 80 })
+    const warmestBandHigh = 1.45
+    expect(aboveRange).toBeCloseTo(warmestBandHigh, 6)
+  })
+})


### PR DESCRIPTION
Fixes CW-75

## Per-issue status

1. **1.25x workout multiplier applied to carbs but not kcal** — already fixed by a prior commit (`50b305e4d`, "Refine glycogen drain so carb and calorie balances stay aligned"). `WORKOUT_DRAIN_MULTIPLIER` is now `1` (the uplift is folded into the calibrated `DRAIN_ANCHORS`) and is applied identically to both the carb and kcal drain in `calculateEnergyTimeline`. No change needed; verified with a hand-computed example and existing/new tests.
2. **22.5g/15min intake cap discarded excess instead of deferring it, kcal uncapped** — fixed. `calculateEnergyTimeline`'s per-interval absorption loop now carries whatever the cap held back (both grams and their paired kcal) into the next 15-minute interval instead of dropping it, using the loop's existing time-slicing rather than a new mechanism. kcal was already gated by the same ratio as carbs (via `absorbedRatio`), so a separate independent kcal cap wasn't introduced — it would need a made-up ceiling with no domain precedent. Verified: a single 400g meal logged at 07:00 now shows the full ~400g/1600kcal credited by day's end instead of losing whatever one interval's cap couldn't clear.
3. **Start-percentage floor asymmetry (0% vs 60%) between the two calculators** — fixed via a new shared `resolveStartingGlycogenPercentage()` helper used by both `calculateGlycogenState` and `calculateEnergyTimeline`. Closes a latent gap where `calculateGlycogenState` would propagate a non-finite (`NaN`) starting value straight through instead of falling back to the metabolic floor like the timeline already did.
4. **Field precedence differences for workout duration/intensity** — fixed via shared `resolveWorkoutDurationMin()` / `resolveWorkoutIntensity()` helpers, now used by both calculators (previously `calculateGlycogenState` checked `duration` and `intensity` first, while `calculateEnergyTimeline` checked `durationSec` and `workIntensity` first). Precedence settled on `durationSec`/`workIntensity` first, matching the canonical Prisma fields on `Workout`/`PlannedWorkout`.
5. **Default start time timezone mismatch (local vs UTC)** — fixed. The date-resolution fallback used when no date is supplied at all previously read `new Date().toISOString()` (the server's UTC "today"), ignoring the timezone argument available in scope. It now uses `formatInTimeZone(new Date(), timezone, 'yyyy-MM-dd')`, matching the `getUserLocalDate`/`getDateKey` convention used elsewhere in this domain. Consolidated into a new shared `resolveSimulationStartTime()` helper used by both calculators (the existing `@db.Date`-based path, where a Date already encodes the intended calendar day via UTC midnight, was left untouched — reinterpreting it through the timezone would have introduced an off-by-one-day regression).
6. **`SWEAT_RATE_LOOKUP_TABLE` gaps (e.g. 9.95°C falls through to "warm")** — fixed. Band edges rewritten as contiguous half-open ranges (`[min, max)`); same rate values, only the top edges moved to meet the next band's bottom edge. Out-of-table temperatures now clamp to the nearest real band instead of a fixed middle-band fallback.

## Verification

```
pnpm vitest run tests/unit/server/utils/nutrition-domain/   # 9 files, 125 tests passed
pnpm vitest run tests/unit/server/utils/nutrition/sweat-rate.test.ts  # 5 tests passed
pnpm typecheck   # exit 0, no errors
```

New/updated tests:
- `tests/unit/server/utils/nutrition-domain/shared-resolvers.test.ts` (new) — covers the 4 shared helpers directly plus an integration test proving the two calculators now agree given a workout with conflicting duration/intensity fields.
- `tests/unit/server/utils/nutrition-domain/metabolic-simulation-balance.test.ts` — updated the "holds back calories" test to snapshot an intermediate point (the cap still bites there) and added a new test proving the deferred amount is fully recovered by day's end and the running total never regresses.
- `tests/unit/server/utils/nutrition/sweat-rate.test.ts` (new) — covers band contiguity, the 9.95°C repro, boundary values, and out-of-range clamping.