### PR TITLE
fix(coaching): role-aware Coaching nav for pure athletes (CW-103)

### DIFF
--- a/app/components/navigation/useCoachingRole.ts
+++ b/app/components/navigation/useCoachingRole.ts
@@ -1,0 +1,91 @@
+export interface CoachingRoleSignals {
+  /** Active coaching relationships where the current user is the coach. */
+  coachedAthletesCount: number
+  /** Pending requests where the current user is being asked to coach someone. */
+  pendingCoachRequestsCount: number
+  /** Active coaching relationships where the current user is the athlete. */
+  ownCoachesCount: number
+}
+
+export interface CoachingRoleResult {
+  /** The user actively coaches at least one athlete, or has a pending request to. */
+  isCoachForAnyone: boolean
+  /**
+   * CW-103: the user is connected to at least one coach of their own, but has
+   * never coached anyone themselves. Brand-new users with no coaching
+   * relationships at all (neither as coach nor as athlete) are NOT considered
+   * pure athletes here, so the "Add Athlete" onboarding path stays reachable.
+   */
+  isPureAthlete: boolean
+  /** Whether the full coach-oriented nav suite should be shown. */
+  showFullCoachingSuite: boolean
+}
+
+/**
+ * Pure decision logic for CW-103: decide whether the sidebar/coaching pages
+ * should render the full coach-oriented suite (Overview, Calendar, Athletes,
+ * Analytics, My Coaches) or the simplified athlete view ("My Coaches" only).
+ *
+ * Kept side-effect free and independent from data fetching so it can be unit
+ * tested without a Nuxt runtime. See `useCoachingRole` below for the wiring.
+ */
+export function resolveCoachingRole(signals: CoachingRoleSignals): CoachingRoleResult {
+  const isCoachForAnyone = signals.coachedAthletesCount > 0 || signals.pendingCoachRequestsCount > 0
+  const isPureAthlete = signals.ownCoachesCount > 0 && !isCoachForAnyone
+
+  return {
+    isCoachForAnyone,
+    isPureAthlete,
+    showFullCoachingSuite: !isPureAthlete
+  }
+}
+
+/**
+ * Nuxt composable wiring `resolveCoachingRole` to the existing coaching
+ * endpoints (`/api/coaching/athletes`, `/api/coaching/athletes/requests`,
+ * `/api/coaching/coaches` - all already used elsewhere in the app). Fetches
+ * run client-side only (`server: false`) so they never block SSR/navigation,
+ * and are cached by key so they execute once per session rather than on
+ * every route change.
+ */
+export function useCoachingRole() {
+  const { data: coachedAthletes } = useLazyFetch<any[], Error, string & {}>(
+    '/api/coaching/athletes',
+    {
+      server: false,
+      default: () => [],
+      key: 'nav-coaching-role-athletes'
+    }
+  )
+
+  const { data: pendingCoachRequests } = useLazyFetch<any[], Error, string & {}>(
+    '/api/coaching/athletes/requests',
+    {
+      server: false,
+      default: () => [],
+      key: 'nav-coaching-role-pending-requests'
+    }
+  )
+
+  const { data: ownCoaches } = useLazyFetch<any[], Error, string & {}>('/api/coaching/coaches', {
+    server: false,
+    default: () => [],
+    key: 'nav-coaching-role-own-coaches'
+  })
+
+  const role = computed(() =>
+    resolveCoachingRole({
+      coachedAthletesCount: Array.isArray(coachedAthletes.value) ? coachedAthletes.value.length : 0,
+      pendingCoachRequestsCount: Array.isArray(pendingCoachRequests.value)
+        ? pendingCoachRequests.value.length
+        : 0,
+      ownCoachesCount: Array.isArray(ownCoaches.value) ? ownCoaches.value.length : 0
+    })
+  )
+
+  return {
+    isCoachForAnyone: computed(() => role.value.isCoachForAnyone),
+    isPureAthlete: computed(() => role.value.isPureAthlete),
+    showFullCoachingSuite: computed(() => role.value.showFullCoachingSuite)
+  }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,6 +2,7 @@
   import { useTranslate, useTolgee } from '@tolgee/vue'
   import type { NavigationMenuItem } from '@nuxt/ui'
   import { useAppLogout } from '#imports'
+  import { useCoachingRole } from '~/components/navigation/useCoachingRole'
 
   const { t } = useTranslate('common')
   const tolgee = useTolgee()
@@ -49,6 +50,11 @@
   )
 
   const { trackNavClick } = useAnalytics()
