### PR TITLE
fix(nutrition): recover from meal recommendation enqueue failures (CW-81)

### DIFF
--- a/server/api/nutrition/recommendations/meal.post.ts
+++ b/server/api/nutrition/recommendations/meal.post.ts
@@ -74,23 +74,40 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  const handle = await dispatchTask(
-    'recommend-nutrition-meal',
-    {
-      userId,
-      date: body.date,
-      windowType: body.windowType,
-      forceLlm: body.forceLlm,
-      targetCarbs: body.targetCarbs,
-      targetProtein: body.targetProtein,
-      targetKcal: body.targetKcal,
-      recommendationId: recommendation.id
-    },
-    {
-      concurrencyKey: userId,
-      tags: [`user:${userId}`]
-    }
-  )
+  let handle: { id: string }
+  try {
+    handle = await dispatchTask(
+      'recommend-nutrition-meal',
+      {
+        userId,
+        date: body.date,
+        windowType: body.windowType,
+        forceLlm: body.forceLlm,
+        targetCarbs: body.targetCarbs,
+        targetProtein: body.targetProtein,
+        targetKcal: body.targetKcal,
+        recommendationId: recommendation.id
+      },
+      {
+        concurrencyKey: userId,
+        tags: [`user:${userId}`]
+      }
+    )
+  } catch (error) {
+    await prisma.nutritionRecommendation.update({
+      where: { id: recommendation.id },
+      data: {
+        status: 'FAILED',
+        contextJson: {
+          requestedTargets,
+          error: 'ENQUEUE_FAILED',
+          errorMessage: error instanceof Error ? error.message : String(error)
+        }
+      }
+    })
+
+    throw createError({ statusCode: 500, message: 'Failed to start meal recommendation' })
+  }
 
   await prisma.nutritionRecommendation.update({
     where: { id: recommendation.id },

--- a/tests/unit/server/api/nutrition/recommendations/meal.post.test.ts
+++ b/tests/unit/server/api/nutrition/recommendations/meal.post.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../../server/utils/auth-guard'
+import { dispatchTask } from '../../../../../../server/utils/task-dispatcher'
+import { prisma } from '../../../../../../server/utils/db'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('createError', (error: any) => {
+  const err = new Error(error.message) as any
+  err.statusCode = error.statusCode
+  return err
+})
+
+let body: any = {}
+vi.stubGlobal('readBody', async () => body)
+
+vi.mock('../../../../../../server/utils/auth-guard', () => ({ requireAuth: vi.fn() }))
+
+vi.mock('../../../../../../server/utils/task-dispatcher', () => ({
+  dispatchTask: vi.fn()
+}))
+
+const { findFirst, create, update } = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn()
+}))
+
+vi.mock('../../../../../../server/utils/db', () => ({
+  prisma: {
+    nutritionRecommendation: { findFirst, create, update }
+  }
+}))
+
+async function post(payload: Record<string, unknown>) {
+  body = payload
+  const handler = (await import('../../../../../../server/api/nutrition/recommendations/meal.post'))
+    .default
+  return handler({} as any)
+}
+
+describe('POST /api/nutrition/recommendations/meal', () => {
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    findFirst.mockResolvedValue(null)
+    create.mockResolvedValue({ id: 'rec-1' })
+    update.mockResolvedValue({})
+  })
+
+  it('marks the recommendation FAILED instead of leaving it stuck in PROCESSING when enqueue throws', async () => {
+    vi.mocked(dispatchTask).mockRejectedValue(new Error('Trigger service unavailable'))
+
+    await expect(
+      post({
+        date: '2026-07-31',
+        windowType: 'PRE_WORKOUT',
+        targetCarbs: 50,
+        targetProtein: 20,
+        targetKcal: 400
+      })
+    ).rejects.toMatchObject({ statusCode: 500 })
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'rec-1' },
+      data: {
+        status: 'FAILED',
+        contextJson: {
+          requestedTargets: { carbs: 50, protein: 20, kcal: 400 },
+          error: 'ENQUEUE_FAILED',
+          errorMessage: 'Trigger service unavailable'
+        }
+      }
+    })
+  })
+
+  it('stores the runId on the recommendation when enqueue succeeds', async () => {
+    vi.mocked(dispatchTask).mockResolvedValue({ id: 'run-123' })
+
+    const result: any = await post({
+      date: '2026-07-31',
+      windowType: 'PRE_WORKOUT',
+      targetCarbs: 50,
+      targetProtein: 20,
+      targetKcal: 400
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.runId).toBe('run-123')
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'rec-1' },
+      data: { runId: 'run-123' }
+    })
+  })
+})

