### PR TITLE
feat(coaching): add read-only athlete nutrition summary for coaches (CW-104)

### DIFF
--- a/app/components/coaching/AthleteNutritionSummary.vue
+++ b/app/components/coaching/AthleteNutritionSummary.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="space-y-6">
+    <div v-if="pending" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <USkeleton class="h-32 w-full" />
+      <USkeleton class="h-32 w-full" />
+      <USkeleton class="h-32 w-full" />
+    </div>
+
+    <UAlert
+      v-else-if="error"
+      color="error"
+      icon="i-heroicons-exclamation-triangle"
+      title="Error loading nutrition summary"
+      :description="error.message || 'Could not load fueling strategy for this athlete.'"
+    />
+
+    <template v-else-if="nutrition">
+      <div class="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-4 gap-4">
+        <UCard :ui="mobileListCardUi">
+          <template #header>
+            <h3 class="font-bold text-xs text-gray-500 uppercase">Goal Profile</h3>
+          </template>
+          <p class="text-2xl font-black capitalize">
+            {{ formatGoalProfile(nutrition.targets.goalProfile) }}
+          </p>
+        </UCard>
+
+        <UCard :ui="mobileListCardUi">
+          <template #header>
+            <h3 class="font-bold text-xs text-gray-500 uppercase">Carb Target (g/hr)</h3>
+          </template>
+          <p class="text-2xl font-black">
+            {{ nutrition.targets.currentCarbMaxPerHour ?? '--' }}
+            <span class="text-sm font-normal text-gray-500">
+              / {{ nutrition.targets.ultimateCarbGoalPerHour ?? '--' }} goal
+            </span>
+          </p>
+        </UCard>
+
+        <UCard :ui="mobileListCardUi">
+          <template #header>
+            <h3 class="font-bold text-xs text-gray-500 uppercase">Sodium Target</h3>
+          </template>
+          <p class="text-2xl font-black">
+            {{ nutrition.targets.sodiumTargetMgPerHour ?? '--' }}
+            <span class="text-sm font-normal text-gray-500">mg/hr</span>
+          </p>
+        </UCard>
+
+        <UCard :ui="mobileListCardUi">
+          <template #header>
+            <h3 class="font-bold text-xs text-gray-500 uppercase">Protein / Fat per kg</h3>
+          </template>
+          <p class="text-2xl font-black">
+            {{ nutrition.targets.proteinPerKg ?? '--' }}g
+            <span class="text-sm font-normal text-gray-500">
+              / {{ nutrition.targets.fatPerKg ?? '--' }}g
+            </span>
+          </p>
+        </UCard>
+      </div>
+
+      <UCard :ui="mobileListCardUi">
+        <template #header>
+          <div>
+            <h3 class="font-bold">Upcoming Fueling Plan</h3>
+            <p class="text-xs text-gray-500">
+              Carb targets and fueling intensity for the next
+              {{ nutrition.upcomingFuelingPlan.length }}
+              days. Read-only strategy view - does not include logged meals.
+            </p>
+          </div>
+        </template>
+
+        <div
+          v-if="nutrition.upcomingFuelingPlan?.length"
+          class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3"
+        >
+          <div
+            v-for="day in nutrition.upcomingFuelingPlan"
+            :key="day.date"
+            class="rounded-lg border border-gray-200 dark:border-gray-800 p-3 text-center"
+          >
+            <p class="text-[10px] font-bold text-gray-400 uppercase">
+              {{ formatDayShort(day.date) }}
+            </p>
+            <UBadge :color="getFuelStateColor(day.state)" variant="subtle" class="mt-1 font-bold">
+              {{ day.label }}
+            </UBadge>
+            <p class="mt-2 text-lg font-black">
+              {{ day.carbsTarget ?? '--' }}
+              <span class="text-xs font-normal text-gray-500">g carbs</span>
+            </p>
+            <p v-if="day.isRest" class="text-[10px] text-gray-400 uppercase mt-1">Rest day</p>
+          </div>
+        </div>
+        <div v-else class="text-center py-8 text-gray-500 italic">
+          No upcoming fueling plan available.
+        </div>
+      </UCard>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { mobileListCardUi } from '~/utils/mobile-surface-ui'
+
+  interface NutritionSummary {
+    athleteId: string
+    timezone: string
+    targets: {
+      goalProfile: string | null
+      targetAdjustmentPercent: number | null
+      carbsPerHour: { low: number | null; medium: number | null; high: number | null }
+      currentCarbMaxPerHour: number | null
+      ultimateCarbGoalPerHour: number | null
+      sodiumTargetMgPerHour: number | null
+      proteinPerKg: number | null
+      fatPerKg: number | null
+      preWorkoutWindowMinutes: number | null
+      postWorkoutWindowMinutes: number | null
+    }
+    upcomingFuelingPlan: Array<{
+      date: string
+      state: number
+      label: string
+      carbsTarget: number | null
+      isRest: boolean
+    }>
+  }
+
+  const props = defineProps<{
+    athleteId: string
+  }>()
+
+  const { formatDateUTC } = useFormat()
+
+  const {
+    data: nutrition,
+    pending,
+    error
+  } = useAsyncData<NutritionSummary>(
+    `athlete-nutrition-${props.athleteId}`,
+    () => ($fetch as any)(`/api/coaching/athletes/${props.athleteId}/nutrition`),
+    { lazy: true }
+  ) as any
+
+  function formatDayShort(date: string) {
+    return formatDateUTC(date, 'EEE')
+  }
+
+  function formatGoalProfile(profile: string | null) {
+    if (!profile) return '--'
+    return profile.toLowerCase().replace(/_/g, ' ')
+  }
+
+  function getFuelStateColor(state: number) {
+    if (state === 3) return 'error'
+    if (state === 2) return 'warning'
+    return 'success'
+  }
+</script>

