### PR TITLE
fix(nutrition): repeat meal modal poll fallback with backoff and timeout (CW-80)

### DIFF
--- a/app/components/nutrition/MealRecommendationModal.vue
+++ b/app/components/nutrition/MealRecommendationModal.vue
@@ -630,40 +630,115 @@
     }
   }
 
-  // Fallback: poll if it stays loading too long
-  let pollTimer: NodeJS.Timeout | null = null
-  watch(loading, (val) => {
-    console.log('[MealRecommendationModal] loading changed', {
-      loading: val,
+  // Fallback: poll run status while waiting, in case WebSocket events are missed.
+  // LLM generation frequently takes well beyond a few seconds, so this can't be a
+  // single check — it needs to keep polling (with backoff) until the run finishes
+  // or a terminal timeout is hit, otherwise the modal is stuck spinning forever.
+  const POLL_INTERVALS_MS = [3000, 3000, 3000, 5000, 5000, 8000]
+  const POLL_MAX_TOTAL_MS = 90000
+  const TERMINAL_RUN_STATUSES = ['FAILED', 'CANCELED', 'TIMED_OUT']
+  let pollTimer: ReturnType<typeof setTimeout> | null = null
+  let pollAttempt = 0
+  let pollStartedAt = 0
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+    pollAttempt = 0
+  }
+
+  function finishWithError(title: string, description: string) {
+    stopPolling()
+    stopLoadingStageRotation()
+    loading.value = false
+    loadingLlm.value = false
+    recommendations.value = []
+    toast.add({
+      title,
+      description,
+      color: 'error',
+      icon: 'i-heroicons-exclamation-circle'
+    })
+  }
+
+  async function pollRunStatus() {
+    pollTimer = null
+
+    if (!isWaitingForRun.value || !currentRunId.value) {
+      stopPolling()
+      return
+    }
+
+    if (Date.now() - pollStartedAt >= POLL_MAX_TOTAL_MS) {
+      console.warn('[MealRecommendationModal] polling timed out', {
+        runId: currentRunId.value
+      })
+      finishWithError(
+        'Still Working',
+        'Meal recommendations are taking longer than expected. Please try again.'
+      )
+      return
+    }
+
+    try {
+      console.log('[MealRecommendationModal] polling run status', {
+        runId: currentRunId.value,
+        attempt: pollAttempt
+      })
+      const run = await ($fetch as any)(`/api/runs/${currentRunId.value}`)
+      console.log('[MealRecommendationModal] polling run status response', {
+        runId: currentRunId.value,
+        status: run.status,
+        hasOutput: !!run.output
+      })
+
+      if (run.status === 'COMPLETED') {
+        stopPolling()
+        await applyRunOutput(run)
+        return
+      }
+
+      if (TERMINAL_RUN_STATUSES.includes(run.status)) {
+        finishWithError(
+          'Recommendation Failed',
+          run.error?.message || 'Failed to generate meal recommendations'
+        )
+        return
+      }
+    } catch (e) {
+      console.warn('[MealRecommendationModal] polling error', e)
+      // Transient network/fetch error — keep polling rather than giving up.
+    }
+
+    if (!isWaitingForRun.value) {
+      stopPolling()
+      return
+    }
+
+    const delay = POLL_INTERVALS_MS[Math.min(pollAttempt, POLL_INTERVALS_MS.length - 1)]
+    pollAttempt += 1
+    pollTimer = setTimeout(() => {
+      void pollRunStatus()
+    }, delay)
+  }
+
+  const isWaitingForRun = computed(() => loading.value || loadingLlm.value)
+
+  watch(isWaitingForRun, (val) => {
+    console.log('[MealRecommendationModal] isWaitingForRun changed', {
+      isWaitingForRun: val,
       currentRunId: currentRunId.value
     })
     if (val) {
-      pollTimer = setTimeout(async () => {
-        if (loading.value && currentRunId.value) {
-          try {
-            console.log('[MealRecommendationModal] polling run status', {
-              runId: currentRunId.value
-            })
-            const run = await ($fetch as any)(`/api/runs/${currentRunId.value}`)
-            console.log('[MealRecommendationModal] polling run status response', {
-              runId: currentRunId.value,
-              status: run.status,
-              hasOutput: !!run.output
-            })
-            if (run.status === 'COMPLETED') {
-              await applyRunOutput(run)
-            }
-          } catch (e) {
-            console.warn('[MealRecommendationModal] polling error', e)
-            // ignore
-          }
-        }
-      }, 3000)
+      pollAttempt = 0
+      pollStartedAt = Date.now()
+      pollTimer = setTimeout(() => {
+        void pollRunStatus()
+      }, POLL_INTERVALS_MS[0])
     } else {
-      if (pollTimer) {
-        clearTimeout(pollTimer)
-        pollTimer = null
-      }
+      stopPolling()
     }
   })
 
@@ -678,6 +753,7 @@
 
   onUnmounted(() => {
     stopLoadingStageRotation()
+    stopPolling()
   })
 
   async function getLlmRecommendations() {
@@ -724,8 +800,17 @@
 
       isOpen.value = false
       emit('updated')
-    } catch (e) {
+    } catch (e: any) {
       console.error('Failed to confirm selection:', e)
+      toast.add({
+        title: 'Failed to Apply Meal',
+        description:
+          e?.data?.message ||
+          e?.message ||
+          'Could not add this meal to your plan. Please try again.',
+        color: 'error',
+        icon: 'i-heroicons-exclamation-circle'
+      })
     } finally {
       confirming.value = false
     }

--- a/tests/unit/app/components/MealRecommendationModal.test.ts
+++ b/tests/unit/app/components/MealRecommendationModal.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import MealRecommendationModal from '../../../../app/components/nutrition/MealRecommendationModal.vue'
+
+const toastAddMock = vi.fn()
+
+mockNuxtImport('useToast', () => () => ({ add: toastAddMock }))
+mockNuxtImport('useUserRunsState', () => () => ({
+  onTaskCompleted: vi.fn(),
+  onTaskFailed: vi.fn()
+}))
+
+const BASE_PROPS = {
+  date: '2026-07-31',
+  targetCarbs: 80,
+  windowType: 'PRE_WORKOUT'
+}
+
+// UModal only renders its named slots when instructed to; the real component's
+// header/body/footer content lives in those slots. UButton is stubbed as a
+// plain <button> so click handlers and :disabled/:loading still behave like a
+// real button under test. NutritionMealOptionCard is stubbed with a clickable
+// element that emits `select`, mirroring its real click-to-select behavior.
+function stubs() {
+  return {
+    UModal: {
+      template: '<div><slot name="header" /><slot name="body" /><slot name="footer" /></div>'
+    },
+    UButton: {
+      props: ['loading', 'disabled', 'color', 'variant', 'icon', 'size'],
+      template: '<button :disabled="disabled"><slot /></button>'
+    },
+    UIcon: { template: '<span />' },
+    NutritionMealOptionCard: {
+      props: ['option', 'selected'],
+      emits: ['select'],
+      template:
+        '<button class="meal-option-card" @click="$emit(\'select\')">{{ option?.title }}</button>'
+    }
+  }
+}
+
+async function mountModal(props: Record<string, any> = {}) {
+  const wrapper = await mountSuspended(MealRecommendationModal, {
+    props: { open: false, ...BASE_PROPS, ...props },
+    global: {
+      renderStubDefaultSlot: true,
+      stubs: stubs()
+    }
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('MealRecommendationModal poll fallback (CW-80)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    toastAddMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps polling run status past the first fallback check instead of giving up after one look', async () => {
+    let runStatusCalls = 0
+    fetchMock = vi.fn((url: string, options: any = {}) => {
+      if (url === '/api/nutrition/recommendations/meal' && options?.method === 'POST') {
+        return Promise.resolve({ runId: 'run-1' })
+      }
+      if (url === '/api/runs/run-1') {
+        runStatusCalls += 1
+        // LLM generation is still EXECUTING for the first couple of checks —
+        // exactly the case where the old single-shot setTimeout gave up.
+        if (runStatusCalls < 3) {
+          return Promise.resolve({ id: 'run-1', status: 'EXECUTING' })
+        }
+        return Promise.resolve({
+          id: 'run-1',
+          status: 'COMPLETED',
+          output: { recommendations: [{ id: 'opt-1', title: 'Bagel' }], source: 'catalog' }
+        })
+      }
+      return Promise.reject(new Error(`Unhandled fetch in test: ${url}`))
+    })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const wrapper = await mountModal()
+    await wrapper.setProps({ open: true })
+    await flushPromises()
+
+    // First fallback poll fires ~3s after loading starts.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(runStatusCalls).toBe(1)
+
+    // A single-shot fallback would stop here forever; it must poll again.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(runStatusCalls).toBe(2)
+
+    // Third check reports COMPLETED and the modal should pick up the result.
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(runStatusCalls).toBe(3)
+
+    expect(wrapper.find('.meal-option-card').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Bagel')
+
+    // Once complete, polling must stop — no further run-status calls.
+    await vi.advanceTimersByTimeAsync(30000)
+    expect(runStatusCalls).toBe(3)
+  })
+
+  it('shows a terminal error toast and stops polling if the run never completes', async () => {
+    let runStatusCalls = 0
+    fetchMock = vi.fn((url: string, options: any = {}) => {
+      if (url === '/api/nutrition/recommendations/meal' && options?.method === 'POST') {
+        return Promise.resolve({ runId: 'run-stuck' })
+      }
+      if (url === '/api/runs/run-stuck') {
+        runStatusCalls += 1
+        return Promise.resolve({ id: 'run-stuck', status: 'EXECUTING' })
+      }
+      return Promise.reject(new Error(`Unhandled fetch in test: ${url}`))
+    })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const wrapper = await mountModal()
+    await wrapper.setProps({ open: true })
+    await flushPromises()
+
+    // Drain the polling loop well past the max total wait window.
+    await vi.advanceTimersByTimeAsync(95000)
+
+    expect(toastAddMock).toHaveBeenCalledWith(expect.objectContaining({ color: 'error' }))
+    const callsBeforeIdle = runStatusCalls
+    expect(callsBeforeIdle).toBeGreaterThan(0)
+
+    // Confirms polling actually stopped after the terminal timeout fired.
+    await vi.advanceTimersByTimeAsync(30000)
+    expect(runStatusCalls).toBe(callsBeforeIdle)
+  })
+
+  it('stops polling once the component unmounts', async () => {
+    let runStatusCalls = 0
+    fetchMock = vi.fn((url: string, options: any = {}) => {
+      if (url === '/api/nutrition/recommendations/meal' && options?.method === 'POST') {
+        return Promise.resolve({ runId: 'run-2' })
+      }
+      if (url === '/api/runs/run-2') {
+        runStatusCalls += 1
+        return Promise.resolve({ id: 'run-2', status: 'EXECUTING' })
+      }
+      return Promise.reject(new Error(`Unhandled fetch in test: ${url}`))
+    })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const wrapper = await mountModal()
+    await wrapper.setProps({ open: true })
+    await flushPromises()
+
+    wrapper.unmount()
+
+    // If the timer weren't cleaned up on unmount, this would still tick and
+    // call the run-status endpoint against an unmounted component.
+    await vi.advanceTimersByTimeAsync(60000)
+    expect(runStatusCalls).toBe(0)
+  })
+})
+
+describe('MealRecommendationModal selection confirmation errors (CW-80)', () => {
+  beforeEach(() => {
+    toastAddMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows an error toast when confirming the selected meal fails', async () => {
+    const fetchMock = vi.fn((url: string, options: any = {}) => {
+      if (url === '/api/nutrition/recommendations/meal' && options?.method === 'POST') {
+        return Promise.resolve({ cached: true, recommendationId: 'rec-1' })
+      }
+      if (url === '/api/nutrition/recommendations/rec-1') {
+        return Promise.resolve({
+          recommendation: {
+            resultJson: {
+              recommendations: [{ id: 'opt-1', title: 'Bagel' }],
+              source: 'catalog'
+            }
+          }
+        })
+      }
+      if (url === '/api/nutrition/plan/meal' && options?.method === 'POST') {
+        return Promise.reject(new Error('Failed to lock in meal'))
+      }
+      return Promise.reject(new Error(`Unhandled fetch in test: ${url}`))
+    })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const wrapper = await mountModal()
+    await wrapper.setProps({ open: true })
+    await flushPromises()
+
+    expect(wrapper.find('.meal-option-card').exists()).toBe(true)
+    await wrapper.find('.meal-option-card').trigger('click')
+
+    const applyButton = wrapper
+      .findAll('button')
+      .find((btn) => btn.text().includes('Apply to Plan'))
+    expect(applyButton).toBeTruthy()
+
+    await applyButton!.trigger('click')
+    await flushPromises()
+
+    expect(toastAddMock).toHaveBeenCalledWith(expect.objectContaining({ color: 'error' }))
+    // A failed confirmation must not be treated as success.
+    expect(wrapper.emitted('updated')).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Fixes CW-80

## Summary
`MealRecommendationModal.vue` used a single one-shot `setTimeout(..., 3000)` as a fallback for missed WebSocket completion events. Because LLM meal generation frequently takes longer than 3 seconds, that fallback checked the run status exactly once while it was still `EXECUTING`, then never checked again — leaving the modal stuck spinning indefinitely if the WebSocket event was missed. The poll timer was also never cleared on unmount, and errors from the meal-selection confirmation call were only logged to the console with no user-facing feedback.

- Replaced the one-shot check with a repeating poll: checks every 3s for the first few attempts, then backs off to 5s and 8s, capped at ~90s of total wait. If a terminal run status (`FAILED`/`CANCELED`/`TIMED_OUT`) or the max wait window is reached without completion, polling stops and an error toast is shown instead of spinning forever.
- Poll timer is now cleared in `onUnmounted` (previously only the loading-stage-text rotation timer was cleaned up there).
- `confirmSelection` now shows an error toast (matching the `useToast().add(...)` pattern used elsewhere in the modal) when applying the selected meal to the plan fails, instead of silently swallowing the error.

## Verification
```
pnpm vitest run tests/unit/app/utils/nutrition-suggestions.test.ts
```
This file is unrelated to the modal (it tests `fuelingSuggestionText`) and passes unchanged — 10/10 tests pass, confirming no regression there.

Added `tests/unit/app/components/MealRecommendationModal.test.ts` (new, `mountSuspended` + `@vitest-environment nuxt`, following the pattern in `NotificationDropdown.test.ts`) covering:
- Repeated polling past the first fallback check until the run completes (using fake timers)
- Terminal error toast + polling stop when a run never completes within the max wait window
- Poll timer cleanup on component unmount (no further fetches fire after unmount)
- Error toast shown when the plan-confirmation call rejects

Both test files: 14/14 passing.

Also ran:
- `pnpm typecheck` — passes (exit 0)
- `pnpm exec eslint app/components/nutrition/MealRecommendationModal.vue tests/unit/app/components/MealRecommendationModal.test.ts` — no errors

## Test plan
- [x] `pnpm vitest run tests/unit/app/utils/nutrition-suggestions.test.ts` passes
- [x] `pnpm vitest run tests/unit/app/components/MealRecommendationModal.test.ts` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm exec eslint` on changed files passes