### PR TITLE
fix(workouts): render elevation/climb/ascent in feet for Miles athletes (CW-201)

### DIFF
--- a/app/components/ActivityFeedCard.vue
+++ b/app/components/ActivityFeedCard.vue
@@ -183,11 +183,11 @@
             <div class="flex items-baseline gap-1 truncate">
               <span
                 class="text-xl sm:text-2xl font-black text-black dark:text-white tabular-nums"
-                >{{ workout.elevationGain }}</span
+                >{{ elevationGainValue(workout.elevationGain) }}</span
               >
               <span
                 class="text-[9px] font-bold text-zinc-600 dark:text-zinc-500 uppercase opacity-65"
-                >m</span
+                >{{ elevationUnitLabel }}</span
               >
             </div>
           </div>
@@ -271,8 +271,10 @@
 
 <script setup lang="ts">
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
+  import { convertElevation, getElevationUnitLabel } from '~/utils/metrics'
 
   const { formatDateTime } = useFormat()
+  const userStore = useUserStore()
 
   const props = defineProps<{
     workout: any
@@ -289,6 +291,14 @@
     if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`
     return `${m}:${s.toString().padStart(2, '0')}`
   }
+
+  function elevationGainValue(meters: number): number {
+    return Math.round(convertElevation(meters, userStore.profile?.distanceUnits || 'Kilometers'))
+  }
+
+  const elevationUnitLabel = computed(() =>
+    getElevationUnitLabel(userStore.profile?.distanceUnits || 'Kilometers')
+  )
 
   function getIntensityColorClass(intensity: number | null, type: 'text' | 'bg' = 'text') {
     const val = intensity || 0

--- a/app/components/WorkoutTimeline.vue
+++ b/app/components/WorkoutTimeline.vue
@@ -117,7 +117,7 @@
     Legend,
     Filler
   } from 'chart.js'
-  import { usesImperialDistance } from '~/utils/metrics'
+  import { convertElevation, getElevationUnitLabel, usesImperialDistance } from '~/utils/metrics'
   import { ensureChartJsAnnotationDefaults, safeChartUpdate } from '~/utils/chartjs-annotation'
 
   // Register Chart.js components
@@ -180,7 +180,12 @@
       })
     }
     if (streamData.value.altitude && streamData.value.altitude.length > 0) {
-      metrics.push({ key: 'altitude', label: 'Altitude', color: 'rgb(34, 197, 94)', unit: 'm' })
+      metrics.push({
+        key: 'altitude',
+        label: 'Altitude',
+        color: 'rgb(34, 197, 94)',
+        unit: getElevationUnitLabel(userStore.profile?.distanceUnits)
+      })
     }
     if (streamData.value.velocity && streamData.value.velocity.length > 0) {
       metrics.push({
@@ -335,6 +340,14 @@
       const divisor = usesImperialDistance(userStore.profile?.distanceUnits) ? 1609.344 : 1000
       return rawDistance.map((value: unknown) =>
         typeof value === 'number' && Number.isFinite(value) ? value / divisor : value
+      )
+    }
+    if (metricKey === 'altitude') {
+      const rawAltitude = streamData.value.altitude || []
+      return rawAltitude.map((value: unknown) =>
+        typeof value === 'number' && Number.isFinite(value)
+          ? convertElevation(value, userStore.profile?.distanceUnits)
+          : value
       )
     }
     if (metricKey === 'targetPower') {

--- a/app/pages/analytics/workout-explorer.vue
+++ b/app/pages/analytics/workout-explorer.vue
@@ -8,6 +8,7 @@
     type WorkoutExplorerVisualType
   } from '~/utils/workout-explorer-presets'
   import { useAnalyticsBus } from '~/composables/useAnalyticsBus'
+  import { formatElevation } from '~/utils/metrics'
 
   type ExplorerSummaryChartType = 'bar' | 'line' | 'combo' | 'radar' | 'scatter'
   type ExplorerStreamField =
@@ -50,6 +51,7 @@
   const router = useRouter()
   const toast = useToast()
   const comparisonStore = useWorkoutComparisonStore()
+  const userStore = useUserStore()
 
   const { data: dashboards, refresh: refreshDashboards } = await useFetch(
     '/api/analytics/dashboards'
@@ -755,8 +757,7 @@
 
   function formatMeters(meters: number | null | undefined) {
     if (meters === null || meters === undefined) return '—'
-    if (Math.abs(meters) >= 1000) return `${(meters / 1000).toFixed(1)} km`
-    return `${Math.round(meters)} m`
+    return formatElevation(meters, userStore.profile?.distanceUnits || 'Kilometers')
   }
 
   function formatLoad(value: number | null | undefined, suffix = 'load') {

--- a/app/pages/workouts/[id]/index.vue
+++ b/app/pages/workouts/[id]/index.vue
@@ -648,11 +648,18 @@
                 >
                 <div class="flex items-baseline gap-1">
                   <span class="text-2xl font-black text-black dark:text-white">{{
-                    workout.elevationGain
+                    Math.round(
+                      convertElevation(
+                        workout.elevationGain,
+                        userStore.profile?.distanceUnits || 'Kilometers'
+                      )
+                    )
                   }}</span>
                   <span
                     class="text-[10px] font-bold text-zinc-400 dark:text-zinc-600 uppercase opacity-50"
-                    >m</span
+                    >{{
+                      getElevationUnitLabel(userStore.profile?.distanceUnits || 'Kilometers')
+                    }}</span
                   >
                 </div>
               </div>
@@ -3734,8 +3741,11 @@
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
   import { metricTooltips } from '~/utils/tooltips'
   import {
+    convertElevation,
     formatDistance as formatDist,
+    formatElevation as formatElev,
     formatTemperature,
+    getElevationUnitLabel,
     getVelocityUnitLabel,
     isRideWorkoutType
   } from '~/utils/metrics'
@@ -4971,7 +4981,7 @@
       metrics.push({
         key: 'elevation',
         label: t.value('metrics_elevation'),
-        value: `${workout.value.elevationGain} m`
+        value: formatElevation(workout.value.elevationGain)
       })
     if (workout.value.kilojoules)
       metrics.push({ key: 'kj', label: 'Work (kJ)', value: `${workout.value.kilojoules} kJ` })
@@ -5167,7 +5177,11 @@
       heartrate: { label: 'Heart Rate', color: '#ef4444', unit: 'bpm' },
       cadence: { label: 'Cadence', color: '#f59e0b', unit: 'rpm' },
       watts: { label: t.value('metrics_avg_power'), color: '#8b5cf6', unit: 'W' },
-      altitude: { label: 'Altitude', color: '#10b981', unit: 'm' },
+      altitude: {
+        label: 'Altitude',
+        color: '#10b981',
+        unit: getElevationUnitLabel(userStore.profile?.distanceUnits || 'Kilometers')
+      },
       latlng: { label: 'GPS', color: '#6366f1', unit: '' },
       grade: { label: 'Grade', color: '#14b8a6', unit: '%' },
       moving: { label: 'Moving', color: '#9ca3af', unit: '' },
@@ -5782,6 +5796,10 @@
 
   function formatDistance(meters: number) {
     return formatDist(meters, userStore.profile?.distanceUnits || 'Kilometers')
+  }
+
+  function formatElevation(meters: number) {
+    return formatElev(meters, userStore.profile?.distanceUnits || 'Kilometers')
   }
 
   function getSourceBadgeClass(source: string) {

--- a/app/pages/workouts/[id]/map.vue
+++ b/app/pages/workouts/[id]/map.vue
@@ -357,7 +357,7 @@
                     @mouseleave="onSplitLeave"
                   >
                     <td class="px-4 py-2.5 text-xs font-black text-gray-900 dark:text-white">
-                      +{{ climb.ascent }}m
+                      +{{ formatElevation(climb.ascent) }}
                     </td>
                     <td
                       class="px-4 py-2.5 text-xs font-medium text-gray-600 dark:text-gray-400 tabular-nums"
@@ -692,7 +692,11 @@
 <script setup lang="ts">
   import { decode } from '@googlemaps/polyline-codec'
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
-  import { formatDistance as formatDist, formatPace as formatPaceShared } from '~/utils/metrics'
+  import {
+    formatDistance as formatDist,
+    formatElevation as formatElev,
+    formatPace as formatPaceShared
+  } from '~/utils/metrics'
 
   import { ref, computed, watch, toRaw, nextTick } from 'vue'
   import draggable from 'vuedraggable'
@@ -814,7 +818,7 @@
       { label: 'NP', value: formatNullableWatts(summary.normalizedPower) },
       { label: 'Avg Power', value: formatNullableWatts(summary.averageWatts) },
       { label: 'Gradient', value: formatNullablePercent(summary.gradientPercent) },
-      { label: 'Elev Gain', value: `${summary.elevationGain || 0}m` },
+      { label: 'Elev Gain', value: formatElevation(summary.elevationGain || 0) },
       { label: 'VAM', value: summary.vam ? `${summary.vam} m/h` : '-' }
     ]
   })
@@ -1519,6 +1523,10 @@
 
   function formatDistance(meters: number) {
     return formatDist(meters, userStore.profile?.distanceUnits || 'Kilometers')
+  }
+
+  function formatElevation(meters: number) {
+    return formatElev(meters, userStore.profile?.distanceUnits || 'Kilometers')
   }
 
   function formatNullableWatts(value: unknown) {

--- a/app/utils/metrics.ts
+++ b/app/utils/metrics.ts
@@ -3,6 +3,7 @@ export const LBS_TO_KG = 0.45359237
 const MPS_TO_KPH = 3.6
 const MPS_TO_MPH = 2.2369362921
 const KM_TO_MILE_PACE_FACTOR = 1.609344
+const METERS_TO_FEET = 3.28084
 
 export interface MetricDefinition {
   label: string
@@ -240,6 +241,38 @@ export function formatTemperature(celsius: number | null | undefined, units: str
 
 export function usesImperialDistance(units: string | null | undefined): boolean {
   return units === 'Miles'
+}
+
+/**
+ * Elevation/climb/ascent units follow the athlete's distance-unit preference
+ * (Kilometers -> meters, Miles -> feet), matching `getVelocityUnitLabel`.
+ */
+export function getElevationUnitLabel(units: string | null | undefined): string {
+  return usesImperialDistance(units) ? 'ft' : 'm'
+}
+
+/**
+ * Convert a raw elevation value (in meters) to the athlete's preferred unit,
+ * without rounding. Useful for chart/stream data where rounding should happen
+ * at render time rather than on the underlying values.
+ */
+export function convertElevation(meters: number, units: string | null | undefined): number {
+  return usesImperialDistance(units) ? meters * METERS_TO_FEET : meters
+}
+
+/**
+ * Format elevation/climb/ascent (given in meters) for display based on the
+ * athlete's distance-unit preference. Mirrors the conversion math in
+ * `server/utils/ai-prompt-format.ts`'s `formatPromptElevation`: elevation
+ * units follow distance units (Kilometers -> meters, Miles -> feet), rounded
+ * to the nearest whole unit.
+ */
+export function formatElevation(
+  meters: number | null | undefined,
+  units: string | null | undefined
+): string {
+  if (meters === null || meters === undefined) return 'N/A'
+  return `${Math.round(convertElevation(meters, units))} ${getElevationUnitLabel(units)}`
 }
 
 export function isRideWorkoutType(type: string | null | undefined): boolean {

--- a/tests/unit/app/metrics.test.ts
+++ b/tests/unit/app/metrics.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  convertElevation,
   convertVelocity,
+  formatElevation,
   formatPace,
   formatVelocity,
+  getElevationUnitLabel,
   getVelocityUnitLabel,
   isRideWorkoutType
 } from '../../../app/utils/metrics'
@@ -61,5 +64,50 @@ describe('formatPace', () => {
     expect(formatPace(undefined, 'Kilometers')).toBe('N/A')
     expect(formatPace(NaN, 'Kilometers')).toBe('N/A')
     expect(formatPace(Infinity, 'Kilometers')).toBe('N/A')
+  })
+})
+
+describe('formatElevation', () => {
+  it('converts to feet and rounds for a Miles-preference athlete', () => {
+    // 100m * 3.28084 = 328.084 -> rounds to 328
+    expect(formatElevation(100, 'Miles')).toBe('328 ft')
+    // 1500m * 3.28084 = 4921.26 -> rounds to 4921
+    expect(formatElevation(1500, 'Miles')).toBe('4921 ft')
+  })
+
+  it('leaves a Kilometers-preference athlete unaffected (existing behavior preserved)', () => {
+    expect(formatElevation(100, 'Kilometers')).toBe('100 m')
+    expect(formatElevation(1500, 'Kilometers')).toBe('1500 m')
+    expect(formatElevation(100, null)).toBe('100 m')
+    expect(formatElevation(100, undefined)).toBe('100 m')
+    expect(formatElevation(100, 'SomethingElse')).toBe('100 m')
+  })
+
+  it('rounds fractional meter values for a Kilometers-preference athlete', () => {
+    expect(formatElevation(123.6, 'Kilometers')).toBe('124 m')
+  })
+
+  it('returns N/A for null/undefined input', () => {
+    expect(formatElevation(null, 'Miles')).toBe('N/A')
+    expect(formatElevation(undefined, 'Kilometers')).toBe('N/A')
+  })
+
+  it('handles zero elevation gain', () => {
+    expect(formatElevation(0, 'Miles')).toBe('0 ft')
+    expect(formatElevation(0, 'Kilometers')).toBe('0 m')
+  })
+})
+
+describe('getElevationUnitLabel / convertElevation', () => {
+  it('labels feet for Miles and meters otherwise', () => {
+    expect(getElevationUnitLabel('Miles')).toBe('ft')
+    expect(getElevationUnitLabel('Kilometers')).toBe('m')
+    expect(getElevationUnitLabel(null)).toBe('m')
+    expect(getElevationUnitLabel(undefined)).toBe('m')
+  })
+
+  it('converts raw meter values without rounding, for chart/stream usage', () => {
+    expect(convertElevation(100, 'Miles')).toBeCloseTo(328.084, 3)
+    expect(convertElevation(100, 'Kilometers')).toBe(100)
   })
 })


### PR DESCRIPTION
Fixes CW-201

## Summary
Elevation/climb/ascent was rendered in meters everywhere in the web UI, regardless of the athlete's imperial/metric preference — unlike distance, speed, weight, height, and temperature, which already respect it. The AI/chat side already had `formatPromptElevation` (server/utils/ai-prompt-format.ts) doing this correctly; this PR adds an equivalent for the web UI and migrates every hardcoded-meters display site.

- Added `formatElevation` / `convertElevation` / `getElevationUnitLabel` to `app/utils/metrics.ts`, mirroring `formatPromptElevation`'s conversion math (meters -> feet, rounded, for `'Miles'` preference; meters otherwise).
- Migrated:
  - `app/components/ActivityFeedCard.vue` — elevation gain stat
  - `app/pages/workouts/[id]/index.vue` — elevation gain stat, metrics-list "Elevation" entry, and altitude stream chart metadata (unit label)
  - `app/pages/workouts/[id]/map.vue` — climb ascent table and selected-segment "Elev Gain"
  - `app/pages/analytics/workout-explorer.vue` — `formatMeters` (elevation gain), now delegates to the shared helper instead of its own km/m-only auto-scaling
  - `app/components/WorkoutTimeline.vue` — altitude stream metadata unit label *and* the actual converted values (this component does its own stream rendering/conversion, unlike `index.vue`'s stream metadata which is only display metadata consumed by `StreamChartModal.vue`)

### Notes on scope / discrepancies vs. the ticket text
- `tests/unit/app/utils/metrics.test.ts` doesn't exist; the real test file for `app/utils/metrics.ts` is `tests/unit/app/metrics.test.ts` — extended that one instead.
- `map.vue:370` (from the ticket) is `{{ formatDistance(climb.distance) }}`, not an elevation site — the file has shifted since the ticket was written. The two real elevation sites in that file (climb ascent, elev gain) are both fixed.
- `workouts/[id]/index.vue`'s altitude stream metadata (`streamMetadata` dict, ~line 5178) only updates the **unit label**, matching exactly how the adjacent `temp` entry in the same dict already behaves (label only — the actual value conversion for that stream happens in `StreamChartModal.vue`, which is not in CW-201's owned paths and doesn't currently convert temperature either). Filed a follow-up suggestion for that gap rather than expanding this PR's scope.
- Left `sessionSummary.totalAscent`/`totalDescent` (FIT-import metrics, same file, ~lines 5073-5087) hardcoded to meters — not among the ticket's listed line locations/acceptance criteria, so out of scope here; flagged separately.

## Verification
```
$ pnpm vitest run tests/unit/app/metrics.test.ts
 Test Files  1 passed (1)
      Tests  16 passed (16)
```
`pnpm typecheck` — passes cleanly (exit 0, no errors).
`pnpm eslint` and `pnpm exec prettier --check` — clean on all changed files.

## Test plan
- [x] `pnpm vitest run tests/unit/app/metrics.test.ts` passes (16/16, including new `formatElevation`/`convertElevation`/`getElevationUnitLabel` coverage for Miles and Kilometers preferences)
- [x] `pnpm typecheck` passes
- [x] `pnpm eslint` + `pnpm exec prettier --check` clean on all changed files