### PR TITLE
fix(nutrition): unify finalizeDay/getDailyTimeline simulation policy (CW-76)

### DIFF
--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -182,7 +182,7 @@ export const metabolicService = {
   },
 
   /**
-   * Internal helper to get merged workouts for a date.
+   * Internal helper to get merged workouts for a date (completed + planned-but-not-yet-completed).
    */
   async getRelevantWorkouts(userId: string, date: Date, timezone: string) {
     const rangeStart = getStartOfDayUTC(timezone, date)
@@ -197,17 +197,65 @@ export const metabolicService = {
   },
 
   /**
-   * Calculates the full energy timeline for a specific day.
-   * Centralizes logic for workout merging, meal synthesis policy, and timeline generation.
-   * Returns both the points (for charts) and the liveStatus (for the tank).
+   * Internal helper to get only completed (real, logged) workouts for a date - no planned/ghost
+   * sessions. Used for days being treated as final, where a workout that was planned but never
+   * actually completed must not be simulated as though it happened.
    */
-  async getDailyTimeline(
+  async getCompletedWorkoutsOnly(userId: string, date: Date, timezone: string) {
+    const rangeStart = getStartOfDayUTC(timezone, date)
+    const rangeEnd = getEndOfDayUTC(timezone, date)
+
+    return workoutRepository.getForUser(userId, {
+      startDate: rangeStart,
+      endDate: rangeEnd,
+      includeDuplicates: false
+    })
+  },
+
+  /**
+   * Canonical single-day metabolic simulation core, shared by `finalizeDay` and `getDailyTimeline`
+   * (CW-76).
+   *
+   * These two used to duplicate this math with different inputs - `finalizeDay` used completed
+   * workouts and real logged nutrition only, while `getDailyTimeline` unconditionally merged in
+   * planned-but-not-yet-completed workouts and, when nothing was logged, synthetic meal
+   * projections. Their `endingGlycogenPercentage` values could drift apart by more than the 1%
+   * tolerance the day-to-day handoff (`getMetabolicStateForDate` / `repairMetabolicChain`) depends
+   * on, bypassing the fast path and forcing a full re-simulation on every read.
+   *
+   * Policy for what a day's simulation should include:
+   *  - `includePlannedWorkouts: false` / `synthesizeMealsIfUnlogged: false` - "finalized" mode.
+   *    A day that has already ended is closed out on what actually happened: completed workouts and
+   *    real logged nutrition. A planned-but-never-completed workout is a ghost session that didn't
+   *    happen and must not drain the tank; a synthetic meal projects a *future* meal-planning
+   *    assumption that no longer applies once the day is over - the real (possibly empty) log is
+   *    what should be trusted instead.
+   *  - `includePlannedWorkouts: true` / `synthesizeMealsIfUnlogged: true` - "projected" mode. Today
+   *    or a future day has no "what actually happened" yet for hours that have not occurred, so
+   *    planned workouts and synthesized meal refills legitimately stand in for real data that
+   *    doesn't exist yet.
+   *
+   * `finalizeDay` always simulates in finalized mode - it exists specifically to close a day out.
+   * `getDailyTimeline` picks the mode per call based on whether the requested date is already in
+   * the past, so simulating a past day here agrees with what `finalizeDay` persisted for it, while
+   * today/future behavior (planned workouts + synthetic meals) is unchanged.
+   */
+  async simulateDayCore(
     userId: string,
     date: Date,
     startingGlycogen: number,
     startingFluid: number,
+    policy: { includePlannedWorkouts: boolean; synthesizeMealsIfUnlogged: boolean },
     currentTime: Date = new Date()
-  ) {
+  ): Promise<{
+    points: any[]
+    dayNutrition: any
+    dayWorkouts: any[]
+    timezone: string
+    settings: any
+    weightKg: number
+    user: { weight?: number | null; weightSourceMode?: string | null; ftp?: number | null } | null
+  }> {
     const timezone = await getUserTimezone(userId)
     const settings = await getUserNutritionSettings(userId)
     const user = await prisma.user.findUnique({
@@ -217,27 +265,12 @@ export const metabolicService = {
 
     const weightKg = await resolveWeightKg(userId, user)
 
-    const dayWorkouts = await this.getRelevantWorkouts(userId, date, timezone)
+    const dayWorkouts = policy.includePlannedWorkouts
+      ? await this.getRelevantWorkouts(userId, date, timezone)
+      : await this.getCompletedWorkoutsOnly(userId, date, timezone)
+
     const dayNutrition = await nutritionRepository.getByDate(userId, date)
 
-    const rangeStart = getStartOfDayUTC(timezone, date)
-    const rangeEnd = getEndOfDayUTC(timezone, date)
-
-    const journeyEvents = await prisma.athleteJourneyEvent.findMany({
-      where: {
-        userId,
-        timestamp: {
-          gte: rangeStart,
-          lte: rangeEnd
-        }
-      },
-      orderBy: { timestamp: 'asc' }
-    })
-
-    const todayLocal = getUserLocalDate(timezone)
-
-    // Synthesize meals if needed (ONLY for Today or Future)
-    let simulationMeals: any[] = []
     const hasLogs = !!(
       dayNutrition &&
       ((Array.isArray(dayNutrition.breakfast) && dayNutrition.breakfast.length > 0) ||
@@ -246,17 +279,15 @@ export const metabolicService = {
         (Array.isArray(dayNutrition.snacks) && dayNutrition.snacks.length > 0))
     )
 
-    const isPast = date < todayLocal
-
-    // If no logs AND not past (i.e. Today or Future), synthesize based on workouts
-    if (!hasLogs && !isPast) {
-      simulationMeals = synthesizeRefills(
-        date,
-        dayWorkouts,
-        { weight: weightKg, ftp: user?.ftp || 250, ...settings },
-        timezone
-      )
-    }
+    const simulationMeals =
+      policy.synthesizeMealsIfUnlogged && !hasLogs
+        ? synthesizeRefills(
+            date,
+            dayWorkouts,
+            { weight: weightKg, ftp: user?.ftp || 250, ...settings },
+            timezone
+          )
+        : []
 
     const points = calculateEnergyTimeline(
       dayNutrition || {
@@ -274,6 +305,52 @@ export const metabolicService = {
         now: currentTime
       }
     )
+
+    return { points, dayNutrition, dayWorkouts, timezone, settings, weightKg, user }
+  },
+
+  /**
+   * Calculates the full energy timeline for a specific day.
+   * Centralizes logic for workout merging, meal synthesis policy, and timeline generation.
+   * Returns both the points (for charts) and the liveStatus (for the tank).
+   */
+  async getDailyTimeline(
+    userId: string,
+    date: Date,
+    startingGlycogen: number,
+    startingFluid: number,
+    currentTime: Date = new Date()
+  ) {
+    const timezone = await getUserTimezone(userId)
+    const todayLocal = getUserLocalDate(timezone)
+    // CW-76: a day that has already ended agrees with `finalizeDay` - completed workouts and real
+    // logged nutrition only. Today/future behavior (planned workouts + synthetic meal projection
+    // when unlogged) is unchanged.
+    const isPast = date < todayLocal
+
+    const { points, dayNutrition, dayWorkouts, settings, weightKg, user } =
+      await this.simulateDayCore(
+        userId,
+        date,
+        startingGlycogen,
+        startingFluid,
+        { includePlannedWorkouts: !isPast, synthesizeMealsIfUnlogged: !isPast },
+        currentTime
+      )
+
+    const rangeStart = getStartOfDayUTC(timezone, date)
+    const rangeEnd = getEndOfDayUTC(timezone, date)
+
+    const journeyEvents = await prisma.athleteJourneyEvent.findMany({
+      where: {
+        userId,
+        timestamp: {
+          gte: rangeStart,
+          lte: rangeEnd
+        }
+      },
+      orderBy: { timestamp: 'asc' }
+    })
 
     // DERIVE LIVE STATUS FROM POINTS (SINGLE SOURCE OF TRUTH)
     const nowTs = currentTime.getTime()
@@ -799,12 +876,6 @@ export const metabolicService = {
   async finalizeDay(userId: string, date: Date) {
     const timezone = await getUserTimezone(userId)
     const settings = await getUserNutritionSettings(userId)
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { weight: true, weightSourceMode: true }
-    })
-
-    const weightKg = await resolveWeightKg(userId, user)
 
     // 1. Get current day's record
     let record = await nutritionRepository.getByDate(userId, date)
@@ -831,25 +902,16 @@ export const metabolicService = {
 
     const startingGlycogen = prevEndingGlycogen
 
-    // 3. Run Simulation
-    const rangeStart = getStartOfDayUTC(timezone, date)
-    const rangeEnd = getEndOfDayUTC(timezone, date)
-    const workouts = await workoutRepository.getForUser(userId, {
-      startDate: rangeStart,
-      endDate: rangeEnd,
-      includeDuplicates: false
-    })
-
-    const timeline = calculateEnergyTimeline(
-      record,
-      workouts,
-      { ...settings, weight: weightKg },
-      timezone,
-      undefined,
-      {
-        startingGlycogenPercentage: startingGlycogen,
-        startingFluidDeficit: prevEndingFluid
-      }
+    // 3. Run Simulation - "finalized" mode (CW-76): completed workouts and real logged nutrition
+    // only. This is the same core `getDailyTimeline` uses once a day is in the past, so the ending
+    // state persisted here for tomorrow's handoff agrees with what a timeline read for this same
+    // day would show - no planned-but-uncompleted ghost workouts, no synthetic meal projection.
+    const { points: timeline } = await this.simulateDayCore(
+      userId,
+      date,
+      startingGlycogen,
+      prevEndingFluid,
+      { includePlannedWorkouts: false, synthesizeMealsIfUnlogged: false }
     )
 
     const lastPoint = timeline[timeline.length - 1]
@@ -945,8 +1007,16 @@ export const metabolicService = {
     }
 
     allWorkouts.forEach((w) => addWorkout(w, w.date))
+    // CW-76: a day that has already ended is reconstructed from what actually happened, not from a
+    // session that was planned but never completed - the same policy `finalizeDay` and
+    // `getDailyTimeline` use for a past day. Only today-or-later keeps planned-but-uncompleted
+    // ("ghost") workouts, since those days still need a projection for hours that have not
+    // happened yet.
     allPlanned
-      .filter((p: any) => !p.completed && !completedPlannedIds.has(p.id))
+      .filter(
+        (p: any) =>
+          !p.completed && !completedPlannedIds.has(p.id) && formatDateUTC(p.date) >= todayKey
+      )
       .forEach((p) => addWorkout(p, p.date))
 
     const daysDiff = Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))

--- a/tests/unit/server/utils/services/metabolicService.test.ts
+++ b/tests/unit/server/utils/services/metabolicService.test.ts
@@ -9,9 +9,15 @@ import { getUserNutritionSettings } from '../../../../../server/utils/nutrition/
 import { formatDateUTC, formatUserTime } from '../../../../../server/utils/date'
 import { bodyMetricResolver } from '../../../../../server/utils/services/bodyMetricResolver'
 import {
+  calculateEnergyTimeline,
   calculateGlycogenState,
   selectRelevantWorkouts
 } from '../../../../../server/utils/nutrition-domain'
+// Real implementations, imported straight from their concrete modules so they bypass the
+// `../nutrition-domain` barrel mock below. Used to exercise real glycogen math for the CW-76
+// finalizeDay/getDailyTimeline unification tests instead of asserting against mocked stand-ins.
+import { calculateEnergyTimeline as realCalculateEnergyTimeline } from '../../../../../server/utils/nutrition-domain/metabolic-simulation'
+import { selectRelevantWorkouts as realSelectRelevantWorkouts } from '../../../../../server/utils/nutrition-domain/workout-selection'
 
 vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
@@ -590,6 +596,188 @@ describe('metabolicService smoke coverage', () => {
           'Carb loading: extra carbohydrate moved here for a big day ahead.'
         )
       })
+    })
+  })
+
+  describe('finalizeDay / getDailyTimeline unification (CW-76)', () => {
+    // "Today" is fixed at 2026-02-13 by the file-level `getUserLocalDate` mock, so this date is
+    // unambiguously in the past (`isPast` true in both finalizeDay and getDailyTimeline).
+    const PAST_DATE = new Date('2026-02-10T00:00:00.000Z')
+    const PAST_DATE_YESTERDAY_KEY = '2026-02-09'
+    const PAST_DATE_KEY = '2026-02-10'
+    // Well after the whole simulated day, so a workout's full duration is always captured
+    // regardless of exactly how each call resolves "now".
+    const AFTER_PAST_DATE = new Date('2026-02-11T00:00:00.000Z')
+
+    const pastDayRecord = {
+      id: 'nutrition-past-day',
+      date: PAST_DATE,
+      carbsGoal: 400,
+      carbs: 350,
+      // Logged exactly on the default meal-pattern times (Breakfast 08:00, Lunch 13:00, Dinner
+      // 19:00) so the simulation's own synthetic DAILY_BASE candidates are all suppressed by
+      // `hasRealLog` - the timeline is driven purely by these logged items, nothing assumed.
+      breakfast: [{ name: 'Oats', carbs: 80, protein: 10, fat: 5, calories: 400, date: '08:00' }],
+      lunch: [
+        { name: 'Rice Bowl', carbs: 120, protein: 20, fat: 10, calories: 700, date: '13:00' }
+      ],
+      dinner: [{ name: 'Pasta', carbs: 150, protein: 20, fat: 15, calories: 900, date: '19:00' }],
+      snacks: []
+    }
+
+    // A real, completed workout - always part of the simulation.
+    const completedWorkout = {
+      id: 'w-completed-1',
+      date: new Date('2026-02-10T00:00:00.000Z'),
+      title: 'Completed Ride',
+      type: 'Ride',
+      durationSec: 3600,
+      intensity: 0.75
+    }
+
+    // Planned for the same day, but never actually completed - a "ghost" workout. CW-76's bug was
+    // that `getDailyTimeline` simulated this as though it happened while `finalizeDay` did not.
+    const ghostWorkout = {
+      id: 'p-ghost-1',
+      date: new Date('2026-02-10T00:00:00.000Z'),
+      title: 'Planned Threshold Intervals',
+      type: 'Ride',
+      durationSec: 5400,
+      workIntensity: 0.85,
+      completed: false
+    }
+
+    const settings = {
+      bmr: 1600,
+      metabolicFloor: 0.6,
+      fuelState1Min: 3
+    }
+
+    function mockNutritionByDate() {
+      vi.mocked(nutritionRepository.getByDate).mockImplementation(
+        async (_userId: string, d: Date) => {
+          const key = d.toISOString().split('T')[0]
+          if (key === PAST_DATE_KEY) return pastDayRecord as any
+          if (key === PAST_DATE_YESTERDAY_KEY) {
+            return { endingGlycogenPercentage: 65, endingFluidDeficit: 0 } as any
+          }
+          return null as any
+        }
+      )
+    }
+
+    beforeEach(() => {
+      // The CW-72 block above spies on `metabolicService.getDailyTimeline` with a fixed stub
+      // return value, and `vi.clearAllMocks()` (run by the file-level beforeEach) clears call
+      // history but does not undo a `vi.spyOn(...).mockResolvedValue(...)`. Restore it here so
+      // these tests exercise the real method regardless of suite run order.
+      const dailyTimelineMock = metabolicService.getDailyTimeline as unknown as {
+        mockRestore?: () => void
+      }
+      dailyTimelineMock.mockRestore?.()
+
+      vi.mocked(getUserNutritionSettings).mockResolvedValue(settings as any)
+      vi.mocked(prisma.user.findUnique).mockResolvedValue({
+        weight: 70,
+        weightSourceMode: 'MANUAL',
+        ftp: 250
+      } as any)
+      // Use the real glycogen math for these tests rather than the module-level mocks, so parity
+      // is proven against actual computed values, not a stand-in.
+      vi.mocked(calculateEnergyTimeline).mockImplementation(realCalculateEnergyTimeline)
+      vi.mocked(selectRelevantWorkouts).mockImplementation(realSelectRelevantWorkouts)
+    })
+
+    it('finalizeDay ending glycogen matches getDailyTimeline last point for identical inputs (no ghost workouts, fully logged)', async () => {
+      mockNutritionByDate()
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([completedWorkout] as any)
+      vi.mocked(plannedWorkoutRepository.list).mockResolvedValue([] as any)
+
+      await metabolicService.finalizeDay(userId, PAST_DATE)
+
+      const updateCall = vi.mocked(nutritionRepository.update).mock.calls[0]
+      expect(updateCall?.[0]).toBe(pastDayRecord.id)
+      const finalizedEndingGlycogen = updateCall?.[1]?.endingGlycogenPercentage
+
+      const timeline = await metabolicService.getDailyTimeline(
+        userId,
+        PAST_DATE,
+        65,
+        0,
+        AFTER_PAST_DATE
+      )
+      const timelineLastPoint = timeline.points[timeline.points.length - 1]
+
+      expect(finalizedEndingGlycogen).toBeDefined()
+      expect(timelineLastPoint.level).toBe(finalizedEndingGlycogen)
+    })
+
+    it('excludes a planned-but-never-completed ("ghost") workout from a past day for both finalizeDay and getDailyTimeline, keeping them in agreement', async () => {
+      mockNutritionByDate()
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([completedWorkout] as any)
+      vi.mocked(plannedWorkoutRepository.list).mockResolvedValue([ghostWorkout] as any)
+
+      await metabolicService.finalizeDay(userId, PAST_DATE)
+      const updateCall = vi.mocked(nutritionRepository.update).mock.calls[0]
+      const finalizedEndingGlycogen = updateCall?.[1]?.endingGlycogenPercentage
+
+      const timeline = await metabolicService.getDailyTimeline(
+        userId,
+        PAST_DATE,
+        65,
+        0,
+        AFTER_PAST_DATE
+      )
+      const timelineLastPoint = timeline.points[timeline.points.length - 1]
+
+      // The two agree...
+      expect(timelineLastPoint.level).toBe(finalizedEndingGlycogen)
+      // ...specifically because getDailyTimeline never even looked at planned workouts for a past
+      // day, not because the numbers coincidentally lined up.
+      expect(plannedWorkoutRepository.list).not.toHaveBeenCalled()
+
+      // Prove the exclusion actually has teeth: simulating the same day with the ghost workout
+      // merged in (the pre-fix behavior) produces a strictly lower ending glycogen, since the extra
+      // 90 minute session drains additional glycogen that never really happened.
+      const withGhostIncluded = realCalculateEnergyTimeline(
+        pastDayRecord,
+        [completedWorkout, ghostWorkout],
+        { ...settings, weight: 70 },
+        'UTC',
+        undefined,
+        { startingGlycogenPercentage: 65, startingFluidDeficit: 0, now: AFTER_PAST_DATE }
+      )
+      const withGhostIncludedLast = withGhostIncluded[withGhostIncluded.length - 1]
+
+      expect(withGhostIncludedLast.level).toBeLessThan(finalizedEndingGlycogen)
+    })
+
+    it('keeps including planned-but-not-yet-completed workouts for getDailyTimeline on today/future days (unchanged behavior)', async () => {
+      const TODAY = new Date('2026-02-13T00:00:00.000Z') // matches the mocked getUserLocalDate
+
+      vi.mocked(nutritionRepository.getByDate).mockResolvedValue({
+        id: 'nutrition-today',
+        date: TODAY,
+        carbsGoal: 400,
+        breakfast: [{ name: 'Oats', carbs: 80, protein: 10, fat: 5, calories: 400, date: '08:00' }],
+        lunch: [],
+        dinner: [],
+        snacks: []
+      } as any)
+      vi.mocked(workoutRepository.getForUser).mockResolvedValue([completedWorkout] as any)
+      vi.mocked(plannedWorkoutRepository.list).mockResolvedValue([ghostWorkout] as any)
+
+      await metabolicService.getDailyTimeline(
+        userId,
+        TODAY,
+        65,
+        0,
+        new Date('2026-02-13T12:00:00.000Z')
+      )
+
+      // Today is not past, so getDailyTimeline still merges in planned-but-uncompleted workouts -
+      // only the finalized-past-day behavior changed.
+      expect(plannedWorkoutRepository.list).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Fixes CW-76

## Problem

`finalizeDay()` and `getDailyTimeline()` duplicated day-simulation math with different inputs:

- `finalizeDay` used **completed workouts only** and **real logged nutrition**, no synthetic meals.
- `getDailyTimeline` **unconditionally** merged in planned-but-not-yet-completed workouts (via `getRelevantWorkouts`/`selectRelevantWorkouts`) regardless of whether the requested date was in the past, and synthesized meal refills when nothing was logged (gated correctly on `isPast` for meals, but not for workouts).

For a day with a workout that was planned but never actually completed, `getDailyTimeline` simulated it as though it happened while `finalizeDay` did not — so `endingGlycogenPercentage` written by `finalizeDay` could diverge from what `getDailyTimeline`/`getWaveRange` would show for the same day by more than the 1% tolerance the day-to-day handoff (`getMetabolicStateForDate` / `repairMetabolicChain`) depends on, bypassing the fast path and forcing a full re-simulation on every read.

## Policy decision

A day that has **already ended** is closed out on what actually happened:
- **Completed workouts only.** A workout that was planned but never marked completed is a "ghost" session that didn't happen and must not drain the tank.
- **Real logged nutrition only, no synthetic meal projection.** A synthetic meal represents a *future* meal-planning assumption ("you'll probably eat around this workout") that no longer applies once the day is over — the real (possibly empty) log is what should be trusted instead.

**Today or a future day** still has no "what actually happened" for hours that haven't occurred yet, so it legitimately needs planned workouts and synthetic meal refills to project forward. That behavior is intentionally **unchanged**.

This matches what `finalizeDay` already did for nutrition/meals, and what `getDailyTimeline` already did for meal synthesis (`isPast` correctly gated synthesis) — the gap was specifically that `getDailyTimeline`'s **workout selection** never respected `isPast`.

## Change

- Extracted a shared `simulateDayCore(userId, date, startingGlycogen, startingFluid, policy, currentTime)` that does the actual workout-fetch → nutrition-fetch → meal-synthesis-decision → `calculateEnergyTimeline()` pipeline, parameterized by `{ includePlannedWorkouts, synthesizeMealsIfUnlogged }`.
- `finalizeDay` always calls it in "finalized" mode (`includePlannedWorkouts: false, synthesizeMealsIfUnlogged: false`) — unchanged behavior for `finalizeDay` itself, now expressed through the shared core.
- `getDailyTimeline` picks the mode based on its existing `isPast` check (`date < todayLocal`): past days now use finalized mode (the fix), today/future days keep the previous behavior (`includePlannedWorkouts: true, synthesizeMealsIfUnlogged: true` when unlogged) — **unchanged**.
- Added `getCompletedWorkoutsOnly()` helper (completed-only workout fetch, used by finalized mode).
- Applied the same past-day workout policy to `getWaveRange()`'s historical-day bucket (previously it also unconditionally merged in planned-but-uncompleted workouts for historical days) — a small, low-risk filter addition, not a full unification of `getWaveRange` into the shared core. `getWaveRange`'s cross-day carry-forward loop is structurally different enough that folding it into `simulateDayCore` felt riskier than warranted for this pass; noted below as follow-up scope.

### Scope note (narrower fix, not full unification)
Per the ticket's "if blocked, prefer a smaller scoped fix" guidance: `getWaveRange` was **not** fully unified into `simulateDayCore` (it computes a multi-day range with its own glycogen carry-forward state between days, structurally different from the single-day core). It only received the matching workout-selection policy fix for historical days. Fully migrating `getWaveRange`'s per-day loop onto `simulateDayCore` is left as follow-up scope if desired.

### Side effect worth flagging
Because `getWaveRange`'s workout list (`workouts` in its return value, used for chart/timeline workout dots) is built from the same filtered map now used for simulation, a planned-but-never-completed workout on a **historical** day will no longer appear in that list either. This is intentional and consistent with the policy above (a ghost session shouldn't be shown as though it happened), but is a minor behavior change on historical-day workout display.

## Verification

```
pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts
# Test Files  1 passed (1) / Tests  15 passed (15)

pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts
# Test Files  1 passed (1) / Tests  27 passed (27)  (24 pre-existing + 3 new CW-76 tests)

pnpm typecheck
# exit 0, no errors

pnpm vitest run tests/unit
# Test Files  321 passed (321) / Tests  1650 passed (1650)
```

New tests added to `tests/unit/server/utils/services/metabolicService.test.ts` (real, unmocked `calculateEnergyTimeline`/`selectRelevantWorkouts` math, not mocked stand-ins):
1. `finalizeDay` ending glycogen matches `getDailyTimeline`'s last point **exactly** for identical inputs (no ghost workouts, fully logged nutrition).
2. A planned-but-never-completed ("ghost") workout on a past day is excluded from **both** `finalizeDay` and `getDailyTimeline` — asserts they still agree, that `plannedWorkoutRepository.list` is never even called by `getDailyTimeline` for a past date, and that including the ghost workout (the pre-fix behavior, computed directly against the real simulation function) would have produced a strictly lower ending glycogen — proving the fix has real effect, not a coincidental match.
3. Today/future days still merge in planned-but-uncompleted workouts via `getDailyTimeline` (unchanged behavior guard).

## Test plan
- [x] `pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts` passes
- [x] `pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts` passes (27/27, includes 3 new CW-76 tests)
- [x] `pnpm typecheck` passes
- [x] Full unit suite (`pnpm vitest run tests/unit`) passes (1650/1650)