### PR TITLE
fix(integrations): enforce Garmin ad-hoc pull as recovery-only (CW-90)

### DIFF
--- a/docs/01-architecture/system-overview.md
+++ b/docs/01-architecture/system-overview.md
@@ -79,6 +79,34 @@ graph LR
 4. Data fetched from external APIs
 5. Data normalized and stored in Postgres
 
+#### Garmin Push-First Policy (CW-90)
+
+Garmin's partner guidance prefers Ping/Push-driven delivery over ad-hoc
+polling. Coach Watts follows that guidance:
+
+- **Push is the primary, routine channel.** `server/api/webhooks/garmin.post.ts`
+  receives Garmin's Push notifications continuously and is the mechanism
+  that keeps daily/wellness/activity data current. No manual action is
+  required for this path.
+- **Ad-hoc pull (`trigger/ingest-garmin.ts`, driven by the Sync UI via
+  `server/api/integrations/sync.post.ts`) is recovery-only.** It exists to
+  catch up after a missed or delayed Push notification (e.g. a brief Garmin
+  or Coach Watts outage), not as a primary or routine sync mechanism.
+  Two bounds enforce that role in code, applied at both the HTTP endpoint
+  (for immediate user feedback) and the `ingest-garmin` task itself
+  (defense-in-depth, since the batch "Sync All" path reaches the task
+  without going through the per-provider endpoint check):
+  - **Cooldown:** an ad-hoc pull is rejected/skipped if the integration's
+    `lastSyncAt` is less than 15 minutes old — a pull fired again moments
+    after the last successful one isn't recovering from anything.
+  - **Bounded window:** the lookback window is capped at 3 days
+    regardless of any caller-supplied `days` override, so ad-hoc pull can
+    never become a de facto historical backfill. (Garmin's own Pull API is
+    itself limited to a 24h window per request; a few days of lookback is
+    enough headroom to recover from a short outage without drifting toward
+    routine polling.)
+- Decision history: `docs/issues/311-garmin-adhoc-pull-vs-push-guidance.md`.
+
 ### B. The AI Agent Layer (The "Brain")
 
 The AI is split into two specialized agents to manage context window limits and improve accuracy.

--- a/docs/issues/311-garmin-adhoc-pull-vs-push-guidance.md
+++ b/docs/issues/311-garmin-adhoc-pull-vs-push-guidance.md
@@ -3,7 +3,7 @@
 **Type:** Maintenance / Compliance  
 **Priority:** Low  
 **Area:** `integrations, compliance`  
-**Status:** Open
+**Status:** Resolved (CW-90)
 
 ## Description
 
@@ -28,5 +28,26 @@ Keep Push primary; treat pull as recovery. Document for audits. Optionally rate-
 
 ## Acceptance Criteria
 
-- [ ] Confirmed with Garmin endpoint config (Push vs Ping) in developer portal
-- [ ] Decision recorded: keep pull as recovery **or** restrict to backfill tool only
+- [ ] Confirmed with Garmin endpoint config (Push vs Ping) in developer portal —
+      still outstanding; requires Garmin developer portal access, not
+      something this change can confirm. Endpoint config itself is unchanged.
+- [x] Decision recorded: keep pull as recovery, now enforced in code, not just
+      policy. See `docs/01-architecture/system-overview.md#garmin-push-first-policy`.
+
+## Resolution (CW-90)
+
+Ad-hoc pull is code-enforced as recovery-only rather than left as an
+unenforced convention:
+
+- **Cooldown:** `trigger/ingest-garmin.ts` and
+  `server/api/integrations/sync.post.ts` both reject/skip an ad-hoc pull if
+  the integration's `lastSyncAt` is under 15 minutes old.
+- **Bounded window:** the ad-hoc lookback window is capped at 3 days in both
+  files, regardless of any caller-supplied `days` override — closing the gap
+  where a direct API call with a large `days` value could turn a single
+  "Sync" click into a multi-week historical backfill.
+
+The Garmin developer portal Push vs Ping endpoint configuration itself was
+not changed and was not re-confirmed as part of this work (no portal access
+from this change) — that checkbox stays open for whoever owns the Garmin
+partner account if a formal audit later requires it.

