### PR TITLE
fix(coaching): coaching pages low-priority polish (CW-89)

### DIFF
--- a/tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
+++ b/tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import CoachCalendarPanel from '../../../../../app/components/coaching/CoachCalendarPanel.vue'
+import CoachCalendarDayCard from '../../../../../app/components/coaching/CoachCalendarDayCard.vue'
+
+vi.mock('../../../../../app/composables/useFormat', () => ({
+  useFormat: () => ({
+    formatDateUTC: (date: string | Date) => String(date)
+  })
+}))
+
+const mountPanel = () =>
+  mount(CoachCalendarPanel, {
+    props: {
+      athlete: { id: 'athlete-1', name: 'Athlete One', image: null },
+      athleteOptions: [],
+      selectedAthleteId: 'athlete-1',
+      viewMode: 'week-board',
+      currentDate: new Date('2026-07-27T00:00:00Z'),
+      data: { activities: [] }
+    },
+    global: {
+      stubs: {
+        UAvatar: { template: '<div />' },
+        USelectMenu: { template: '<div />' },
+        UBadge: { template: '<div><slot /></div>' },
+        USkeleton: { template: '<div />' },
+        UAlert: { template: '<div />' },
+        CoachCalendarDayCard: true
+      }
+    }
+  })
+
+describe('CoachCalendarPanel drop handling', () => {
+  it('swallows a malformed JSON drop payload instead of throwing', () => {
+    const wrapper = mountPanel()
+    const firstDayCard = wrapper.findComponent(CoachCalendarDayCard)
+    expect(firstDayCard.exists()).toBe(true)
+
+    const dropEvent = {
+      dataTransfer: {
+        getData: () => '{not valid json'
+      }
+    }
+
+    expect(() => firstDayCard.vm.$emit('drop', dropEvent)).not.toThrow()
+
+    wrapper.unmount()
+  })
+
+  it('ignores a drop payload with no application/json data', () => {
+    const wrapper = mountPanel()
+    const firstDayCard = wrapper.findComponent(CoachCalendarDayCard)
+
+    const dropEvent = {
+      dataTransfer: {
+        getData: () => ''
+      }
+    }
+
+    expect(() => firstDayCard.vm.$emit('drop', dropEvent)).not.toThrow()
+    expect(wrapper.emitted('movePlannedWorkout')).toBeUndefined()
+    expect(wrapper.emitted('scheduleTemplate')).toBeUndefined()
+    expect(wrapper.emitted('duplicatePlannedWorkout')).toBeUndefined()
+
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/server/utils/repositories/coachingRepository.approveCoachingRequest.test.ts
+++ b/tests/unit/server/utils/repositories/coachingRepository.approveCoachingRequest.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { coachingRepository } from '../../../../../server/utils/repositories/coachingRepository'
+import { prisma } from '../../../../../server/utils/db'
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    $transaction: vi.fn()
+  }
+}))
+
+describe('coachingRepository.approveCoachingRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('conditionally updates on status PENDING inside a transaction (no read-then-write race)', async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 })
+    const findFirst = vi.fn().mockResolvedValue({ id: 'req-1', athleteId: 'athlete-1' })
+    const upsert = vi.fn().mockResolvedValue({ coachId: 'coach-1', athleteId: 'athlete-1' })
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) =>
+      callback({
+        coachingRequest: { updateMany, findFirst },
+        coachingRelationship: { upsert }
+      })
+    )
+
+    await coachingRepository.approveCoachingRequest('coach-1', 'req-1')
+
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'req-1',
+          coachId: 'coach-1',
+          status: 'PENDING'
+        })
+      })
+    )
+  })
+
+  it('rejects a second concurrent approval once the request is no longer PENDING', async () => {
+    // Simulates a double-click race: the second call's conditional update
+    // matches zero rows because the first call already flipped the status.
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 })
+    const findFirst = vi.fn()
+    const upsert = vi.fn()
+
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) =>
+      callback({
+        coachingRequest: { updateMany, findFirst },
+        coachingRelationship: { upsert }
+      })
+    )
+
+    await expect(coachingRepository.approveCoachingRequest('coach-1', 'req-1')).rejects.toThrow(
+      'Request not found'
+    )
+
+    // Must not proceed to create/upsert a relationship for an already-handled request.
+    expect(upsert).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes CW-89

