### PR TITLE
fix(nutrition): correct planned-kJ formula and undefined advice text (CW-67)

### DIFF
--- a/tests/unit/trigger/adjust-fueling-post-workout.test.ts
+++ b/tests/unit/trigger/adjust-fueling-post-workout.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { findRecoveryWindowIndex } from '../../../trigger/adjust-fueling-post-workout'
-import type { SerializedFuelingPlan } from '../../../server/utils/nutrition-domain'
+import {
+  buildBoostedRecoveryWindow,
+  calculatePlannedEnergyKj,
+  findRecoveryWindowIndex
+} from '../../../trigger/adjust-fueling-post-workout'
+import type {
+  SerializedFuelingPlan,
+  SerializedFuelingWindow
+} from '../../../server/utils/nutrition-domain'
 
 function planWith(windows: any[]): SerializedFuelingPlan {
   return { windows, dailyTotals: {} as any, notes: [] } as any
@@ -87,5 +94,90 @@ describe('findRecoveryWindowIndex', () => {
         endedAt: new Date('2026-07-22T18:45:00.000Z')
       })
     ).toBe(1)
+  })
+})
+
+describe('calculatePlannedEnergyKj', () => {
+  it('uses the FTP-based formula (watts * IF * seconds / 1000), not duration * IF * 60', () => {
+    // A 1-hour endurance ride at FTP 200W and IF 0.65 should cost ~468 kJ, not ~172,800 kJ
+    // (the bug produced by the old `durationSec * workIntensity * 60` formula).
+    const durationSec = 60 * 60
+    const plannedKj = calculatePlannedEnergyKj(200, 0.65, durationSec)
+
+    expect(plannedKj).toBeCloseTo(468, 5)
+    expect(plannedKj).toBeLessThan(1000)
+  })
+
+  it('scales linearly with FTP, intensity factor, and duration', () => {
+    expect(calculatePlannedEnergyKj(250, 1, 1000)).toBeCloseTo(250, 5)
+    expect(calculatePlannedEnergyKj(250, 0.5, 1000)).toBeCloseTo(125, 5)
+    expect(calculatePlannedEnergyKj(0, 0.65, 3600)).toBe(0)
+  })
+
+  it('makes a real hard-effort delta satisfy the 10% "harder than planned" threshold', () => {
+    // A rider with FTP 250 doing a planned 90-minute endurance ride (IF 0.65) plans for ~877 kJ.
+    // If the actual ride cost 1050 kJ (a genuinely harder effort), the boost should now fire —
+    // under the old formula (durationSec * workIntensity * 60) plannedKj would have been ~210,600,
+    // making this threshold impossible to clear for any real ride.
+    const plannedKj = calculatePlannedEnergyKj(250, 0.65, 90 * 60)
+    const actualKj = 1050
+
+    expect(actualKj).toBeGreaterThan(plannedKj * 1.1)
+  })
+})
+
+describe('buildBoostedRecoveryWindow', () => {
+  const baseWindow: SerializedFuelingWindow = {
+    type: 'POST_WORKOUT',
+    startTime: '2026-07-22T08:00:00.000Z',
+    endTime: '2026-07-22T09:00:00.000Z',
+    targetCarbs: 40,
+    targetProtein: 20,
+    targetFat: 10,
+    targetFluid: 500,
+    targetSodium: 300,
+    description: 'Recovery shake with fruit.',
+    status: 'PENDING'
+  }
+
+  it('increases carb and protein targets by the boost amounts', () => {
+    const boosted = buildBoostedRecoveryWindow(baseWindow)
+
+    expect(boosted.targetCarbs).toBe(70)
+    expect(boosted.targetProtein).toBe(30)
+    expect(boosted.status).toBe('PENDING')
+  })
+
+  it('appends the boost note to the always-present description field', () => {
+    const boosted = buildBoostedRecoveryWindow(baseWindow)
+
+    expect(boosted.description).toContain('Recovery shake with fruit.')
+    expect(boosted.description).toContain('Boosted by +30g carbs')
+    expect(boosted.description).not.toContain('undefined')
+  })
+
+  it('sets a complete advice sentence rather than concatenating onto an undefined value', () => {
+    // The original bug did `${currentWindow.advice} (Boosted ...)` where `advice` was undefined
+    // for freshly generated windows (only `description` is populated by the plan generator),
+    // producing the literal string "undefined (Boosted ...)".
+    expect(baseWindow.advice).toBeUndefined()
+
+    const boosted = buildBoostedRecoveryWindow(baseWindow)
+
+    expect(boosted.advice).toBeDefined()
+    expect(boosted.advice).not.toContain('undefined')
+    expect(boosted.advice).toContain('Boosted by +30g carbs / +10g protein')
+  })
+
+  it('still produces real, non-undefined text when the window already has advice set', () => {
+    const windowWithAdvice: SerializedFuelingWindow = {
+      ...baseWindow,
+      advice: 'Balanced recovery meal to maintain base energy.'
+    }
+
+    const boosted = buildBoostedRecoveryWindow(windowWithAdvice)
+
+    expect(boosted.advice).not.toContain('undefined')
+    expect(boosted.advice).toContain('Boosted by +30g carbs')
   })
 })

