### PR TITLE
fix(nutrition): bound repairMetabolicChain recursion and fix create/upsert race (CW-72)

### DIFF
--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -702,13 +702,11 @@ export const metabolicService = {
       }
     }
 
-    // Check if yesterday is in the future relative to "Real Today"
-    const timezone = await getUserTimezone(userId)
-    const todayLocal = getUserLocalDate(timezone)
-
-    // If yesterday is Future OR (Past/Today and we are within recursion limit), simulate it.
-    // We prefer simulation over DB lookup to ensure dynamic continuity, unless we hit depth limit.
-    const shouldSimulate = yesterday >= todayLocal || recursionDepth < 5
+    // We prefer simulation over DB lookup to ensure dynamic continuity, but recursionDepth is an
+    // unconditional cap. Without this, a targetDate far in the future keeps "yesterday" in the
+    // future too (yesterday >= todayLocal stays true every level), so a future-dated call would
+    // recurse once per day all the way from targetDate back to today instead of stopping at 5.
+    const shouldSimulate = recursionDepth < 5
 
     if (shouldSimulate) {
       // 1. Get Yesterday's Starting State (recursive)
@@ -720,7 +718,7 @@ export const metabolicService = {
 
       // 2. Simulate Yesterday to get its Ending State (which is Target's Starting State)
       // Using centralized getDailyTimeline logic
-      const { points, dayNutrition } = await this.getDailyTimeline(
+      const { points } = await this.getDailyTimeline(
         userId,
         yesterday,
         currentGlycogen,
@@ -734,14 +732,14 @@ export const metabolicService = {
       }
 
       // PERSISTENCE: Link the chain
+      // Upsert (keyed on the userId+date unique constraint) rather than a plain create, so
+      // overlapping repair calls racing to persist the same missing day don't fail on the
+      // @@unique([userId, date]) constraint.
       // 1. Update Yesterday's Ending State
-      if (dayNutrition) {
-        await nutritionRepository.update(dayNutrition.id, {
-          endingGlycogenPercentage: currentGlycogen,
-          endingFluidDeficit: currentFluid
-        })
-      } else {
-        await nutritionRepository.create({
+      await nutritionRepository.upsert(
+        userId,
+        yesterday,
+        {
           userId,
           date: yesterday,
           endingGlycogenPercentage: currentGlycogen,
@@ -750,17 +748,18 @@ export const metabolicService = {
           protein: 0,
           carbs: 0,
           fat: 0
-        })
-      }
+        },
+        {
+          endingGlycogenPercentage: currentGlycogen,
+          endingFluidDeficit: currentFluid
+        }
+      )
 
       // 2. Update Today's Starting State
-      if (targetRecord) {
-        await nutritionRepository.update(targetRecord.id, {
-          startingGlycogenPercentage: currentGlycogen,
-          startingFluidDeficit: currentFluid
-        })
-      } else {
-        await nutritionRepository.create({
+      await nutritionRepository.upsert(
+        userId,
+        targetDate,
+        {
           userId,
           date: targetDate,
           startingGlycogenPercentage: currentGlycogen,
@@ -769,8 +768,12 @@ export const metabolicService = {
           protein: 0,
           carbs: 0,
           fat: 0
-        })
-      }
+        },
+        {
+          startingGlycogenPercentage: currentGlycogen,
+          startingFluidDeficit: currentFluid
+        }
+      )
 
       return {
         startingGlycogen: currentGlycogen,

--- a/tests/unit/server/utils/services/metabolicService.test.ts
+++ b/tests/unit/server/utils/services/metabolicService.test.ts
@@ -44,7 +44,10 @@ vi.mock('../../../../../server/utils/services/bodyMetricResolver', () => ({
 
 vi.mock('../../../../../server/utils/repositories/nutritionRepository', () => ({
   nutritionRepository: {
-    getByDate: vi.fn()
+    getByDate: vi.fn(),
+    upsert: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
   }
 }))
 
@@ -174,6 +177,81 @@ describe('metabolicService smoke coverage', () => {
     expect(result).toEqual({
       startingGlycogen: 50,
       startingFluid: 40
+    })
+  })
+
+  describe('repairMetabolicChain recursion depth & persistence (CW-72)', () => {
+    beforeEach(() => {
+      vi.mocked(getUserNutritionSettings).mockResolvedValue({ metabolicFloor: 0.6 } as any)
+      vi.spyOn(metabolicService, 'getDailyTimeline').mockResolvedValue({
+        points: [{ level: 55, fluidDeficit: 5 }]
+      } as any)
+      vi.mocked(nutritionRepository.upsert).mockResolvedValue({
+        record: { id: 'nutrition-x' },
+        isNew: true
+      } as any)
+    })
+
+    it('bounds recursion depth for a target date far in the future', async () => {
+      // No persisted rows anywhere in the chain, so the fast path never short-circuits and every
+      // level must decide whether to keep recursing.
+      vi.mocked(nutritionRepository.getByDate).mockResolvedValue(null as any)
+
+      // ~60 days after the "today" baked into the file-level getUserLocalDate mock
+      // (2026-02-13). Before the fix, `yesterday >= todayLocal` stayed true at every level for a
+      // future date, so this recursed once per day all the way back to today (~60 levels, ~120
+      // persistence calls) instead of stopping at the depth-5 cap.
+      const farFuture = new Date('2026-04-13T00:00:00.000Z')
+
+      const result = await metabolicService.repairMetabolicChain(userId, farFuture)
+
+      expect(result.startingGlycogen).toBe(55)
+      // 5 simulate levels (depth 0-4) x 2 upserts per level (yesterday's ending state + target's
+      // starting state) = 10. Depth 5 hits the base case and persists nothing.
+      expect(nutritionRepository.upsert).toHaveBeenCalledTimes(10)
+      expect(metabolicService.getDailyTimeline).toHaveBeenCalledTimes(5)
+    })
+
+    it('still walks backward through past missing days up to the depth cap', async () => {
+      vi.mocked(nutritionRepository.getByDate).mockResolvedValue(null as any)
+
+      // Comfortably in the past relative to the mocked "today" (2026-02-13), so the legitimate
+      // backward-repair behavior (not just the future-date bug) must keep working.
+      const pastDate = new Date('2026-01-01T00:00:00.000Z')
+
+      const result = await metabolicService.repairMetabolicChain(userId, pastDate)
+
+      expect(result.startingGlycogen).toBe(55)
+      expect(nutritionRepository.upsert).toHaveBeenCalledTimes(10)
+      expect(metabolicService.getDailyTimeline).toHaveBeenCalledTimes(5)
+    })
+
+    it('persists missing days via upsert, never a plain create, so overlapping repair calls cannot collide on the (userId, date) unique constraint', async () => {
+      vi.mocked(nutritionRepository.getByDate).mockResolvedValue(null as any)
+      // create() is deliberately left rejecting: if this ever regresses back to create(), the test
+      // fails loudly (simulating the unique-constraint violation from a real concurrent insert)
+      // instead of silently passing.
+      vi.mocked(nutritionRepository.create).mockRejectedValue(
+        new Error('Unique constraint failed on the fields: (`userId`,`date`)')
+      )
+
+      const dayA = new Date('2026-02-20T00:00:00.000Z')
+      const dayB = new Date('2026-02-21T00:00:00.000Z') // overlaps dayA's chain via a shared "yesterday"
+
+      const [resultA, resultB] = await Promise.all([
+        metabolicService.repairMetabolicChain(userId, dayA),
+        metabolicService.repairMetabolicChain(userId, dayB)
+      ])
+
+      expect(resultA.startingGlycogen).toBe(55)
+      expect(resultB.startingGlycogen).toBe(55)
+      expect(nutritionRepository.create).not.toHaveBeenCalled()
+      expect(nutritionRepository.upsert).toHaveBeenCalled()
+      // Every upsert call is keyed on (userId, date), matching the @@unique([userId, date]) constraint.
+      for (const call of vi.mocked(nutritionRepository.upsert).mock.calls) {
+        expect(call[0]).toBe(userId)
+        expect(call[1]).toBeInstanceOf(Date)
+      }
     })
   })
 


### PR DESCRIPTION
Fixes CW-72

## Problem

`metabolicService.repairMetabolicChain` had two defects:

1. **Unbounded recursion for future dates.** The recursion guard was:
   ```ts
   const shouldSimulate = yesterday >= todayLocal || recursionDepth < 5
   ```
   For a `targetDate` in the future, `yesterday` (targetDate - 1) is always `>= todayLocal`
   too, so the first clause stayed `true` at every recursion level regardless of
   `recursionDepth`. A target 60 days out recursed ~60 times (≈120 DB writes) instead of
   stopping at the intended depth-5 cap.

2. **Create/upsert race on missing days.** Missing-day persistence used
   `nutritionRepository.create()`. Two overlapping `repairMetabolicChain` calls (e.g.
   triggered by concurrent requests touching adjacent dates) racing to insert the same
   missing `(userId, date)` row could both pass the "record not found" check and then
   both call `create()`, one of which fails on the `@@unique([userId, date])` constraint.

## Fix

- `shouldSimulate` is now just `recursionDepth < 5` — an unconditional cap. This still
  preserves the legitimate backward walk-through-past-days behavior, which was already
  gated solely by `recursionDepth` in the old code (the future-date bug came from the
  `yesterday >= todayLocal ||` clause bypassing that cap entirely).
- Missing-day persistence now goes through the existing
  `nutritionRepository.upsert(userId, date, createData, updateData)` (keyed on the same
  `(userId, date)` unique constraint) instead of a manual create-or-update branch.

Dead code cleanup: removed the now-unused `timezone`/`todayLocal` locals and the
`dayNutrition` destructure that only existed to drive the old create/update branch.

## Owned paths

- `server/utils/services/metabolicService.ts` — both fixes.
- `server/utils/repositories/nutritionRepository.ts` — inspected only; a suitable
  `upsert()` method already existed (atomic Prisma upsert keyed on `userId_date`), so no
  change was needed there.

## Tests

Added 3 tests to `tests/unit/server/utils/services/metabolicService.test.ts` (the file
that already contains `repairMetabolicChain` coverage — `nutritionRepository` and
`getUserNutritionSettings` are properly mocked there):

- Recursion is bounded to depth 5 for a target date ~60 days in the future (asserts
  `upsert` is called exactly 10 times = 5 levels × 2 upserts/level, not ~120).
- The legitimate past-day walk-back still recurses through the depth-5 cap correctly
  (no regression to intended behavior).
- Concurrent-style overlapping repair calls for adjacent dates only ever call
  `upsert()`, never `create()` (mocked to reject, so any regression back to `create()`
  fails loudly).

Note: `tests/unit/server/utils/services/nutritionPlanService.test.ts` (named in the
ticket's verification command) mocks the entire `metabolicService` module down to a
single `getNutritionDay` stub, so it can't exercise `repairMetabolicChain`'s internals.
It still passes unchanged as a regression check.

## Verification

```
pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts
# Test Files  1 passed (1) / Tests  15 passed (15)

pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts
# Test Files  1 passed (1) / Tests  24 passed (24)

pnpm vitest run tests/unit/server/utils/services/
# Test Files  20 passed (20) / Tests  173 passed (173)

pnpm typecheck
# exit 0, no errors
```