--- a/app/pages/coaching/athletes/[id]/index.vue
+++ b/app/pages/coaching/athletes/[id]/index.vue
@@ -582,6 +582,10 @@
                 </UCard>
               </div>
             </div>
+
+            <div v-else-if="item.value === 'nutrition'" class="space-y-6 pt-4">
+              <CoachingAthleteNutritionSummary :athlete-id="athleteId" />
+            </div>
           </template>
         </UTabs>
       </div>
@@ -729,7 +733,8 @@
   const tabItems = [
     { value: 'overview', label: 'Overview', icon: 'i-heroicons-squares-2x2' },
     { value: 'calendar', label: 'Calendar', icon: 'i-heroicons-calendar' },
-    { value: 'zones', label: 'Zones', icon: 'i-heroicons-adjustments-horizontal' }
+    { value: 'zones', label: 'Zones', icon: 'i-heroicons-adjustments-horizontal' },
+    { value: 'nutrition', label: 'Nutrition', icon: 'i-heroicons-cake' }
   ]
 
   const performanceSummary = computed(() => athlete.value?.performanceSummary ?? null)

--- a/server/api/coaching/athletes/[id]/nutrition.get.ts
+++ b/server/api/coaching/athletes/[id]/nutrition.get.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod/v3'
+import { requireCoachAccessToAthlete } from '../../../../utils/coaching-auth'
+import { getUserTimezone, getUserLocalDate, formatDateUTC } from '../../../../utils/date'
+import { getUserNutritionSettings } from '../../../../utils/nutrition/settings'
+import { metabolicService } from '../../../../utils/services/metabolicService'
+
+defineRouteMeta({
+  openAPI: {
+    tags: ['Coaching'],
+    summary: 'Get athlete nutrition summary',
+    description:
+      'Returns a read-only summary of fueling strategy/targets for an athlete coached by the ' +
+      'authenticated user. Does not include daily food logs or logged meal entries.',
+    responses: {
+      200: { description: 'Success' },
+      401: { description: 'Unauthorized' },
+      403: { description: 'Forbidden (Not coaching this athlete)' }
+    }
+  }
+})
+
+const paramsSchema = z.object({
+  id: z.string()
+})
+
+// Only the next few days are surfaced here - enough for a coach to see the upcoming fueling
+// plan shape without exposing a long history of the athlete's logged intake.
+const UPCOMING_DAYS = 7
+
+export default defineEventHandler(async (event) => {
+  const { id: athleteId } = await getValidatedRouterParams(event, paramsSchema.parse)
+
+  // Verify the coaching relationship is ACTIVE before returning anything.
+  await requireCoachAccessToAthlete(event, athleteId)
+
+  const timezone = await getUserTimezone(athleteId)
+  const today = getUserLocalDate(timezone)
+  const settings = await getUserNutritionSettings(athleteId)
+
+  const upcomingFuelingPlan = []
+  for (let i = 0; i < UPCOMING_DAYS; i++) {
+    const date = new Date(today)
+    date.setUTCDate(today.getUTCDate() + i)
+
+    const dayPlan = await metabolicService.calculateFuelingPlanForDate(athleteId, date, {
+      persist: false
+    })
+    const plan = dayPlan.plan as any
+    const totals = plan?.dailyTotals
+    const state = totals?.fuelState || 1
+
+    upcomingFuelingPlan.push({
+      date: formatDateUTC(date),
+      state,
+      label: state === 3 ? 'Performance' : state === 2 ? 'Steady' : 'Eco',
+      carbsTarget: totals ? Math.round(totals.carbs) : null,
+      isRest: !plan?.windows?.some((w: any) => w.type !== 'DAILY_BASE')
+    })
+  }
+
+  return {
+    athleteId,
+    timezone,
+    // Fueling strategy/targets only - intentionally excludes logged meals, hydration debt,
+    // and symptom history since those are more sensitive, log-derived athlete data.
+    targets: {
+      goalProfile: settings.goalProfile,
+      targetAdjustmentPercent: settings.targetAdjustmentPercent,
+      carbsPerHour: {
+        low: settings.carbsPerHourLow,
+        medium: settings.carbsPerHourMedium,
+        high: settings.carbsPerHourHigh
+      },
+      currentCarbMaxPerHour: settings.currentCarbMax,
+      ultimateCarbGoalPerHour: settings.ultimateCarbGoal,
+      sodiumTargetMgPerHour: settings.sodiumTarget,
+      proteinPerKg: settings.baseProteinPerKg,
+      fatPerKg: settings.baseFatPerKg,
+      preWorkoutWindowMinutes: settings.preWorkoutWindow,
+      postWorkoutWindowMinutes: settings.postWorkoutWindow
+    },
+    upcomingFuelingPlan
+  }
+})


