### PR TITLE
fix(integrations): handle Withings rate-limit status 601 (CW-228)

### DIFF
--- a/server/utils/withings.ts
+++ b/server/utils/withings.ts
@@ -103,6 +103,30 @@ export const WITHINGS_MEASURE_TYPES = {
 }
 
 /**
+ * Withings-documented status code for "Too Many Requests" (application temporarily
+ * rate-limited). https://developer.withings.com/api-reference/#section/Response-status
+ */
+const WITHINGS_RATE_LIMIT_STATUS = 601
+
+/**
+ * Throws a retryable IntegrationProviderError when the Withings body-level status
+ * indicates the app has been rate-limited. Trigger.dev's task-level retry config
+ * (see trigger.config.ts) will back off and retry automatically, and the global
+ * onFailure hook (trigger/init.ts) suppresses Sentry reporting until the final
+ * attempt via shouldReportIntegrationErrorToSentry.
+ */
+function throwIfWithingsRateLimited(status: number, integrationId: string): void {
+  if (status === WITHINGS_RATE_LIMIT_STATUS) {
+    throw new IntegrationProviderError({
+      provider: 'withings',
+      integrationId,
+      statusCode: status,
+      message: `Withings API rate limit exceeded (Status ${status})`
+    })
+  }
+}
+
+/**
  * Refreshes an expired Withings access token using the refresh token
  */
 export async function refreshWithingsToken(integration: Integration): Promise<Integration> {
@@ -244,6 +268,8 @@ export async function fetchWithingsMeasures(
   const data: WithingsMeasureResponse = await response.json()
 
   if (data.status !== 0) {
+    throwIfWithingsRateLimited(data.status, validIntegration.id)
+
     // 401: Invalid access token
     if (data.status === 401) {
       console.log('[Withings] Token invalid (401), attempting refresh...')
@@ -254,6 +280,7 @@ export async function fetchWithingsMeasures(
       const retryData: WithingsMeasureResponse = await retryResponse.json()
 
       if (retryData.status !== 0) {
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
 
@@ -300,6 +327,8 @@ export async function fetchWithingsActivities(
   const data: WithingsActivityResponse = await response.json()
 
   if (data.status !== 0) {
+    throwIfWithingsRateLimited(data.status, validIntegration.id)
+
     // 401: Invalid access token
     if (data.status === 401) {
       console.log('[Withings] Token invalid (401), attempting refresh...')
@@ -310,6 +339,7 @@ export async function fetchWithingsActivities(
       const retryData: WithingsActivityResponse = await retryResponse.json()
 
       if (retryData.status !== 0) {
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
 
@@ -502,13 +532,17 @@ export async function fetchWithingsWorkouts(
   const data: WithingsWorkoutResponse = await response.json()
 
   if (data.status !== 0) {
+    throwIfWithingsRateLimited(data.status, validIntegration.id)
+
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
       const retryResponse = await fetch(url.toString())
       const retryData: WithingsWorkoutResponse = await retryResponse.json()
-      if (retryData.status !== 0)
+      if (retryData.status !== 0) {
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
+      }
       return retryData.body.series || []
     }
     throw new Error(`Withings API error: Status ${data.status}`)
@@ -545,13 +579,17 @@ export async function fetchWithingsIntraday(
   const data: any = await response.json()
 
   if (data.status !== 0) {
+    throwIfWithingsRateLimited(data.status, validIntegration.id)
+
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
       const retryResponse = await fetch(url.toString())
       const retryData: any = await retryResponse.json()
-      if (retryData.status !== 0)
+      if (retryData.status !== 0) {
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
+      }
       // Return raw series object (keys are timestamps)
       return retryData.body.series || {}
     }
@@ -712,13 +750,17 @@ export async function fetchWithingsSleep(
   const data: WithingsSleepResponse = await response.json()
 
   if (data.status !== 0) {
+    throwIfWithingsRateLimited(data.status, validIntegration.id)
+
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
       const retryResponse = await fetch(url.toString())
       const retryData: WithingsSleepResponse = await retryResponse.json()
-      if (retryData.status !== 0)
+      if (retryData.status !== 0) {
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
+      }
       return retryData.body.series || []
     }
     throw new Error(`Withings API error: Status ${data.status}`)

--- a/tests/unit/server/utils/withings.test.ts
+++ b/tests/unit/server/utils/withings.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fetchWithingsActivities,
+  fetchWithingsIntraday,
+  fetchWithingsMeasures,
+  fetchWithingsSleep,
+  fetchWithingsWorkouts
+} from '../../../../server/utils/withings'
+import { IntegrationProviderError } from '../../../../server/utils/integration-errors'
+
+// A token that is not expired so ensureValidToken() never needs to hit the DB.
+const integration = {
+  id: 'integration-withings-rate-limit',
+  accessToken: 'valid-token',
+  refreshToken: 'valid-refresh-token',
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000)
+} as any
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+describe('Withings status 601 (rate limit)', () => {
+  it('fetchWithingsMeasures throws a retryable IntegrationProviderError, not a generic Error', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+
+    const error = await fetchWithingsMeasures(
+      integration,
+      new Date('2024-01-01'),
+      new Date('2024-01-02')
+    ).catch((err) => err)
+
+    expect(error).toBeInstanceOf(IntegrationProviderError)
+    expect(error).toMatchObject({
+      name: 'IntegrationProviderError',
+      provider: 'withings',
+      integrationId: integration.id,
+      statusCode: 601,
+      retryable: true
+    })
+  })
+
+  it('fetchWithingsActivities throws a retryable IntegrationProviderError on status 601', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+
+    await expect(
+      fetchWithingsActivities(integration, new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toBeInstanceOf(IntegrationProviderError)
+  })
+
+  it('fetchWithingsWorkouts throws a retryable IntegrationProviderError on status 601', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+
+    await expect(
+      fetchWithingsWorkouts(integration, new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toBeInstanceOf(IntegrationProviderError)
+  })
+
+  it('fetchWithingsIntraday throws a retryable IntegrationProviderError on status 601', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+
+    await expect(
+      fetchWithingsIntraday(integration, new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toBeInstanceOf(IntegrationProviderError)
+  })
+
+  it('fetchWithingsSleep throws a retryable IntegrationProviderError on status 601', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+
+    await expect(
+      fetchWithingsSleep(integration, new Date('2024-01-01'), new Date('2024-01-02'))
+    ).rejects.toBeInstanceOf(IntegrationProviderError)
+  })
+
+  it('still throws a plain Error for other non-zero, non-rate-limit statuses', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 100, body: {} }))
+
+    const error = await fetchWithingsMeasures(
+      integration,
+      new Date('2024-01-01'),
+      new Date('2024-01-02')
+    ).catch((err) => err)
+
+    expect(error).not.toBeInstanceOf(IntegrationProviderError)
+    expect(String(error.message)).toContain('Status 100')
+  })
+})


### PR DESCRIPTION
Fixes CW-228

## Problem
`server/utils/withings.ts` only special-cased HTTP-body status `401` (token refresh) before retrying. Every other non-zero Withings body-level status — including `601`, Withings' documented "Too Many Requests" / rate-limit code — fell through to an unconditional `throw new Error(...)`, which crashed straight to Sentry instead of being treated as a transient condition.

This affected all 5 fetch functions in the file: `fetchWithingsMeasures`, `fetchWithingsActivities`, `fetchWithingsWorkouts`, `fetchWithingsIntraday`, `fetchWithingsSleep` (both the initial request and the post-401-refresh retry path in each).

## Fix
Added a `throwIfWithingsRateLimited()` helper that raises the existing `IntegrationProviderError` (`retryable = true`) when status is `601`, mirroring the existing `401` branch's structure at all 5 call sites.

This reuses infrastructure already established in this codebase rather than inventing a new mechanism:
- `IntegrationProviderError` is already used in this same file (503/5xx during token refresh) and in `oura.ts` / `whoop.ts` / `ultrahuman.ts` for 5xx errors.
- Trigger.dev's task-level retry config (`trigger.config.ts`: `maxAttempts: 3`, exponential backoff 1s–10s) already wraps `ingest-withings.ts` and will retry automatically — no in-function retry loop needed.
- The global `tasks.onFailure` hook (`trigger/init.ts`) calls `shouldReportIntegrationErrorToSentry(error, ctx.attempt?.number, ctx.run.maxAttempts)`, which suppresses Sentry reporting until the final retry attempt is exhausted.

So a 601 now: gets retried automatically by the Trigger.dev task runner with backoff, and only reaches Sentry if it's still failing after the last retry attempt — instead of always crashing to Sentry on the first hit.

## Out of scope
`refreshWithingsToken()` (same file) currently groups `601` together with `401` as an unrecoverable auth failure (marks the integration `FAILED`, tells the user to reconnect). That's arguably a related bug — a rate limit during token refresh shouldn't be treated as "refresh token revoked" — but it's a different code path (already branches explicitly, doesn't hit the generic throw) and changing it affects auth-revocation UX, so I left it untouched to keep this fix scoped to the ticket's described root cause. Worth a follow-up ticket if desired.

## Verification
- Added `tests/unit/server/utils/withings.test.ts`: 6 tests covering all 5 fetch functions receiving status 601 (asserting `IntegrationProviderError` with `retryable: true`, `statusCode: 601`), plus one test confirming other non-zero/non-601 statuses still throw a plain `Error` (regression guard for existing behavior).
- `pnpm vitest run tests/unit/server/utils/withings.test.ts tests/unit/server/utils/withings-notifications.test.ts` → 2 files, 12 tests, all passed.
- `pnpm typecheck` → passed with no errors.
- `pnpm exec eslint server/utils/withings.ts tests/unit/server/utils/withings.test.ts` → clean.