### PR TITLE
fix(email): fix idempotency P2002 detection under driver-adapter error shape (CW-227)

### DIFF
--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -88,6 +88,24 @@ function classifyResendError(error: {
   })
 }
 
+/**
+ * Extracts the list of column names involved in a P2002 unique-constraint
+ * violation. The shape of `PrismaClientKnownRequestError.meta` differs
+ * depending on which query engine produced the error:
+ * - Classic engine: `error.meta.target` is the field list directly.
+ * - Driver adapter engine (this app uses `@prisma/adapter-pg`, see
+ *   server/utils/db.ts): `meta.target` does not exist. Prisma instead
+ *   constructs the error as `new PrismaClientKnownRequestError(message, code,
+ *   { driverAdapterError: originalError })`, so the field list is nested at
+ *   `meta.driverAdapterError.cause.constraint.fields` (verified against
+ *   @prisma/client 7.8.0's runtime: `Ge()`/`Tn()` in runtime/client.js).
+ * Check both shapes defensively in case any code path in this app ever
+ * produces a classic-engine-shaped error.
+ */
+function getUniqueConstraintFields(dbError: any): string[] | undefined {
+  return dbError?.meta?.target ?? dbError?.meta?.driverAdapterError?.cause?.constraint?.fields
+}
+
 export const EmailDeliveryService = {
   /**
    * Dispatches a queued or failed email delivery record via Resend.
@@ -357,7 +375,10 @@ export const EmailDeliveryService = {
         }
       })
     } catch (dbError: any) {
-      if (dbError.code === 'P2002' && dbError.meta?.target?.includes('idempotencyKey')) {
+      if (
+        dbError.code === 'P2002' &&
+        getUniqueConstraintFields(dbError)?.includes('idempotencyKey')
+      ) {
         const existing = dedupeKey
           ? await prisma.emailDelivery.findUnique({ where: { idempotencyKey: dedupeKey } })
           : null

--- a/tests/unit/trigger/send-email.test.ts
+++ b/tests/unit/trigger/send-email.test.ts
@@ -114,15 +114,30 @@ describe('sendEmailTask', () => {
     )
   })
 
-  it('should skip as a true duplicate when the colliding delivery already sent successfully', async () => {
+  it('should skip as a true duplicate when the colliding delivery already sent successfully (driver-adapter error shape)', async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
     vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)
 
+    // This app uses @prisma/adapter-pg (server/utils/db.ts). Under that
+    // driver-adapter engine, PrismaClientKnownRequestError does NOT have
+    // `meta.target` - the field list is nested at
+    // `meta.driverAdapterError.cause.constraint.fields` instead (see
+    // getUniqueConstraintFields in emailDeliveryService.ts). This mock
+    // mirrors that real shape so the guard is tested against reality, not
+    // just the classic-engine shape.
     const dbError = {
       code: 'P2002',
-      meta: { target: ['idempotencyKey'] },
-      message: 'Unique constraint failed'
+      meta: {
+        driverAdapterError: {
+          name: 'DriverAdapterError',
+          cause: {
+            kind: 'UniqueConstraintViolation',
+            constraint: { fields: ['idempotencyKey'] }
+          }
+        }
+      },
+      message: 'Unique constraint failed on the fields: (`idempotencyKey`)'
     }
 
     vi.mocked(prisma.emailDelivery.create).mockRejectedValue(dbError)
@@ -151,6 +166,10 @@ describe('sendEmailTask', () => {
     // the row is still FAILED, not SENT. The retry must resume dispatch
     // against that same row instead of treating it as an already-handled
     // duplicate (which would silently drop the email, the original bug).
+    //
+    // This mock intentionally uses the classic-engine `meta.target` shape
+    // (rather than the driver-adapter shape used elsewhere in this file) so
+    // the guard's fallback for that shape stays covered too.
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any)
     vi.mocked(prisma.emailDelivery.findFirst).mockResolvedValue(null)
     vi.mocked(prisma.emailSuppression.findFirst).mockResolvedValue(null)


### PR DESCRIPTION
Fixes CW-227

## Summary

The idempotency-key duplicate guard in `runSendEmail` checked `dbError.meta?.target?.includes('idempotencyKey')`. This app uses the `@prisma/adapter-pg` driver adapter (`server/utils/db.ts`), and under that engine `PrismaClientKnownRequestError` is constructed as `new PrismaClientKnownRequestError(message, code, { driverAdapterError: originalError })` - there is no `meta.target` in this shape, so the guard's condition was always false and every idempotency-key collision threw instead of being handled by the CW-57 collision-resume logic.

Added `getUniqueConstraintFields(dbError)` which checks both:
- `meta.target` (classic engine shape)
- `meta.driverAdapterError.cause.constraint.fields` (driver-adapter shape)

and used it in the P2002 guard instead of the old `meta.target`-only check.

## What I confirmed about the real error shape

Installed dependencies and inspected the generated `@prisma/client@7.8.0` runtime (`node_modules/.pnpm/@prisma+client@7.8.0.../runtime/client.js`) directly rather than trusting the ticket's diagnosis blindly:

- `Ge(e)` (the driver-adapter error wrapper) does: `throw new N(message, code, { driverAdapterError: e })` where `N` is `PrismaClientKnownRequestError`.
- `hp(e)` maps `e.cause.kind === "UniqueConstraintViolation"` -> code `"P2002"` (so `dbError.code === 'P2002'` was already correct).
- `ds(e)` / `Tn(e)` build the error message from `e.cause.constraint`, and `Tn` checks `"fields" in e.cause.constraint` for the affected column list.

This confirms the ticket's claim exactly: the field list under the driver-adapter path lives at `meta.driverAdapterError.cause.constraint.fields`, not `meta.target`.

## Test changes

- Updated the "true duplicate" test in `tests/unit/trigger/send-email.test.ts` to mock a realistic driver-adapter-shaped `dbError` (`meta.driverAdapterError.cause.constraint.fields`).
- Kept the "resume dispatch" and "default idempotency key" tests on the classic `meta.target` shape, with a comment explaining why, so both shapes stay covered.
- Did not touch the CW-57 collision-resume logic (existing-row lookup, `ALREADY_DISPATCHED_STATUSES` check, resume-vs-skip branching) - only the detection guard feeding into it.

## Verification

- `pnpm test:unit tests/unit/trigger/send-email.test.ts` - 11/11 passed
- `pnpm typecheck` - passed, no errors