+
+  // CW-103: role-aware Coaching nav — pure athletes (connected to a coach but
+  // never coaching anyone themselves) see a simplified "My Coaches" entry
+  // instead of the full coach roster/teams suite.
+  const { showFullCoachingSuite } = useCoachingRole()
 
   function wrapNavItems(items: NavigationMenuItem[]): NavigationMenuItem[] {
     return items.map((item) => {
@@ -299,54 +305,67 @@
           }
         ]
       },
-      {
-        label: 'Coaching',
-        icon: 'i-lucide-users',
-        defaultOpen: route.path.startsWith('/coaching'),
-        children: [
-          {
-            label: 'Overview',
-            icon: 'i-lucide-layout-dashboard',
-            to: '/coaching',
-            exact: true,
-            onSelect: () => {
-              open.value = false
+      ...(showFullCoachingSuite.value
+        ? [
+            {
+              label: 'Coaching',
+              icon: 'i-lucide-users',
+              defaultOpen: route.path.startsWith('/coaching'),
+              children: [
+                {
+                  label: 'Overview',
+                  icon: 'i-lucide-layout-dashboard',
+                  to: '/coaching',
+                  exact: true,
+                  onSelect: () => {
+                    open.value = false
+                  }
+                },
+                {
+                  label: 'Calendar',
+                  icon: 'i-lucide-calendar-days',
+                  to: '/coaching/calendar',
+                  onSelect: () => {
+                    open.value = false
+                  }
+                },
+                {
+                  label: 'Athletes',
+                  icon: 'i-lucide-users-round',
+                  to: '/coaching/athletes',
+                  onSelect: () => {
+                    open.value = false
+                  }
+                },
+                {
+                  label: 'Analytics',
+                  icon: 'i-lucide-bar-chart-3',
+                  to: '/analytics',
+                  onSelect: () => {
+                    open.value = false
+                  }
+                },
+                {
+                  label: 'My Coaches',
+                  icon: 'i-lucide-building-2',
+                  to: '/coaching/team',
+                  onSelect: () => {
+                    open.value = false
+                  }
+                }
+              ]
             }
-          },
-          {
-            label: 'Calendar',
-            icon: 'i-lucide-calendar-days',
-            to: '/coaching/calendar',
-            onSelect: () => {
-              open.value = false
+          ]
+        : [
+            {
+              label: 'My Coaches',
+              icon: 'i-lucide-users',
+              to: '/coaching/team',
+              onSelect: () => {
+                open.value = false
+              }
             }
-          },
-          {
-            label: 'Athletes',
-            icon: 'i-lucide-users-round',
-            to: '/coaching/athletes',
-            onSelect: () => {
-              open.value = false
-            }
-          },
-          {
-            label: 'Analytics',
-            icon: 'i-lucide-bar-chart-3',
-            to: '/analytics',
-            onSelect: () => {
-              open.value = false
-            }
-          },
-          {
-            label: 'My Coaches',
-            icon: 'i-lucide-building-2',
-            to: '/coaching/team',
-            onSelect: () => {
-              open.value = false
-            }
-          }
-        ]
-      },
+          ]),
       {
         label: navLabel('navigation_help_center', 'Help Center'),
         icon: 'i-heroicons-question-mark-circle',
@@ -606,41 +625,51 @@
         id: 'coaching',
         label: label('navigation_coaching', 'Coaching'),
         defaultOpen: route.path.startsWith('/coaching') || route.path === '/analytics',
-        items: sectionItems([
-          {
-            label: label('navigation_coaching', 'Coaching'),
-            icon: 'i-lucide-users',
-            defaultOpen: route.path.startsWith('/coaching') || route.path === '/analytics',
-            children: [
-              {
-                label: label('navigation_coaching_overview', 'Overview'),
-                icon: 'i-lucide-layout-dashboard',
-                to: '/coaching',
-                exact: true
-              },
-              {
-                label: label('navigation_coaching_calendar', 'Calendar'),
-                icon: 'i-lucide-calendar-days',
-                to: '/coaching/calendar'
-              },
-              {
-                label: label('navigation_coaching_athletes', 'Athletes'),
-                icon: 'i-lucide-users-round',
-                to: '/coaching/athletes'
-              },
-              {
-                label: label('navigation_analytics', 'Analytics'),
-                icon: 'i-lucide-bar-chart-3',
-                to: '/analytics'
-              },
-              {
-                label: label('navigation_coaching_team', 'My Coaches'),
-                icon: 'i-lucide-building-2',
-                to: '/coaching/team'
-              }
-            ]
-          }
-        ])
+        items: sectionItems(
+          showFullCoachingSuite.value
+            ? [
+                {
+                  label: label('navigation_coaching', 'Coaching'),
+                  icon: 'i-lucide-users',
+                  defaultOpen: route.path.startsWith('/coaching') || route.path === '/analytics',
+                  children: [
+                    {
+                      label: label('navigation_coaching_overview', 'Overview'),
+                      icon: 'i-lucide-layout-dashboard',
+                      to: '/coaching',
+                      exact: true
+                    },
+                    {
+                      label: label('navigation_coaching_calendar', 'Calendar'),
+                      icon: 'i-lucide-calendar-days',
+                      to: '/coaching/calendar'
+                    },
+                    {
+                      label: label('navigation_coaching_athletes', 'Athletes'),
+                      icon: 'i-lucide-users-round',
+                      to: '/coaching/athletes'
+                    },
+                    {
+                      label: label('navigation_analytics', 'Analytics'),
+                      icon: 'i-lucide-bar-chart-3',
+                      to: '/analytics'
+                    },
+                    {
+                      label: label('navigation_coaching_team', 'My Coaches'),
+                      icon: 'i-lucide-building-2',
+                      to: '/coaching/team'
+                    }
+                  ]
+                }
+              ]
+            : [
+                {
+                  label: label('navigation_coaching_team', 'My Coaches'),
+                  icon: 'i-lucide-users',
+                  to: '/coaching/team'
+                }
+              ]
+        )
       },
       {
         id: 'account',

--- a/app/pages/coaching/index.vue
+++ b/app/pages/coaching/index.vue
@@ -255,6 +255,28 @@
           // Requests endpoint may be unavailable for some roles; keep overview CTA as-is.
         }
       }
+
+      // CW-103: this "Overview" page is a coach dashboard. A user with no
+      // coaching-as-coach relationships (no active athletes, no pending
+      // requests to become someone's coach) who IS connected to at least one
+      // coach of their own is a pure athlete — send them to their active
+      // coaching connections instead of the coach-only "Connect Your First
+      // Athlete" empty state. Brand-new users with no coaching relationships
+      // at all (neither role) keep seeing the coach empty state so the
+      // "Add Athlete" onboarding path stays reachable.
+      if (overviewData.value.athletes.length === 0 && pendingRequestCount.value === 0) {
+        try {
+          const coaches = await $fetch<any, string & {}>('/api/coaching/coaches')
+          const isPureAthlete = Array.isArray(coaches) && coaches.length > 0
+          if (isPureAthlete) {
+            await navigateTo('/coaching/team', { replace: true })
+            return
+          }
+        } catch {
+          // If we can't determine athlete-role, fall back to the existing
+          // coach empty state rather than redirecting incorrectly.
+        }
+      }
     } catch (e) {
       console.error(e)
       toast.add({ title: 'Failed to load coaching overview', color: 'error' })

--- a/tests/unit/composables/useCoachingRole.test.ts
+++ b/tests/unit/composables/useCoachingRole.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCoachingRole } from '~/components/navigation/useCoachingRole'
+
+describe('resolveCoachingRole (CW-103)', () => {
+  it('shows the full coaching suite for an active coach', () => {
+    const role = resolveCoachingRole({
+      coachedAthletesCount: 3,
+      pendingCoachRequestsCount: 0,
+      ownCoachesCount: 0
+    })
+
+    expect(role.isCoachForAnyone).toBe(true)
+    expect(role.isPureAthlete).toBe(false)
+    expect(role.showFullCoachingSuite).toBe(true)
+  })
+
+  it('shows the full coaching suite for a coach awaiting first athlete approval', () => {
+    const role = resolveCoachingRole({
+      coachedAthletesCount: 0,
+      pendingCoachRequestsCount: 2,
+      ownCoachesCount: 0
+    })
+
+    expect(role.isCoachForAnyone).toBe(true)
+    expect(role.isPureAthlete).toBe(false)
+    expect(role.showFullCoachingSuite).toBe(true)
+  })
+
+  it('treats a user connected to a coach with no coaching relationships of their own as a pure athlete', () => {
+    const role = resolveCoachingRole({
+      coachedAthletesCount: 0,
+      pendingCoachRequestsCount: 0,
+      ownCoachesCount: 1
+    })
+
+    expect(role.isCoachForAnyone).toBe(false)
+    expect(role.isPureAthlete).toBe(true)
+    expect(role.showFullCoachingSuite).toBe(false)
+  })
+
+  it('keeps the full suite for a brand-new user with no coaching relationships at all', () => {
+    const role = resolveCoachingRole({
+      coachedAthletesCount: 0,
+      pendingCoachRequestsCount: 0,
+      ownCoachesCount: 0
+    })
+
+    expect(role.isCoachForAnyone).toBe(false)
+    expect(role.isPureAthlete).toBe(false)
+    expect(role.showFullCoachingSuite).toBe(true)
+  })
+
+  it('prioritizes the coach suite when a user both coaches others and has their own coach', () => {
+    const role = resolveCoachingRole({
+      coachedAthletesCount: 1,
+      pendingCoachRequestsCount: 0,
+      ownCoachesCount: 1
+    })
+
+    expect(role.isCoachForAnyone).toBe(true)
+    expect(role.isPureAthlete).toBe(false)
+    expect(role.showFullCoachingSuite).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes CW-103

## Problem
Sidebar Coaching links (Overview, Calendar, Athletes, Analytics, My Coaches) were shown to every user regardless of role. Athletes who only connect to a coach (no coaching relationships where they are the coach) landed on `/coaching` and hit the coach-only "Connect Your First Athlete" empty state instead of anything relevant to them.

## Changes
- **`app/components/navigation/useCoachingRole.ts`** (new): a pure `resolveCoachingRole()` decision function plus a `useCoachingRole()` composable that wires it to the existing `/api/coaching/athletes`, `/api/coaching/athletes/requests`, and `/api/coaching/coaches` endpoints (all already used elsewhere in the app). Fetches are client-only (`server: false`) and cached by key so they run once per session and never block SSR/navigation.
- **`app/layouts/default.vue`**: both the desktop and mobile Coaching nav sections now render the full coach suite (Overview/Calendar/Athletes/Analytics/My Coaches) only when the user actively coaches someone (or has a pending request to). Pure athletes see a single "My Coaches" link to the existing `/coaching/team` page.
- **`app/pages/coaching/index.vue`**: this page is a coach dashboard. When a user has no coaching-as-coach relationships but is connected to at least one coach of their own, redirect from `/coaching` to `/coaching/team` (which already lists their active coaches + an "Invite a Coach" flow) instead of showing the coach-only empty state. Brand-new users with no coaching relationships at all keep seeing the existing "Connect Your First Athlete" empty state so the onboarding path for new coaches stays intact.
- **`tests/unit/composables/useCoachingRole.test.ts`** (new): unit tests for the role decision logic (coach, pending-coach, pure athlete, brand-new user, and both-roles cases).

`/coaching/team` ("My Coaches & Teams") already existed and already covers the athlete-facing "view my coaches / invite a coach" need — this was largely a routing/nav fix to surface and gate it correctly, not new UI.

## Known follow-up (flagged, not fixed here)
- A brand-new user who wants to become a coach for the first time must still know to navigate directly to `/coaching/athletes`, since the sidebar only reveals the full coach suite once a coaching relationship (active or pending) already exists. Worth a dedicated "Start Coaching" entry point in a follow-up ticket if this matters for onboarding.
- `app/components/coaching/CoachingNavbarLinks.vue` (the in-page tab bar shown at the top of `/coaching/*` pages) still shows the full coach tab set unconditionally. It's outside this ticket's owned paths (sidebar only), but it has the same underlying issue and could use the same `useCoachingRole()` composable in a follow-up.

## Verification
```
pnpm typecheck
```
Exits 0, no errors.

```
npx vitest run tests/unit/composables/useCoachingRole.test.ts
```
5/5 passing.