### PR TITLE
fix(tests): add missing happy-dom environment to CoachCalendarPanel test

### DIFF
--- a/tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
+++ b/tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 


### PR DESCRIPTION
Follow-up to #411 (CW-260).

## Problem
#411 switched vitest's default `environment` from `happy-dom` to `node`, adding `// @vitest-environment happy-dom` to the 6 files it found mounting real Vue components. It missed `tests/unit/app/components/coaching/CoachCalendarPanel.test.ts`, which also `mount()`s a component via `@vue/test-utils` — it now fails with `ReferenceError: document is not defined` on `develop`, discovered when CI ran for an unrelated PR (#446) against current develop.

## Fix
Added the same `// @vitest-environment happy-dom` directive this file needed, matching the pattern #411 already established.

## Verification
```
pnpm vitest run tests/unit/app/components/coaching/CoachCalendarPanel.test.ts
Test Files  1 passed (1)
     Tests  2 passed (2)
```

Also re-grepped all 322 test files for `mount(`/`@vue/test-utils`/`document.`/`window.`/etc. without an existing `@vitest-environment` override — this was the only genuine miss (two other broader DOM-keyword matches were false positives on the word "window" appearing in comments about fueling windows).