### PR TITLE
fix(nutrition): grocery list Week range anchored to viewed plan week (CW-315)

### DIFF
--- a/app/pages/nutrition/index.vue
+++ b/app/pages/nutrition/index.vue
@@ -549,7 +549,14 @@
               </div>
 
               <div v-else-if="!groceryData.items.length" class="py-8 text-center text-gray-500">
-                No planned meal ingredients found for this range yet.
+                <p>No planned meal ingredients found for this range yet.</p>
+                <p class="mt-1 text-xs">
+                  {{
+                    groceryRange === 'week'
+                      ? `The Week range covers the plan week you are viewing (${weekStartDate} – ${weekEndDate}).`
+                      : 'The 24h/48h/7d ranges look forward from today — switch to Week to cover the plan week you are viewing.'
+                  }}
+                </p>
               </div>
 
               <ul v-else class="space-y-2">
@@ -699,7 +706,7 @@
   const upcomingPlan = ref<any>(null)
   const showGroceryList = ref(false)
   const groceryLoading = ref(false)
-  const groceryRange = ref<'24h' | '48h' | '7d'>('48h')
+  const groceryRange = ref<'week' | '24h' | '48h' | '7d'>('week')
   const groceryData = ref<{ items: any[]; totals: { ingredients: number; meals: number } }>({
     items: [],
     totals: { ingredients: 0, meals: 0 }
@@ -1069,20 +1076,26 @@
   }
 
   const groceryRangeOptions = [
+    { value: 'week', label: 'Week' },
     { value: '24h', label: '24h' },
     { value: '48h', label: '48h' },
     { value: '7d', label: '7d' }
   ] as const
 
   function getGroceryRangeDates() {
+    // 'week' covers the plan week currently shown in the dashboard; the hour-based
+    // options roll forward from today. The API treats `end` as inclusive end-of-day.
+    if (groceryRange.value === 'week') {
+      return { start: weekStartDate.value, end: weekEndDate.value }
+    }
     const start = format(new Date(), 'yyyy-MM-dd')
     if (groceryRange.value === '24h') {
-      return { start, end: format(addDays(new Date(), 1), 'yyyy-MM-dd') }
+      return { start, end: start }
     }
     if (groceryRange.value === '7d') {
       return { start, end: format(addDays(new Date(), 6), 'yyyy-MM-dd') }
     }
-    return { start, end: format(addDays(new Date(), 2), 'yyyy-MM-dd') }
+    return { start, end: format(addDays(new Date(), 1), 'yyyy-MM-dd') }
   }
 
   async function loadGroceryList() {


### PR DESCRIPTION
Fixes CW-315

## Problem

The Grocery List modal only offered ranges rolling forward from today (24h/48h/7d). Locked meals earlier in the viewed plan week were invisible — reproduced in production for `hdkiller@gmail.com` on 2026-08-02 (Sunday): two `PLANNED` meals dated Monday 2026-07-27 in the current plan week, yet every range option returned "0 ingredients from 0 planned meals" while the weekly grid behind the modal showed them. Not data loss; a range-selection gap.

## Changes (client-only, `app/pages/nutrition/index.vue`)

- New **Week** range option covering `weekStartDate`–`weekEndDate` of the plan week being viewed in the dashboard; now the default selection. Fixes the reported case including when the viewed week is the current week.
- Trimmed 24h/48h ends to match their labels: the API treats `end` as inclusive end-of-day, so the old values fetched 2 and 3 calendar days respectively. Now 24h = today, 48h = today+1, 7d = today+6 (unchanged).
- Empty state now explains the range semantics (forward-looking vs. viewed week) instead of the bare "nothing found" message that caused the confusion.

No server changes — `grocery.get.ts` / `getGroceryList` were reviewed and behave correctly for any range they receive (validation, NaN guarding, and overlapping-plan merge all covered by existing unit tests).

## Verification

- `npx vitest run tests/unit/server/api/nutrition/grocery.get.test.ts tests/unit/server/utils/services/nutritionPlanService.test.ts` — 24/24 pass
- `pnpm typecheck` — clean (exit 0)
- eslint on the edited file — clean

Note: new UI strings ("Week", empty-state hint) are hardcoded English matching the surrounding modal copy, which is already partially unlocalized; localizing this modal would be a separate i18n pass.