### PR TITLE
fix(infra): wire pnpm test:mcp into CI (CW-126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,29 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test:unit
+
+  mcp-tests:
+    name: MCP tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare Nuxt
+        run: pnpm exec nuxt prepare
+
+      - name: Run MCP server tests
+        run: pnpm test:mcp

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "glob": "^13.0.6",
+    "h3": "1.15.11",
     "happy-dom": "^20.3.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      h3:
+        specifier: 1.15.11
+        version: 1.15.11
       happy-dom:
         specifier: ^20.3.1
         version: 20.3.1


### PR DESCRIPTION
Fixes CW-126

## Summary

- Adds an `mcp-tests` job to `.github/workflows/ci.yml` that runs `pnpm test:mcp` (the MCP server / OAuth unit test suite), following the exact same job structure as the existing `typecheck` / `lint` / `unit-tests` jobs (checkout, pnpm setup, node via `.nvmrc`, install, `nuxt prepare`, run command).
- Fixes a pre-existing bug that made `pnpm test:mcp` fail in a clean install, discovered while verifying it before wiring it into CI (see below).
- Leaves `.github/workflows/e2e.yml` untouched — reasoning below.

## MCP tests: found and fixed a real bug

Per the ticket's verification steps, I ran `pnpm test:mcp` locally with a clean `pnpm install --frozen-lockfile` before wiring it into CI. It did **not** pass cleanly: 3 of 10 test files (12 of 39 tests) failed with `Cannot find package 'h3'`.

Root cause: `vitest.mcp.config.ts` uses a bare `defineConfig` from `vitest/config`, unlike the Nuxt-aware `vitest.config.ts` (`defineVitestConfig` from `@nuxt/test-utils/config`) used by `test:unit`. The bare config lacks Nuxt/Nitro's module resolution setup, so it can't resolve `h3` — a transitive dependency of `nuxt`/`nitropack` that pnpm's strict, isolated `node_modules` layout does not hoist to the project root for files outside the Nuxt build pipeline. The same source files (e.g. `server/utils/canonical-workout-serializer.ts`) resolve `h3` fine under `test:unit` because Nuxt's tooling handles it there.

Fix: added `h3` as an explicit devDependency pinned to `1.15.11` — the exact version already resolved elsewhere in the dependency tree (via `@nuxt/nitro-server`, `@nuxt/content`, `@nuxt/test-utils`), so this introduces no new version, just makes an existing resolved version reachable from the project root. Verified with a fresh `pnpm install --frozen-lockfile` (identical to CI's install step) that all 39 MCP tests now pass. The `pnpm-lock.yaml` diff is minimal (3 lines) — I hand-edited it rather than letting `pnpm install` rewrite it, since a plain reinstall reformatted the entire file's YAML style unrelated to this change.

This was a real, previously-undetected gap — exactly the kind of regression this ticket exists to catch. It just wasn't a test failure; it was that the suite couldn't even run outside a developer's local Nuxt-primed environment.

## E2E: left `.github/workflows/e2e.yml` unchanged (judgment call — please sanity-check)

The ticket allows "dedicated CI workflows" for the E2E requirement, and `e2e.yml` already exists as one: a full Docker Compose + Playwright (+ optional Lighthouse) workflow. Its trigger is currently PRs targeting `master`, or PRs labeled `run-e2e`/`run-lighthouse`, or manual `workflow_dispatch` — it does **not** run automatically on `develop` PRs, which is where most feature work (including this whole backlog) merges.

I considered expanding the trigger to `develop` PRs but decided against it, based on clear evidence this scoping is deliberate rather than an oversight:

- `e2e.yml` runs on `runs-on: [self-hosted, e2e]` — a single physical machine (`mac-mini-e2e`, per `docs/04-guides/e2e-testing.md`), not an elastic runner pool.
- `concurrency: { group: e2e-mac-mini, cancel-in-progress: false }` — runs queue serially with zero parallel capacity on that one machine.
- Git history shows the `master`-only + opt-in-label scoping was added deliberately in commit `c51d6daa` ("feat(ci): add PR triggers for E2E workflow (#270)"), in the same change that established `develop` as the default PR target branch and `master` as a release gate. This wasn't a default that got left behind — it was set intentionally alongside that branching model.
- The repo currently has dozens of active branches merging into `develop` concurrently (many from parallel agent-driven work). Running a 120-minute Docker Compose + Playwright suite on every `develop` PR against one shared machine would create a serial bottleneck, likely backing up PR turnaround for the whole team.

Given all of that, I judged the conservative, well-justified choice is to leave the E2E trigger scope as-is rather than silently expanding its blast radius. If the team wants `develop` PRs to get automatic E2E coverage, that's a separate, deliberate follow-up (e.g., a lighter smoke-test subset, more runner capacity, or scheduled nightly runs against `develop`) rather than a side effect of this ticket. Flagging this explicitly for reviewer attention since it's the one part of this PR that's a judgment call rather than a mechanical fix.

## Verification

```
$ pnpm typecheck
... (exit 0, no errors)

$ pnpm test:mcp   # after adding h3 devDependency, fresh frozen-lockfile install
 Test Files  10 passed (10)
      Tests  39 passed (39)

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"   # OK
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e.yml'))"  # OK
```

Branch protection: I did not (and cannot) modify `develop`'s required status checks. The new job is named `MCP tests` (job id `mcp-tests`) so a human can add it as a required check once comfortable with its stability.