### PR TITLE
fix(auth): require workout:write scope on orchestrate progress endpoint (CW-233)

### DIFF
--- a/server/api/orchestrate/progress.get.ts
+++ b/server/api/orchestrate/progress.get.ts
@@ -22,8 +22,12 @@ defineRouteMeta({
 })
 
 export default defineEventHandler(async (event) => {
+  // Require the same scope as full-sync.post.ts (which starts the sync this
+  // endpoint reports progress for) — workout:write and workout:read are
+  // independent OAuth scopes in this codebase, so a client authorized to
+  // start a full sync must also be authorized to poll its progress.
   // Use the same user.id key as full-sync.post.ts stores in activeSyncs
-  const user = await requireAuth(event)
+  const user = await requireAuth(event, ['workout:write'])
   const userId = user.id
 
   // Set SSE headers

--- a/tests/unit/server/api/orchestrate/progress.get.test.ts
+++ b/tests/unit/server/api/orchestrate/progress.get.test.ts
@@ -101,7 +101,7 @@ describe('GET /api/orchestrate/progress', () => {
         'task-a': { taskId: 'task-a', status: 'running' }
       }
     })
-    expect(requireAuth).toHaveBeenCalledWith(event)
+    expect(requireAuth).toHaveBeenCalledWith(event, ['workout:write'])
   })
 
   it('returns no_sync when no entry exists for user.id', async () => {
@@ -121,5 +121,21 @@ describe('GET /api/orchestrate/progress', () => {
       type: 'no_sync',
       message: 'No active sync in progress'
     })
+  })
+
+  it('rejects a validly-authenticated token missing the workout:write scope', async () => {
+    const forbidden = Object.assign(
+      new Error('Insufficient permissions. Required scopes: workout:write'),
+      { statusCode: 403 }
+    )
+    vi.mocked(requireAuth).mockRejectedValue(forbidden)
+
+    const handler = await getHandler()
+
+    await expect(handler(createMockEvent() as any)).rejects.toMatchObject({
+      statusCode: 403,
+      message: 'Insufficient permissions. Required scopes: workout:write'
+    })
+    expect(requireAuth).toHaveBeenCalledWith(expect.anything(), ['workout:write'])
   })
 })


### PR DESCRIPTION
Fixes CW-233

## Summary
- `server/api/orchestrate/progress.get.ts` called `requireAuth(event)` with no scope requirement, while its sibling `server/api/orchestrate/full-sync.post.ts` (which starts the sync this endpoint reports progress for) requires `workout:write`. Any validly-authenticated OAuth token, regardless of scope, could poll sync progress.
- Added the same `workout:write` requirement to `progress.get.ts`, matching `full-sync.post.ts`.
- `workout:write` and `workout:read` are independent scopes in this codebase's taxonomy (`server/utils/oauth/scopes.ts`). Since this endpoint only ever reports on a sync started via `full-sync.post.ts` (which requires `workout:write`), reusing `workout:write` here (rather than the existing `workout:read` scope) keeps the two endpoints' access requirements aligned and avoids breaking clients that can start a sync but weren't granted `workout:read`.
- Not a cross-user data leak — progress is correctly keyed by `user.id` per the earlier CW-8/CW-56 fix. This is a least-privilege / consistency cleanup.

## Changes
- `server/api/orchestrate/progress.get.ts`: `requireAuth(event)` → `requireAuth(event, ['workout:write'])`
- `tests/unit/server/api/orchestrate/progress.get.test.ts`: updated the existing CW-8 regression test's `requireAuth` call assertion to include the scope array, and added a new test asserting a token lacking `workout:write` is rejected with 403.

## Verification
```
$ pnpm test:unit tests/unit/server/api/orchestrate/progress.get.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ pnpm typecheck
(exit 0, no errors)
```