### PR TITLE
fix(ci): install Playwright Chromium system deps on e2e runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,7 +106,7 @@ jobs:
             playwright-chromium-${{ runner.os }}-
 
       - name: Install Playwright Chromium
-        run: pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright
         if: ${{ !inputs.lighthouse_only }}

--- a/cli/worker/ensure-heap.ts
+++ b/cli/worker/ensure-heap.ts
@@ -32,7 +32,7 @@ export function ensureWorkerHeapLimit(): void {
   process.env.NODE_OPTIONS = nextNodeOptions
   process.env[READY_MARKER] = '1'
 
-  const result = spawnSync(process.argv[0], process.argv.slice(1), {
+  const result = spawnSync(process.argv[0], buildRelaunchArgs(process.execArgv, process.argv), {
     stdio: 'inherit',
     env: process.env
   })
@@ -51,6 +51,16 @@ export function hasMaxOldSpaceSize(nodeOptions: string): boolean {
 
 export function appendNodeOption(nodeOptions: string, flag: string): string {
   return `${nodeOptions} ${flag}`.trim()
+}
+
+/**
+ * Build the argv for the relaunched process. Runtime loaders (e.g. tsx's
+ * --require/--import hooks) are injected via execArgv, not argv — dropping
+ * them relaunches under bare node, which cannot resolve our extensionless
+ * relative TS imports and fails with ERR_MODULE_NOT_FOUND.
+ */
+export function buildRelaunchArgs(execArgv: readonly string[], argv: readonly string[]): string[] {
+  return [...execArgv, ...argv.slice(1)]
 }
 
 function isWatchInvocation(): boolean {

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -120,6 +120,9 @@ services:
       DISABLE_EMAILS: 'true'
       NODE_ENV: production
       CI: 'true'
+      # Set directly (matches dev:worker/cw:worker/run.sh) so ensure-heap.ts's
+      # relaunch path — which re-execs with an elevated heap limit — is a no-op here.
+      NODE_OPTIONS: '--max-old-space-size=8192'
       CW_WORKER_HEALTH_PORT: '8081'
       NUXT_PUBLIC_SITE_URL: 'http://127.0.0.1:3199/'
       NUXT_PUBLIC_SUBSCRIPTIONS_ENABLED: 'true'

--- a/tests/unit/cli/worker-ensure-heap.test.ts
+++ b/tests/unit/cli/worker-ensure-heap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   appendNodeOption,
+  buildRelaunchArgs,
   hasMaxOldSpaceSize,
   WORKER_MAX_OLD_SPACE_SIZE_MB
 } from '../../../cli/worker/ensure-heap'
@@ -20,5 +21,28 @@ describe('worker ensure-heap helpers', () => {
     expect(
       appendNodeOption('--inspect', `--max-old-space-size=${WORKER_MAX_OLD_SPACE_SIZE_MB}`)
     ).toBe(`--inspect --max-old-space-size=${WORKER_MAX_OLD_SPACE_SIZE_MB}`)
+  })
+
+  it('preserves execArgv loader flags (e.g. tsx) when rebuilding the relaunch argv', () => {
+    // Regression: tsx injects itself via execArgv, not argv. Dropping execArgv
+    // on relaunch runs bare `node cli/worker/index.ts`, which cannot resolve
+    // extensionless relative imports and fails with ERR_MODULE_NOT_FOUND.
+    const execArgv = [
+      '--require',
+      '/app/node_modules/tsx/dist/preflight.cjs',
+      '--import',
+      'file:///app/node_modules/tsx/dist/loader.mjs'
+    ]
+    const argv = ['/usr/bin/node', 'cli/worker/index.ts', 'start']
+
+    expect(buildRelaunchArgs(execArgv, argv)).toEqual([...execArgv, 'cli/worker/index.ts', 'start'])
+  })
+
+  it('drops only argv[0] (the node binary), keeping the rest of argv intact', () => {
+    expect(buildRelaunchArgs([], ['/usr/bin/node', 'script.ts', 'foo', 'bar'])).toEqual([
+      'script.ts',
+      'foo',
+      'bar'
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- The self-hosted `e2e-mac-mini` runner is missing a system library (`libnspr4.so`) that Chromium headless needs, discovered while validating the CW-263 worker fix (run [30693855289](https://github.com/watt-mind/coach/actions/runs/30693855289/job/91353200845)): every browser-driven Playwright test failed instantly with `error while loading shared libraries: libnspr4.so: cannot open shared object file`.
- `.github/workflows/e2e.yml` installed Chromium with `playwright install chromium` (no `--with-deps`), so Playwright never installs/repairs the OS-level packages the browser binary needs.
- Switching to `playwright install --with-deps chromium` has Playwright install those system dependencies itself on each run.

## Risk
This is a self-hosted runner, not a hosted GitHub Actions image — `--with-deps` shells out to `apt-get` and needs root/passwordless-sudo. If the runner user doesn't have that, this step will fail loudly (clear permission error) rather than silently no-op, which is an acceptable way to find out.

Fixes CW-289

## Test plan
- [ ] Label this PR `run-e2e` and confirm the "Install Playwright Chromium" step succeeds and browser-driven specs actually execute (not just the ~19 API-only specs that passed before)