--- a/trigger/adjust-fueling-post-workout.ts
+++ b/trigger/adjust-fueling-post-workout.ts
@@ -1,4 +1,5 @@
 import { task } from '@trigger.dev/sdk/v3'
+import { prisma } from '../server/utils/db'
 import { getUserLocalDate, getUserTimezone } from '../server/utils/date'
 import { nutritionRepository } from '../server/utils/repositories/nutritionRepository'
 import { workoutRepository } from '../server/utils/repositories/workoutRepository'
@@ -6,6 +7,56 @@ import type {
   SerializedFuelingPlan,
   SerializedFuelingWindow
 } from '../server/utils/nutrition-domain'
+
+/** Fallback FTP (watts) used when the athlete has not set one, matching metabolicService's default. */
+const DEFAULT_FTP_WATTS = 250
+/** Fallback intensity factor (0-1) used when a planned workout has no recorded IF. */
+const DEFAULT_INTENSITY_FACTOR = 0.65
+
+const BOOST_CARBS_G = 30
+const BOOST_PROTEIN_G = 10
+
+/**
+ * Estimates the energy cost (kJ) of a planned session from FTP-based training load.
+ *
+ * Watts * seconds = joules, so `ftp * intensityFactor` approximates the average power for the
+ * session (a normalized-power proxy) and multiplying by duration then dividing by 1000 converts to
+ * kilojoules. This mirrors how `actualKj` is measured from real power-meter data so the two values
+ * are directly comparable (the previous `durationSec * workIntensity * 60` formula overestimated
+ * planned energy by roughly two orders of magnitude).
+ */
+export function calculatePlannedEnergyKj(
+  ftpWatts: number,
+  intensityFactor: number,
+  durationSec: number
+): number {
+  return (ftpWatts * intensityFactor * durationSec) / 1000
+}
+
+/**
+ * Returns a copy of the recovery window with the post-workout boost applied.
+ *
+ * `description` is always populated by the plan generator, so the boost note is appended there.
+ * `advice` is optional and, elsewhere in the codebase, callers fall back to `description` when it
+ * is unset — so this always assigns `advice` a complete, self-contained sentence instead of
+ * concatenating onto a possibly-undefined value (which previously produced literal "undefined"
+ * text in the window's advice).
+ */
+export function buildBoostedRecoveryWindow(
+  window: SerializedFuelingWindow,
+  boost: { carbs: number; protein: number } = { carbs: BOOST_CARBS_G, protein: BOOST_PROTEIN_G }
+): SerializedFuelingWindow {
+  const boostNote = `Boosted by +${boost.carbs}g carbs / +${boost.protein}g protein — that session ran harder than planned.`
+
+  return {
+    ...window,
+    targetCarbs: window.targetCarbs + boost.carbs,
+    targetProtein: window.targetProtein + boost.protein,
+    description: window.description ? `${window.description} ${boostNote}` : boostNote,
+    advice: boostNote,
+    status: 'PENDING'
+  }
+}
 
 /**
  * Picks the recovery window that belongs to the session that was just completed.
@@ -73,8 +124,14 @@ export const adjustFuelingPostWorkoutTask = task({
 
     const planned = workout.plannedWorkout
     const actualKj = workout.kilojoules || 0
-    const plannedKj = (planned.durationSec || 0) * (planned.workIntensity || 0.65) * 60 // Rough estimate if KJ not present? Or assume `tss` is proxy?
-    // Let's rely on TSS or IF if KJ is missing, but KJ is king.
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { ftp: true }
+    })
+    const ftp = user?.ftp || DEFAULT_FTP_WATTS
+    const intensityFactor = planned.workIntensity ?? DEFAULT_INTENSITY_FACTOR
+    const plannedKj = calculatePlannedEnergyKj(ftp, intensityFactor, planned.durationSec || 0)
 
     // Calculate Delta
     const kjThreshold = (plannedKj || 1000) * 1.1 // 10% more
@@ -113,20 +170,13 @@ export const adjustFuelingPostWorkoutTask = task({
       return
     }
 
-    // Boost Recovery: +50g Carbs? Or +20%?
-    // Let's do +30g Carbs and +10g Protein
+    // Boost Recovery: +30g Carbs and +10g Protein
     const currentWindow = plan.windows[postWindowIndex]
-    const newWindow: SerializedFuelingWindow = {
-      ...currentWindow,
-      targetCarbs: currentWindow.targetCarbs + 30,
-      targetProtein: currentWindow.targetProtein + 10,
-      advice: `${currentWindow.advice} (Boosted by +30g C due to high intensity effort!)`,
-      status: 'PENDING' // Reset to pending? Or if already hit, just note it?
-    }
+    const newWindow = buildBoostedRecoveryWindow(currentWindow)
 
     plan.windows[postWindowIndex] = newWindow
-    plan.dailyTotals.carbs += 30
-    plan.dailyTotals.protein += 10
+    plan.dailyTotals.carbs += BOOST_CARBS_G
+    plan.dailyTotals.protein += BOOST_PROTEIN_G
 
     // 4. Save
     await nutritionRepository.update(nutrition.id, {


### PR DESCRIPTION
Fixes CW-67

## Summary

`trigger/adjust-fueling-post-workout.ts` boosts recovery fueling targets when a completed workout was harder than planned. Two of the three known bugs are fixed here:

1. **Broken kJ formula (fixed):** replaced `durationSec * workIntensity * 60` (which overestimated planned energy by ~2 orders of magnitude, e.g. 172,800 kJ vs ~700 kJ actual for a 1-hour ride) with the correct FTP-based formula `ftp * intensityFactor * durationSec / 1000`. FTP is read from the user record (defaulting to 250W, matching `metabolicService`'s existing default), IF from the planned workout's `workIntensity` (defaulting to 0.65). This is extracted as a pure, unit-tested `calculatePlannedEnergyKj` function.
2. **`currentWindow.advice` producing `undefined` (fixed):** fueling windows are only guaranteed to have `description` populated by the plan generator — `advice` is an optional enrichment field set later, elsewhere in `metabolicService.ts`. The old code did `` `${currentWindow.advice} (Boosted by +30g C...)` ``, which rendered as the literal string `"undefined (Boosted by +30g C due to high intensity effort!)"` for any freshly generated window. The boost note is now appended to `description` (always real text) and `advice` is always set to a complete, self-contained sentence — matching the pattern used elsewhere in `metabolicService.ts` (`w.advice = 'Carb loading: ...'`). Extracted as a pure, unit-tested `buildBoostedRecoveryWindow` function.

## Not included: wiring the trigger into the ingest/linking flow

The task is still never dispatched anywhere (bug #1 from the ticket). Wiring it in turned out to be a genuine design decision rather than a mechanical change: the existing `// REACTIVE: Trigger fueling plan update` pattern this task would piggyback on is **independently duplicated** across:

- `trigger/ingest-strava-activity.ts`
- `trigger/ingest-intervals.ts`
- `server/api/workouts/[id]/link.post.ts` (manual link)
- `server/api/planned-workouts/[id]/complete.post.ts` (manual complete)
- `server/utils/services/stravaService.ts` (bulk backfill sync — doesn't even call `calculateFuelingPlanForDate`)

None of these are in this ticket's owned paths (`trigger/adjust-fueling-post-workout.ts`, `server/utils/services/metabolicService.ts`), and centralizing inside `metabolicService.calculateFuelingPlanForDate` isn't safe as-is since that function is also called from many unrelated contexts (calendar views, AI tools, manual nutrition edits) where firing the adjustment task would be wrong.

Two concrete follow-up options (recommend filing as a separate Linear issue):
- **Option A:** add an explicit opt-in param to `calculateFuelingPlanForDate` (e.g. `{ persist: true, reactToWorkoutId }`) and update each of the ~4-5 REACTIVE call sites to pass it when reacting to a genuinely-completed workout.
- **Option B:** dispatch `adjust-fueling-post-workout` directly from each REACTIVE call site via `dispatchTask`, matching the existing per-site pattern, idempotency-keyed on workout id.

## Verification

```
pnpm vitest run tests/unit/trigger/adjust-fueling-post-workout.test.ts
# Test Files  1 passed (1)
#      Tests  12 passed (12)

pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts
# Test Files  1 passed (1)
#      Tests  15 passed (15)

pnpm typecheck
# exit 0, no errors
```

## Test plan
- [x] `pnpm vitest run tests/unit/trigger/adjust-fueling-post-workout.test.ts` passes (12 tests, including new coverage for the kJ formula and advice/description behavior)
- [x] `pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts` passes (ticket's specified verification command)
- [x] `pnpm typecheck` passes
- [x] `pnpm eslint` clean on changed files