### PR TITLE
fix(integrations): map Garmin recovery from documented Health API fields (CW-96)

### DIFF
--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -176,10 +176,53 @@ export function extractGarminReadinessScore(record: Record<string, unknown> | nu
   return normalizeReadinessScore(clampPercentage(readiness))
 }
 
+/**
+ * Garmin's Stress Details schema exposes an absolute Body Battery *level* sampled
+ * throughout the day via `timeOffsetBodyBatteryValues` (a map of seconds-since-start-of-day
+ * to a 0-100 battery reading), the same shape as `timeOffsetSleepSpo2`. Body Battery is
+ * highest right after sleep/rest and drains through the day with activity and stress, so the
+ * peak sampled value is the best documented proxy for "how recovered" the user was that day.
+ */
+function extractGarminBodyBatteryPeakFromTimeSeries(value: unknown): number | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+
+  const values = Object.values(value as Record<string, unknown>)
+    .map((entry) => toFiniteNumber(entry))
+    .filter((entry): entry is number => entry !== null)
+
+  if (values.length === 0) return null
+
+  return Math.max(...values)
+}
+
 export function extractGarminBodyBatteryScore(record: Record<string, unknown> | null | undefined) {
   if (!record || typeof record !== 'object') return null
 
-  const bodyBattery = extractGarminNumericMetric(record, [
+  // Preferred source: Garmin Stress Details' documented time-series field. This carries an
+  // absolute Body Battery level (not a delta), so it maps directly onto our 0-100 recovery scale.
+  const timeSeriesPeak = extractGarminBodyBatteryPeakFromTimeSeries(
+    record.timeOffsetBodyBatteryValues
+  )
+  if (timeSeriesPeak !== null) {
+    return clampPercentage(timeSeriesPeak)
+  }
+
+  // Garmin Daily Summary's documented fields only expose the amount of Body Battery charged
+  // and drained over the day (deltas), not an absolute level. Derive a recovery percentage
+  // centered on a neutral 50: a net-positive day (charged > drained) moves the score up toward
+  // 100, a net-negative day moves it down toward 0. Charged/drained are each roughly 0-100, so
+  // halving the net keeps the result within the 0-100 recovery range before clamping.
+  const chargedValue = extractGarminNumericMetric(record, ['bodyBatteryChargedValue'])
+  const drainedValue = extractGarminNumericMetric(record, ['bodyBatteryDrainedValue'])
+  if (chargedValue !== null || drainedValue !== null) {
+    const netChange = (chargedValue ?? 0) - (drainedValue ?? 0)
+    return clampPercentage(50 + netChange / 2)
+  }
+
+  // Legacy/non-standard field names some earlier payload shapes used before this extractor was
+  // aligned with the documented Garmin Health API models. Kept as a fallback so any
+  // already-integrated data source that only ever sent these keeps working (CW-96).
+  const legacyBodyBattery = extractGarminNumericMetric(record, [
     'bodyBatteryMostRecentValue',
     'bodyBatteryCurrentValue',
     'bodyBatteryEndingValue',
@@ -189,8 +232,8 @@ export function extractGarminBodyBatteryScore(record: Record<string, unknown> | 
     'bodyBatteryMaxValue'
   ])
 
-  if (bodyBattery !== null) {
-    return clampPercentage(bodyBattery)
+  if (legacyBodyBattery !== null) {
+    return clampPercentage(legacyBodyBattery)
   }
 
   // Some Garmin devices surface readiness-style recovery metrics without a body battery field.
@@ -319,6 +362,7 @@ export const GarminService = {
       if (wellnessEnabled && dailies.length > 0) await this.processWellness(userId, dailies)
       if (wellnessEnabled && sleeps.length > 0) await this.processSleep(userId, sleeps)
       if (wellnessEnabled && hrv.length > 0) await this.processHRV(userId, hrv)
+      if (wellnessEnabled && stress.length > 0) await this.processStressDetails(userId, stress)
       if (activitiesEnabled && activities.length > 0)
         await this.processActivities(userId, activities, integration, pullToken)
       if (activitiesEnabled && activityFiles.length > 0) {
@@ -501,6 +545,44 @@ export const GarminService = {
       }
 
       await wellnessRepository.upsert(userId, utcDate, hrvData, hrvData, 'garmin')
+    }
+  },
+
+  /**
+   * Process Garmin Stress Details push records.
+   *
+   * These carry the `timeOffsetBodyBatteryValues` time series (and, in the future, stress
+   * level samples) that Dailies alone cannot provide an absolute Body Battery reading from.
+   * Previously these records were counted toward `hasSummaryData` but never persisted -
+   * recognized recovery-bearing summaries were silently discarded (CW-96). Only recoveryScore
+   * is written here; the wellnessRepository upsert only overwrites non-null fields, so this
+   * merges into whatever Dailies/Sleep/HRV already wrote for the same day without clobbering it.
+   */
+  async processStressDetails(userId: string, data: any[]) {
+    for (const record of data) {
+      const utcDate = this.resolveWellnessDate(record, {
+        timestampField: 'startTimeInSeconds',
+        offsetField: 'startTimeOffsetInSeconds'
+      })
+      if (!utcDate) continue
+
+      const recoveryScore = extractGarminBodyBatteryScore(record)
+      if (recoveryScore === null) continue
+
+      const stressDetailsData: any = {
+        userId,
+        date: utcDate,
+        recoveryScore,
+        rawJson: record
+      }
+
+      await wellnessRepository.upsert(
+        userId,
+        utcDate,
+        stressDetailsData,
+        stressDetailsData,
+        'garmin'
+      )
     }
   },
 

--- a/tests/unit/server/utils/services/garminService.test.ts
+++ b/tests/unit/server/utils/services/garminService.test.ts
@@ -197,6 +197,72 @@ describe('extractGarminBodyBatteryScore', () => {
   })
 })
 
+describe('extractGarminBodyBatteryScore (documented Garmin Health API fields)', () => {
+  it('derives an absolute recovery level from Stress Details timeOffsetBodyBatteryValues', () => {
+    // Real Garmin Stress Details push payloads sample Body Battery throughout the day as
+    // { "<secondsSinceStartOfDay>": level }. The peak sample is the best documented proxy
+    // for "how recovered" the user was (Body Battery is highest right after sleep/rest).
+    expect(
+      extractGarminBodyBatteryScore({
+        userId: 'garmin-user-1',
+        calendarDate: '2026-03-10',
+        timeOffsetBodyBatteryValues: {
+          '0': 62,
+          '3600': 78,
+          '7200': 55,
+          '10800': 40
+        }
+      })
+    ).toBe(78)
+  })
+
+  it('derives a net recovery percentage from Daily bodyBatteryChargedValue/bodyBatteryDrainedValue', () => {
+    // Garmin Daily Summary only documents charged/drained deltas, not an absolute level.
+    // Product rule: 50 (neutral) + netChange/2, clamped to 0-100.
+    expect(
+      extractGarminBodyBatteryScore({
+        calendarDate: '2026-03-10',
+        bodyBatteryChargedValue: 60,
+        bodyBatteryDrainedValue: 40
+      })
+    ).toBe(60)
+  })
+
+  it('clamps a fully-drained day to 0 when only bodyBatteryDrainedValue is present', () => {
+    expect(
+      extractGarminBodyBatteryScore({
+        bodyBatteryDrainedValue: 100
+      })
+    ).toBe(0)
+  })
+
+  it('clamps a fully-charged day to 100 when only bodyBatteryChargedValue is present', () => {
+    expect(
+      extractGarminBodyBatteryScore({
+        bodyBatteryChargedValue: 100
+      })
+    ).toBe(100)
+  })
+
+  it('prefers the Stress Details time series over Daily charged/drained deltas when both are present', () => {
+    expect(
+      extractGarminBodyBatteryScore({
+        timeOffsetBodyBatteryValues: { '0': 45, '3600': 90 },
+        bodyBatteryChargedValue: 10,
+        bodyBatteryDrainedValue: 80
+      })
+    ).toBe(90)
+  })
+
+  it('still falls back to the legacy non-standard fields when only those are present (kept for backward compatibility)', () => {
+    expect(
+      extractGarminBodyBatteryScore({
+        bodyBatteryMostRecentValue: 68
+      })
+    ).toBe(68)
+  })
+})
+
 describe('extractGarminReadinessScore', () => {
   it('normalizes Garmin training readiness scores into the app readiness scale', () => {
     expect(
@@ -250,6 +316,57 @@ describe('extractGarminSpO2Percentage', () => {
         averageStressLevel: 18
       })
     ).toBeNull()
+  })
+})
+
+describe('GarminService.processStressDetails', () => {
+  it('persists a recognized recovery-bearing Stress Details summary instead of discarding it (CW-96)', async () => {
+    const wellnessRepoModule =
+      await import('../../../../../server/utils/repositories/wellnessRepository')
+    const upsertSpy = vi
+      .spyOn(wellnessRepoModule.wellnessRepository, 'upsert')
+      .mockResolvedValue({ record: {} as any, isNew: true })
+
+    await GarminService.processStressDetails('user-1', [
+      {
+        userId: 'garmin-ext-1',
+        calendarDate: '2026-03-10',
+        startTimeInSeconds: 1773097200,
+        startTimeOffsetInSeconds: 0,
+        timeOffsetBodyBatteryValues: {
+          '0': 40,
+          '3600': 85,
+          '7200': 60
+        }
+      }
+    ])
+
+    expect(upsertSpy).toHaveBeenCalledTimes(1)
+    expect(upsertSpy).toHaveBeenCalledWith(
+      'user-1',
+      expect.any(Date),
+      expect.objectContaining({ recoveryScore: 85 }),
+      expect.objectContaining({ recoveryScore: 85 }),
+      'garmin'
+    )
+
+    vi.restoreAllMocks()
+  })
+
+  it('skips Stress Details records with no usable date or recovery signal without throwing', async () => {
+    const wellnessRepoModule =
+      await import('../../../../../server/utils/repositories/wellnessRepository')
+    const upsertSpy = vi
+      .spyOn(wellnessRepoModule.wellnessRepository, 'upsert')
+      .mockResolvedValue({ record: {} as any, isNew: true })
+
+    await GarminService.processStressDetails('user-1', [
+      { calendarDate: '2026-03-10', averageStressLevel: 20 }
+    ])
+
+    expect(upsertSpy).not.toHaveBeenCalled()
+
+    vi.restoreAllMocks()
   })
 })
 


### PR DESCRIPTION
Fixes CW-96

## Problem
`extractGarminBodyBatteryScore` only read non-standard field names (`bodyBatteryMostRecentValue`, `bodyBatteryCurrentValue`, etc.) that do not appear in Garmin's documented Health API schemas. Real Garmin payloads carry:
- Daily Summary: `bodyBatteryChargedValue` / `bodyBatteryDrainedValue` (deltas over the day)
- Stress Details: `timeOffsetBodyBatteryValues` (a time series of absolute Body Battery levels sampled through the day)

As a result, `Wellness.recoveryScore` stayed unpopulated for users whose Garmin payloads only used the documented shape. Additionally, `stressDetails`/`stress` push records were extracted and counted toward `hasSummaryData`, but there was no processor for them at all — recognized recovery-bearing summaries were silently discarded.

## Field-mapping decision
- **Stress Details (`timeOffsetBodyBatteryValues`) — preferred source.** This is an absolute 0-100 Body Battery level sampled at multiple points in the day, so it maps directly onto our `recoveryScore` scale. We take the **peak sampled value** for the day, since Body Battery is highest right after sleep/rest and this is the closest documented analog to the old `bodyBatteryHighestValue`/`bodyBatteryMostRecentValue` intent.
- **Daily Summary (`bodyBatteryChargedValue` / `bodyBatteryDrainedValue`) — fallback when no time series is available.** These are only deltas, not an absolute level, so we derive a percentage centered on a neutral 50: `recoveryScore = clamp(50 + (charged - drained) / 2, 0, 100)`. A net-positive day (more charged than drained) moves the score up toward 100; a net-negative day moves it down toward 0.
- **Legacy non-standard fields — kept as a further fallback**, not removed, so any already-integrated data source that only ever sent the old keys keeps working. This felt safer than a hard removal given we can't verify every historical payload shape in flight.
- **Readiness-score fallback — unchanged**, left as the last resort exactly as before.

New: `GarminService.processStressDetails` persists `recoveryScore` from Stress Details push records into `Wellness` via the existing `wellnessRepository.upsert` (which only overwrites non-null fields, so it merges safely alongside whatever Dailies/Sleep/HRV already wrote for that day). Wired into `processWebhookEvent` for `wellnessEnabled` integrations.

## Scope notes
- Only `server/utils/services/garminService.ts` and its test file were touched, per the ticket's owned paths (CW-97/CW-99 also target `garminService.ts` and are intentionally not running in parallel).
- The pull-based ingestion path (`runIngestGarmin`) still doesn't fetch Stress Details at all — there's no `fetchGarminStressDetails`/backfill type in `server/utils/garmin.ts` yet, and adding one is out of scope here (that file is owned by other in-flight tickets). Daily-based recovery (`bodyBatteryChargedValue`/`bodyBatteryDrainedValue`) does flow through the pull path already, since it reuses the same extractor via `processWellness`.
- `extractGarminReadinessScore`'s primary field (`trainingReadinessScore`) was intentionally left untouched — the ticket's acceptance criteria specifically scope this fix to the Daily/Stress body-battery mapping, and training readiness field correctness looks like it belongs to a sibling ticket touching the same file.

## Verification
```
pnpm test tests/unit/server/utils/services/garminService.test.ts
# Test Files  1 passed (1)
# Tests  33 passed (33)

pnpm typecheck
# exits 0, no errors
```