### PR TITLE
fix(infra): stop re-registering Trigger.dev cloud schedules for redis-cron tasks (CW-188)

### DIFF
--- a/tests/unit/trigger/trial-ending-reminder.test.ts
+++ b/tests/unit/trigger/trial-ending-reminder.test.ts
@@ -46,12 +46,10 @@ vi.mock('@trigger.dev/sdk/v3', () => ({
     warn: loggerWarn,
     error: loggerError
   },
-  schedules: {
-    task: vi.fn().mockImplementation((config) => ({
-      run: config.run,
-      id: config.id
-    }))
-  }
+  task: vi.fn().mockImplementation((config) => ({
+    run: config.run,
+    id: config.id
+  }))
 }))
 
 function trialUser(id: string, trialEndsAt: Date) {

--- a/trigger/finalize-daily-nutrition.ts
+++ b/trigger/finalize-daily-nutrition.ts
@@ -1,4 +1,4 @@
-import { logger, schedules, task } from '@trigger.dev/sdk/v3'
+import { logger, task } from '@trigger.dev/sdk/v3'
 import { getUserTimezone, getUserLocalDate } from '../server/utils/date'
 import { metabolicService } from '../server/utils/services/metabolicService'
 import { prisma } from '../server/utils/db'
@@ -21,10 +21,17 @@ export const finalizeDailyNutritionTask = task({
   }
 })
 
