### PR TITLE
fix(infra): standardize CI Node.js version to node-version-file (CW-124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: pnpm
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: pnpm
 
       - name: Install dependencies
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes CW-124

## Problem
Workflows in `.github/workflows/` declared the Node.js toolchain version inconsistently. `ci.yml` hardcoded `node-version: 24` in three `actions/setup-node` steps, while `e2e.yml` and `reusable-trigger-deploy.yml` already read `node-version-file: .nvmrc`. A drift between the pinned literal and `.nvmrc` (currently `24.18`) could let CI pass on one Node version while deploy resolves a different one.

## Inventory (every place a Node/pnpm version is declared)

| File | Before | After |
|---|---|---|
| `.github/workflows/ci.yml` (typecheck job) | `node-version: 24` | `node-version-file: '.nvmrc'` |
| `.github/workflows/ci.yml` (lint job) | `node-version: 24` | `node-version-file: '.nvmrc'` |
| `.github/workflows/ci.yml` (unit-tests job) | `node-version: 24` | `node-version-file: '.nvmrc'` |
| `.github/workflows/e2e.yml` | `node-version-file: '.nvmrc'` | unchanged (already correct) |
| `.github/workflows/reusable-trigger-deploy.yml` | `node-version-file: '.nvmrc'` | unchanged (already correct) |
| `.github/workflows/deploy.yml` | no Node setup (Docker-only build + webhook trigger) | unchanged, out of scope |
| `.github/workflows/security.yml` | no Node setup (CodeQL-only) | unchanged, out of scope |
| `.github/workflows/publish-mcp.yml` | no Node setup (downloads a pinned Go binary) | unchanged, out of scope |
| `.github/workflows/jules.yml` | no Node setup | unchanged, out of scope |
| `.github/workflows/linear-post-merge.yml` | no Node setup (Python only) | unchanged, out of scope |

**pnpm version:** every `pnpm/action-setup@v6` step across all workflows (`ci.yml` x3, `e2e.yml`, `reusable-trigger-deploy.yml`) omits an explicit `version:` and already relies on `packageManager` autodetection from `package.json` (`pnpm@11.17.0`). This was already the consistent, dominant pattern repo-wide, so no change was needed for pnpm.

`.nvmrc` at repo root: `24.18` (unchanged, single source of truth).

## Scope
Only `.github/workflows/ci.yml` changed (3 one-line edits). No jobs added/removed, no other workflow behavior changed — that's covered by separate tickets (CW-125 SHA-pinning, CW-126 E2E/MCP jobs), intentionally not touched here.

## Verification
- All `.github/workflows/*.yml` files parsed successfully with `python3 -c "import yaml; yaml.safe_load(...)"` (8/8 OK).
- `pnpm typecheck` — exits 0, no errors (expected no-op regression check for a YAML-only change).