### PR DESCRIPTION
Fixes CW-104

## Summary
- Adds a coach-scoped nutrition endpoint `GET /api/coaching/athletes/[id]/nutrition` that reuses the existing `requireCoachAccessToAthlete` helper (same ACTIVE-relationship check used by the sibling `calendar.get.ts` endpoint) before returning anything.
- Surfaces a read-only "Nutrition" tab on the coach athlete detail page (`app/pages/coaching/athletes/[id]/index.vue`), backed by a new `CoachingAthleteNutritionSummary` component.
- Access control: the endpoint 403s unless an `ACTIVE` `CoachingRelationship` exists between the authenticated coach and the requested athlete, exactly like the other coach-scoped athlete endpoints.

### What "nutrition summary" means here
Reused `metabolicService` / `getUserNutritionSettings` (the same building blocks as the self-service `server/api/nutrition/strategy.get.ts` endpoint) to expose only **fueling strategy/targets**:
- Goal profile, carb targets (current max / ultimate goal per hour), sodium target, protein/fat per kg, pre/post-workout windows.
- The upcoming 7-day fueling plan (date, fueling intensity state/label, carb target, rest-day flag) - the same shape as the athlete-facing strategy matrix, just computed for the athlete instead of the caller.

Intentionally **excluded** to avoid over-exposing sensitive athlete data (left as follow-up scope if actually wanted later):
- Raw daily food logs / meal entries.
- Hydration debt (derived from logged fluid intake).
- Recent symptom/wellness event history (e.g. GI distress, fatigue flags) that the self-service strategy endpoint surfaces.

## Verification
`pnpm typecheck` passes cleanly (exit 0, no type errors).

## Owned paths touched
- `server/api/coaching/athletes/[id]/nutrition.get.ts` (new)
- `app/components/coaching/AthleteNutritionSummary.vue` (new)
- `app/pages/coaching/athletes/[id]/index.vue` (added Nutrition tab)