CW-89 covers 5 small, distinct coaching-pages polish items. On inspection of the current code, 4 of the 5 turned out to already be fixed by earlier commits (`09dcd22c0`, `125fc717f`). Only regression test coverage was added for this PR; no production code changes were needed for items 1-4.

## Per-item status

1. **`approveCoachingRequest` double-click race** — already fixed. `server/utils/repositories/coachingRepository.ts` already wraps the approval in `prisma.$transaction` and uses a conditional `updateMany({ where: { id, coachId, status: 'PENDING' } })`; a second concurrent approval now matches zero rows and throws `Request not found` instead of double-approving. Added a regression test (`tests/unit/server/utils/repositories/coachingRepository.approveCoachingRequest.test.ts`) asserting the conditional where-clause and that a second concurrent call is rejected without touching the relationship.

2. **`CoachCalendarPanel.vue` unguarded `JSON.parse` on drop** — already fixed. `onDrop` already wraps `JSON.parse(raw)` in a `try/catch` that silently returns on malformed payloads. Added a regression test (`tests/unit/app/components/coaching/CoachCalendarPanel.test.ts`) covering a malformed-JSON drop and an empty-payload drop, both of which must not throw and must not emit any of the schedule/move/duplicate events.

3. **`teams/[id].delete.ts` ownership check ordering** — already fixed. The handler calls `teamRepository.checkTeamAccess(teamId, user.id, ['OWNER'])` and throws 404 before ever fetching team details, so a non-owner can no longer observe existence/detail differences.

4. **Dead code (`copyInvite`, empty `athleteInTeam` block)** — already fixed. `copyInvite` is no longer present anywhere in `app/pages/coaching/team/index.vue` (confirmed via `git log -S`, removed in an earlier pass). The empty `if (!athleteInTeam) { /* comment only */ }` block that historically existed in the groups-members endpoint has already been replaced with a real check that throws a 403 when the athlete isn't on the team.

5. **`useCoachingMessageAthlete` missing context** — investigated, **skipped** (flagging for follow-up). Found `docs/issues/116-coaching-message-athlete-no-context.md`, which describes this exact composable and is marked "Fixed," but its own acceptance checkbox ("Coach AI chat receives identifiable athlete context") is still unchecked. Current behavior: `messageAthlete` embeds the athlete's name/id as free text in `initialMessage` (e.g. `"...athlete Jane (id: abc123)..."`) and navigates to `/chat`. `app/pages/chat.vue`'s `loadChat()` only reads `route.query.initialMessage` as a plain string prefill for the input box — there is no structured `athleteId` query param or room-metadata handling, so the chat agent has no reliable, structured way to scope subsequent tool calls to that specific athlete; it would have to parse the id out of prose. A real fix requires changes to `app/pages/chat.vue` and the chat-agent/tool-execution layer (`server/utils/chat/*`), which are outside this ticket's owned paths (`server/utils/repositories/coachingRepository.ts`, `app/components/coaching/CoachCalendarPanel.vue`, `server/api/coaching/teams/*`, `app/pages/coaching/team/*`) and beyond a "small polish" scope. Leaving unfixed per the ticket's guidance to skip and flag rather than block the rest.

## Verification

```
pnpm typecheck
# exit code 0, no errors

pnpm vitest run tests/unit/server/utils/repositories/coachingRepository.approveCoachingRequest.test.ts tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
#  Test Files  2 passed (2)
#       Tests  4 passed (4)

pnpm vitest run tests/unit/server/utils/repositories/coachingRepository.invites.test.ts tests/unit/server/utils/coaching-auth.test.ts tests/unit/server/api/coaching tests/unit/app/stores/coaching.test.ts
#  Test Files  4 passed (4)
#       Tests  15 passed (15)
```