### PR TITLE
fix(chat): sanitize bare tool-approval-response parts and tool-result Date leaks (CW-293)

### DIFF
--- a/server/api/chat/sanitize-tool-approval.ts
+++ b/server/api/chat/sanitize-tool-approval.ts
@@ -143,22 +143,28 @@ export function sanitizeChatMessagesForToolApprovals(messages: any[]): any[] {
     const parts = getMessageParts(message)
     if (parts.length === 0) return message
 
-    if (message.role === 'tool') {
-      const sanitizedParts = parts
-        .map((part) =>
-          part?.type === 'tool-approval-response' ? sanitizeToolApprovalResponsePart(part) : part
-        )
-        .filter((part) => part != null)
+    // Bare tool-approval-response parts can appear under any role (assistant-role
+    // history rows included), so normalize them regardless of the parent message.
+    const sanitizedParts = parts
+      .map((part) => {
+        if (part?.type === 'tool-approval-response') {
+          return sanitizeToolApprovalResponsePart(part)
+        }
+        if (message.role === 'assistant') {
+          return sanitizeAssistantToolApprovalPart(part)
+        }
+        return part
+      })
+      .filter((part) => part != null)
 
-      return withMessageParts(message, sanitizedParts)
+    if (message.role !== 'tool' && message.role !== 'assistant') {
+      const changed =
+        sanitizedParts.length !== parts.length ||
+        sanitizedParts.some((part, i) => part !== parts[i])
+      if (!changed) return message
     }
 
-    if (message.role === 'assistant') {
-      const sanitizedParts = parts.map((part) => sanitizeAssistantToolApprovalPart(part))
-      return withMessageParts(message, sanitizedParts)
-    }
-
-    return message
+    return withMessageParts(message, sanitizedParts)
   })
 }
 
@@ -170,15 +176,27 @@ export function sanitizeCoreMessagesForToolApprovals(messages: any[]): any[] {
 
   return messages
     .map((message) => {
-      if (message?.role !== 'tool' || !Array.isArray(message.content)) return message
+      if (!message || !Array.isArray(message.content)) return message
 
-      const content = message.content
-        .map((part: any) =>
-          part?.type === 'tool-approval-response' ? sanitizeToolApprovalResponsePart(part) : part
-        )
-        .filter((part: any) => part != null)
+      if (message.role === 'tool') {
+        const content = message.content
+          .map((part: any) =>
+            part?.type === 'tool-approval-response' ? sanitizeToolApprovalResponsePart(part) : part
+          )
+          .filter((part: any) => part != null)
 
-      if (content.length === 0) return null
+        if (content.length === 0) return null
+
+        return { ...message, content }
+      }
+
+      // The ModelMessage schema only allows tool-approval-response parts inside
+      // tool-role messages; anywhere else they crash standardizePrompt, so drop them.
+      const content = message.content.filter((part: any) => part?.type !== 'tool-approval-response')
+      if (content.length === message.content.length) return message
+      if (content.length === 0 && message.role === 'assistant') {
+        content.push({ type: 'text', text: ' ' })
+      }
 
       return { ...message, content }
     })

--- a/server/utils/ai-history.ts
+++ b/server/utils/ai-history.ts
@@ -189,8 +189,13 @@ export async function transformHistoryToCoreMessages(historyMessages: any[]) {
 
   for (const msg of historyMessages) {
     if (msg.role === 'tool') {
-      // Handle tool results
-      const parts = Array.isArray(msg.content) ? msg.content : msg.parts || []
+      // Handle tool results. Tool outputs loaded from the database can carry raw
+      // Date fields (e.g. plannedWorkout sync timestamps) that the AI SDK's
+      // JSON-only prompt schema rejects, so make the payload JSON-safe first.
+      const safeToolMsg = toJsonSafe(msg)
+      const parts = Array.isArray(safeToolMsg.content)
+        ? safeToolMsg.content
+        : safeToolMsg.parts || []
       const results = parts
         .filter(
           (p: any) =>

--- a/tests/unit/server/api/chat.test.ts
+++ b/tests/unit/server/api/chat.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeCoreMessagesForToolApprovals,
   sanitizeToolApprovalResponsePart
 } from '../../../../server/api/chat/sanitize-tool-approval'
+import { transformHistoryToCoreMessages } from '../../../../server/utils/ai-history'
 import { normalizeMessagesForSdk } from '../../../../server/utils/chat/turn-executor'
 
 describe('sanitizeToolApprovalResponsePart', () => {
@@ -111,6 +112,30 @@ describe('sanitizeChatMessagesForToolApprovals', () => {
     })
     expect(result[0].parts[0].approval).not.toHaveProperty('reason')
   })
+
+  it('normalizes bare tool-approval-response parts inside assistant messages (CW-293)', () => {
+    const result = sanitizeChatMessagesForToolApprovals([
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Done.' },
+          { type: 'tool-approval-response', toolCallId: 'call_1', approved: 'true' },
+          { type: 'tool-approval-response', approved: true }
+        ]
+      }
+    ])
+
+    expect(result[0].parts).toEqual([
+      { type: 'text', text: 'Done.' },
+      {
+        type: 'tool-approval-response',
+        approvalId: 'call_1',
+        toolCallId: 'call_1',
+        approved: true
+      }
+    ])
+  })
 })
 
 describe('sanitizeCoreMessagesForToolApprovals', () => {
@@ -150,6 +175,77 @@ describe('sanitizeCoreMessagesForToolApprovals', () => {
     ])
 
     expect(result).toEqual([{ role: 'user', content: 'hello' }])
+  })
+
+  it('drops tool-approval-response parts from assistant model messages (CW-293)', () => {
+    const result = sanitizeCoreMessagesForToolApprovals([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Done.' },
+          { type: 'tool-approval-response', toolCallId: 'call_1', approved: true }
+        ]
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-approval-response', toolCallId: 'call_2', approved: false }]
+      }
+    ])
+
+    expect(result[0].content).toEqual([{ type: 'text', text: 'Done.' }])
+    // An assistant message left empty must not reach the provider with no content
+    expect(result[1].content).toEqual([{ type: 'text', text: ' ' }])
+  })
+})
+
+describe('transformHistoryToCoreMessages Date serialization (CW-293)', () => {
+  it('serializes Date fields nested in tool-role result payloads', async () => {
+    const lastSyncedAt = new Date('2026-07-31T10:00:00.000Z')
+    const history = [
+      {
+        id: '1',
+        role: 'assistant',
+        content: 'Fetching workout.',
+        parts: [
+          { type: 'text', text: 'Fetching workout.' },
+          {
+            type: 'tool-approval-request',
+            toolCallId: 'call_pw',
+            toolName: 'plannedWorkout',
+            args: {}
+          }
+        ]
+      },
+      {
+        id: '2',
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call_pw',
+            toolName: 'plannedWorkout',
+            result: {
+              workout: {
+                lastSyncedAt,
+                lastStructureEditedAt: new Date('2026-07-31T11:00:00.000Z'),
+                nested: { lastRemoteStructureSeenAt: new Date('2026-07-31T12:00:00.000Z') }
+              }
+            }
+          }
+        ]
+      }
+    ]
+
+    const result = await transformHistoryToCoreMessages(history)
+
+    const toolMsg = result.find((m: any) => m.role === 'tool')
+    expect(toolMsg).toBeDefined()
+    const output = toolMsg.content[0].output
+    expect(output.type).toBe('json')
+    expect(output.value.workout.lastSyncedAt).toBe('2026-07-31T10:00:00.000Z')
+    expect(output.value.workout.lastStructureEditedAt).toBe('2026-07-31T11:00:00.000Z')
+    expect(output.value.workout.nested.lastRemoteStructureSeenAt).toBe('2026-07-31T12:00:00.000Z')
+    expect(JSON.stringify(result)).not.toContain('[object Date]')
   })
 })
 


