### PR TITLE
fix(nutrition): group completed workouts by local day in wave range (CW-84)

### DIFF
--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -22,7 +22,8 @@ import {
   synthesizeRefills,
   ABSORPTION_PROFILES,
   getAbsorbedInInterval,
-  getProfileForItem
+  getProfileForItem,
+  getDateKey
 } from '../nutrition-domain'
 import { HYDRATION_DEBT_NUDGE_THRESHOLD_ML, MEAL_LINKED_WATER_ML } from '../nutrition/hydration'
 import { getUserNutritionSettings } from '../nutrition/settings'
@@ -1000,24 +1001,28 @@ export const metabolicService = {
       allWorkouts.map((w: any) => w.plannedWorkoutId).filter(Boolean)
     )
 
-    const addWorkout = (w: any, date: Date) => {
-      const key = date.toISOString().split('T')[0] as string
+    const addWorkout = (w: any, key: string) => {
       if (!workoutsByDate.has(key)) workoutsByDate.set(key, [])
       workoutsByDate.get(key)!.push(w)
     }
 
-    allWorkouts.forEach((w) => addWorkout(w, w.date))
+    // CW-84: Workout.date is a real timestamp, so it must be bucketed by the user's local
+    // calendar day (not the UTC date) - otherwise a late-night or early-morning session shifts
+    // onto the wrong day's glycogen simulation.
+    allWorkouts.forEach((w) => addWorkout(w, getDateKey(w.date, timezone)))
     // CW-76: a day that has already ended is reconstructed from what actually happened, not from a
     // session that was planned but never completed - the same policy `finalizeDay` and
     // `getDailyTimeline` use for a past day. Only today-or-later keeps planned-but-uncompleted
     // ("ghost") workouts, since those days still need a projection for hours that have not
     // happened yet.
+    // PlannedWorkout.date is a @db.Date column (a calendar date, not a timestamp), so it is
+    // already keyed by day and does not need timezone conversion.
     allPlanned
       .filter(
         (p: any) =>
           !p.completed && !completedPlannedIds.has(p.id) && formatDateUTC(p.date) >= todayKey
       )
-      .forEach((p) => addWorkout(p, p.date))
+      .forEach((p) => addWorkout(p, formatDateUTC(p.date)))
 
     const daysDiff = Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
     for (let i = 0; i <= daysDiff; i++) {
@@ -1584,16 +1589,19 @@ export const metabolicService = {
     )
 
     // Helper to group by local date
-    const addWorkout = (w: any, date: Date) => {
-      const key = date.toISOString().split('T')[0] as string
+    const addWorkout = (w: any, key: string) => {
       if (!workoutsByDate.has(key)) workoutsByDate.set(key, [])
       workoutsByDate.get(key)!.push(w)
     }
 
-    allWorkouts.forEach((w) => addWorkout(w, w.date))
+    // CW-84: Workout.date is a real timestamp, so it must be bucketed by the user's local
+    // calendar day (not the UTC date) to line up with the day-by-day simulation below.
+    allWorkouts.forEach((w) => addWorkout(w, getDateKey(w.date, timezone)))
+    // PlannedWorkout.date is a @db.Date column (a calendar date, not a timestamp), so it is
+    // already keyed by day and does not need timezone conversion.
     allPlanned
       .filter((p: any) => !p.completed && !completedPlannedIds.has(p.id))
-      .forEach((p) => addWorkout(p, p.date))
+      .forEach((p) => addWorkout(p, formatDateUTC(p.date)))
 
     // 3. Single-pass simulation through the range
     const statesByDate = new Map<string, { startingGlycogen: number; startingFluid: number }>()

--- a/tests/unit/server/utils/nutrition-timezone.test.ts
+++ b/tests/unit/server/utils/nutrition-timezone.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { buildAthleteContext } from '../../../../server/utils/services/chatContextService'
 import { prisma } from '../../../../server/utils/db'
 import { nutritionRepository } from '../../../../server/utils/repositories/nutritionRepository'
+import { workoutRepository } from '../../../../server/utils/repositories/workoutRepository'
+import { plannedWorkoutRepository } from '../../../../server/utils/repositories/plannedWorkoutRepository'
 import { nutritionTools } from '../../../../server/utils/ai-tools/nutrition'
 import { wellnessTools } from '../../../../server/utils/ai-tools/wellness'
 import { metabolicService } from '../../../../server/utils/services/metabolicService'
+import { calculateEnergyTimeline } from '../../../../server/utils/nutrition-domain'
 
 // Mock dependencies
 vi.mock('../../../../server/utils/db', () => ({
@@ -46,6 +49,12 @@ vi.mock('../../../../server/utils/repositories/wellnessRepository', () => ({
   }
 }))
 
+vi.mock('../../../../server/utils/repositories/plannedWorkoutRepository', () => ({
+  plannedWorkoutRepository: {
+    list: vi.fn().mockResolvedValue([])
+  }
+}))
+
 vi.mock('../../../../server/utils/training-metrics', () => ({
   generateTrainingContext: vi.fn().mockResolvedValue({ summary: {} }),
   formatTrainingContextForPrompt: vi.fn().mockReturnValue('Mocked Training Context')
@@ -57,6 +66,35 @@ vi.mock('../../../../server/utils/services/metabolicService', () => ({
     getDailyTimeline: vi.fn()
   }
 }))
+
+vi.mock('../../../../server/utils/nutrition/settings', () => ({
+  getUserNutritionSettings: vi.fn().mockResolvedValue({
+    fuelState1Min: 2.5,
+    metabolicFloor: 0.6
+  })
+}))
+
+vi.mock('../../../../server/utils/services/bodyMetricResolver', () => ({
+  bodyMetricResolver: {
+    resolveEffectiveWeight: vi.fn().mockResolvedValue({
+      value: 70,
+      source: { type: 'profile', label: 'Profile' }
+    })
+  }
+}))
+
+// getWaveRange/getMetabolicStatesForRange (CW-84) exercise the real nutrition simulation
+// per-day. Everything except the day-grouping logic under test is stubbed out so the test only
+// asserts which day a workout timestamp is bucketed into.
+vi.mock('../../../../server/utils/nutrition-domain', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../server/utils/nutrition-domain')>()
+  return {
+    ...actual,
+    calculateEnergyTimeline: vi.fn().mockReturnValue([{ level: 70, fluidDeficit: 0 }]),
+    synthesizeRefills: vi.fn().mockReturnValue([]),
+    estimateDailyCarbTargetGrams: vi.fn().mockReturnValue(300)
+  }
+})
 
 describe('Nutrition Timezone Handling', () => {
   const userId = 'user-123'
@@ -193,5 +231,96 @@ describe('Nutrition Timezone Handling', () => {
     expect(result.fuel_tank.breakdown.replenished).toBe(19)
     expect(result.workouts_on_day).toBe(2)
     expect(result.nutrition_summary.calories.logged).toBe(1401)
+  })
+})
+
+describe('getWaveRange / getMetabolicStatesForRange local-day workout grouping (CW-84)', () => {
+  const userId = 'user-tz-84'
+  // Fixed UTC+2 offset (no DST), so the local-vs-UTC day boundary is unambiguous.
+  const timezone = 'Etc/GMT-2'
+
+  // 00:30 local time on Feb 15 is 22:30 UTC on Feb 14 - the previous UTC calendar day.
+  const localMidnightThirtyWorkout = new Date('2026-02-14T22:30:00.000Z')
+
+  const startDate = new Date('2026-02-14T00:00:00.000Z')
+  const endDate = new Date('2026-02-15T00:00:00.000Z')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: userId,
+      timezone,
+      weight: 70,
+      weightSourceMode: 'MANUAL',
+      ftp: 250
+    } as any)
+    vi.mocked(prisma.athleteJourneyEvent.findMany).mockResolvedValue([] as any)
+    vi.mocked(nutritionRepository.getForUser).mockResolvedValue([])
+    vi.mocked(plannedWorkoutRepository.list).mockResolvedValue([])
+  })
+
+  it('buckets a workout logged at 00:30 local (+2 TZ) onto the correct local day, not the UTC day', async () => {
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+      {
+        id: 'w1',
+        date: localMidnightThirtyWorkout,
+        durationSec: 3600,
+        intensity: 0.7,
+        type: 'Ride'
+      }
+    ] as any)
+
+    const { metabolicService: realMetabolicService } = await vi.importActual<
+      typeof import('../../../../server/utils/services/metabolicService')
+    >('../../../../server/utils/services/metabolicService')
+
+    vi.spyOn(realMetabolicService, 'getMetabolicStateForDate').mockResolvedValue({
+      startingGlycogen: 70,
+      startingFluid: 0
+    } as any)
+
+    await realMetabolicService.getWaveRange(userId, startDate, endDate)
+
+    const calls = vi.mocked(calculateEnergyTimeline).mock.calls
+    expect(calls).toHaveLength(2)
+
+    // Call 0 = Feb 14 (local), Call 1 = Feb 15 (local) - the day-by-day loop runs in order.
+    const feb14Workouts = calls[0]![1] as any[]
+    const feb15Workouts = calls[1]![1] as any[]
+
+    expect(feb14Workouts.map((w) => w.id)).not.toContain('w1')
+    expect(feb15Workouts.map((w) => w.id)).toContain('w1')
+  })
+
+  it('getMetabolicStatesForRange buckets the same 00:30 local workout onto the correct local day', async () => {
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+      {
+        id: 'w1',
+        date: localMidnightThirtyWorkout,
+        durationSec: 3600,
+        intensity: 0.7,
+        type: 'Ride'
+      }
+    ] as any)
+
+    const { metabolicService: realMetabolicService } = await vi.importActual<
+      typeof import('../../../../server/utils/services/metabolicService')
+    >('../../../../server/utils/services/metabolicService')
+
+    vi.spyOn(realMetabolicService, 'getMetabolicStateForDate').mockResolvedValue({
+      startingGlycogen: 70,
+      startingFluid: 0
+    } as any)
+
+    await realMetabolicService.getMetabolicStatesForRange(userId, startDate, endDate)
+
+    const calls = vi.mocked(calculateEnergyTimeline).mock.calls
+    expect(calls).toHaveLength(2)
+
+    const feb14Workouts = calls[0]![1] as any[]
+    const feb15Workouts = calls[1]![1] as any[]
+
+    expect(feb14Workouts.map((w) => w.id)).not.toContain('w1')
+    expect(feb15Workouts.map((w) => w.id)).toContain('w1')
   })
 })


