### PR TITLE
docs: resolve 325h depth items with verified product behavior (CW-101)

### DIFF
--- a/content/documentation/1.athletes/19.activity-management.md
+++ b/content/documentation/1.athletes/19.activity-management.md
@@ -59,6 +59,14 @@ Use [Data Management](/documentation/athletes/data-management) when you need to 
 
 On smaller screens, start the drag action from the workout card, move to the target day or workout, and release on the highlighted destination. If precise drag-and-drop is difficult, use **Link Workouts** or open the workout directly for the equivalent action.
 
+## Hiding, locking, and repeating workouts
+
+These are common requests that Coach Watts does not support as saved workout properties today:
+
+- **Hiding a workout** — there is no per-workout "hide" flag. Use calendar filters to reduce visual noise for sports or record types instead; filters change what you see, not the underlying data.
+- **Locking a workout** — there is no per-workout lock against edits or deletion.
+- **True recurring workouts** — there is no ongoing repeat rule. You can duplicate a week in the Plan Architect when building a blueprint, and coaches can drag-copy a single planned workout to another athlete in split view, but both create an independent one-time copy rather than a recurring series.
+
 ## Common mistakes
 
 - Dropping a planned workout onto another planned workout does not merge completed activities.

--- a/content/documentation/1.athletes/26.structured-workouts.md
+++ b/content/documentation/1.athletes/26.structured-workouts.md
@@ -85,6 +85,10 @@ Wait for background generation to finish (Chat or plan generation can run asynch
 
 Check start time and sport, unlink a wrong match, then use **Link Workouts**. Very short or manually created activities may need a manual link.
 
+### Stream data (power/HR/GPS) is wrong or incomplete after import
+
+There is no in-place "re-import" action for an existing workout's streams. Delete the workout, then either let the next sync from the source integration re-ingest it or upload a corrected `.fit` file via **Dashboard → Upload**. If the same session arrives twice afterward, resolve it with [Duplicate Workouts & Versions](/documentation/athletes/duplicate-workouts) instead of keeping both copies.
+
 ## Related guides
 
 - [Workout, Exercise & Plan Libraries](/documentation/athletes/library)

--- a/content/documentation/2.coaches/5.coach-library.md
+++ b/content/documentation/2.coaches/5.coach-library.md
@@ -22,7 +22,7 @@ Workout and plan libraries support folders, search, bulk movement, and item prev
 3. Set the sport, structure, targets, and descriptive fields supported by that editor.
 4. Save it and place it in a folder if needed.
 
-Plan blueprints can be edited in the Plan Architect, where you manage blocks, weeks, workouts, public details, and publication options.
+Plan blueprints can be edited in the Plan Architect, where you manage blocks, weeks, workouts, public details, and publication options. **Duplicate week** copies a week's workouts into the next slot so you can quickly build out a repeating block — it is a one-time copy of that week, not an ongoing recurrence rule, so later edits to one week do not propagate to weeks duplicated from it.
 
 ## Plan visibility
 

--- a/content/documentation/4.help/1.faq.md
+++ b/content/documentation/4.help/1.faq.md
@@ -36,6 +36,31 @@ See [Duplicate Workouts & Versions](/documentation/athletes/duplicate-workouts) 
 
 Use **Dashboard → Upload** or **Workouts → Upload** to submit a `.fit` file.
 
+### Can I re-import or fix a workout's stream data in place?
+
+There is no dedicated "re-import" action that refreshes an existing workout's power/HR/GPS streams while keeping the same record. If a file imported with bad or incomplete stream data:
+
+1. Open the workout and delete it (this also removes the stored file behind it).
+2. Either wait for the next sync from the source integration to re-ingest the activity, or upload the corrected `.fit` file again via **Dashboard → Upload**.
+3. If the source re-delivers the same session a second time, resolve it with [Duplicate Workouts & Versions](/documentation/athletes/duplicate-workouts) rather than keeping both.
+
+### Does Coach Watts have keyboard shortcuts?
+
+Press <kbd>Cmd</kbd>+<kbd>K</kbd> (Mac) or <kbd>Ctrl</kbd>+<kbd>K</kbd> (Windows/Linux) to open documentation search from any docs page. There are no additional keyboard shortcuts today for the Activities calendar, workout editor, or Chat.
+
+### Can I hide or lock a workout?
+
+Not as a saved property on the workout itself. Two related controls exist instead: calendar **filters** let you hide sports or record types you don't want to see in the current view, and the workout detail page's section toolbar lets you hide or reorder which _sections_ (map, streams, and so on) display for that workout. Neither one hides a workout from other views or locks it against edits.
+
+### Can I make a workout repeat automatically every week?
+
+Coach Watts does not have true recurring workouts (an ongoing rule that keeps generating future sessions). The closest tools are one-time copies:
+
+- In the **Plan Architect**, **Duplicate week** copies a week's workouts into the next slot when you're building a blueprint.
+- In the coaching calendar's split view, dragging a planned workout into another athlete's lane copies it once to that athlete and day.
+
+Both create an independent copy — editing or completing one instance does not affect any other.
+
 ## AI coaching
 
 ### How is the AI coach different from ChatGPT?


### PR DESCRIPTION
Fixes CW-101

Verified the four remaining 325h "depth" items directly against current code (Prisma schema, server API routes, and app components) rather than assuming — see findings below — and updated docs to state actual behavior instead of leaving them undocumented/ambiguous.

## Per-item findings

**1. Workout stream re-import** — Not supported as a standalone action. Checked `server/api/workouts/[id].delete.ts` and grepped for reimport/reupload endpoints: no route re-processes an existing workout's stored streams in place. The only paths are (a) delete the workout (cascades to delete the `FitFile` row) then let the source integration re-sync it or re-upload a `.fit` file, or (b) resolve a re-delivered duplicate via the existing Deduplicate flow. Documented this exact workflow in the FAQ and in Structured Workouts' troubleshooting section.

**2. Keyboard shortcuts** — Only one exists: `Cmd/Ctrl+K` opens documentation search (`app/components/docs/DocsSearch.vue`, `defineShortcuts`). Grepped the whole app for `keydown`/`useMagicKeys`/`defineShortcuts`; found nothing for the Activities calendar, workout editor, or Chat pages beyond a mobile-only Enter-as-newline behavior in `ChatInput.vue`. Documented the one real shortcut and stated plainly that no others exist yet.

**3. Hiding/locking workouts** — No `isHidden`/`isLocked` (or equivalent) field on `Workout` or `PlannedWorkout` in `prisma/schema.prisma`. The feature does not exist. What does exist and is easily confused with it: calendar view filters (hide sport/record types from the current view) and the workout detail page's section-visibility toggle (hides which *sections* of one workout's page render). Documented the distinction and that no true hide/lock exists.

