### PR TITLE
perf(nutrition): batch fueling plan calculations for date ranges (CW-83)

### DIFF
--- a/server/api/nutrition/strategy.get.ts
+++ b/server/api/nutrition/strategy.get.ts
@@ -2,8 +2,6 @@ import { requireAuth } from '../../utils/auth-guard'
 import { metabolicService } from '../../utils/services/metabolicService'
 import { getUserTimezone, getUserLocalDate, formatDateUTC } from '../../utils/date'
 import { prisma } from '../../utils/db'
-import { getUserNutritionSettings } from '../../utils/nutrition/settings'
-import { bodyMetricResolver } from '../../utils/services/bodyMetricResolver'
 import {
   getHydrationAdviceSummary,
   getHydrationRingStatus,
@@ -57,29 +55,34 @@ export default defineEventHandler(async (event) => {
 
   try {
     // 1. Calculate Fueling Matrix (7 days: Today + 6 ahead)
-    const settings = await getUserNutritionSettings(userId)
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { weight: true, weightSourceMode: true, ftp: true }
-    })
-    const weight =
-      (await bodyMetricResolver.resolveEffectiveWeight(userId, user || undefined)).value || 75
+    // CW-83: a single batched call for the whole 7-day window instead of 7 sequential
+    // calculateFuelingPlanForDate() calls, each of which independently re-fetched timezone,
+    // nutrition settings, weight and that single day's workouts. (The per-day settings/user/weight
+    // fetches this replaced were already unused by the rest of this handler - calculateFuelingPlansForRange
+    // resolves them itself from the shared context it fetches once.)
+    const matrixEndDate = new Date(today)
+    matrixEndDate.setUTCDate(today.getUTCDate() + 6)
+    const dayPlans = await metabolicService.calculateFuelingPlansForRange(
+      userId,
+      today,
+      matrixEndDate,
+      { persist: false }
+    )
 
     const fuelingMatrix = []
     for (let i = 0; i < 7; i++) {
       const date = new Date(today)
       date.setUTCDate(today.getUTCDate() + i)
+      const dateKey = formatDateUTC(date)
 
-      const dayPlan = await metabolicService.calculateFuelingPlanForDate(userId, date, {
-        persist: false
-      })
-      const plan = dayPlan.plan as any
+      const dayPlan = dayPlans.get(dateKey)
+      const plan = dayPlan?.plan as any
 
       const totals = plan.dailyTotals
       const state = totals.fuelState || 1
 
       fuelingMatrix.push({
-        date: formatDateUTC(date),
+        date: dateKey,
         state,
         label: state === 3 ? 'Performance' : state === 2 ? 'Steady' : 'Eco',
         carbsTarget: Math.round(totals.carbs),

--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -1138,6 +1138,176 @@ export const metabolicService = {
   },
 
   /**
+   * Builds the `FuelingProfile` passed to `buildDayFuelingPlan`.
+   *
+   * Shared by `calculateFuelingPlanForDate` and `calculateFuelingPlansForRange` (CW-83) so the two
+   * cannot drift apart - it depends only on the user's settings/weight/ftp, none of which vary
+   * across a date range, which is exactly why the range version fetches them once instead of once
+   * per day.
+   */
+  buildFuelingProfile(settings: any, weightKg: number, ftp: number) {
+    return {
+      weight: weightKg,
+      ftp: ftp || 250,
+      currentCarbMax: settings.currentCarbMax,
+      sodiumTarget: settings.sodiumTarget,
+      sweatRate: settings.sweatRate ?? undefined,
+      preWorkoutWindow: settings.preWorkoutWindow,
+      postWorkoutWindow: settings.postWorkoutWindow,
+      fuelingSensitivity: settings.fuelingSensitivity,
+      fuelState1Trigger: settings.fuelState1Trigger,
+      fuelState1Min: settings.fuelState1Min,
+      fuelState1Max: settings.fuelState1Max,
+      fuelState2Trigger: settings.fuelState2Trigger,
+      fuelState2Min: settings.fuelState2Min,
+      fuelState2Max: settings.fuelState2Max,
+      fuelState3Min: settings.fuelState3Min,
+      fuelState3Max: settings.fuelState3Max,
+      bmr: settings.bmr ?? 1600,
+      activityLevel: settings.activityLevel || 'ACTIVE',
+      baseCaloriesMode: (settings.baseCaloriesMode === 'MANUAL_NON_EXERCISE'
+        ? 'MANUAL_NON_EXERCISE'
+        : 'AUTO') as 'AUTO' | 'MANUAL_NON_EXERCISE',
+      nonExerciseBaseCalories: settings.nonExerciseBaseCalories ?? undefined,
+      targetAdjustmentPercent: settings.targetAdjustmentPercent ?? 0,
+      baseProteinPerKg: settings.baseProteinPerKg,
+      baseFatPerKg: settings.baseFatPerKg
+    }
+  },
+
+  /**
+   * Turns a day's completed + planned workouts into the workout contexts `buildDayFuelingPlan`
+   * expects. Shared by `calculateFuelingPlanForDate` and `calculateFuelingPlansForRange` (CW-83).
+   */
+  resolveDayWorkoutContexts(
+    completedWorkouts: any[],
+    plannedWorkouts: any[],
+    timezone: string
+  ): any[] {
+    const contexts: any[] = []
+    const completedPlannedIds = new Set(
+      completedWorkouts.map((w) => w.plannedWorkoutId).filter(Boolean)
+    )
+    const remainingPlanned = plannedWorkouts.filter((w) => !completedPlannedIds.has(w.id))
+
+    for (const completed of completedWorkouts) {
+      contexts.push({
+        id: completed.id,
+        title: completed.title || 'Completed Workout',
+        durationSec: completed.durationSec || 0,
+        type: completed.type || 'Workout',
+        source: completed.source || 'completed',
+        date: completed.date,
+        startTime: completed.date,
+        durationHours: (completed.durationSec || 0) / 3600,
+        intensity: completed.intensity || 0.6,
+        calories: completed.calories,
+        kilojoules: completed.kilojoules,
+        strategyOverride: completed.plannedWorkout?.fuelingStrategy || undefined
+      })
+    }
+
+    for (const work of remainingPlanned) {
+      let startTimeDate: Date | null = null
+      if (work.startTime && typeof work.startTime === 'string' && work.startTime.includes(':')) {
+        startTimeDate = buildZonedDateTimeFromUtcDate(work.date, work.startTime, timezone, 10, 0)
+      } else if ((work.startTime as any) instanceof Date) {
+        startTimeDate = work.startTime as any as Date
+      }
+
+      contexts.push({
+        ...work,
+        source: 'planned',
+        startTime: startTimeDate,
+        durationHours: (work.durationSec || 0) / 3600,
+        intensity: work.workIntensity || 0.5,
+        strategyOverride: work.fuelingStrategy || undefined
+      })
+    }
+
+    return contexts
+  },
+
+  /**
+   * Resolves the day's meal-pattern slots into absolute times. Shared by
+   * `calculateFuelingPlanForDate` and `calculateFuelingPlansForRange` (CW-83).
+   */
+  resolveDayMealSlots(
+    settings: any,
+    targetDateStart: Date,
+    timezone: string
+  ): { name: string; at: Date }[] {
+    // Meal-pattern slots become the day's DAILY_BASE windows, so that baseline eating is planned
+    // on rest days too rather than leaving the day with no windows at all.
+    const mealPattern =
+      Array.isArray(settings.mealPattern) && settings.mealPattern.length > 0
+        ? (settings.mealPattern as any[])
+        : [
+            { name: 'Breakfast', time: '08:00' },
+            { name: 'Lunch', time: '13:00' },
+            { name: 'Dinner', time: '19:00' }
+          ]
+
+    return mealPattern
+      .map((slot: any) => {
+        const name = typeof slot?.name === 'string' && slot.name.trim() ? slot.name.trim() : 'Meal'
+        const at = buildZonedDateTimeFromUtcDate(targetDateStart, slot?.time, timezone, 12, 0)
+        return at instanceof Date && !Number.isNaN(at.getTime()) ? { name, at } : null
+      })
+      .filter((slot): slot is { name: string; at: Date } => slot !== null)
+  },
+
+  /**
+   * Builds the final serialized fueling plan for one day from already-resolved inputs (profile,
+   * workout contexts, meal slots, symptom override). Pure given its inputs - no fetching - so it is
+   * the single place `calculateFuelingPlanForDate` and `calculateFuelingPlansForRange` (CW-83) both
+   * call, guaranteeing they can never compute a day's plan differently.
+   */
+  buildFuelingPlanFromContexts(
+    profile: any,
+    contexts: any[],
+    targetDateStart: Date,
+    mealSlots: { name: string; at: Date }[],
+    override: {
+      carbAdjustment?: number
+      strategy?: string
+      notes?: string[]
+      isRescueProtocol?: boolean
+    } | null,
+    timezone: string
+  ) {
+    const dayPlan = buildDayFuelingPlan(profile, contexts as any, {
+      date: targetDateStart,
+      mealSlots,
+      carbAdjustment: override?.carbAdjustment ?? 1,
+      strategyOverride: override?.strategy
+    })
+
+    const labelledWindows = dayPlan.windows.map((w) => ({
+      ...w,
+      label: this.buildWindowLabel(w, timezone)
+    }))
+
+    const uniqueNotes = Array.from(new Set([...dayPlan.notes, ...(override?.notes || [])]))
+    const macroCalories = dayPlan.dailyTotals.calories
+    const energyTarget = dayPlan.dailyTotals.baseCalories + dayPlan.dailyTotals.activityCalories
+    const calories =
+      dayPlan.dailyTotals.activityCalories > 0
+        ? Math.max(energyTarget + dayPlan.dailyTotals.adjustmentCalories, macroCalories)
+        : energyTarget + dayPlan.dailyTotals.adjustmentCalories
+
+    return {
+      windows: labelledWindows,
+      notes: uniqueNotes,
+      dailyTotals: {
+        ...dayPlan.dailyTotals,
+        calories,
+        isRescueProtocol: override?.isRescueProtocol || false
+      }
+    }
+  },
+
+  /**
    * Computes a daily fueling plan synchronously.
    * Optional persistence keeps backward compatibility while enabling real-time on-demand generation.
    *
@@ -1212,128 +1382,21 @@ export const metabolicService = {
 
     const weightKg = await resolveWeightKg(userId, user)
 
-    const profile = {
-      weight: weightKg,
-      ftp: user?.ftp || 250,
-      currentCarbMax: settings.currentCarbMax,
-      sodiumTarget: settings.sodiumTarget,
-      sweatRate: settings.sweatRate ?? undefined,
-      preWorkoutWindow: settings.preWorkoutWindow,
-      postWorkoutWindow: settings.postWorkoutWindow,
-      fuelingSensitivity: settings.fuelingSensitivity,
-      fuelState1Trigger: settings.fuelState1Trigger,
-      fuelState1Min: settings.fuelState1Min,
-      fuelState1Max: settings.fuelState1Max,
-      fuelState2Trigger: settings.fuelState2Trigger,
-      fuelState2Min: settings.fuelState2Min,
-      fuelState2Max: settings.fuelState2Max,
-      fuelState3Min: settings.fuelState3Min,
-      fuelState3Max: settings.fuelState3Max,
-      bmr: settings.bmr ?? 1600,
-      activityLevel: settings.activityLevel || 'ACTIVE',
-      baseCaloriesMode: (settings.baseCaloriesMode === 'MANUAL_NON_EXERCISE'
-        ? 'MANUAL_NON_EXERCISE'
-        : 'AUTO') as 'AUTO' | 'MANUAL_NON_EXERCISE',
-      nonExerciseBaseCalories: settings.nonExerciseBaseCalories ?? undefined,
-      targetAdjustmentPercent: settings.targetAdjustmentPercent ?? 0,
-      baseProteinPerKg: settings.baseProteinPerKg,
-      baseFatPerKg: settings.baseFatPerKg
-    }
-
-    const contexts: any[] = []
-    const completedPlannedIds = new Set(
-      completedWorkouts.map((w) => w.plannedWorkoutId).filter(Boolean)
-    )
-    const remainingPlanned = plannedWorkouts.filter((w) => !completedPlannedIds.has(w.id))
+    const profile = this.buildFuelingProfile(settings, weightKg, user?.ftp || 250)
 
     // Check for symptom-based overrides
     const override = await remediationService.getActiveFuelingOverride(userId, date)
+    const contexts = this.resolveDayWorkoutContexts(completedWorkouts, plannedWorkouts, timezone)
+    const mealSlots = this.resolveDayMealSlots(settings, targetDateStart, timezone)
 
-    if (remainingPlanned.length > 0 || completedWorkouts.length > 0) {
-      for (const completed of completedWorkouts) {
-        contexts.push({
-          id: completed.id,
-          title: completed.title || 'Completed Workout',
-          durationSec: completed.durationSec || 0,
-          type: completed.type || 'Workout',
-          source: completed.source || 'completed',
-          date: completed.date,
-          startTime: completed.date,
-          durationHours: (completed.durationSec || 0) / 3600,
-          intensity: completed.intensity || 0.6,
-          calories: completed.calories,
-          kilojoules: completed.kilojoules,
-          strategyOverride: completed.plannedWorkout?.fuelingStrategy || undefined
-        })
-      }
-
-      for (const work of remainingPlanned) {
-        let startTimeDate: Date | null = null
-        if (work.startTime && typeof work.startTime === 'string' && work.startTime.includes(':')) {
-          startTimeDate = buildZonedDateTimeFromUtcDate(work.date, work.startTime, timezone, 10, 0)
-        } else if ((work.startTime as any) instanceof Date) {
-          startTimeDate = work.startTime as any as Date
-        }
-
-        contexts.push({
-          ...work,
-          source: 'planned',
-          startTime: startTimeDate,
-          durationHours: (work.durationSec || 0) / 3600,
-          intensity: work.workIntensity || 0.5,
-          strategyOverride: work.fuelingStrategy || undefined
-        })
-      }
-    }
-
-    // Meal-pattern slots become the day's DAILY_BASE windows, so that baseline eating is planned
-    // on rest days too rather than leaving the day with no windows at all.
-    const mealPattern =
-      Array.isArray(settings.mealPattern) && settings.mealPattern.length > 0
-        ? (settings.mealPattern as any[])
-        : [
-            { name: 'Breakfast', time: '08:00' },
-            { name: 'Lunch', time: '13:00' },
-            { name: 'Dinner', time: '19:00' }
-          ]
-
-    const mealSlots = mealPattern
-      .map((slot: any) => {
-        const name = typeof slot?.name === 'string' && slot.name.trim() ? slot.name.trim() : 'Meal'
-        const at = buildZonedDateTimeFromUtcDate(targetDateStart, slot?.time, timezone, 12, 0)
-        return at instanceof Date && !Number.isNaN(at.getTime()) ? { name, at } : null
-      })
-      .filter((slot): slot is { name: string; at: Date } => slot !== null)
-
-    const dayPlan = buildDayFuelingPlan(profile, contexts as any, {
-      date: targetDateStart,
+    const finalPlan = this.buildFuelingPlanFromContexts(
+      profile,
+      contexts,
+      targetDateStart,
       mealSlots,
-      carbAdjustment: override?.carbAdjustment ?? 1,
-      strategyOverride: override?.strategy
-    })
-
-    const labelledWindows = dayPlan.windows.map((w) => ({
-      ...w,
-      label: this.buildWindowLabel(w, timezone)
-    }))
-
-    const uniqueNotes = Array.from(new Set([...dayPlan.notes, ...(override?.notes || [])]))
-    const macroCalories = dayPlan.dailyTotals.calories
-    const energyTarget = dayPlan.dailyTotals.baseCalories + dayPlan.dailyTotals.activityCalories
-    const calories =
-      dayPlan.dailyTotals.activityCalories > 0
-        ? Math.max(energyTarget + dayPlan.dailyTotals.adjustmentCalories, macroCalories)
-        : energyTarget + dayPlan.dailyTotals.adjustmentCalories
-
-    const finalPlan = {
-      windows: labelledWindows,
-      notes: uniqueNotes,
-      dailyTotals: {
-        ...dayPlan.dailyTotals,
-        calories,
-        isRescueProtocol: override?.isRescueProtocol || false
-      }
-    }
+      override,
+      timezone
+    )
 
     if (persist) {
       await nutritionRepository.upsert(
@@ -1365,6 +1428,184 @@ export const metabolicService = {
       skipped: false,
       plan: finalPlan
     }
+  },
+
+  /**
+   * Batched, range-based counterpart to `calculateFuelingPlanForDate` (CW-83).
+   *
+   * `calculateFuelingPlanForDate` independently re-fetches the user's timezone, nutrition settings,
+   * weight and that single day's workouts on every call. Looping it once per day - as
+   * `strategy.get.ts`'s 7-day fueling matrix and `getUpcomingFuelingWindows`' lookahead both do -
+   * turns those into N redundant queries for values that do not vary across the range.
+   *
+   * This follows the same single-pass convention `getWaveRange` and `getMetabolicStatesForRange`
+   * already use: the shared per-user context (timezone/settings/weight) and the full range's
+   * workouts/nutrition are fetched ONCE, then one day-by-day loop builds each day's plan from the
+   * already-fetched data via the same `buildFuelingPlanFromContexts` helper
+   * `calculateFuelingPlanForDate` uses - so the two can never disagree on a given day (proven in
+   * nutritionPlanService.test.ts).
+   *
+   * `startDate`/`endDate` are treated as UTC-midnight calendar dates (the same convention
+   * `getWaveRange`/`getMetabolicStatesForRange` use), inclusive on both ends.
+   *
+   * Note: like `calculateFuelingPlanForDate`, workouts are queried by their raw UTC day rather than
+   * the user's local calendar day (the CW-84 `getDateKey` timezone bucketing that `getWaveRange` and
+   * `getMetabolicStatesForRange` use does not apply here) - this intentionally matches
+   * `calculateFuelingPlanForDate`'s existing per-day query bounds exactly, rather than changing
+   * fueling-plan generation's day-boundary behavior as a side effect of batching it.
+   *
+   * Returns a `Map` keyed by `yyyy-MM-dd`, one entry per day in the range, in the same
+   * `{ success, skipped, reason, plan }` shape `calculateFuelingPlanForDate` returns for a single
+   * day.
+   *
+   * `strategy.get.ts` is the only current caller (its Owned Paths), but nothing here is specific to
+   * it - `getUpcomingFuelingWindows`'s per-day loop and the `active-feed` endpoint could adopt this
+   * the same way without further changes to this function.
+   */
+  async calculateFuelingPlansForRange(
+    userId: string,
+    startDate: Date,
+    endDate: Date,
+    options: { persist?: boolean } = {}
+  ): Promise<Map<string, { success: boolean; skipped: boolean; reason?: string; plan: any }>> {
+    const persist = options.persist ?? true
+
+    const dayCursorStart = new Date(startDate)
+    dayCursorStart.setUTCHours(0, 0, 0, 0)
+    const dayCursorEnd = new Date(endDate)
+    dayCursorEnd.setUTCHours(0, 0, 0, 0)
+
+    const rangeStart = new Date(dayCursorStart)
+    const rangeEnd = new Date(dayCursorEnd)
+    rangeEnd.setUTCHours(23, 59, 59, 999)
+
+    // --- 1. Shared per-user context, fetched ONCE for the whole range ---
+    const settings = await getUserNutritionSettings(userId)
+    const timezone = await getUserTimezone(userId)
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { weight: true, weightSourceMode: true, ftp: true }
+    })
+    const weightKg = await resolveWeightKg(userId, user)
+    const profile = this.buildFuelingProfile(settings, weightKg, user?.ftp || 250)
+
+    // --- 2. Workouts + existing nutrition for the FULL range, fetched ONCE ---
+    const [plannedWorkouts, completedWorkouts, existingNutritionRows] = await Promise.all([
+      prisma.plannedWorkout.findMany({
+        where: {
+          userId,
+          date: { gte: rangeStart, lte: rangeEnd },
+          completed: { not: true },
+          completedWorkouts: { none: {} }
+        },
+        orderBy: { date: 'asc' }
+      }),
+      prisma.workout.findMany({
+        where: {
+          userId,
+          isDuplicate: false,
+          date: { gte: rangeStart, lte: rangeEnd }
+        },
+        orderBy: { date: 'asc' },
+        include: {
+          plannedWorkout: {
+            select: { fuelingStrategy: true, startTime: true }
+          }
+        }
+      }),
+      nutritionRepository.getForUser(userId, { startDate: rangeStart, endDate: rangeEnd })
+    ])
+
+    const plannedByDate = new Map<string, any[]>()
+    plannedWorkouts.forEach((w: any) => {
+      const key = formatDateUTC(w.date)
+      if (!plannedByDate.has(key)) plannedByDate.set(key, [])
+      plannedByDate.get(key)!.push(w)
+    })
+
+    const completedByDate = new Map<string, any[]>()
+    completedWorkouts.forEach((w: any) => {
+      const key = formatDateUTC(w.date)
+      if (!completedByDate.has(key)) completedByDate.set(key, [])
+      completedByDate.get(key)!.push(w)
+    })
+
+    const nutritionByDate = new Map<string, any>()
+    existingNutritionRows.forEach((n: any) => nutritionByDate.set(formatDateUTC(n.date), n))
+
+    // --- 3. Single-pass per-day loop over the already-fetched data ---
+    const results = new Map<
+      string,
+      { success: boolean; skipped: boolean; reason?: string; plan: any }
+    >()
+
+    const daysDiff = Math.round(
+      (dayCursorEnd.getTime() - dayCursorStart.getTime()) / (1000 * 60 * 60 * 24)
+    )
+
+    for (let i = 0; i <= daysDiff; i++) {
+      const date = new Date(dayCursorStart)
+      date.setUTCDate(dayCursorStart.getUTCDate() + i)
+      const dateKey = formatDateUTC(date)
+
+      const existingNutrition = nutritionByDate.get(dateKey)
+      if (persist && existingNutrition?.isManualLock) {
+        results.set(dateKey, {
+          success: true,
+          skipped: true,
+          reason: 'MANUAL_LOCK',
+          plan: existingNutrition.fuelingPlan
+        })
+        continue
+      }
+
+      const dayCompleted = completedByDate.get(dateKey) || []
+      const dayPlanned = plannedByDate.get(dateKey) || []
+
+      // Check for symptom-based overrides - genuinely per-day (a 24h rolling lookback), so this
+      // stays a per-day call rather than something batchable from the shared context above.
+      const override = await remediationService.getActiveFuelingOverride(userId, date)
+      const contexts = this.resolveDayWorkoutContexts(dayCompleted, dayPlanned, timezone)
+      const mealSlots = this.resolveDayMealSlots(settings, date, timezone)
+
+      const finalPlan = this.buildFuelingPlanFromContexts(
+        profile,
+        contexts,
+        date,
+        mealSlots,
+        override,
+        timezone
+      )
+
+      if (persist) {
+        await nutritionRepository.upsert(
+          userId,
+          date,
+          {
+            userId,
+            date,
+            fuelingPlan: finalPlan as any,
+            sourcePrecedence: 'AI',
+            caloriesGoal: finalPlan.dailyTotals.calories,
+            carbsGoal: finalPlan.dailyTotals.carbs,
+            proteinGoal: finalPlan.dailyTotals.protein,
+            fatGoal: finalPlan.dailyTotals.fat
+          },
+          {
+            fuelingPlan: finalPlan as any,
+            sourcePrecedence: 'AI',
+            caloriesGoal: finalPlan.dailyTotals.calories,
+            carbsGoal: finalPlan.dailyTotals.carbs,
+            proteinGoal: finalPlan.dailyTotals.protein,
+            fatGoal: finalPlan.dailyTotals.fat
+          }
+        )
+      }
+
+      results.set(dateKey, { success: true, skipped: false, plan: finalPlan })
+    }
+
+    return results
   },
 
   /**

--- a/tests/unit/server/utils/services/nutritionPlanService.test.ts
+++ b/tests/unit/server/utils/services/nutritionPlanService.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nutritionPlanService } from '../../../../../server/utils/services/nutritionPlanService'
+import { metabolicService } from '../../../../../server/utils/services/metabolicService'
 import { prisma } from '../../../../../server/utils/db'
 import { getUserTimezone } from '../../../../../server/utils/date'
 import { slugifySlot } from '../../../../../server/utils/nutrition-domain/day-plan'
+import { buildDayFuelingPlan } from '../../../../../server/utils/nutrition-domain'
+import { getUserNutritionSettings } from '../../../../../server/utils/nutrition/settings'
+import { bodyMetricResolver } from '../../../../../server/utils/services/bodyMetricResolver'
+import { nutritionRepository } from '../../../../../server/utils/repositories/nutritionRepository'
 
 vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
@@ -28,19 +33,76 @@ vi.mock('../../../../../server/utils/db', () => ({
     },
     user: {
       findUnique: vi.fn()
+    },
+    // CW-83: calculateFuelingPlanForDate/calculateFuelingPlansForRange query these two directly.
+    workout: {
+      findMany: vi.fn()
+    },
+    plannedWorkout: {
+      findMany: vi.fn()
+    },
+    // Queried by remediationService.getActiveFuelingOverride (real module, not mocked below).
+    athleteJourneyEvent: {
+      findMany: vi.fn()
     }
   }
 }))
 
-vi.mock('../../../../../server/utils/date', () => ({
-  getUserTimezone: vi.fn()
+vi.mock('../../../../../server/utils/date', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../server/utils/date')>()
+  return {
+    // CW-83 tests exercise the real metabolicService, which needs the real date helpers
+    // (formatDateUTC, buildZonedDateTimeFromUtcDate, ...) to bucket days correctly - only
+    // getUserTimezone itself stays mockable, as it always has been in this file.
+    ...actual,
+    getUserTimezone: vi.fn()
+  }
+})
+
+vi.mock('../../../../../server/utils/nutrition/settings', () => ({
+  getUserNutritionSettings: vi.fn()
 }))
 
-vi.mock('../../../../../server/utils/services/metabolicService', () => ({
-  metabolicService: {
-    getNutritionDay: vi.fn()
+vi.mock('../../../../../server/utils/services/bodyMetricResolver', () => ({
+  bodyMetricResolver: {
+    resolveEffectiveWeight: vi.fn()
   }
 }))
+
+vi.mock('../../../../../server/utils/repositories/nutritionRepository', () => ({
+  nutritionRepository: {
+    getByDate: vi.fn(),
+    getForUser: vi.fn(),
+    upsert: vi.fn()
+  }
+}))
+
+// The barrel is left real (pure functions, no side-effecting imports) except buildDayFuelingPlan,
+// which is wrapped in a spy that still calls through to the real implementation. This lets the
+// CW-83 tests below assert exactly how many times the day builder - and therefore the dominant
+// fuel-state determination it computes internally - runs, while every other test in this file
+// keeps exercising the real fueling-plan math untouched.
+vi.mock('../../../../../server/utils/nutrition-domain', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../server/utils/nutrition-domain')>()
+  return {
+    ...actual,
+    buildDayFuelingPlan: vi.fn((...args: Parameters<typeof actual.buildDayFuelingPlan>) =>
+      actual.buildDayFuelingPlan(...args)
+    )
+  }
+})
+
+vi.mock('../../../../../server/utils/services/metabolicService', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../server/utils/services/metabolicService')>()
+  return {
+    metabolicService: {
+      ...actual.metabolicService,
+      getNutritionDay: vi.fn()
+    }
+  }
+})
 
 describe('nutritionPlanService', () => {
   beforeEach(() => {
@@ -433,5 +495,162 @@ describe('nutritionPlanService', () => {
         })
       )
     })
+  })
+})
+
+describe('metabolicService.calculateFuelingPlansForRange batching (CW-83)', () => {
+  const userId = 'user-83'
+
+  const baseSettings = {
+    bmr: 1600,
+    activityLevel: 'ACTIVE',
+    baseCaloriesMode: 'AUTO',
+    nonExerciseBaseCalories: null,
+    baseProteinPerKg: 1.6,
+    baseFatPerKg: 1.0,
+    currentCarbMax: 90,
+    sodiumTarget: 750,
+    sweatRate: null,
+    preWorkoutWindow: 90,
+    postWorkoutWindow: 60,
+    fuelingSensitivity: 1.0,
+    fuelState1Trigger: 0.7,
+    fuelState1Min: 2.5,
+    fuelState1Max: 4.0,
+    fuelState2Trigger: 0.85,
+    fuelState2Min: 4.5,
+    fuelState2Max: 6.5,
+    fuelState3Min: 7.0,
+    fuelState3Max: 10.0,
+    targetAdjustmentPercent: 0,
+    mealPattern: null
+  }
+
+  // Two completed workouts on different days of a 5-day window, so the fixture proves per-day
+  // grouping actually varies day to day rather than every day getting the same plan by accident.
+  const allCompletedWorkouts = [
+    {
+      id: 'w-1',
+      title: 'Morning Ride',
+      durationSec: 3600,
+      type: 'Ride',
+      date: new Date('2026-03-01T08:00:00.000Z'),
+      intensity: 0.9,
+      calories: 600,
+      kilojoules: 2500,
+      plannedWorkoutId: null
+    },
+    {
+      id: 'w-2',
+      title: 'Long Endurance Ride',
+      durationSec: 4 * 3600,
+      type: 'Ride',
+      date: new Date('2026-03-03T09:00:00.000Z'),
+      intensity: 0.75,
+      calories: 2400,
+      kilojoules: 10000,
+      plannedWorkoutId: null
+    }
+  ]
+
+  const withinRange = (date: Date, gte?: Date, lte?: Date) =>
+    (!gte || date.getTime() >= gte.getTime()) && (!lte || date.getTime() <= lte.getTime())
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(getUserTimezone).mockResolvedValue('UTC')
+    vi.mocked(getUserNutritionSettings).mockResolvedValue(baseSettings as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      weight: 70,
+      weightSourceMode: 'MANUAL',
+      ftp: 250
+    } as any)
+    vi.mocked(bodyMetricResolver.resolveEffectiveWeight).mockResolvedValue({ value: 70 } as any)
+    vi.mocked(prisma.athleteJourneyEvent.findMany).mockResolvedValue([])
+    vi.mocked(nutritionRepository.getByDate).mockResolvedValue(null)
+    vi.mocked(nutritionRepository.getForUser).mockResolvedValue([])
+
+    // Mimic real DB date-range filtering so a single-day query (the per-day loop) and a
+    // multi-day query (the batched range) against this same fixture return the correct subset.
+    vi.mocked(prisma.workout.findMany).mockImplementation((async (args: any) =>
+      allCompletedWorkouts.filter((w) =>
+        withinRange(w.date, args?.where?.date?.gte, args?.where?.date?.lte)
+      )) as any)
+    vi.mocked(prisma.plannedWorkout.findMany).mockResolvedValue([])
+  })
+
+  it('produces identical per-day plans to looping calculateFuelingPlanForDate (no behavior regression)', async () => {
+    const startDate = new Date('2026-03-01T00:00:00.000Z')
+    const endDate = new Date('2026-03-03T00:00:00.000Z')
+
+    const rangeResult = await metabolicService.calculateFuelingPlansForRange(
+      userId,
+      startDate,
+      endDate,
+      { persist: false }
+    )
+
+    expect(rangeResult.size).toBe(3)
+
+    // Sanity check that the fixture actually exercises different code paths day to day, so the
+    // equality assertions below are not vacuously comparing empty/identical plans: 03-01 has the
+    // workout and gets workout windows, 03-02 is a rest day and gets baseline windows only.
+    const workoutDay = rangeResult.get('2026-03-01')?.plan as any
+    const restDay = rangeResult.get('2026-03-02')?.plan as any
+    expect(workoutDay.windows.some((w: any) => w.type === 'INTRA_WORKOUT')).toBe(true)
+    expect(restDay.windows.every((w: any) => w.type === 'DAILY_BASE')).toBe(true)
+
+    for (let i = 0; i <= 2; i++) {
+      const date = new Date(startDate)
+      date.setUTCDate(startDate.getUTCDate() + i)
+      const dateKey = date.toISOString().split('T')[0] as string
+
+      const loopDay = await metabolicService.calculateFuelingPlanForDate(userId, date, {
+        persist: false
+      })
+
+      expect(rangeResult.get(dateKey)).toEqual(loopDay)
+    }
+  })
+
+  it('fetches shared per-user context and range data only once for a multi-day range, not once per day', async () => {
+    const startDate = new Date('2026-03-01T00:00:00.000Z')
+    const endDate = new Date('2026-03-05T00:00:00.000Z') // 5 days
+
+    const result = await metabolicService.calculateFuelingPlansForRange(
+      userId,
+      startDate,
+      endDate,
+      { persist: false }
+    )
+
+    expect(result.size).toBe(5)
+    expect(getUserNutritionSettings).toHaveBeenCalledTimes(1)
+    expect(getUserTimezone).toHaveBeenCalledTimes(1)
+    expect(prisma.user.findUnique).toHaveBeenCalledTimes(1)
+    expect(bodyMetricResolver.resolveEffectiveWeight).toHaveBeenCalledTimes(1)
+    expect(prisma.workout.findMany).toHaveBeenCalledTimes(1)
+    expect(prisma.plannedWorkout.findMany).toHaveBeenCalledTimes(1)
+    expect(nutritionRepository.getForUser).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes the dominant fuel-state determination (buildDayFuelingPlan) exactly once per day, not twice', async () => {
+    const startDate = new Date('2026-03-01T00:00:00.000Z')
+    const endDate = new Date('2026-03-03T00:00:00.000Z') // 3 days
+
+    await metabolicService.calculateFuelingPlansForRange(userId, startDate, endDate, {
+      persist: false
+    })
+
+    expect(buildDayFuelingPlan).toHaveBeenCalledTimes(3)
+  })
+
+  it('calculateFuelingPlanForDate itself also invokes the day builder exactly once per call', async () => {
+    const date = new Date('2026-03-01T00:00:00.000Z')
+
+    await metabolicService.calculateFuelingPlanForDate(userId, date, { persist: false })
+
+    expect(buildDayFuelingPlan).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Fixes CW-83

## Summary

`/nutrition`'s `strategy` endpoint looped `calculateFuelingPlanForDate()` once per day for its 7-day fueling matrix. Each call independently re-fetched the user's timezone, nutrition settings, weight, and that single day's workouts - turning one page load into 7x the queries for values that don't vary across the range.

- Added `metabolicService.calculateFuelingPlansForRange(userId, startDate, endDate, options)`: fetches the shared per-user context (timezone/settings/weight) and the full range's workouts/nutrition **once**, then runs a single day-by-day loop over the already-fetched data. This follows the same single-pass convention `getWaveRange`/`getMetabolicStatesForRange` already use in this file.
- Factored `calculateFuelingPlanForDate`'s per-day logic into shared helpers (`buildFuelingProfile`, `resolveDayWorkoutContexts`, `resolveDayMealSlots`, `buildFuelingPlanFromContexts`) that both the single-day and batched functions call, so the two can never compute a given day differently. `calculateFuelingPlanForDate`'s own signature/behavior is otherwise unchanged - lower risk than rewriting it to delegate into the range function, since it's still called from several other places (`getMealTargetContext`, `getUpcomingFuelingWindows`, `getNutritionDay`).
- `strategy.get.ts` now calls `calculateFuelingPlansForRange` once for its 7-day window instead of looping `calculateFuelingPlanForDate` 7 times. Also removed a pre-existing dead read of `settings`/`user`/`weight` in that handler - fetched but never used by anything downstream even before this change.

### Investigated but did not change

The ticket's claim that `calculateFuelingStrategy` is invoked twice per context inside `calculateFuelingPlanForDate` does not hold against the current code: `calculateFuelingPlanForDate` calls `buildDayFuelingPlan` (which computes the dominant fuel state via `resolveDayFuelState`) **exactly once** already. `calculateFuelingStrategy` is a separate single-workout view (used by the planned-workout fueling panel, an unrelated endpoint) - it isn't called from `calculateFuelingPlanForDate` at all. This looks like it was already fixed by an earlier refactor ("Build day-level fueling plans that reconcile to daily macro targets") that replaced the old per-workout strategy calls with the single day-level builder. Added a test asserting this stays true (`buildDayFuelingPlan` invoked exactly once per day, not twice).

`getUpcomingFuelingWindows` and the `active-feed` endpoint still loop/recompute per day and are not touched here (out of this ticket's Owned Paths), but `calculateFuelingPlansForRange` is generic enough that either could adopt it later without further core changes - satisfying the "reuse across strategy, upcoming plan, and active feed requests" part of the acceptance criteria without expanding this PR's scope.

## Verification

```
pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)

pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts
 Test Files  1 passed (1)
      Tests  27 passed (27)   # no regressions from CW-71/72/76/84's changes to this file today

pnpm typecheck
 exit 0
```

New tests added (`tests/unit/server/utils/services/nutritionPlanService.test.ts`, describe block `metabolicService.calculateFuelingPlansForRange batching (CW-83)`):
- batched function produces identical per-day results to looping `calculateFuelingPlanForDate` (includes a sanity check that a workout day and a rest day in the fixture produce genuinely different windows, so the equality assertion isn't vacuous)
- shared context (settings/timezone/user/weight) and range workout/nutrition queries are each fetched exactly once for a 5-day range, not once per day
- `buildDayFuelingPlan` (the dominant fuel-state determination) is invoked exactly once per day in both the batched and single-day paths

## Test plan

- [x] `pnpm vitest run tests/unit/server/utils/services/nutritionPlanService.test.ts`
- [x] `pnpm vitest run tests/unit/server/utils/services/metabolicService.test.ts`
- [x] `pnpm typecheck`
- [x] Broader regression pass: `pnpm vitest run tests/unit/server/api/nutrition tests/unit/server/utils` (180 files, 1116 tests passed)