### PR TITLE
fix(infra): SHA-pin third-party GitHub Actions (CW-125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -53,13 +53,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -79,13 +79,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,16 +44,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         with:
           name: coach
           keep-state: true
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -70,7 +70,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64
@@ -123,7 +123,7 @@ jobs:
           esac
 
       - name: Discord Notification
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         if: always() && env.DISCORD_WEBHOOK != ''
         with:
           webhook: ${{ env.DISCORD_WEBHOOK }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,15 +53,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and start Docker e2e stack
         run: pnpm e2e:setup
@@ -98,7 +98,7 @@ jobs:
           docker compose --env-file .env.e2e -p coach-e2e -f docker-compose.e2e.yml ps || true
 
       - name: Cache Playwright Chromium
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always() && !inputs.lighthouse_only
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report-${{ github.run_id }}
           path: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload Lighthouse report
         if: always() && (github.base_ref == 'master' || inputs.with_lighthouse == true || inputs.lighthouse_only == true || contains(github.event.pull_request.labels.*.name, 'run-lighthouse'))
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: lighthouserc-report-${{ github.run_id }}
           path: .lighthouseci/

--- a/.github/workflows/jules.yml
+++ b/.github/workflows/jules.yml
@@ -24,7 +24,7 @@ jobs:
       issues: read
     steps:
       - name: Invoke Jules
-        uses: google-labs-code/jules-action@v1.0.0
+        uses: google-labs-code/jules-action@bff7875eaa123cac6742b7cfc51005b95ba4d566 # v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           starting_branch: master

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/mcp-v')

--- a/.github/workflows/reusable-trigger-deploy.yml
+++ b/.github/workflows/reusable-trigger-deploy.yml
@@ -61,13 +61,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -162,7 +162,7 @@ jobs:
           echo "🎉 Trigger.dev deployment completed successfully!"
 
       - name: Discord Notification
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         if: always() && env.DISCORD_WEBHOOK != ''
         with:
           webhook: ${{ env.DISCORD_WEBHOOK }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Fixes CW-125

## Summary
All third-party GitHub Action references under `.github/workflows/*.yml` were pinned to full-length (40-char) commit SHAs, with a trailing comment annotation preserving the original version tag for readability — e.g. `uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`.

This closes a supply-chain risk: mutable tags (`@v7`, `@v4`, etc.) can be repointed by the upstream maintainer (or an attacker who compromises their account) to a different commit without any change on our side, silently altering what code runs in CI.

Local reusable-workflow references (`uses: ./.github/workflows/ci.yml` in `deploy.yml`) were intentionally left untouched — same-repo/same-commit references carry no supply-chain risk.

### Actions pinned (full inventory, with SHA resolution method)

Each SHA was resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`. Two tags (`pnpm/action-setup@v6` and `github/codeql-action@v4`) are annotated tags — the ref API returned a tag object SHA (`type: "tag"`), which was dereferenced via `gh api repos/<owner>/<repo>/git/tags/<tag-object-sha>` to get the underlying commit SHA. All others resolved directly (`type: "commit"`).

| Action | Tag | Resolved commit SHA | Resolution |
|---|---|---|---|
| `actions/checkout` | v7 | `3d3c42e5aac5ba805825da76410c181273ba90b1` | direct (refs/tags) |
| `pnpm/action-setup` | v6 | `0ebf47130e4866e96fce0953f49152a61190b271` | dereferenced annotated tag |
| `actions/setup-node` | v7 | `820762786026740c76f36085b0efc47a31fe5020` | direct (refs/tags) |
| `docker/setup-buildx-action` | v4 | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` | direct (refs/tags) |
| `docker/login-action` | v4 | `dbcb813823bdd20940b903addbd779551569679f` | direct (refs/tags) |
| `docker/metadata-action` | v6 | `dc802804100637a589fabce1cb79ff13a1411302` | direct (refs/tags) |
| `docker/build-push-action` | v7 | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | direct (refs/tags) |
| `sarisia/actions-status-discord` | v1 | `eb045afee445dc055c18d3d90bd0f244fd062708` | direct (refs/tags) |
| `actions/cache` | v6 | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` | direct (refs/tags) |
| `actions/upload-artifact` | v7 | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | direct (refs/tags) |
| `github/codeql-action/init` | v4 | `f205ea1c3313d32999d8d6a48b4f6530d4437b38` | dereferenced annotated tag |
| `github/codeql-action/analyze` | v4 | `f205ea1c3313d32999d8d6a48b4f6530d4437b38` | dereferenced annotated tag (same repo/tag as `init`) |
| `google-labs-code/jules-action` | v1.0.0 | `bff7875eaa123cac6742b7cfc51005b95ba4d566` | direct (refs/tags) |

### Files changed
`ci.yml`, `deploy.yml`, `e2e.yml`, `jules.yml`, `publish-mcp.yml`, `reusable-trigger-deploy.yml`, `security.yml` (7 files, 31 insertions / 31 deletions — no jobs added/removed, no behavior change beyond pinning).

`linear-post-merge.yml` was inspected and has no `uses:` action references (pure `run:` shell steps), so it required no changes.

## Verification
- `pnpm typecheck` — passed cleanly (no-op from typecheck's perspective, as expected for a YAML-only change).
- Every changed workflow file re-validated as parseable YAML via `python3 -c "import yaml; yaml.safe_load(open(f))"`.
- Manually confirmed no `uses:` line under `.github/workflows/*.yml` still references a mutable tag (`grep -n "uses:" .github/workflows/*.yml` shows only SHA-pinned third-party refs and the one local reusable-workflow path reference).