### PR TITLE
fix(auth): always refresh session in onboarding.global.ts (CW-231)

### DIFF
--- a/app/middleware/onboarding.global.ts
+++ b/app/middleware/onboarding.global.ts
@@ -4,9 +4,13 @@ import { sanitizeCallbackUrl } from '#shared/safe-callback-url'
 export default defineNuxtRouteMiddleware(async (to) => {
   const { status, data, getSession, signOut } = useAuth()
 
-  if (status.value === 'loading') {
-    await getSession().catch(() => null)
-  }
+  // Always refresh so a deactivation that lands mid-session (deactivatedAt from the
+  // DB) is observed before making an onboarding-redirect decision. This global
+  // middleware runs before the named auth/guest/oauth-auth middlewares on every
+  // navigation, so on a pure client-side route change with no other auth middleware
+  // it would otherwise be the only thing consulting a stale cached session. Mirrors
+  // the unconditional refresh in app/middleware/auth.ts.
+  await getSession().catch(() => null)
 
   if (status.value === 'loading') return
 

--- a/tests/unit/app/middleware/onboarding.global.test.ts
+++ b/tests/unit/app/middleware/onboarding.global.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment nuxt
+
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RouteLocationNormalizedGeneric } from 'vue-router'
+import onboardingMiddleware from '~/middleware/onboarding.global'
+
+type MockUser = {
+  termsAcceptedAt?: string | null
+  deactivatedAt?: string | Date | null
+}
+
+type AuthMockState = {
+  status: { value: 'authenticated' | 'unauthenticated' | 'loading' }
+  data: { value: { user: MockUser } | null }
+  getSession: ReturnType<typeof vi.fn>
+  signOut: ReturnType<typeof vi.fn>
+}
+
+const { navigateToMock, authMockRef } = vi.hoisted(() => ({
+  navigateToMock: vi.fn(),
+  // Mutable ref so each test can swap in its own auth state before invoking the
+  // middleware, while the mock factory itself stays static (required by the
+  // mockNuxtImport macro, which is transpiled at module scope).
+  authMockRef: { current: null as AuthMockState | null }
+}))
+
+mockNuxtImport('navigateTo', () => navigateToMock)
+mockNuxtImport('useAuth', () => () => authMockRef.current)
+
+function makeRoute(path: string): RouteLocationNormalizedGeneric {
+  return {
+    path,
+    fullPath: path,
+    query: {},
+    params: {},
+    hash: '',
+    matched: [],
+    meta: {},
+    name: undefined,
+    redirectedFrom: undefined
+  } as unknown as RouteLocationNormalizedGeneric
+}
+
+function buildAuthMock(options: {
+  status?: 'authenticated' | 'unauthenticated' | 'loading'
+  user?: MockUser
+  getSession?: ReturnType<typeof vi.fn>
+  signOut?: ReturnType<typeof vi.fn>
+}): AuthMockState {
+  return {
+    status: { value: options.status ?? 'authenticated' },
+    data: { value: options.user ? { user: options.user } : null },
+    getSession: options.getSession ?? vi.fn().mockResolvedValue(null),
+    signOut: options.signOut ?? vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('onboarding.global middleware', () => {
+  beforeEach(() => {
+    navigateToMock.mockReset()
+    authMockRef.current = null
+  })
+
+  afterEach(() => {
+    authMockRef.current = null
+  })
+
+  it('refreshes the session unconditionally -- not only when status is "loading" -- before making any onboarding decision', async () => {
+    const auth = buildAuthMock({
+      status: 'authenticated',
+      user: { termsAcceptedAt: '2024-01-01T00:00:00.000Z', deactivatedAt: null }
+    })
+    authMockRef.current = auth
+
+    const to = makeRoute('/dashboard')
+    await onboardingMiddleware(to, to)
+
+    // The fix under test: getSession must run even though status was never 'loading'.
+    expect(auth.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).not.toHaveBeenCalled()
+    expect(navigateToMock).not.toHaveBeenCalled()
+  })
+
+  it('kicks out a user deactivated mid-session on a client-side nav to a route with no other auth middleware, instead of trusting the stale cached session', async () => {
+    const auth = buildAuthMock({
+      // Stale cached session: authenticated, not yet flagged deactivated.
+      status: 'authenticated',
+      user: { termsAcceptedAt: '2024-01-01T00:00:00.000Z', deactivatedAt: null }
+    })
+    auth.getSession.mockImplementation(async () => {
+      // Simulate the DB-backed refresh discovering the deactivation and updating
+      // the shared auth state, exactly like the real getSession() would.
+      auth.data.value = {
+        user: {
+          termsAcceptedAt: '2024-01-01T00:00:00.000Z',
+          deactivatedAt: '2024-06-01T00:00:00.000Z'
+        }
+      }
+      return null
+    })
+    authMockRef.current = auth
+
+    // A route with no 'auth' / 'oauth-auth' middleware of its own -- onboarding.global.ts
+    // (global) is the only middleware guaranteed to run on this navigation.
+    const to = makeRoute('/some-public-app-route')
+    await onboardingMiddleware(to, to)
+
+    expect(auth.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).toHaveBeenCalledWith({ callbackUrl: '/login?error=deactivated' })
+    expect(navigateToMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves existing onboarding-redirect behavior unchanged: redirects an active user who has not accepted terms to /onboarding', async () => {
+    const auth = buildAuthMock({
+      status: 'authenticated',
+      user: { termsAcceptedAt: null, deactivatedAt: null }
+    })
+    authMockRef.current = auth
+
+    const to = makeRoute('/dashboard')
+    await onboardingMiddleware(to, to)
+
+    expect(auth.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).not.toHaveBeenCalled()
+    expect(navigateToMock).toHaveBeenCalledTimes(1)
+    expect(navigateToMock).toHaveBeenCalledWith({
+      path: '/onboarding',
+      query: { redirect: '/dashboard' }
+    })
+  })
+
+  it('leaves existing onboarding-redirect behavior unchanged: lets an active user who has accepted terms through without redirect', async () => {
+    const auth = buildAuthMock({
+      status: 'authenticated',
+      user: { termsAcceptedAt: '2024-01-01T00:00:00.000Z', deactivatedAt: null }
+    })
+    authMockRef.current = auth
+
+    const to = makeRoute('/dashboard')
+    const result = await onboardingMiddleware(to, to)
+
+    expect(auth.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).not.toHaveBeenCalled()
+    expect(navigateToMock).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
+  })
+
+  it('does not treat an unauthenticated visitor as deactivated after the forced refresh', async () => {
+    const auth = buildAuthMock({ status: 'unauthenticated' })
+    authMockRef.current = auth
+
+    const to = makeRoute('/login')
+    await onboardingMiddleware(to, to)
+
+    expect(auth.getSession).toHaveBeenCalledTimes(1)
+    expect(auth.signOut).not.toHaveBeenCalled()
+    expect(navigateToMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Fixes CW-231

## Summary

`app/middleware/onboarding.global.ts` is a GLOBAL middleware, which per Nuxt's
execution order runs before the named `auth`/`guest`/`oauth-auth` middlewares
on every navigation. It previously only refreshed the auth session via
`getSession()` when `status === 'loading'`, so on a pure client-side route
change to a page with no other auth middleware, it could act on a stale
cached session and let a since-deactivated user keep navigating client-side
until something else forced a refresh.

This mirrors the exact pattern already used in the CW-35 fix
(`app/middleware/auth.ts`, PR #390): call `await getSession()`
unconditionally, before making any onboarding-redirect decision. The
existing `deactivatedAt -> signOut()` check further down in this same file
then catches the deactivation using freshly-refreshed data, so no
additional redirect logic was needed here.

This is a narrow residual-window fix, not a reintroduced auth bypass -- the
server-side `server/middleware/auth.ts` (also from CW-35) already
hard-invalidates DB sessions/cookies on any SSR/API round-trip; this closes
the remaining client-side-only navigation gap.

Only touched the owned paths for this ticket:
- `app/middleware/onboarding.global.ts`
- `tests/unit/app/middleware/onboarding.global.test.ts` (new)

## Verification

```
$ pnpm test:unit tests/unit/app/middleware/onboarding.global.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ pnpm typecheck
(exit 0, no errors)

$ pnpm test:unit
 Test Files  362 passed (362)
      Tests  2001 passed (2001)
```