**4. True recurring workouts** — No recurrence/RRULE field on `PlannedWorkout`. The closest things are one-time copy actions: Plan Architect's `duplicateWeek` (`app/composables/usePlanArchitect.ts`) clones a week's workouts into the next slot when building a blueprint, and the coaching calendar's split view lets a coach drag-copy a single planned workout into another athlete's lane (`app/pages/coaching/calendar.vue`). Neither creates an ongoing rule — confirmed both are independent, one-time clones with no linkage back to the source. Documented this clearly as "not true recurrence."

## Docs changed
- `content/documentation/4.help/1.faq.md` — added FAQ entries for all four items
- `content/documentation/1.athletes/26.structured-workouts.md` — added a troubleshooting entry for bad/incomplete stream data
- `content/documentation/1.athletes/19.activity-management.md` — added a "Hiding, locking, and repeating workouts" section stating what is and isn't supported
- `content/documentation/2.coaches/5.coach-library.md` — clarified that Plan Architect's "Duplicate week" is a one-time copy, not recurrence

No new guide pages were needed, so no documentation index files required new links — the edited pages were already linked from `content/documentation/1.athletes/index.md`, `2.coaches/index.md`, and `4.help/index.md`.

## Verification
`pnpm typecheck` passes cleanly (exit 0, no errors) — expected, since only markdown content changed.