### PR DESCRIPTION
Fixes CW-293

## Problem
`AI_TypeValidationError` from `standardizePrompt` kept recurring in prod after CW-209 (88 occurrences/24h). Two gaps:

1. **Sanitizer coverage gap** — a bare `tool-approval-response` part sitting directly in an assistant-role message bypassed both sanitizers: `sanitizeChatMessagesForToolApprovals` only handled the `.approval`-wrapper path for assistant messages, and `sanitizeCoreMessagesForToolApprovals` only touched `role === 'tool'` messages. The AI SDK's `assistantModelMessageSchema` doesn't allow `tool-approval-response` parts at all, so these crash validation regardless of field shape.
2. **Date leak** — `transformHistoryToCoreMessages` runs `toJsonSafe` on every history message **except** `role === 'tool'` messages, so tool-result payloads loaded from the DB (e.g. plannedWorkout `lastSyncedAt` / `lastStructureEditedAt` / `lastRemoteStructureSeenAt`) reached the prompt with raw `Date` objects.

## Fix
- `sanitizeChatMessagesForToolApprovals`: normalize/drop bare `tool-approval-response` parts in **any** message role (assistant included), keeping the existing wrapper repair path.
- `sanitizeCoreMessagesForToolApprovals`: process all roles — tool messages as before; other roles drop `tool-approval-response` parts (schema forbids them there), substituting a blank text part if an assistant message would become empty.
- `transformHistoryToCoreMessages`: run `toJsonSafe` on tool-role messages before extracting result payloads.

## Verification
- 3 new regression tests in `tests/unit/server/api/chat.test.ts` — all fail on pre-fix source, pass with the fix.
- `pnpm test tests/unit/server/api/chat.test.ts` → 11 passed
- `server/utils/ai-history.test.ts` → 12 passed, `server/utils/chat/turn-executor.test.ts` → 29 passed
- tsc/eslint/prettier clean on touched files

Post-deploy: confirm via `sudo docker service logs coach-watts-app-z8rrhj_app --since <deploy-time>` that `AI_TypeValidationError` stops recurring.