### PR TITLE
fix(security): convert wellness/training-plan share sanitizers to allowlist (CW-232)

### DIFF
--- a/server/utils/share-response.ts
+++ b/server/utils/share-response.ts
@@ -54,37 +54,50 @@ export function sanitizeSharedPlannedWorkout(
   }
 }
 
-/** Fields safe for unauthenticated WELLNESS share pages (metrics + AI summary). */
-export function sanitizeSharedWellness(wellness: Record<string, unknown>) {
-  const {
-    userId: _userId,
-    rawJson: _rawJson,
-    comments: _comments,
-    history: _history,
-    lastSource: _lastSource,
-    feedback: _feedback,
-    feedbackText: _feedbackText,
-    customMetrics: _customMetrics,
-    aiAnalysis: _aiAnalysis,
-    aiAnalysisStatus: _aiAnalysisStatus,
-    aiAnalyzedAt: _aiAnalyzedAt,
-    // Clinical / sensitive biometrics not shown on the public share page
-    bloodGlucose: _bloodGlucose,
-    diastolic: _diastolic,
-    systolic: _systolic,
-    injury: _injury,
-    menstrualPhase: _menstrualPhase,
-    lactate: _lactate,
-    abdomen: _abdomen,
-    bodyFat: _bodyFat,
-    hydration: _hydration,
-    hydrationVolume: _hydrationVolume,
-    skinTemp: _skinTemp,
-    tags: _tags,
-    ...safe
-  } = wellness
+const SHARED_WELLNESS_FIELDS = [
+  'id',
+  'date',
+  'hrv',
+  'hrvSdnn',
+  'restingHr',
+  'avgSleepingHr',
+  'sleepSecs',
+  'sleepHours',
+  'sleepScore',
+  'sleepQuality',
+  'sleepDeepSecs',
+  'sleepRemSecs',
+  'sleepLightSecs',
+  'sleepAwakeSecs',
+  'readiness',
+  'recoveryScore',
+  'soreness',
+  'fatigue',
+  'stress',
+  'mood',
+  'motivation',
+  'weight',
+  'spO2',
+  'ctl',
+  'atl',
+  'tsb',
+  'createdAt',
+  'updatedAt',
+  'respiration',
+  'vo2max',
+  'restingCaloriesBurned',
+  'activeCaloriesBurned',
+  'totalCaloriesBurned',
+  'steps',
+  'distanceMeters',
+  'exerciseMinutes',
+  'floors',
+  'aiAnalysisJson'
+] as const
 
-  return safe
+/** Allowlisted fields safe for unauthenticated WELLNESS share pages (metrics + AI summary). */
+export function sanitizeSharedWellness(wellness: Record<string, unknown>) {
+  return pickFields(wellness, SHARED_WELLNESS_FIELDS)
 }
 
 const SHARED_REPORT_FIELDS = [
@@ -148,25 +161,50 @@ function sanitizeSharedPlanGoal(goal: unknown) {
   return title === undefined ? null : { title }
 }
 
+const SHARED_TRAINING_PLAN_FIELDS = [
+  'id',
+  'goalId',
+  'startDate',
+  'targetDate',
+  'strategy',
+  'status',
+  'currentBlockId',
+  'createdAt',
+  'updatedAt',
+  'description',
+  'isTemplate',
+  'isPublic',
+  'slug',
+  'visibility',
+  'accessState',
+  'primarySport',
+  'sportSubtype',
+  'difficulty',
+  'skillLevel',
+  'planLanguage',
+  'daysPerWeek',
+  'weeklyVolumeBand',
+  'goalLabel',
+  'equipmentTags',
+  'publicHeadline',
+  'publicDescription',
+  'methodology',
+  'whoItsFor',
+  'faq',
+  'extraContent',
+  'isFeatured',
+  'name',
+  'activityTypes',
+  'recoveryRhythm'
+] as const
+
 /**
  * Sanitize TRAINING_PLAN rows returned by GET /api/share/[token].
  * Primary UI uses /api/public/plans/access/[token]; this path still must not
  * leak userId, private notes, or sync/internal workout fields.
  */
 export function sanitizeSharedTrainingPlan(plan: Record<string, unknown>) {
-  const {
-    userId: _userId,
-    teamId: _teamId,
-    folderId: _folderId,
-    coachNotes: _coachNotes,
-    athleteNotes: _athleteNotes,
-    customInstructions: _customInstructions,
-    fromTemplateId: _fromTemplateId,
-    hasBeenSavedAsTemplate: _hasBeenSavedAsTemplate,
-    goal,
-    blocks,
-    ...rest
-  } = plan
+  const { goal, blocks } = plan
 
   const sanitizedBlocks = Array.isArray(blocks)
     ? blocks.map((block) => {
@@ -191,7 +229,7 @@ export function sanitizeSharedTrainingPlan(plan: Record<string, unknown>) {
     : blocks
 
   return {
-    ...rest,
+    ...pickFields(plan, SHARED_TRAINING_PLAN_FIELDS),
     goal: sanitizeSharedPlanGoal(goal),
     blocks: sanitizedBlocks
   }

--- a/tests/unit/server/api/share/share-response-sanitize.test.ts
+++ b/tests/unit/server/api/share/share-response-sanitize.test.ts
@@ -66,6 +66,25 @@ describe('share response sanitizers (CW-147)', () => {
     }
   })
 
+  it('excludes a hypothetical future Wellness field not present in the allowlist', () => {
+    // Simulates a new column being added to the Prisma Wellness model in the
+    // future. Because sanitizeSharedWellness is allowlist-based, an unknown
+    // field must be dropped by default instead of leaking automatically.
+    const result = sanitizeSharedWellness({
+      id: 'wellness-2',
+      date: '2026-07-29',
+      recoveryScore: 90,
+      futureClinicalMetric: 'super-secret-future-field'
+    })
+
+    expect(result).toEqual({
+      id: 'wellness-2',
+      date: '2026-07-29',
+      recoveryScore: 90
+    })
+    expect(result).not.toHaveProperty('futureClinicalMetric')
+  })
+
   it('allowlists REPORT / ATHLETE_PROFILE fields and drops private ones', () => {
     const analysisJson = {
       title: 'Athlete Profile',
@@ -216,5 +235,26 @@ describe('share response sanitizers (CW-147)', () => {
     expect(workout).not.toHaveProperty('syncStatus')
     expect(workout).not.toHaveProperty('externalId')
     expect(workout).not.toHaveProperty('lastGenerationContext')
+  })
+
+  it('excludes a hypothetical future TrainingPlan field not present in the allowlist', () => {
+    // Simulates a new column being added to the Prisma TrainingPlan model in
+    // the future. Because sanitizeSharedTrainingPlan is allowlist-based, an
+    // unknown top-level field must be dropped by default instead of leaking.
+    const result = sanitizeSharedTrainingPlan({
+      id: 'plan-2',
+      name: 'Peak Block',
+      internalBillingTier: 'super-secret-future-field',
+      goal: null,
+      blocks: []
+    })
+
+    expect(result).toEqual({
+      id: 'plan-2',
+      name: 'Peak Block',
+      goal: null,
+      blocks: []
+    })
+    expect(result).not.toHaveProperty('internalBillingTier')
   })
 })


### PR DESCRIPTION
Fixes CW-232

## Summary
- `sanitizeSharedWellness` and the top-level field handling in `sanitizeSharedTrainingPlan` in `server/utils/share-response.ts` previously used a denylist (destructure-and-omit) pattern, inconsistent with the allowlist (`pickFields`) pattern used everywhere else in this file (`sanitizeSharedReport`, `sanitizeSharedPlanWorkout`).
- This was a defense-in-depth gap: a future field added to the `Wellness` or `TrainingPlan` Prisma models would be included in public share payloads by default, until someone remembered to add it to the denylist.
- Both sanitizers now use `pickFields` with new `SHARED_WELLNESS_FIELDS` / `SHARED_TRAINING_PLAN_FIELDS` allowlist arrays, built directly from the Prisma schema (`prisma/schema.prisma`) cross-referenced against the CURRENT denylist behavior — every field the old denylist did *not* already exclude is now explicitly allowlisted, so no previously-shared field is newly hidden and no previously-hidden field is newly exposed.
- The nested `goal`/`blocks` handling in `sanitizeSharedTrainingPlan` (which already used allowlist-based `sanitizeSharedPlanWorkout`/`sanitizeSharedPlanGoal`) is unchanged.
- No known current exploit; this is a hardening item per CW-232.

## Test plan
- Added a regression test per sanitizer: a hypothetical new/unknown field (simulating a future Prisma schema addition) is excluded from sanitized output by default.
- All existing tests in `tests/unit/server/api/share/share-response-sanitize.test.ts` still pass unmodified in behavior (assertions on denylisted fields still hold since the new allowlists exclude the same fields).

## Verification
```
$ pnpm test:unit tests/unit/server/api/share/share-response-sanitize.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ pnpm typecheck
(exit code 0, no errors)
```