### PR TITLE
fix(integrations): extract run and swim cadence from Garmin activities (CW-97)

### DIFF
--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -177,6 +177,41 @@ export function extractGarminReadinessScore(record: Record<string, unknown> | nu
 }
 
 /**
+ * Garmin's Activity summary exposes distinct average/max cadence fields per sport family:
+ * cycling (`...BikeCadenceInRoundsPerMinute`), running (`...RunCadenceInStepsPerMinute`), and
+ * swimming (`...SwimCadenceInStrokesPerMinute`). Our Workout model only stores one generic
+ * averageCadence/maxCadence pair, so pick the source field pair based on the activity's
+ * normalized sport (see `normalizeGarminActivityType`). Cycling (including virtual/mountain
+ * biking) keeps the original bike-field-only behavior; anything else that isn't running or
+ * swimming has no documented cadence fields and yields null, same as before this fix.
+ */
+export function extractGarminActivityCadence(
+  record: Record<string, unknown> | null | undefined,
+  normalizedType: string
+): { average: number | null; max: number | null } {
+  if (!record || typeof record !== 'object') return { average: null, max: null }
+
+  if (normalizedType === 'Run') {
+    return {
+      average: extractGarminNumericMetric(record, ['averageRunCadenceInStepsPerMinute']),
+      max: extractGarminNumericMetric(record, ['maxRunCadenceInStepsPerMinute'])
+    }
+  }
+
+  if (normalizedType === 'Swim') {
+    return {
+      average: extractGarminNumericMetric(record, ['averageSwimCadenceInStrokesPerMinute']),
+      max: extractGarminNumericMetric(record, ['maxSwimCadenceInStrokesPerMinute'])
+    }
+  }
+
+  return {
+    average: extractGarminNumericMetric(record, ['averageBikeCadenceInRoundsPerMinute']),
+    max: extractGarminNumericMetric(record, ['maxBikeCadenceInRoundsPerMinute'])
+  }
+}
+
+/**
  * Garmin's Stress Details schema exposes an absolute Body Battery *level* sampled
  * throughout the day via `timeOffsetBodyBatteryValues` (a map of seconds-since-start-of-day
  * to a 0-100 battery reading), the same shape as `timeOffsetSleepSpo2`. Body Battery is
@@ -672,25 +707,24 @@ export const GarminService = {
         continue
       }
 
+      const activityType = normalizeGarminActivityType(record.activityType)
+      const cadence = extractGarminActivityCadence(record, activityType)
+
       const workoutData: any = {
         userId,
         externalId,
         source: 'garmin',
         date: startDate,
         title: record.activityName || `Garmin ${record.activityType}`,
-        type: normalizeGarminActivityType(record.activityType),
+        type: activityType,
         durationSec: record.durationInSeconds,
         elapsedTimeSec: record.durationInSeconds || null,
         distanceMeters: record.distanceInMeters || null,
         elevationGain: record.totalElevationGainInMeters
           ? Math.round(record.totalElevationGainInMeters)
           : null,
-        averageCadence: record.averageBikeCadenceInRoundsPerMinute
-          ? Math.round(record.averageBikeCadenceInRoundsPerMinute)
-          : null,
-        maxCadence: record.maxBikeCadenceInRoundsPerMinute
-          ? Math.round(record.maxBikeCadenceInRoundsPerMinute)
-          : null,
+        averageCadence: cadence.average !== null ? Math.round(cadence.average) : null,
+        maxCadence: cadence.max !== null ? Math.round(cadence.max) : null,
         averageSpeed: record.averageSpeedInMetersPerSecond || null,
         averageHr: record.averageHeartRateInBeatsPerMinute || null,
         maxHr: record.maxHeartRateInBeatsPerMinute || null,

--- a/tests/unit/server/utils/services/garminService.test.ts
+++ b/tests/unit/server/utils/services/garminService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  extractGarminActivityCadence,
   extractGarminBodyBatteryScore,
   extractGarminReadinessScore,
   extractGarminSpO2Percentage,
@@ -316,6 +317,191 @@ describe('extractGarminSpO2Percentage', () => {
         averageStressLevel: 18
       })
     ).toBeNull()
+  })
+})
+
+describe('extractGarminActivityCadence (CW-97)', () => {
+  it('extracts cycling cadence from bike cadence fields, unchanged from prior behavior', () => {
+    const record = {
+      activityType: 'ROAD_BIKING',
+      averageBikeCadenceInRoundsPerMinute: 84.6,
+      maxBikeCadenceInRoundsPerMinute: 102.3,
+      // Should be ignored for a cycling activity even if present.
+      averageRunCadenceInStepsPerMinute: 170,
+      averageSwimCadenceInStrokesPerMinute: 32
+    }
+
+    expect(extractGarminActivityCadence(record, 'Ride')).toEqual({
+      average: 84.6,
+      max: 102.3
+    })
+  })
+
+  it('extracts running cadence from run cadence fields', () => {
+    const record = {
+      activityType: 'RUNNING',
+      averageRunCadenceInStepsPerMinute: 172.4,
+      maxRunCadenceInStepsPerMinute: 188.1,
+      // A run summary has no bike cadence fields at all in real Garmin payloads.
+      averageBikeCadenceInRoundsPerMinute: undefined
+    }
+
+    expect(extractGarminActivityCadence(record, 'Run')).toEqual({
+      average: 172.4,
+      max: 188.1
+    })
+  })
+
+  it('extracts swimming cadence from swim cadence fields', () => {
+    const record = {
+      activityType: 'LAP_SWIMMING',
+      averageSwimCadenceInStrokesPerMinute: 31.5,
+      maxSwimCadenceInStrokesPerMinute: 38
+    }
+
+    expect(extractGarminActivityCadence(record, 'Swim')).toEqual({
+      average: 31.5,
+      max: 38
+    })
+  })
+
+  it('returns null cadence for activity types with no documented cadence fields', () => {
+    const record = {
+      activityType: 'STRENGTH_TRAINING'
+    }
+
+    expect(extractGarminActivityCadence(record, 'WeightTraining')).toEqual({
+      average: null,
+      max: null
+    })
+  })
+
+  it('returns null cadence for a null/undefined record', () => {
+    expect(extractGarminActivityCadence(null, 'Run')).toEqual({ average: null, max: null })
+    expect(extractGarminActivityCadence(undefined, 'Ride')).toEqual({ average: null, max: null })
+  })
+})
+
+describe('GarminService.processActivities cadence mapping (CW-97)', () => {
+  it('maps run cadence into averageCadence/maxCadence for a running activity', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ dashboardSettings: {} })
+    prismaMock.fitFile = { findUnique: vi.fn().mockResolvedValue(null) } as any
+
+    const workoutRepoModule =
+      await import('../../../../../server/utils/repositories/workoutRepository')
+    const upsertSpy = vi.spyOn(workoutRepoModule.workoutRepository, 'upsert').mockResolvedValue({
+      record: { id: 'workout-run-1' } as any,
+      created: true
+    })
+
+    const streamRepoModule =
+      await import('../../../../../server/utils/repositories/workoutStreamRepository')
+    vi.spyOn(streamRepoModule.workoutStreamRepository, 'existsByWorkoutId').mockResolvedValue(false)
+
+    await GarminService.processActivities(
+      'user-1',
+      [
+        {
+          summaryId: 'activity-run-1',
+          startTimeInSeconds: 1700000000,
+          durationInSeconds: 1800,
+          activityType: 'RUNNING',
+          averageRunCadenceInStepsPerMinute: 175.8,
+          maxRunCadenceInStepsPerMinute: 190.2,
+          averageBikeCadenceInRoundsPerMinute: 999 // must not leak into a run's cadence
+        }
+      ],
+      { id: 'int-1' }
+    )
+
+    expect(upsertSpy).toHaveBeenCalledWith(
+      'user-1',
+      'garmin',
+      'activity-run-1',
+      expect.objectContaining({ type: 'Run', averageCadence: 176, maxCadence: 190 }),
+      expect.objectContaining({ type: 'Run', averageCadence: 176, maxCadence: 190 })
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('maps swim cadence into averageCadence/maxCadence for a swimming activity', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ dashboardSettings: {} })
+    prismaMock.fitFile = { findUnique: vi.fn().mockResolvedValue(null) } as any
+
+    const workoutRepoModule =
+      await import('../../../../../server/utils/repositories/workoutRepository')
+    const upsertSpy = vi.spyOn(workoutRepoModule.workoutRepository, 'upsert').mockResolvedValue({
+      record: { id: 'workout-swim-1' } as any,
+      created: true
+    })
+
+    const streamRepoModule =
+      await import('../../../../../server/utils/repositories/workoutStreamRepository')
+    vi.spyOn(streamRepoModule.workoutStreamRepository, 'existsByWorkoutId').mockResolvedValue(false)
+
+    await GarminService.processActivities(
+      'user-1',
+      [
+        {
+          summaryId: 'activity-swim-1',
+          startTimeInSeconds: 1700000000,
+          durationInSeconds: 2400,
+          activityType: 'LAP_SWIMMING',
+          averageSwimCadenceInStrokesPerMinute: 30.6,
+          maxSwimCadenceInStrokesPerMinute: 36.4
+        }
+      ],
+      { id: 'int-1' }
+    )
+
+    expect(upsertSpy).toHaveBeenCalledWith(
+      'user-1',
+      'garmin',
+      'activity-swim-1',
+      expect.objectContaining({ type: 'Swim', averageCadence: 31, maxCadence: 36 }),
+      expect.objectContaining({ type: 'Swim', averageCadence: 31, maxCadence: 36 })
+    )
+    vi.restoreAllMocks()
+  })
+
+  it('keeps mapping bike cadence into averageCadence/maxCadence for a cycling activity', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ dashboardSettings: {} })
+    prismaMock.fitFile = { findUnique: vi.fn().mockResolvedValue(null) } as any
+
+    const workoutRepoModule =
+      await import('../../../../../server/utils/repositories/workoutRepository')
+    const upsertSpy = vi.spyOn(workoutRepoModule.workoutRepository, 'upsert').mockResolvedValue({
+      record: { id: 'workout-ride-1' } as any,
+      created: true
+    })
+
+    const streamRepoModule =
+      await import('../../../../../server/utils/repositories/workoutStreamRepository')
+    vi.spyOn(streamRepoModule.workoutStreamRepository, 'existsByWorkoutId').mockResolvedValue(false)
+
+    await GarminService.processActivities(
+      'user-1',
+      [
+        {
+          summaryId: 'activity-ride-1',
+          startTimeInSeconds: 1700000000,
+          durationInSeconds: 3600,
+          activityType: 'ROAD_BIKING',
+          averageBikeCadenceInRoundsPerMinute: 85.2,
+          maxBikeCadenceInRoundsPerMinute: 104.9
+        }
+      ],
+      { id: 'int-1' }
+    )
+
+    expect(upsertSpy).toHaveBeenCalledWith(
+      'user-1',
+      'garmin',
+      'activity-ride-1',
+      expect.objectContaining({ type: 'Ride', averageCadence: 85, maxCadence: 105 }),
+      expect.objectContaining({ type: 'Ride', averageCadence: 85, maxCadence: 105 })
+    )
+    vi.restoreAllMocks()
   })
 })
 


### PR DESCRIPTION
Fixes CW-97

## Summary
Garmin Activity summaries expose distinct cadence fields per sport: cycling (`averageBikeCadenceInRoundsPerMinute`), running (`averageRunCadenceInStepsPerMinute`), and swimming (`averageSwimCadenceInStrokesPerMinute`). `garminService.ts`'s activity mapper only ever read the bike cadence fields, so run and swim cadence data was silently discarded on import.

- Added `extractGarminActivityCadence()` in `server/utils/services/garminService.ts`, which selects the correct average/max cadence source field pair based on the activity's normalized sport (`normalizeGarminActivityType` from `activity-mapping.ts`):
  - Running -> `averageRunCadenceInStepsPerMinute` / `maxRunCadenceInStepsPerMinute`
  - Swimming -> `averageSwimCadenceInStrokesPerMinute` / `maxSwimCadenceInStrokesPerMinute`
  - Everything else (cycling, indoor cycling, mountain biking, etc.) -> `averageBikeCadenceInRoundsPerMinute` / `maxBikeCadenceInRoundsPerMinute`, unchanged from before
- `processActivities` now calls this helper instead of hardcoding the bike fields; the result still writes into the existing generic `averageCadence`/`maxCadence` columns on `Workout` (confirmed via `prisma/schema.prisma` that these are single generic Int fields, not sport-specific, so no schema change is needed)
- Added unit tests in `tests/unit/server/utils/services/garminService.test.ts`:
  - Direct coverage of `extractGarminActivityCadence` for cycling (unchanged), running, swimming, an activity type with no documented cadence fields, and null/undefined records
  - `processActivities` integration tests asserting the correct `averageCadence`/`maxCadence` land on the upserted workout for each of the three sport families, including a check that a run's bike-cadence-shaped field (if present) does not leak into its cadence

Built fresh off `develop` so it includes the just-merged CW-96 recovery-field-mapping fix to the same file. CW-99 (a third ticket touching this file) is intentionally not being worked in parallel with this change.

## Verification
\`\`\`
$ pnpm test tests/unit/server/utils/services/garminService.test.ts
 Test Files  1 passed (1)
      Tests  41 passed (41)

$ pnpm typecheck
(no errors)
\`\`\`