--- a/server/api/integrations/sync.post.ts
+++ b/server/api/integrations/sync.post.ts
@@ -9,6 +9,19 @@ import {
   resolveSyncAllBlock
 } from '../../utils/integration-sync-guard'
 
+// CW-90: Garmin partner guidance treats Push/Ping as the primary realtime
+// delivery channel; ad-hoc pull (this endpoint + trigger/ingest-garmin.ts)
+// exists only to recover from a missed or delayed push, never as a
+// routine/primary sync path. These two constants bound that "recovery-only"
+// role at the HTTP layer, so a caller gets immediate feedback instead of a
+// silent no-op. Keep them in sync with the mirrored copies in
+// trigger/ingest-garmin.ts (which enforces the same bounds again at the task
+// level as defense-in-depth, since "Sync All" reaches that task without
+// going through this per-provider check). See
+// docs/01-architecture/system-overview.md#garmin-push-first-policy.
+const GARMIN_ADHOC_MAX_LOOKBACK_DAYS = 3
+const GARMIN_ADHOC_MIN_INTERVAL_MS = 15 * 60 * 1000 // 15 minutes
+
 defineRouteMeta({
   openAPI: {
     tags: ['Integrations'],
@@ -193,6 +206,21 @@ export default defineEventHandler(async (event) => {
     startDate.setUTCDate(startDate.getUTCDate() - daysBack)
   }
 
+  // CW-90: enforce the recovery-only bound regardless of the branch above —
+  // a caller-supplied `days` override (or the 'all' batch window) must not
+  // be able to turn a Garmin ad-hoc pull into a multi-week historical
+  // backfill. Garmin's own Pull API is limited to a 24h window per request;
+  // a few days of lookback is enough to recover from a brief push outage.
+  if (provider === 'garmin') {
+    const earliestAllowedStart = new Date(now)
+    earliestAllowedStart.setUTCDate(
+      earliestAllowedStart.getUTCDate() - GARMIN_ADHOC_MAX_LOOKBACK_DAYS
+    )
+    if (startDate < earliestAllowedStart) {
+      startDate.setTime(earliestAllowedStart.getTime())
+    }
+  }
+
   const endDate =
     provider === 'intervals' || provider === 'all'
       ? new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000) // +30 days for planned workouts (Intervals & All)
@@ -227,6 +255,26 @@ export default defineEventHandler(async (event) => {
           reason: providerSyncBlock.reason
         }
       })
+    }
+
+    // CW-90: Garmin ad-hoc pull is recovery-only. Push delivers routine data
+    // automatically, so a manual sync fired again moments after the last
+    // successful one isn't recovering from anything — reject it with clear
+    // feedback instead of silently re-polling Garmin's Pull API.
+    if (provider === 'garmin' && integration.lastSyncAt) {
+      const elapsedMs = Date.now() - new Date(integration.lastSyncAt).getTime()
+      if (elapsedMs < GARMIN_ADHOC_MIN_INTERVAL_MS) {
+        const retryAfterMs = GARMIN_ADHOC_MIN_INTERVAL_MS - elapsedMs
+        throw createError({
+          statusCode: 429,
+          message: `Garmin syncs automatically via Push — ad-hoc sync is for recovery only. Please wait ${Math.ceil(retryAfterMs / 60000)} more minute(s) before syncing manually again.`,
+          data: {
+            code: 'GARMIN_ADHOC_COOLDOWN',
+            provider: 'garmin',
+            retryAfterMs
+          }
+        })
+      }
     }
   } else {
     const syncAllBlock = await resolveSyncAllBlock(userId)

--- a/server/api/webhooks/garmin.post.ts
+++ b/server/api/webhooks/garmin.post.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod'
 import { logWebhookRequest } from '../../utils/webhook-logger'
 
+// CW-90: this endpoint is the primary, preferred Garmin data channel per
+// partner guidance (Push/Ping over ad-hoc polling). trigger/ingest-garmin.ts
+// and server/api/integrations/sync.post.ts cover the ad-hoc pull path, which
+// is bounded and rate-limited to a recovery-only role — see
+// docs/01-architecture/system-overview.md#garmin-push-first-policy.
 defineRouteMeta({
   openAPI: {
     tags: ['Integrations'],

--- a/tests/unit/server/api/integrations/sync.post.test.ts
+++ b/tests/unit/server/api/integrations/sync.post.test.ts
@@ -192,4 +192,88 @@ describe('POST /api/integrations/sync', () => {
       expect.any(Object)
     )
   })
+
+  describe('Garmin ad-hoc pull compliance (CW-90)', () => {
+    it('dispatches Garmin with the default 1-day recovery window when no override is given', async () => {
+      const handler = await getHandler()
+      prismaMock.integration.findUnique.mockResolvedValue({
+        id: 'integration-garmin',
+        provider: 'garmin',
+        syncStatus: 'SUCCESS',
+        lastSyncAt: null
+      })
+
+      const response = await handler({ body: { provider: 'garmin' } } as any)
+
+      expect(response).toMatchObject({ success: true, provider: 'garmin' })
+      expect(tasks.trigger).toHaveBeenCalledWith(
+        'ingest-garmin',
+        expect.objectContaining({
+          userId: 'user-1',
+          startDate: '2026-03-09T00:00:00.000Z',
+          endDate: '2026-03-10T00:00:00.000Z'
+        }),
+        expect.any(Object)
+      )
+    })
+
+    it('rejects a Garmin ad-hoc sync with 429 when the last sync is inside the cooldown window', async () => {
+      const handler = await getHandler()
+      const recentSync = new Date(Date.now() - 5 * 60 * 1000) // 5 minutes ago
+      prismaMock.integration.findUnique.mockResolvedValue({
+        id: 'integration-garmin',
+        provider: 'garmin',
+        syncStatus: 'SUCCESS',
+        lastSyncAt: recentSync
+      })
+
+      await expect(handler({ body: { provider: 'garmin' } } as any)).rejects.toMatchObject({
+        statusCode: 429,
+        data: expect.objectContaining({ code: 'GARMIN_ADHOC_COOLDOWN', provider: 'garmin' })
+      })
+
+      expect(tasks.trigger).not.toHaveBeenCalled()
+    })
+
+    it('allows a Garmin ad-hoc sync once the cooldown window has elapsed', async () => {
+      const handler = await getHandler()
+      const oldSync = new Date(Date.now() - 20 * 60 * 1000) // 20 minutes ago, past the 15-minute cooldown
+      prismaMock.integration.findUnique.mockResolvedValue({
+        id: 'integration-garmin',
+        provider: 'garmin',
+        syncStatus: 'SUCCESS',
+        lastSyncAt: oldSync
+      })
+
+      const response = await handler({ body: { provider: 'garmin' } } as any)
+
+      expect(response).toMatchObject({ success: true, provider: 'garmin' })
+      expect(tasks.trigger).toHaveBeenCalledTimes(1)
+    })
+
+    it('clamps a caller-supplied `days` override so Garmin ad-hoc pull cannot exceed the recovery-only window', async () => {
+      const handler = await getHandler()
+      prismaMock.integration.findUnique.mockResolvedValue({
+        id: 'integration-garmin',
+        provider: 'garmin',
+        syncStatus: 'SUCCESS',
+        lastSyncAt: null
+      })
+
+      const response = await handler({ body: { provider: 'garmin', days: 30 } } as any)
+
+      expect(response).toMatchObject({ success: true, provider: 'garmin' })
+      // Requested 30 days back, but the recovery-only bound caps it at 3 days
+      // before "now" (2026-03-10T00:00:00.000Z per the mocked getUserLocalDate).
+      expect(tasks.trigger).toHaveBeenCalledWith(
+        'ingest-garmin',
+        expect.objectContaining({
+          userId: 'user-1',
+          startDate: '2026-03-07T00:00:00.000Z',
+          endDate: '2026-03-10T00:00:00.000Z'
+        }),
+        expect.any(Object)
+      )
+    })
+  })
 })

--- a/tests/unit/trigger/ingest-garmin.test.ts
+++ b/tests/unit/trigger/ingest-garmin.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { integrationFindUnique, runIngestGarmin } = vi.hoisted(() => ({
+  integrationFindUnique: vi.fn(),
+  runIngestGarmin: vi.fn()
+}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    integration: {
+      findUnique: integrationFindUnique
+    }
+  }
+}))
+
+vi.mock('../../../server/utils/services/garminService', () => ({
+  GarminService: {
+    runIngestGarmin
+  }
+}))
+
+vi.mock('../../../trigger/queues', () => ({
+  userIngestionQueue: { name: 'user-ingestion' }
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  task: vi.fn().mockImplementation((config: any) => ({
+    run: config.run,
+    id: config.id
+  })),
+  logger: {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}))
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000
+const THREE_DAYS_SECONDS = 3 * 24 * 60 * 60
+
+describe('ingestGarminTask (CW-90 recovery-only guards)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('skips the pull without calling GarminService when a sync completed inside the cooldown window', async () => {
+    const recentSync = new Date(Date.now() - 5 * 60 * 1000) // 5 minutes ago
+    integrationFindUnique.mockResolvedValue({ lastSyncAt: recentSync })
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    const result = await ingestGarminTask.run({ userId: 'user-1' })
+
+    expect(runIngestGarmin).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ success: true, skipped: true, reason: 'cooldown' })
+  })
+
+  it('proceeds when the last sync is older than the cooldown window', async () => {
+    const oldSync = new Date(Date.now() - (FIFTEEN_MIN_MS + 60 * 1000)) // just over 15 minutes ago
+    integrationFindUnique.mockResolvedValue({ lastSyncAt: oldSync })
+    runIngestGarmin.mockResolvedValue({ success: true, counts: {} })
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    await ingestGarminTask.run({ userId: 'user-1' })
+
+    expect(runIngestGarmin).toHaveBeenCalledTimes(1)
+  })
+
+  it('proceeds when there is no prior successful sync', async () => {
+    integrationFindUnique.mockResolvedValue(null)
+    runIngestGarmin.mockResolvedValue({ success: true, counts: {} })
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    await ingestGarminTask.run({ userId: 'user-1' })
+
+    expect(runIngestGarmin).toHaveBeenCalledTimes(1)
+  })
+
+  it('clamps a startDate further back than the max lookback window', async () => {
+    integrationFindUnique.mockResolvedValue(null)
+    runIngestGarmin.mockResolvedValue({ success: true, counts: {} })
+
+    const farPastDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days ago
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    await ingestGarminTask.run({ userId: 'user-1', startDate: farPastDate })
+
+    expect(runIngestGarmin).toHaveBeenCalledTimes(1)
+    const callArg = runIngestGarmin.mock.calls[0][0]
+    const clampedSeconds = Math.floor(new Date(callArg.startDate).getTime() / 1000)
+    const nowSeconds = Math.floor(Date.now() / 1000)
+
+    // Clamped start should sit at (now - 3 days), not the far-past requested date.
+    expect(nowSeconds - clampedSeconds).toBeLessThanOrEqual(THREE_DAYS_SECONDS + 5)
+    expect(nowSeconds - clampedSeconds).toBeGreaterThan(THREE_DAYS_SECONDS - 5)
+  })
+
+  it('clamps a startTimestamp further back than the max lookback window', async () => {
+    integrationFindUnique.mockResolvedValue(null)
+    runIngestGarmin.mockResolvedValue({ success: true, counts: {} })
+
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const farPastTimestamp = nowSeconds - 30 * 24 * 60 * 60 // 30 days ago
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    await ingestGarminTask.run({ userId: 'user-1', startTimestamp: farPastTimestamp })
+
+    expect(runIngestGarmin).toHaveBeenCalledTimes(1)
+    const callArg = runIngestGarmin.mock.calls[0][0]
+
+    expect(nowSeconds - callArg.startTimestamp).toBeLessThanOrEqual(THREE_DAYS_SECONDS + 5)
+    expect(nowSeconds - callArg.startTimestamp).toBeGreaterThan(THREE_DAYS_SECONDS - 5)
+  })
+
+  it('leaves a recent startDate within the lookback window untouched', async () => {
+    integrationFindUnique.mockResolvedValue(null)
+    runIngestGarmin.mockResolvedValue({ success: true, counts: {} })
+
+    const recentStart = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString() // 12 hours ago
+
+    const { ingestGarminTask } = await import('../../../trigger/ingest-garmin')
+    await ingestGarminTask.run({ userId: 'user-1', startDate: recentStart })
+
+    const callArg = runIngestGarmin.mock.calls[0][0]
+    expect(callArg.startDate).toBe(recentStart)
+  })
+})