--- a/tests/unit/trigger/recommend-nutrition-meal.test.ts
+++ b/tests/unit/trigger/recommend-nutrition-meal.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../trigger/init', () => ({}))
+
+const { update, findUnique, create } = vi.hoisted(() => ({
+  update: vi.fn(),
+  findUnique: vi.fn(),
+  create: vi.fn()
+}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    nutritionRecommendation: { update, findUnique, create }
+  }
+}))
+
+vi.mock('../../../server/utils/quotas/engine', () => ({
+  checkQuota: vi.fn()
+}))
+
+vi.mock('../../../server/utils/services/mealRecommendationService', () => ({
+  mealRecommendationService: { getRecommendations: vi.fn() }
+}))
+
+vi.mock('@trigger.dev/sdk/v3', async () => {
+  const actual = await vi.importActual('@trigger.dev/sdk/v3')
+  return {
+    ...actual,
+    logger: {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn()
+    },
+    task: vi.fn().mockImplementation((config) => ({
+      run: config.run,
+      id: config.id
+    }))
+  }
+})
+
+describe('recommendNutritionMealTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('merges quota error info into the existing contextJson instead of replacing it', async () => {
+    const { checkQuota } = await import('../../../server/utils/quotas/engine')
+    const quotaError: any = new Error('Quota exceeded')
+    quotaError.statusCode = 429
+    vi.mocked(checkQuota).mockRejectedValue(quotaError)
+
+    findUnique.mockResolvedValue({
+      contextJson: { requestedTargets: { carbs: 50, protein: 20, kcal: 400 } }
+    })
+
+    const { recommendNutritionMealTask } = await import('../../../trigger/recommend-nutrition-meal')
+
+    const result = await recommendNutritionMealTask.run({
+      userId: 'user-1',
+      date: '2026-07-31',
+      windowType: 'PRE_WORKOUT',
+      recommendationId: 'rec-1'
+    })
+
+    expect(result).toEqual({ success: false, reason: 'QUOTA_EXCEEDED' })
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'rec-1' },
+      select: { contextJson: true }
+    })
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'rec-1' },
+      data: {
+        status: 'FAILED',
+        contextJson: {
+          requestedTargets: { carbs: 50, protein: 20, kcal: 400 },
+          error: 'QUOTA_EXCEEDED'
+        }
+      }
+    })
+  })
+})

--- a/trigger/recommend-nutrition-meal.ts
+++ b/trigger/recommend-nutrition-meal.ts
@@ -40,11 +40,19 @@ export const recommendNutritionMealTask = task({
         logger.warn('Meal recommendation quota exceeded', { userId })
 
         if (recommendationId) {
+          const existing = await prisma.nutritionRecommendation.findUnique({
+            where: { id: recommendationId },
+            select: { contextJson: true }
+          })
+
           await prisma.nutritionRecommendation.update({
             where: { id: recommendationId },
             data: {
               status: 'FAILED',
-              contextJson: { error: 'QUOTA_EXCEEDED' }
+              contextJson: {
+                ...((existing?.contextJson as object | null) ?? {}),
+                error: 'QUOTA_EXCEEDED'
+              }
             }
           })
         } else {


### PR DESCRIPTION
Fixes CW-81

## Summary
- `server/api/nutrition/recommendations/meal.post.ts`: the trigger enqueue call (`dispatchTask`) is now wrapped in try/catch. If it throws, the `NutritionRecommendation` row is updated to `FAILED` (preserving `requestedTargets` and recording the error) before the request responds with a 500, instead of leaving the row permanently stuck in `PROCESSING` with `runId: null`.
- `trigger/recommend-nutrition-meal.ts`: on a quota error (429) for an existing `recommendationId`, the existing `contextJson` is now fetched and spread before adding `error: 'QUOTA_EXCEEDED'`, instead of replacing the whole object and losing the original context (e.g. `requestedTargets`).

## Verification
```
pnpm typecheck
```
Passes cleanly (`vue-tsc`, no errors).

Added unit tests:
- `tests/unit/server/api/nutrition/recommendations/meal.post.test.ts` — asserts the recommendation is marked `FAILED` with merged context when enqueue throws, and that a successful enqueue still records `runId`.
- `tests/unit/trigger/recommend-nutrition-meal.test.ts` — asserts the quota-error path merges into the existing `contextJson` rather than replacing it.

```
pnpm vitest run tests/unit/server/api/nutrition/recommendations/meal.post.test.ts tests/unit/trigger/recommend-nutrition-meal.test.ts
```
3 tests passed.