### PR TITLE
fix(chat): surface heartbeat-timeout recovery telemetry to Sentry/console (CW-295)

### DIFF
--- a/server/utils/services/chatTurnService.ts
+++ b/server/utils/services/chatTurnService.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@prisma/client'
+import * as Sentry from '@sentry/nuxt'
 import { prisma } from '../db'
 import { expandStoredChatMessages, truncateMessages } from '../chat/history'
 import { shouldExcludeAssistantMessageFromHistory } from '../chat/message-state'
@@ -602,7 +603,7 @@ class ChatTurnService {
     ]
     const cutoff = new Date(now.getTime() - CHAT_TURN_HEARTBEAT_TIMEOUT_MS)
 
-    return await prisma.$transaction(async (tx) => {
+    const result = await prisma.$transaction(async (tx) => {
       const claimed = await tx.chatTurn.updateMany({
         where: {
           id: turn.id,
@@ -757,6 +758,41 @@ class ChatTurnService {
           ? ('completed' as const)
           : ('interrupted' as const)
     })
+
+    // Recovery telemetry previously only landed in ChatTurnEvent rows (DB-only, no
+    // alerting/searchability). Surface it to Sentry/console so a recurrence is
+    // diagnosable without depending on docker log retention (see CW-295).
+    if (result === 'requeued' || result === 'interrupted') {
+      const elapsedMs =
+        turn.startedAt instanceof Date
+          ? now.getTime() - turn.startedAt.getTime()
+          : now.getTime() - turn.createdAt.getTime()
+      const logPayload = {
+        turnId: turn.id,
+        roomId: turn.roomId,
+        userId: turn.userId,
+        recoveryReason: reason,
+        recoveryAttempts,
+        recoveryClaimant,
+        previousRunId: turn.runId,
+        deploymentId: getDeploymentIdentity(),
+        elapsedMs,
+        hasUncertainMutation
+      }
+
+      if (result === 'interrupted') {
+        console.error('[ChatTurn] Turn interrupted after recovery attempts exhausted.', logPayload)
+        Sentry.captureMessage('ChatTurn heartbeat-timeout recovery exhausted', {
+          level: 'warning',
+          tags: { turnId: turn.id, recoveryReason: reason },
+          extra: logPayload
+        })
+      } else {
+        console.warn('[ChatTurn] Turn requeued after heartbeat timeout.', logPayload)
+      }
+    }
+
+    return result
   }
 
   async recoverStaleTurns(now = new Date(), recoveryClaimant = 'unknown') {

--- a/tests/unit/server/utils/services/chatTurnService-recovery.test.ts
+++ b/tests/unit/server/utils/services/chatTurnService-recovery.test.ts
@@ -9,7 +9,8 @@ const mocks = vi.hoisted(() => ({
   messageUpdate: vi.fn(),
   eventCreate: vi.fn(),
   usageUpdateMany: vi.fn(),
-  transaction: vi.fn()
+  transaction: vi.fn(),
+  captureMessage: vi.fn()
 }))
 
 vi.mock('../../../../../server/utils/db', () => ({
@@ -21,6 +22,10 @@ vi.mock('../../../../../server/utils/db', () => ({
     },
     $transaction: mocks.transaction
   }
+}))
+
+vi.mock('@sentry/nuxt', () => ({
+  captureMessage: mocks.captureMessage
 }))
 
 const now = new Date('2026-07-12T12:00:00.000Z')
@@ -148,6 +153,52 @@ describe('chat turn restart recovery', () => {
         })
       })
     )
+  })
+
+  it('reports requeue and interruption telemetry to Sentry/console (CW-295)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    mocks.findMany.mockResolvedValue([buildTurn()])
+    await chatTurnService.recoverStaleTurns(now)
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[ChatTurn] Turn requeued after heartbeat timeout.',
+      expect.objectContaining({ turnId: 'turn-1', recoveryReason: 'heartbeat_timeout' })
+    )
+    expect(mocks.captureMessage).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    mocks.transaction.mockImplementation(async (callback) =>
+      callback({
+        chatTurn: { updateMany: mocks.updateMany },
+        chatMessage: { update: mocks.messageUpdate },
+        chatTurnEvent: { create: mocks.eventCreate },
+        llmUsage: { updateMany: mocks.usageUpdateMany }
+      })
+    )
+    mocks.updateMany.mockResolvedValue({ count: 1 })
+    mocks.messageUpdate.mockResolvedValue({})
+    mocks.eventCreate.mockResolvedValue({})
+    mocks.usageUpdateMany.mockResolvedValue({ count: 1 })
+    mocks.findMany.mockResolvedValue([buildTurn(2)])
+
+    await chatTurnService.recoverStaleTurns(now)
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[ChatTurn] Turn interrupted after recovery attempts exhausted.',
+      expect.objectContaining({ turnId: 'turn-1', recoveryReason: 'heartbeat_timeout' })
+    )
+    expect(mocks.captureMessage).toHaveBeenCalledWith(
+      'ChatTurn heartbeat-timeout recovery exhausted',
+      expect.objectContaining({
+        level: 'warning',
+        tags: { turnId: 'turn-1', recoveryReason: 'heartbeat_timeout' }
+      })
+    )
+
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
   })
 
   it('does not recover a turn whose heartbeat was concurrently refreshed', async () => {


### PR DESCRIPTION
Fixes CW-295

## Problem

Investigating CW-295 (~6 chat turns/day silently dying via heartbeat-timeout recovery exhaustion), I ruled out deploys as the cause (52% of 7-day interruptions fall inside a 2-day window with zero deploys), but couldn't go further: `chatTurnService.recoverTurn` writes recovery telemetry only into `ChatTurnEvent` rows — never to console or Sentry. Combined with short docker log retention (a full 9-hour incident window with 84 turns produced only 5 retained log lines) and zero Sentry/tracing coverage on the chat-turn path, a recurrence of this bug is exactly as undiagnosable as the one I just investigated.

## Fix

Pure additive observability change, no control-flow changes:

- When a turn is **requeued** after a heartbeat timeout: `console.warn` with turn/recovery context (turnId, roomId, userId, recoveryAttempts, elapsedMs, etc.) — captured by Sentry's existing `consoleLoggingIntegration`.
- When a turn is **interrupted** after recovery attempts are exhausted (the actual user-facing failure): `console.error` **and** an explicit `Sentry.captureMessage` (warning level, tagged by turnId/recoveryReason) so it shows up as a searchable, alertable Sentry event rather than only a DB row nobody queries proactively.
- The 'completed' (recovered-from-mutation) and 'skipped' outcomes are intentionally left unlogged to avoid noise — they're the healthy paths.

## Verification

- New regression test in `chatTurnService-recovery.test.ts` asserts both the requeue-warn and interrupt-error+Sentry paths fire with the right payload/tags.
- `pnpm test tests/unit/server/utils/services/chatTurnService-recovery.test.ts` → 10 passed (was 9; all prior tests pass unmodified, confirming this is purely additive)
- `pnpm test tests/unit/server/utils/services/ server/utils/services/` → 203 passed, no regressions
- tsc/eslint/prettier clean on touched files

## Non-goals (documented on the ticket, not this PR)

- Root-causing the underlying hang itself — blocked on this same observability gap; next occurrence will now actually be diagnosable.
- Extending docker log retention — that's host/Dokploy config outside this repo.
- Auto-retrying interrupted turns server-side — flagged as a product decision on the ticket, not made here.