### PR TITLE
fix(worker): preserve execArgv on heap-limit re-exec

### DIFF
--- a/cli/worker/ensure-heap.ts
+++ b/cli/worker/ensure-heap.ts
@@ -32,7 +32,7 @@ export function ensureWorkerHeapLimit(): void {
   process.env.NODE_OPTIONS = nextNodeOptions
   process.env[READY_MARKER] = '1'
 
-  const result = spawnSync(process.argv[0], process.argv.slice(1), {
+  const result = spawnSync(process.argv[0], buildRelaunchArgs(process.execArgv, process.argv), {
     stdio: 'inherit',
     env: process.env
   })
@@ -51,6 +51,16 @@ export function hasMaxOldSpaceSize(nodeOptions: string): boolean {
 
 export function appendNodeOption(nodeOptions: string, flag: string): string {
   return `${nodeOptions} ${flag}`.trim()
+}
+
+/**
+ * Build the argv for the relaunched process. Runtime loaders (e.g. tsx's
+ * --require/--import hooks) are injected via execArgv, not argv — dropping
+ * them relaunches under bare node, which cannot resolve our extensionless
+ * relative TS imports and fails with ERR_MODULE_NOT_FOUND.
+ */
+export function buildRelaunchArgs(execArgv: readonly string[], argv: readonly string[]): string[] {
+  return [...execArgv, ...argv.slice(1)]
 }
 
 function isWatchInvocation(): boolean {

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -120,6 +120,9 @@ services:
       DISABLE_EMAILS: 'true'
       NODE_ENV: production
       CI: 'true'
+      # Set directly (matches dev:worker/cw:worker/run.sh) so ensure-heap.ts's
+      # relaunch path — which re-execs with an elevated heap limit — is a no-op here.
+      NODE_OPTIONS: '--max-old-space-size=8192'
       CW_WORKER_HEALTH_PORT: '8081'
       NUXT_PUBLIC_SITE_URL: 'http://127.0.0.1:3199/'
       NUXT_PUBLIC_SUBSCRIPTIONS_ENABLED: 'true'

--- a/tests/unit/cli/worker-ensure-heap.test.ts
+++ b/tests/unit/cli/worker-ensure-heap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   appendNodeOption,
+  buildRelaunchArgs,
   hasMaxOldSpaceSize,
   WORKER_MAX_OLD_SPACE_SIZE_MB
 } from '../../../cli/worker/ensure-heap'
@@ -20,5 +21,28 @@ describe('worker ensure-heap helpers', () => {
     expect(
       appendNodeOption('--inspect', `--max-old-space-size=${WORKER_MAX_OLD_SPACE_SIZE_MB}`)
     ).toBe(`--inspect --max-old-space-size=${WORKER_MAX_OLD_SPACE_SIZE_MB}`)
+  })
+
+  it('preserves execArgv loader flags (e.g. tsx) when rebuilding the relaunch argv', () => {
+    // Regression: tsx injects itself via execArgv, not argv. Dropping execArgv
+    // on relaunch runs bare `node cli/worker/index.ts`, which cannot resolve
+    // extensionless relative imports and fails with ERR_MODULE_NOT_FOUND.
+    const execArgv = [
+      '--require',
+      '/app/node_modules/tsx/dist/preflight.cjs',
+      '--import',
+      'file:///app/node_modules/tsx/dist/loader.mjs'
+    ]
+    const argv = ['/usr/bin/node', 'cli/worker/index.ts', 'start']
+
+    expect(buildRelaunchArgs(execArgv, argv)).toEqual([...execArgv, 'cli/worker/index.ts', 'start'])
+  })
+
+  it('drops only argv[0] (the node binary), keeping the rest of argv intact', () => {
+    expect(buildRelaunchArgs([], ['/usr/bin/node', 'script.ts', 'foo', 'bar'])).toEqual([
+      'script.ts',
+      'foo',
+      'bar'
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- The e2e worker container was crashing on startup with `ERR_MODULE_NOT_FOUND`, failing the Playwright E2E job on develop→master release PRs (e.g. run [30660453170](https://github.com/watt-mind/coach/actions/runs/30660453170/job/91255173988)).
- `cli/worker/ensure-heap.ts` re-execs the worker process to apply an elevated V8 heap limit, but rebuilt argv from `process.argv.slice(1)` alone, dropping `process.execArgv`. Under `tsx`, the loader hooks (`--require`/`--import`) are injected via `execArgv`, not `argv` — so the relaunched process ran as bare `node`, which can't resolve the codebase's extensionless relative TS imports.
- This only shows up in the e2e Docker worker (`worker-e2e` in `docker-compose.e2e.yml`) because it's the only entry point that doesn't preset `NODE_OPTIONS` upfront (unlike `dev:worker`/`cw:worker`/`run.sh`), so it's the only caller that actually exercises the re-exec path.

## Changes
- `cli/worker/ensure-heap.ts`: new `buildRelaunchArgs()` helper preserves `execArgv` ahead of the trimmed `argv` when relaunching.
- `docker-compose.e2e.yml`: set `NODE_OPTIONS` directly on `worker-e2e`, matching the other entry points, so the re-exec path is a no-op there too (belt-and-braces).
- `tests/unit/cli/worker-ensure-heap.test.ts`: added regression tests covering the tsx-execArgv scenario (previously untested).

## Test plan
- [x] Reproduced the exact CI failure standalone (bare re-exec dropping execArgv → `ERR_MODULE_NOT_FOUND`) and confirmed the fix resolves it
- [x] Ran `tsx cli/worker/index.ts --help` with no `NODE_OPTIONS` preset (matching e2e worker env) — succeeds post-fix
- [x] `pnpm vitest run tests/unit/cli/worker-ensure-heap.test.ts` — 4/4 passing
- [x] `eslint` on changed files — clean
- [ ] CI e2e run on this PR (verifies the container actually comes up healthy)

Fixes CW-263