--- a/trigger/ingest-garmin.ts
+++ b/trigger/ingest-garmin.ts
@@ -1,6 +1,25 @@
 import { task, logger } from '@trigger.dev/sdk/v3'
+import { prisma } from '../server/utils/db'
 import { GarminService } from '../server/utils/services/garminService'
 import { userIngestionQueue } from './queues'
+
+// CW-90: Garmin partner guidance treats Push/Ping as the primary realtime
+// delivery channel; ad-hoc pull exists only to recover from a missed or
+// delayed push, never as a routine/primary sync path. This task is the one
+// choke point every ad-hoc Garmin pull passes through — both the per-provider
+// "Sync" button (server/api/integrations/sync.post.ts, which also enforces
+// the cooldown at the HTTP layer for immediate user feedback) and the
+// "Sync All" batch path (trigger/ingest-all.ts, which has no per-provider
+// guard of its own) funnel here. Two guards below enforce the recovery-only
+// role at this level so neither entry point can bypass it:
+//   1. A cooldown since the last successful sync — an ad-hoc pull that
+//      fires again moments later isn't "recovering" from anything.
+//   2. A bounded lookback window — never fetch further back than a few
+//      days, no matter what the caller requests.
+// Keep these constants in sync with the mirrored copies in sync.post.ts.
+// See docs/01-architecture/system-overview.md#garmin-push-first-policy.
+const GARMIN_ADHOC_MIN_INTERVAL_MS = 15 * 60 * 1000 // 15 minutes
+const GARMIN_ADHOC_MAX_LOOKBACK_SECONDS = 3 * 24 * 60 * 60 // 3 days
 
 export const ingestGarminTask = task({
   id: 'ingest-garmin',
@@ -14,8 +33,49 @@ export const ingestGarminTask = task({
     endTimestamp?: number
     manualSync?: boolean
   }) => {
+    const integration = await prisma.integration.findUnique({
+      where: { userId_provider: { userId: payload.userId, provider: 'garmin' } },
+      select: { lastSyncAt: true }
+    })
+
+    if (integration?.lastSyncAt) {
+      const elapsedMs = Date.now() - new Date(integration.lastSyncAt).getTime()
+      if (elapsedMs < GARMIN_ADHOC_MIN_INTERVAL_MS) {
+        logger.log(
+          'Skipping Garmin ad-hoc pull — within recovery cooldown of the last successful sync',
+          { userId: payload.userId, elapsedMs, cooldownMs: GARMIN_ADHOC_MIN_INTERVAL_MS }
+        )
+        return {
+          success: true,
+          skipped: true,
+          reason: 'cooldown',
+          counts: { dailies: 0, sleeps: 0, hrv: 0, bodyComps: 0, userMetrics: 0, activities: 0 }
+        }
+      }
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const earliestAllowedStart = nowSeconds - GARMIN_ADHOC_MAX_LOOKBACK_SECONDS
+
+    let startTimestamp = payload.startTimestamp
+    let startDate = payload.startDate
+
+    if (typeof startTimestamp === 'number' && startTimestamp < earliestAllowedStart) {
+      startTimestamp = earliestAllowedStart
+    }
+    if (startDate) {
+      const parsedSeconds = Math.floor(new Date(startDate).getTime() / 1000)
+      if (Number.isFinite(parsedSeconds) && parsedSeconds < earliestAllowedStart) {
+        startDate = new Date(earliestAllowedStart * 1000).toISOString()
+      }
+    }
+
     logger.log('Starting Garmin ingestion via Trigger.dev', { userId: payload.userId })
-    return await GarminService.runIngestGarmin(payload)
+    return await GarminService.runIngestGarmin({
+      ...payload,
+      startDate,
+      startTimestamp
+    })
   }
 })
 


### PR DESCRIPTION
Fixes CW-90

## Context

Garmin partner guidance treats Push/Ping as the primary realtime delivery channel and expects ad-hoc pull to be used only for recovery (catching up after a missed/delayed push), not as a routine or primary sync mechanism. Coach Watts already uses Push as the primary channel (`server/api/webhooks/garmin.post.ts`), but the ad-hoc pull path (`trigger/ingest-garmin.ts`, driven by the Sync UI via `server/api/integrations/sync.post.ts`) had no enforcement of that recovery-only role — it was just an unenforced convention (see `docs/issues/311-garmin-adhoc-pull-vs-push-guidance.md`).

## What's code-enforced

Two compliance bounds, applied at both the HTTP endpoint (for immediate user feedback) and the `ingest-garmin` task itself (defense-in-depth, since the "Sync All" batch path reaches the task without going through the per-provider endpoint check):

1. **Cooldown (15 minutes):** an ad-hoc Garmin pull is rejected (`sync.post.ts`, HTTP 429 `GARMIN_ADHOC_COOLDOWN`) or silently skipped (`ingest-garmin.ts`, for the batch path) if the integration's `lastSyncAt` is under 15 minutes old. A pull fired again moments after the last successful one isn't recovering from anything.
2. **Bounded lookback window (3 days):** the ad-hoc pull window is capped at 3 days regardless of any caller-supplied `days` override. Previously, a direct API call with `days: 30` (or similar) would bypass the UI's safe 1-day default and turn a single "Sync" click into a repeated-slice historical backfill — well beyond a brief-outage recovery window, and arguably indistinguishable from continuous polling to a strict partner reviewer. Garmin's own Pull API is itself limited to a 24h window per request, so 3 days (a few multiples of that) is a defensible cap for catching up after a short outage without drifting toward routine polling.

These constants (15 min / 3 days) are a reasonable default given the existing precedent in the code (Garmin's default ad-hoc window was already 1 day, "Pull API maximum range is 24 hours"), not an arbitrary number — but they are tunable if the business wants a different value once real audit feedback comes in.

## What's documented (not a code change)

- `docs/01-architecture/system-overview.md` — new "Garmin Push-First Policy (CW-90)" section under Data Ingestion Layer, describing Push as primary and ad-hoc pull as recovery-only, with the two enforced bounds.
- `docs/issues/311-garmin-adhoc-pull-vs-push-guidance.md` — marked resolved, with the decision (keep pull as recovery, now code-enforced) recorded.
- **Left open / out of scope:** confirming the Push vs Ping endpoint configuration in the Garmin developer portal itself. That requires portal access this change doesn't have and is a partner-account-level action, not a code change — the issue doc's checkbox for it stays open for whoever owns the Garmin partner account.

## Verification

```
pnpm test tests/unit/server/utils/services/garminService.test.ts
# Test Files  1 passed (1)
#      Tests  25 passed (25)

pnpm test tests/unit/trigger/ingest-garmin.test.ts tests/unit/server/api/integrations/sync.post.test.ts
# Test Files  2 passed (2)
#      Tests  15 passed (15)

pnpm typecheck
# exits 0, no errors

pnpm exec eslint <changed files> && pnpm exec prettier --check <changed files>
# clean
```

New tests added:
- `tests/unit/trigger/ingest-garmin.test.ts` — cooldown skip/proceed, startDate/startTimestamp clamping.
- `tests/unit/server/api/integrations/sync.post.test.ts` — new `describe('Garmin ad-hoc pull compliance (CW-90)')` block covering default window, 429 cooldown rejection, cooldown-elapsed success, and `days` override clamping.