### PR TITLE
fix(infra): handle email.sent Resend webhook event (CW-211)

### DIFF
--- a/server/utils/services/resendService.ts
+++ b/server/utils/services/resendService.ts
@@ -6,6 +6,8 @@ import { prisma } from '../db'
  */
 function mapStatus(type: string): EmailDeliveryStatus | null {
   switch (type) {
+    case 'email.sent':
+      return 'SENT'
     case 'email.delivered':
       return 'DELIVERED'
     case 'email.opened':
@@ -71,6 +73,9 @@ export const ResendService = {
       data?.bounce?.message || data?.complaint?.feedback_type || data?.failed?.message
 
     switch (status) {
+      case 'SENT':
+        updateData.sentAt = timestamp
+        break
       case 'DELIVERED':
         updateData.deliveredAt = timestamp
         break

--- a/tests/unit/server/utils/services/resendService.test.ts
+++ b/tests/unit/server/utils/services/resendService.test.ts
@@ -33,6 +33,25 @@ describe('ResendService', () => {
       status: 'SENT'
     }
 
+    it('should update delivery status to SENT', async () => {
+      vi.mocked(prisma.emailDelivery.findUnique).mockResolvedValue(mockDelivery as any)
+
+      const result = await ResendService.processWebhookEvent(
+        'email.sent',
+        { email_id: mockEmailId },
+        mockCreatedAt
+      )
+
+      expect(result.handled).toBe(true)
+      expect(prisma.emailDelivery.update).toHaveBeenCalledWith({
+        where: { id: mockDelivery.id },
+        data: expect.objectContaining({
+          status: 'SENT',
+          sentAt: new Date(mockCreatedAt)
+        })
+      })
+    })
+
     it('should update delivery status to DELIVERED', async () => {
       vi.mocked(prisma.emailDelivery.findUnique).mockResolvedValue(mockDelivery as any)
 


### PR DESCRIPTION
Fixes CW-211

## Summary
The `process-resend-webhook` Trigger.dev task logged `Unhandled webhook type: email.sent` because `ResendService.mapStatus()` (in `server/utils/services/resendService.ts`) had no case for the Resend `email.sent` event. This event fires when Resend has accepted/sent the message, distinct from `email.delivered` (confirmed inbox delivery).

- Mapped `email.sent` to the existing `EmailDeliveryStatus.SENT` enum value (already defined in `prisma/schema.prisma`, no migration needed).
- Recorded the event on `EmailDelivery.sentAt`, mirroring the existing pattern used for `email.delivered` → `deliveredAt`, `email.opened` → `openedAt`, etc.
- Added a unit test covering the new `email.sent` → `SENT` mapping in `tests/unit/server/utils/services/resendService.test.ts`.

**Note on owned paths:** the ticket named `server/utils/services/emailService.ts` and `tests/unit/server/utils/services/emailService.test.ts`, but neither file exists in this codebase. The actual Resend webhook-mapping logic lives in `server/utils/services/resendService.ts` (consumed by `trigger/process-resend-webhook.ts`), and its tests live in `tests/unit/server/utils/services/resendService.test.ts`. The fix and test were applied there instead, since that's where the described bug actually lives.

## Verification
```
$ pnpm test tests/unit/server/utils/services/resendService.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ pnpm typecheck
(no errors, exit code 0)
```