### PR DESCRIPTION
Fixes CW-84

## Summary
`getWaveRange` and `getMetabolicStatesForRange` in `server/utils/services/metabolicService.ts` bucketed completed workouts (`Workout.date`, a real timestamp) into per-day simulation buckets using `date.toISOString().split('T')[0]` — the UTC calendar date. For a user ahead of UTC (e.g. +2), a workout logged shortly after local midnight has a UTC timestamp still on the previous day, so it was bucketed onto the wrong local day and drained glycogen for the wrong day's simulation.

Both functions now key completed workouts using the existing `getDateKey(date, timezone)` helper (`server/utils/nutrition-domain/date-context.ts`), matching the timezone-aware pattern already used elsewhere in this file (`getRelevantWorkouts`, `getCompletedWorkoutsOnly`, etc.).

Planned workouts (`PlannedWorkout.date`) are a `@db.Date` column with no time component — they're already a calendar date, not a timestamp, so they keep using `formatDateUTC` rather than a timezone conversion, which would be a no-op there but risks papering over the actual distinction.

Diff is scoped to the two owned files only; no other logic in `metabolicService.ts` was touched (CW-83's caching refactor is intentionally sequenced after this).

## Verification
```
pnpm vitest run tests/unit/server/utils/nutrition-timezone.test.ts
```
6 passed (4 pre-existing + 2 new CW-84 tests covering `getWaveRange` and `getMetabolicStatesForRange`).

```
pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts
```
27 passed, no regressions.

```
pnpm typecheck
```
Passes cleanly (exit 0).

Full `tests/unit/server` suite (248 files / 1325 tests) also passes.

## Test plan
- [x] New unit test: workout logged at 00:30 local time (+2 TZ, i.e. 22:30 UTC the previous day) buckets onto the correct local day in both `getWaveRange` and `getMetabolicStatesForRange`
- [x] Existing `nutrition-timezone.test.ts` and `metabolicService.test.ts` suites pass unchanged
- [x] Full server unit test suite passes
- [x] Typecheck passes