### PR TITLE
fix(integrations): enforce unique Garmin externalUserId mapping (CW-99)

### DIFF
--- a/prisma/migrations/20260731180902_add_integration_provider_external_user_unique/migration.sql
+++ b/prisma/migrations/20260731180902_add_integration_provider_external_user_unique/migration.sql
@@ -1,0 +1,55 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[provider,externalUserId]` on the table `Integration` will be added.
+
+  CW-99: the app-level "is this externalUserId already linked to another
+  user?" check in the Garmin OAuth callback (and equivalent checks for other
+  providers) was a plain findFirst-then-write with no DB-level guarantee
+  between the two, so two concurrent callbacks could both pass the check and
+  create two Integration rows mapped to the same (provider, externalUserId).
+
+  Before the constraint can be added we must resolve any such duplicates that
+  may already exist in production, or the CREATE UNIQUE INDEX below would
+  fail outright.
+
+  Duplicate-resolution policy (deliberately non-destructive):
+  For each (provider, externalUserId) group with more than one row and a
+  non-null externalUserId, keep exactly one row's externalUserId intact —
+  preferring the row with the most recent lastSyncAt (most recently active /
+  most likely to be the account still in real use), falling back to id for a
+  fully deterministic tie-break. On every other row in the group we only
+  clear externalUserId to NULL; we do NOT delete the Integration row.
+
+  This preserves every user's own tokens/settings/sync history (deleting the
+  row would silently disconnect an integration a user believes is still
+  connected), while releasing the externalUserId so the new unique index can
+  be created. Any user left with externalUserId = NULL here no longer
+  receives Garmin push-webhook data (which is keyed by externalUserId) until
+  they reconnect - reconnecting will then hit the app-level P2002 handling
+  added alongside this migration and correctly report "already linked" if
+  the id truly still belongs to someone else, or re-populate externalUserId
+  cleanly if it doesn't.
+*/
+
+-- Resolve pre-existing duplicate (provider, externalUserId) mappings before
+-- the unique index can be created. Only rows with a non-null externalUserId
+-- can collide; NULLs are already distinct under a Postgres unique index.
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "provider", "externalUserId"
+      ORDER BY "lastSyncAt" DESC NULLS LAST, "id" ASC
+    ) AS rn
+  FROM "Integration"
+  WHERE "externalUserId" IS NOT NULL
+)
+UPDATE "Integration" i
+SET "externalUserId" = NULL
+FROM ranked
+WHERE i."id" = ranked."id"
+  AND ranked.rn > 1;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Integration_provider_externalUserId_key" ON "Integration"("provider", "externalUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -638,6 +638,12 @@ model Integration {
   user                 User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, provider])
+  // Prevents two different users from concurrently linking the same external
+  // provider account (e.g. two Garmin OAuth callbacks racing on the same
+  // externalUserId). Postgres unique indexes treat NULL as distinct from any
+  // other value, so providers that never populate externalUserId (ultrahuman,
+  // hevy, yazio, ...) are unaffected and can still have unlimited NULL rows.
+  @@unique([provider, externalUserId])
 }
 
 model Workout {

--- a/server/api/integrations/garmin/callback.get.ts
+++ b/server/api/integrations/garmin/callback.get.ts
@@ -3,6 +3,7 @@ import { dispatchTask } from '../../../utils/task-dispatcher'
 import { getServerSession } from '../../../utils/session'
 import { prisma } from '../../../utils/db'
 import { refreshGarminIntegrationPermissions } from '../../../utils/garmin'
+import { isGarminExternalUserIdConflict } from '../../../utils/services/garminService'
 
 defineRouteMeta({
   openAPI: {
@@ -114,6 +115,12 @@ export default defineEventHandler(async (event) => {
     return sendRedirect(event, '/settings/apps?garmin_error=profile-fetch-failed')
   }
 
+  // Best-effort pre-check: fails fast for the common case without touching
+  // the write path. This is NOT the source of truth against concurrent
+  // callbacks - two requests can both pass this findFirst before either has
+  // written. The real guarantee is the Integration_provider_externalUserId_key
+  // unique index added in CW-99 (prisma/schema.prisma), enforced by the
+  // catch block around the upsert below.
   const existingOwner = await prisma.integration.findFirst({
     where: {
       provider: 'garmin',
@@ -138,31 +145,53 @@ export default defineEventHandler(async (event) => {
     return sendRedirect(event, '/settings/apps?garmin_error=account-already-linked')
   }
 
-  const integration = await prisma.integration.upsert({
-    where: { userId_provider: { userId: session.user.id, provider: 'garmin' } },
-    create: {
-      userId: session.user.id,
-      provider: 'garmin',
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt: new Date(Date.now() + tokenData.expires_in * 1000),
-      externalUserId,
-      scope: tokenData.scope || null,
-      ingestWorkouts: true,
-      syncStatus: 'SUCCESS',
-      errorMessage: null
-    },
-    update: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt: new Date(Date.now() + tokenData.expires_in * 1000),
-      externalUserId,
-      scope: tokenData.scope || null,
-      ingestWorkouts: true,
-      syncStatus: 'SUCCESS',
-      errorMessage: null
+  let integration
+  try {
+    integration = await prisma.integration.upsert({
+      where: { userId_provider: { userId: session.user.id, provider: 'garmin' } },
+      create: {
+        userId: session.user.id,
+        provider: 'garmin',
+        accessToken: tokenData.access_token,
+        refreshToken: tokenData.refresh_token,
+        expiresAt: new Date(Date.now() + tokenData.expires_in * 1000),
+        externalUserId,
+        scope: tokenData.scope || null,
+        ingestWorkouts: true,
+        syncStatus: 'SUCCESS',
+        errorMessage: null
+      },
+      update: {
+        accessToken: tokenData.access_token,
+        refreshToken: tokenData.refresh_token,
+        expiresAt: new Date(Date.now() + tokenData.expires_in * 1000),
+        externalUserId,
+        scope: tokenData.scope || null,
+        ingestWorkouts: true,
+        syncStatus: 'SUCCESS',
+        errorMessage: null
+      }
+    })
+  } catch (dbError: any) {
+    // A second callback (for a different user) raced us between the
+    // findFirst check above and this write, and the Integration_provider_
+    // externalUserId_key unique index (CW-99) caught what the app-level
+    // check couldn't. Treat it the same as the pre-check case above instead
+    // of surfacing an unhandled 500.
+    if (isGarminExternalUserIdConflict(dbError)) {
+      console.error(
+        '[GarminCallback] Garmin account already connected to another user (race detected at write time)',
+        {
+          externalUserId,
+          currentUserId: session.user.id
+        }
+      )
+      deleteCookie(event, 'garmin_code_verifier')
+      deleteCookie(event, 'garmin_oauth_state')
+      return sendRedirect(event, '/settings/apps?garmin_error=account-already-linked')
     }
-  })
+    throw dbError
+  }
 
   // Best-effort: merge export permissions (HEALTH_EXPORT, WORKOUT_IMPORT, …) into scope.
   await refreshGarminIntegrationPermissions(integration)

--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -111,6 +111,43 @@ function extractGarminNumericMetric(
 }
 
 /**
+ * Detects whether a Prisma error is a P2002 unique-constraint violation on
+ * the Integration(provider, externalUserId) index added in CW-99 to close a
+ * race where two concurrent Garmin OAuth callbacks could both pass the
+ * application-level "is this externalUserId already linked?" check and then
+ * both write an Integration row for the same externalUserId.
+ *
+ * The shape of `PrismaClientKnownRequestError.meta` differs by query engine:
+ * - Classic engine: `error.meta.target` is the field list directly, e.g.
+ *   `["provider", "externalUserId"]`.
+ * - Driver adapter engine (this app uses `@prisma/adapter-pg`, see
+ *   server/utils/db.ts): `meta.target` does not exist. Prisma instead
+ *   constructs the error as `new PrismaClientKnownRequestError(message, code,
+ *   { driverAdapterError: originalError })`, so the field list is nested at
+ *   `meta.driverAdapterError.cause.constraint.fields` (same finding used in
+ *   emailDeliveryService.ts's getUniqueConstraintFields for CW-227).
+ *
+ * One extra wrinkle discovered while building this, verified against a live
+ * Postgres 16 + @prisma/adapter-pg 7.8.0 instance: for a *multi-column*
+ * unique index, the driver adapter's field list is derived from Postgres's
+ * own rendering of the index definition, which quotes camelCase identifiers
+ * but not lowercase ones. A real violation of this exact constraint reported
+ * `constraint.fields: ["provider", "\"externalUserId\""]` - note the second
+ * entry carries literal embedded double-quote characters that a naive
+ * `.includes('externalUserId')` check would silently fail to match. We strip
+ * surrounding quotes from every field before comparing to stay correct
+ * regardless of which shape/quoting shows up.
+ */
+export function isGarminExternalUserIdConflict(error: any): boolean {
+  if (!error || error.code !== 'P2002') return false
+  const rawFields: unknown =
+    error?.meta?.target ?? error?.meta?.driverAdapterError?.cause?.constraint?.fields
+  if (!Array.isArray(rawFields)) return false
+  const fields = rawFields.map((f) => (typeof f === 'string' ? f.replace(/^"+|"+$/g, '') : f))
+  return fields.includes('provider') && fields.includes('externalUserId')
+}
+
+/**
  * Garmin Push list keys per Health API (preferred first), plus legacy aliases we
  * historically looked for so existing payloads keep working.
  */

--- a/tests/unit/server/utils/services/garminService.test.ts
+++ b/tests/unit/server/utils/services/garminService.test.ts
@@ -5,14 +5,17 @@ import {
   extractGarminBodyBatteryScore,
   extractGarminReadinessScore,
   extractGarminSpO2Percentage,
-  GarminService
+  GarminService,
+  isGarminExternalUserIdConflict
 } from '../../../../../server/utils/services/garminService'
 
 const { prismaMock } = vi.hoisted(() => ({
   prismaMock: {
     integration: {
       findUnique: vi.fn(),
-      update: vi.fn()
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn()
     },
     user: {
       findUnique: vi.fn()
@@ -859,5 +862,152 @@ describe('GarminService activity push stream & file ingestion', () => {
     expect(errorSpy).not.toHaveBeenCalled()
 
     vi.restoreAllMocks()
+  })
+})
+
+// CW-99: Integration(provider, externalUserId) unique index + P2002 handling.
+describe('isGarminExternalUserIdConflict', () => {
+  it('detects a driver-adapter P2002 error, stripping the quote artifact Postgres adds to camelCase field names', () => {
+    // This is the exact shape captured from a real Postgres 16 +
+    // @prisma/adapter-pg 7.8.0 violation of the multi-column
+    // Integration_provider_externalUserId_key index: the "provider" entry is
+    // clean, but "externalUserId" comes back with literal embedded quotes
+    // because Postgres quotes camelCase identifiers when rendering the index
+    // definition and the driver adapter does not strip them.
+    const dbError = {
+      code: 'P2002',
+      meta: {
+        modelName: 'Integration',
+        driverAdapterError: {
+          name: 'DriverAdapterError',
+          cause: {
+            originalCode: '23505',
+            originalMessage:
+              'duplicate key value violates unique constraint "Integration_provider_externalUserId_key"',
+            kind: 'UniqueConstraintViolation',
+            constraint: { fields: ['provider', '"externalUserId"'] }
+          }
+        }
+      }
+    }
+
+    expect(isGarminExternalUserIdConflict(dbError)).toBe(true)
+  })
+
+  it('detects a classic-engine-shaped P2002 error (meta.target)', () => {
+    const dbError = {
+      code: 'P2002',
+      meta: { target: ['provider', 'externalUserId'] }
+    }
+
+    expect(isGarminExternalUserIdConflict(dbError)).toBe(true)
+  })
+
+  it('ignores P2002 on an unrelated constraint, e.g. Integration_userId_provider_key', () => {
+    const dbError = {
+      code: 'P2002',
+      meta: {
+        driverAdapterError: {
+          cause: { constraint: { fields: ['"userId"', 'provider'] } }
+        }
+      }
+    }
+
+    expect(isGarminExternalUserIdConflict(dbError)).toBe(false)
+  })
+
+  it('ignores non-P2002 errors and malformed error shapes', () => {
+    expect(isGarminExternalUserIdConflict(new Error('boom'))).toBe(false)
+    expect(isGarminExternalUserIdConflict({ code: 'P2025' })).toBe(false)
+    expect(isGarminExternalUserIdConflict(null)).toBe(false)
+    expect(isGarminExternalUserIdConflict(undefined)).toBe(false)
+    expect(isGarminExternalUserIdConflict({ code: 'P2002' })).toBe(false)
+    expect(isGarminExternalUserIdConflict({ code: 'P2002', meta: {} })).toBe(false)
+  })
+})
+
+describe('CW-99: concurrent Garmin OAuth callback race', () => {
+  // Mirrors the try/catch structure in
+  // server/api/integrations/garmin/callback.get.ts: an application-level
+  // findFirst pre-check, then an upsert whose P2002 is interpreted with the
+  // real isGarminExternalUserIdConflict guard under test. This proves the
+  // exported guard, wired the way the callback wires it, turns a raw DB
+  // constraint violation into a clean "already linked" outcome instead of an
+  // unhandled crash.
+  async function runGarminCallbackUpsert(userId: string, externalUserId: string) {
+    const existingOwner = await prismaMock.integration.findFirst({
+      where: { provider: 'garmin', externalUserId, NOT: { userId } },
+      select: { userId: true }
+    })
+
+    if (existingOwner) {
+      return { outcome: 'already-linked' as const }
+    }
+
+    try {
+      const integration = await prismaMock.integration.upsert({
+        where: { userId_provider: { userId, provider: 'garmin' } },
+        create: { userId, provider: 'garmin', externalUserId },
+        update: { externalUserId }
+      })
+      return { outcome: 'linked' as const, integration }
+    } catch (dbError: any) {
+      if (isGarminExternalUserIdConflict(dbError)) {
+        return { outcome: 'already-linked' as const }
+      }
+      throw dbError
+    }
+  }
+
+  it('gives the second of two concurrent callbacks for the same externalUserId a clean already-linked outcome, not a crash or a duplicate row', async () => {
+    const externalUserId = 'garmin-ext-race-1'
+    const driverAdapterP2002 = {
+      code: 'P2002',
+      meta: {
+        modelName: 'Integration',
+        driverAdapterError: {
+          cause: {
+            originalCode: '23505',
+            kind: 'UniqueConstraintViolation',
+            constraint: { fields: ['provider', '"externalUserId"'] }
+          }
+        }
+      }
+    }
+
+    // Both requests race past the pre-check before either has written.
+    prismaMock.integration.findFirst.mockResolvedValue(null)
+
+    // First writer wins the DB-level race and succeeds.
+    prismaMock.integration.upsert.mockResolvedValueOnce({
+      id: 'int-user-a',
+      userId: 'user-a',
+      provider: 'garmin',
+      externalUserId
+    })
+    // Second writer loses the race: the unique index added in CW-99 rejects
+    // the write with P2002 instead of silently creating a duplicate mapping.
+    prismaMock.integration.upsert.mockRejectedValueOnce(driverAdapterP2002)
+
+    const [resultA, resultB] = await Promise.all([
+      runGarminCallbackUpsert('user-a', externalUserId),
+      runGarminCallbackUpsert('user-b', externalUserId)
+    ])
+
+    expect(resultA).toEqual({
+      outcome: 'linked',
+      integration: { id: 'int-user-a', userId: 'user-a', provider: 'garmin', externalUserId }
+    })
+    expect(resultB).toEqual({ outcome: 'already-linked' })
+    expect(prismaMock.integration.upsert).toHaveBeenCalledTimes(2)
+  })
+
+  it('rethrows unrelated database errors instead of masking them as already-linked', async () => {
+    prismaMock.integration.findFirst.mockResolvedValue(null)
+    prismaMock.integration.upsert.mockRejectedValueOnce(new Error('connection reset'))
+
+    await expect(runGarminCallbackUpsert('user-c', 'garmin-ext-2')).rejects.toThrow(
+      'connection reset'
+    )
   })
 })


### PR DESCRIPTION
Fixes CW-99

## Problem
The Garmin OAuth callback (`server/api/integrations/garmin/callback.get.ts`) checked whether a Garmin `externalUserId` already belonged to another user via a plain `findFirst`, then did a separate `upsert`. There was no DB-level guarantee between the check and the write, and no unique constraint on `(provider, externalUserId)` in `Integration`, so two concurrent callbacks for different users could both pass the check and each create a row mapped to the same Garmin account.

## Fix

- **Schema**: added `@@unique([provider, externalUserId])` to `Integration` in `prisma/schema.prisma`. `externalUserId` is nullable and several providers (ultrahuman, hevy, yazio) never populate it; Postgres unique indexes treat `NULL` as distinct from any other value, so those rows are unaffected.
- **Migration** (`prisma/migrations/20260731180902_add_integration_provider_external_user_unique/migration.sql`): before creating the unique index, it resolves any pre-existing duplicate `(provider, externalUserId)` mappings **non-destructively**:
  - For each `(provider, externalUserId)` group with more than one row, it ranks rows by `lastSyncAt DESC NULLS LAST` (tie-broken deterministically by `id`, since `Integration` has no `createdAt`/`updatedAt`).
  - The top-ranked row (most recently active) keeps its `externalUserId`.
  - Every other row in the group only has `externalUserId` set to `NULL` — the `Integration` row itself (tokens, settings, sync history) is never deleted, so no user silently loses a connected integration. A row left with `externalUserId = NULL` just stops receiving Garmin push-webhook data (keyed by `externalUserId`) until the user reconnects, at which point the app-level P2002 handling below reports "already linked" if the Garmin account genuinely still belongs to someone else.
  - Verified against the local dev DB (`watts-postgres`, no existing duplicates there) that the migration applies cleanly end-to-end via `prisma migrate deploy`.
  - **Flag for reviewer**: this migration should ideally run against a low-traffic window, and it would be worth spot-checking `SELECT provider, "externalUserId", count(*) FROM "Integration" WHERE "externalUserId" IS NOT NULL GROUP BY provider, "externalUserId" HAVING count(*) > 1;` against production before/after deploy to see how many rows (if any) actually get their `externalUserId` cleared, since those users will stop receiving webhook pushes until they reconnect.
- **Callback handling**: `callback.get.ts` now wraps the `upsert` in a try/catch. If the new constraint fires (P2002), it's treated the same as the existing pre-check failure — redirect to `/settings/apps?garmin_error=account-already-linked` — instead of an unhandled 500.
- **`isGarminExternalUserIdConflict`** (new export in `server/utils/services/garminService.ts`) detects this specific P2002 following the `getUniqueConstraintFields` pattern from `emailDeliveryService.ts` (CW-227): checks both the classic-engine `meta.target` shape and the `@prisma/adapter-pg` driver-adapter shape at `meta.driverAdapterError.cause.constraint.fields`.
  - Extra finding verified live against Postgres 16 + `@prisma/adapter-pg` 7.8.0: for this *multi-column* index, the driver adapter's field list came back as `["provider", "\"externalUserId\""]` — the camelCase field has literal embedded quote characters (Postgres quotes camelCase identifiers when rendering the index definition; the adapter doesn't strip them). A naive `.includes('externalUserId')` would silently miss this. The detector strips surrounding quotes from every field before comparing.

## Test coverage
Added to `tests/unit/server/utils/services/garminService.test.ts`:
- Unit tests for `isGarminExternalUserIdConflict` covering the driver-adapter shape (including the quoting artifact), the classic-engine shape, unrelated-constraint P2002s, and non-P2002/malformed errors.
- An integration-style test that mirrors the callback's findFirst-then-upsert-then-catch flow and runs two "concurrent" callbacks (`Promise.all`) for two different users mapping to the same `externalUserId`: the first upsert resolves, the second is mocked to reject with the real P2002 shape, and the test asserts the second gets a clean `already-linked` outcome rather than a duplicate row or a crash. A second test confirms unrelated DB errors are still rethrown, not swallowed.

## Verification
```
pnpm test tests/unit/server/utils/services/garminService.test.ts
# Test Files  1 passed (1)
#      Tests  47 passed (47)

pnpm typecheck
# exits 0, no errors
```

Migration was also applied end-to-end against the local dev Postgres (`prisma migrate deploy`) and confirmed via `\d "Integration"` that the new unique index exists alongside the pre-existing `(userId, provider)` one.

## Note on scope
The ticket's "Owned Paths" listed `server/utils/services/garminService.ts`, `prisma/schema.prisma`, and the test file, but the actual check-then-write race lives in `server/api/integrations/garmin/callback.get.ts` (confirmed by reading its current state after CW-96/CW-97 merged). Fixing the acceptance criteria ("Callback gracefully handles uniqueness conflict") required a small, scoped change there too — the substantive P2002-detection logic stays in `garminService.ts` as an exported helper; `callback.get.ts` only gained an import and a try/catch.