-export const finalizeDailyNutritionCron = schedules.task({
+// CW-188: This used to be a `schedules.task` with a declarative `cron`, which
+// keeps re-registering an active schedule trigger on Trigger.dev Cloud every
+// time it's deployed there. Actual scheduling now happens exclusively via
+// cw:worker's Redis/BullMQ job scheduler (see cli/worker/start.ts,
+// registerScheduledTasks), driven off the `schedule.cron` entry for this task
+// id in server/utils/task-manifest.json. Keep this a plain `task()` so no
+// declarative schedule gets synced back to Trigger.dev Cloud.
+export const finalizeDailyNutritionCron = task({
   id: 'finalize-daily-nutrition-cron',
-  // Run daily (02:10) to persist yesterday/today chain state.
-  cron: '10 2 * * *',
+  // Actual cron ("10 2 * * *", run daily at 02:10 UTC) lives in
+  // server/utils/task-manifest.json and is registered by cw:worker.
   run: async () => {
     const users = await prisma.user.findMany({
       where: {

--- a/trigger/poll-ultrahuman.ts
+++ b/trigger/poll-ultrahuman.ts
@@ -1,12 +1,24 @@
-import { schedules } from '@trigger.dev/sdk/v3'
+import { task } from '@trigger.dev/sdk/v3'
 import { prisma } from '../server/utils/db'
 import { getUserTimezone, getUserLocalDate } from '../server/utils/date'
 import type { UltrahumanSettings } from '../server/utils/ultrahuman'
 import { dispatchTask } from '../server/utils/task-dispatcher'
 
-export const pollUltrahumanTask = schedules.task({
+// CW-188: This used to be a `schedules.task` with a declarative `cron`, which
+// keeps re-registering an active schedule trigger on Trigger.dev Cloud every
+// time it's deployed there. Actual scheduling now happens exclusively via
+// cw:worker's Redis/BullMQ job scheduler (see cli/worker/start.ts,
+// registerScheduledTasks), driven off the `schedule.cron` entry for this task
+// id in server/utils/task-manifest.json. Keep this a plain `task()` so no
+// declarative schedule gets synced back to Trigger.dev Cloud. The Redis
+// scheduler synthesizes the same { timestamp, timezone, scheduleId, upcoming }
+// payload shape the SDK's schedules.task would have provided (see
+// mainTaskWorker in cli/worker/start.ts), so `payload.timestamp` below still
+// works.
+export const pollUltrahumanTask = task({
   id: 'poll-ultrahuman',
-  cron: '5 * * * *', // Run at 5 minutes past every hour
+  // Actual cron ("5 * * * *", every hour at :05) lives in
+  // server/utils/task-manifest.json and is registered by cw:worker.
   run: async (payload) => {
     const now = new Date(payload.timestamp)
 

--- a/trigger/trial-ending-reminder.ts
+++ b/trigger/trial-ending-reminder.ts
@@ -1,4 +1,4 @@
-import { schedules, logger } from '@trigger.dev/sdk/v3'
+import { task, logger } from '@trigger.dev/sdk/v3'
 import { prisma } from '../server/utils/db'
 import { QUOTA_REGISTRY } from '../server/utils/quotas/registry'
 import { formatUserDate } from '../server/utils/date'
@@ -49,9 +49,17 @@ function formatSupporterHighlights() {
   ]
 }
 
-export const trialEndingReminderCron = schedules.task({
+// CW-188: This used to be a `schedules.task` with a declarative `cron`, which
+// keeps re-registering an active schedule trigger on Trigger.dev Cloud every
+// time it's deployed there. Actual scheduling now happens exclusively via
+// cw:worker's Redis/BullMQ job scheduler (see cli/worker/start.ts,
+// registerScheduledTasks), driven off the `schedule.cron` entry for this task
+// id in server/utils/task-manifest.json. Keep this a plain `task()` so no
+// declarative schedule gets synced back to Trigger.dev Cloud.
+export const trialEndingReminderCron = task({
   id: 'trial-ending-reminder-cron',
-  cron: '0 9 * * *',
+  // Actual cron ("0 9 * * *", daily at 09:00 UTC) lives in
+  // server/utils/task-manifest.json and is registered by cw:worker.
   run: async () => {
     const now = new Date()
     const { windowStart, windowEnd } = getTrialEndingWindow(now)


### PR DESCRIPTION
## Summary

- `finalize-daily-nutrition-cron`, `poll-ultrahuman`, and `trial-ending-reminder-cron` were still defined with `schedules.task({ cron: ... })` in `trigger/`. Per Trigger.dev's own docs, a declarative `cron` on `schedules.task` re-syncs an **active schedule trigger to Trigger.dev Cloud on every `deploy`/`dev` run** — this is a genuine code-level bug, not just a dashboard setting.
- Actual scheduling for these three tasks already happens independently via `cw:worker`'s own Redis/BullMQ job scheduler (`registerScheduledTasks` in `cli/worker/start.ts`), which reads the `schedule.cron` entries already present in `server/utils/task-manifest.json`. So once `TASK_QUEUE_DRIVER=redis` is the active driver, the Trigger.dev Cloud schedule is pure duplication — both the cloud schedule (invoking the deployed task directly on Trigger.dev's own infra) and the Redis repeatable job fire the same logic.
- There's direct precedent for this exact fix: CW-78 (`af1189824`) already converted `nutrition-last-call` from `schedules.task` to a plain `task()` for the same reason, leaving `server/utils/task-manifest.json` as the sole source of truth for the cron pattern. This PR applies the same conversion to the remaining three tasks that hadn't been migrated yet.
- No behavior change for the Redis path: `cli/worker/start.ts`'s `mainTaskWorker` already synthesizes the same `{ timestamp, timezone, scheduleId, upcoming }` payload shape for scheduled jobs regardless of whether the task is declared via `schedules.task` or `task`, so `poll-ultrahuman`'s use of `payload.timestamp` is unaffected.
- Updated `tests/unit/trigger/trial-ending-reminder.test.ts`'s SDK mock to mock `task` instead of `schedules.task` (the other two already had a `task` mock available).

## What still needs manual action (cannot be done from code)

This PR stops **future** deploys from re-syncing these three schedules to Trigger.dev Cloud, but per Trigger.dev's docs, declarative schedules already active on the platform "are managed in your code, so they can't be edited or deleted from [the dashboard]" — removing them requires the code change to actually reach Trigger.dev via a `deploy`. Note that the production CI pipeline's `trigger.dev deploy` step was already disabled in a separate recent change (`c4fca04e`, "ci: disable Trigger.dev deploy from production pipeline") while migrating off the platform. So:

- Someone with `trigger-bud.newpush.com` production credentials needs to run a **one-time manual `trigger.dev deploy`** (or briefly re-enable `deploy-trigger` in `.github/workflows/deploy.yml` for a single run) after this PR merges, so Trigger.dev picks up the removed `cron` properties and drops the three stale declarative schedules (`finalize-daily-nutrition-cron`, `poll-ultrahuman`, `trial-ending-reminder-cron`) from its platform.
- Separately, the ticket named `deduplicate-workouts`, `daily-coach`, and `review-goals` as schedules to deactivate. I checked the full git history of `trigger/deduplicate-workouts.ts`, `trigger/daily-coach.ts`, and `trigger/review-goals.ts` — **none of them have ever been `schedules.task` with a `cron` in this repo's history.** They are (and always were) plain `task()` calls with no declarative schedule. If they show up as active schedules on the Trigger.dev dashboard, those must be imperative schedules created directly on the dashboard (or via the SDK's `schedules.create()`, which no code in this repo calls), entirely decoupled from our code. Those three need to be paused/deleted directly on `trigger-bud.newpush.com`'s Tasks → Schedules tab — there's no code path that created or can remove them.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm eslint` on changed files — clean
- [x] `pnpm vitest run tests/unit/trigger tests/unit/cli tests/unit/server/utils/task-handler-loader.test.ts tests/unit/server/utils/task-dispatcher.test.ts` — 20 files / 132 tests passed
- [ ] Did **not** run `pnpm cw:cli monitor --prod` (hits live production infrastructure — out of scope for this session)