### PR TITLE
fix(plans): validate and clamp AI block generation against weekly volume targets (CW-316)

### DIFF
--- a/server/utils/plans/block-volume.ts
+++ b/server/utils/plans/block-volume.ts
@@ -1,0 +1,176 @@
+/**
+ * Validation and deterministic clamping for AI-generated training block weeks.
+ *
+ * The block generator prompts Gemini with per-week volume targets, but the model
+ * sometimes schedules far more than requested (e.g. filling every availability
+ * slot every day). These helpers verify the generated schedule against the
+ * wizard-defined week targets and, as a last resort, scale it down so a week can
+ * never be persisted at a multiple of what the athlete asked for. (CW-316)
+ */
+
+export interface GeneratedBlockWorkout {
+  dayOfWeek: number
+  title?: string
+  description?: string
+  type: string
+  durationMinutes?: number
+  tssEstimate?: number
+  intensity?: string
+}
+
+export interface GeneratedBlockWeek {
+  weekNumber: number
+  focus_key?: string
+  focus_label?: string
+  explanation?: string
+  volumeTargetMinutes?: number
+  workouts?: GeneratedBlockWorkout[]
+}
+
+export interface WeekVolumeTarget {
+  weekNumber: number
+  volumeTargetMinutes: number | null
+  isRecovery?: boolean
+  /** UTC days (0=Sun..6=Sat) that can actually receive workouts. When set, workouts on other days are ignored (they are dropped at insert time anyway). */
+  allowedDaysOfWeek?: number[]
+}
+
+export interface BlockVolumeViolation {
+  weekNumber: number
+  kind: 'over_volume' | 'invalid_duration'
+  message: string
+}
+
+/** A week is rejected when its scheduled minutes exceed target * VOLUME_TOLERANCE. */
+export const VOLUME_TOLERANCE = 1.2
+/** When clamping, scale down to target * CLAMP_RATIO. */
+export const CLAMP_RATIO = 1.1
+export const MIN_WORKOUT_MINUTES = 15
+export const MAX_WORKOUT_MINUTES = 420
+
+const REST_TYPES = new Set(['Rest'])
+
+function isRest(workout: GeneratedBlockWorkout): boolean {
+  return REST_TYPES.has(workout.type)
+}
+
+function countsForWeek(workout: GeneratedBlockWorkout, target: WeekVolumeTarget): boolean {
+  if (isRest(workout)) return false
+  if (target.allowedDaysOfWeek && !target.allowedDaysOfWeek.includes(workout.dayOfWeek)) {
+    return false
+  }
+  return true
+}
+
+export function weekScheduledMinutes(week: GeneratedBlockWeek, target: WeekVolumeTarget): number {
+  return (week.workouts || [])
+    .filter((w) => countsForWeek(w, target))
+    .reduce((sum, w) => sum + (w.durationMinutes || 0), 0)
+}
+
+export function validateGeneratedBlockWeeks(
+  weeks: GeneratedBlockWeek[],
+  targets: WeekVolumeTarget[]
+): BlockVolumeViolation[] {
+  const violations: BlockVolumeViolation[] = []
+
+  for (const week of weeks) {
+    const target = targets.find((t) => t.weekNumber === Number(week.weekNumber))
+    if (!target) continue
+
+    for (const workout of week.workouts || []) {
+      if (!countsForWeek(workout, target)) continue
+      const minutes = workout.durationMinutes || 0
+      if (minutes < MIN_WORKOUT_MINUTES || minutes > MAX_WORKOUT_MINUTES) {
+        violations.push({
+          weekNumber: week.weekNumber,
+          kind: 'invalid_duration',
+          message: `Week ${week.weekNumber}: "${workout.title || workout.type}" has an implausible duration of ${minutes} minutes (must be ${MIN_WORKOUT_MINUTES}-${MAX_WORKOUT_MINUTES} for a non-Rest session).`
+        })
+      }
+    }
+
+    if (!target.volumeTargetMinutes || target.volumeTargetMinutes <= 0) continue
+
+    const scheduled = weekScheduledMinutes(week, target)
+    if (scheduled > target.volumeTargetMinutes * VOLUME_TOLERANCE) {
+      violations.push({
+        weekNumber: week.weekNumber,
+        kind: 'over_volume',
+        message: `Week ${week.weekNumber}${target.isRecovery ? ' (RECOVERY week)' : ''}: scheduled ${scheduled} minutes but the volume target is ${target.volumeTargetMinutes} minutes. Reduce total scheduled time to within ±10% of the target — do not fill every availability slot.`
+      })
+    }
+  }
+
+  return violations
+}
+
+export function formatViolationsFeedback(violations: BlockVolumeViolation[]): string {
+  return [
+    'YOUR PREVIOUS RESPONSE WAS REJECTED FOR THE FOLLOWING VOLUME VIOLATIONS:',
+    ...violations.map((v) => `- ${v.message}`),
+    '',
+    "Regenerate the FULL block fixing every violation. The weekly volume targets are hard budgets: the sum of workout durations in each week MUST stay within ±10% of that week's target. Availability slots are windows when the athlete CAN train — schedule only as many sessions as the volume budget allows, never one per slot per day."
+  ].join('\n')
+}
+
+/**
+ * Deterministic fallback when the AI ignores corrective feedback: clamp
+ * implausible durations and proportionally scale down over-volume weeks
+ * (durations and TSS together) to target * CLAMP_RATIO.
+ * Mutates nothing; returns new week objects plus a log of adjustments.
+ */
+export function clampGeneratedBlockWeeks(
+  weeks: GeneratedBlockWeek[],
+  targets: WeekVolumeTarget[]
+): { weeks: GeneratedBlockWeek[]; adjustments: string[] } {
+  const adjustments: string[] = []
+
+  const clamped = weeks.map((week) => {
+    const target = targets.find((t) => t.weekNumber === Number(week.weekNumber))
+    if (!target) return week
+
+    let workouts = (week.workouts || []).map((w) => {
+      if (!countsForWeek(w, target)) return w
+      const minutes = w.durationMinutes || 0
+      if (minutes < MIN_WORKOUT_MINUTES || minutes > MAX_WORKOUT_MINUTES) {
+        const fixed = Math.min(Math.max(minutes, MIN_WORKOUT_MINUTES), MAX_WORKOUT_MINUTES)
+        adjustments.push(
+          `Week ${week.weekNumber}: "${w.title || w.type}" duration ${minutes}min -> ${fixed}min`
+        )
+        return { ...w, durationMinutes: fixed }
+      }
+      return w
+    })
+
+    if (target.volumeTargetMinutes && target.volumeTargetMinutes > 0) {
+      const scheduled = workouts
+        .filter((w) => countsForWeek(w, target))
+        .reduce((sum, w) => sum + (w.durationMinutes || 0), 0)
+
+      if (scheduled > target.volumeTargetMinutes * VOLUME_TOLERANCE) {
+        const factor = (target.volumeTargetMinutes * CLAMP_RATIO) / scheduled
+        workouts = workouts.map((w) => {
+          if (!countsForWeek(w, target)) return w
+          const minutes = w.durationMinutes || 0
+          const scaledMinutes = Math.max(
+            MIN_WORKOUT_MINUTES,
+            Math.round((minutes * factor) / 5) * 5
+          )
+          const scaled: GeneratedBlockWorkout = { ...w, durationMinutes: scaledMinutes }
+          if (typeof w.tssEstimate === 'number') {
+            scaled.tssEstimate = Math.round(w.tssEstimate * factor)
+          }
+          return scaled
+        })
+        adjustments.push(
+          `Week ${week.weekNumber}: scaled ${scheduled}min down to ~${Math.round(target.volumeTargetMinutes * CLAMP_RATIO)}min (target ${target.volumeTargetMinutes}min)`
+        )
+      }
+    }
+
+    return { ...week, workouts }
+  })
+
+  return { weeks: clamped, adjustments }
+}

--- a/tests/unit/server/utils/plans/block-volume.test.ts
+++ b/tests/unit/server/utils/plans/block-volume.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  weekScheduledMinutes,
+  VOLUME_TOLERANCE,
+  CLAMP_RATIO,
+  MIN_WORKOUT_MINUTES,
+  type GeneratedBlockWeek,
+  type WeekVolumeTarget
+} from '../../../../../server/utils/plans/block-volume'
+
+const ride = (dayOfWeek: number, durationMinutes: number, tssEstimate?: number) => ({
+  dayOfWeek,
+  title: 'Ride',
+  type: 'Ride',
+  durationMinutes,
+  tssEstimate,
+  intensity: 'easy'
+})
+
+const target = (
+  weekNumber: number,
+  volumeTargetMinutes: number | null,
+  extra: Partial<WeekVolumeTarget> = {}
+): WeekVolumeTarget => ({ weekNumber, volumeTargetMinutes, ...extra })
+
+describe('weekScheduledMinutes', () => {
+  it('sums non-rest workout durations', () => {
+    const week: GeneratedBlockWeek = {
+      weekNumber: 1,
+      workouts: [ride(1, 90), ride(3, 60), { dayOfWeek: 2, type: 'Rest', durationMinutes: 0 }]
+    }
+    expect(weekScheduledMinutes(week, target(1, 480))).toBe(150)
+  })
+
+  it('ignores workouts on days outside allowedDaysOfWeek (they are dropped at insert)', () => {
+    const week: GeneratedBlockWeek = {
+      weekNumber: 1,
+      workouts: [ride(1, 90), ride(5, 120)]
+    }
+    expect(weekScheduledMinutes(week, target(1, 480, { allowedDaysOfWeek: [1, 2, 3] }))).toBe(90)
+  })
+})
+
+describe('validateGeneratedBlockWeeks', () => {
+  it('accepts a week within tolerance of its target', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 90), ride(3, 90), ride(6, 180)] }
+    ]
+    expect(validateGeneratedBlockWeeks(weeks, [target(1, 360)])).toEqual([])
+  })
+
+  it('flags a week scheduled beyond target * tolerance', () => {
+    // Reproduces CW-316: 480min target, ~919min scheduled
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [
+          ride(1, 90),
+          ride(2, 180),
+          ride(3, 180),
+          ride(4, 180),
+          ride(5, 180),
+          ride(6, 109)
+        ]
+      }
+    ]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ weekNumber: 1, kind: 'over_volume' })
+  })
+
+  it('mentions recovery in the violation for recovery weeks', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 3, workouts: [ride(1, 400), ride(3, 400)] }]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(3, 288, { isRecovery: true })])
+    expect(violations[0]!.message).toContain('RECOVERY')
+  })
+
+  it('flags implausible workout durations', () => {
+    // Prod example: 6-minute strength session with TSS 35
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [{ dayOfWeek: 2, title: 'Strength C', type: 'Gym', durationMinutes: 6 }]
+      }
+    ]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ kind: 'invalid_duration' })
+  })
+
+  it('skips weeks without a volume target and unmatched week numbers', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 400), ride(2, 400), ride(3, 400)] },
+      { weekNumber: 9, workouts: [ride(1, 400), ride(2, 400), ride(3, 400)] }
+    ]
+    expect(validateGeneratedBlockWeeks(weeks, [target(1, 0), target(2, 300)])).toEqual([])
+  })
+
+  it('does not count out-of-schedule workouts toward volume', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 300), ride(5, 300), ride(6, 300)] }
+    ]
+    // Only Monday is schedulable, so effective volume is 300 <= 360 * 1.2
+    expect(
+      validateGeneratedBlockWeeks(weeks, [target(1, 360, { allowedDaysOfWeek: [1] })])
+    ).toEqual([])
+  })
+})
+
+describe('clampGeneratedBlockWeeks', () => {
+  it('scales an over-volume week down to target * CLAMP_RATIO, durations and TSS together', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 300, 200), ride(3, 300, 200), ride(6, 300, 200)] }
+    ]
+    const { weeks: clamped, adjustments } = clampGeneratedBlockWeeks(weeks, [target(1, 450)])
+
+    const total = weekScheduledMinutes(clamped[0]!, target(1, 450))
+    expect(total).toBeLessThanOrEqual(450 * VOLUME_TOLERANCE)
+    // ~450 * 1.1 = 495, allow rounding slack from 5-minute steps
+    expect(total).toBeGreaterThanOrEqual(450 * CLAMP_RATIO * 0.9)
+    const w = clamped[0]!.workouts![0]!
+    expect(w.tssEstimate).toBeLessThan(200)
+    expect(adjustments.length).toBeGreaterThan(0)
+  })
+
+  it('clamps implausible durations into bounds', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [{ dayOfWeek: 2, type: 'Gym', durationMinutes: 6 }] }
+    ]
+    const { weeks: clamped } = clampGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(clamped[0]!.workouts![0]!.durationMinutes).toBe(MIN_WORKOUT_MINUTES)
+  })
+
+  it('leaves compliant weeks untouched', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 1, workouts: [ride(1, 90), ride(3, 90)] }]
+    const { weeks: clamped, adjustments } = clampGeneratedBlockWeeks(weeks, [target(1, 300)])
+    expect(clamped[0]!.workouts).toEqual(weeks[0]!.workouts)
+    expect(adjustments).toEqual([])
+  })
+
+  it('does not touch rest days or out-of-schedule workouts when scaling', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [
+          ride(1, 400),
+          ride(2, 400),
+          { dayOfWeek: 3, type: 'Rest', durationMinutes: 0 },
+          ride(6, 240)
+        ]
+      }
+    ]
+    const { weeks: clamped } = clampGeneratedBlockWeeks(weeks, [
+      target(1, 300, { allowedDaysOfWeek: [1, 2, 3] })
+    ])
+    const rest = clamped[0]!.workouts!.find((w) => w.type === 'Rest')!
+    const saturday = clamped[0]!.workouts!.find((w) => w.dayOfWeek === 6)!
+    expect(rest.durationMinutes).toBe(0)
+    expect(saturday.durationMinutes).toBe(240)
+  })
+})
+
+describe('formatViolationsFeedback', () => {
+  it('produces a corrective instruction listing each violation', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 1, workouts: [ride(1, 400), ride(2, 400)] }]
+    const feedback = formatViolationsFeedback(validateGeneratedBlockWeeks(weeks, [target(1, 300)]))
+    expect(feedback).toContain('REJECTED')
+    expect(feedback).toContain('Week 1')
+    expect(feedback).toContain('windows')
+  })
+})

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -19,6 +19,12 @@ import { TRAINING_BLOCK_TYPES, TRAINING_BLOCK_FOCUSES } from '../app/utils/train
 import { availabilityRepository } from '../server/utils/repositories/availabilityRepository'
 import { enqueuePlannedWorkoutStructureGeneration } from '../server/utils/planned-workout-structure-trigger'
 import { registerTaskHandler } from '../server/utils/task-registry'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  type WeekVolumeTarget
+} from '../server/utils/plans/block-volume'
 
 const trainingBlockSchema = {
   type: 'object',
@@ -124,7 +130,8 @@ export async function runGenerateTrainingBlock(payload: {
         select: {
           weekNumber: true,
           volumeTargetMinutes: true,
-          tssTarget: true
+          tssTarget: true,
+          isRecovery: true
         },
         orderBy: { weekNumber: 'asc' }
       }
@@ -381,7 +388,7 @@ CURRENT BLOCK CONTEXT:
 
 VOLUME TARGETS (Baseline from Plan Wizard):
 ${volumeTargets}
-*Use these targets as a guide. You may adjust slightly (+/- 10%) based on the phase and progression needs, but aim to hit these durations.*
+*These are HARD weekly duration budgets chosen by the athlete. The sum of all workout durations in a week MUST be within ±10% of that week's target. Never exceed it, and reduce recovery weeks accordingly.*
 
 WEEKLY SCHEDULE CONSTRAINTS (Explicit Dates):
 ${calendarContext}
@@ -389,6 +396,7 @@ ${calendarContext}
 
 TRAINING AVAILABILITY (when athlete can train):
 ${availabilitySummary || 'No availability set - assume flexible schedule'}
+*Availability slots are windows when the athlete CAN train — they are NOT sessions to fill. Schedule only as many sessions as the weekly volume budget allows; most days should use at most one slot.*
 
 LOCKED/ANCHOR WORKOUTS (DO NOT CHANGE OR REPLACE):
 ${
@@ -442,21 +450,58 @@ Return valid JSON matching the schema provided.`
     blockId,
     userId
   })
-  const result = await generateStructuredAnalysis<any>(
-    prompt,
-    trainingBlockSchema,
-    aiSettings.aiModelPreference,
-    {
+  const generateWeeks = (promptText: string) =>
+    generateStructuredAnalysis<any>(promptText, trainingBlockSchema, aiSettings.aiModelPreference, {
       userId,
       operation: 'generate_training_block',
       entityType: 'TrainingBlock',
       entityId: blockId
-    }
-  )
+    })
+
+  const result = await generateWeeks(prompt)
 
   // 5. Persist Results
   if (!result.weeks || result.weeks.length === 0) {
     throw new Error('AI returned no weeks for the block')
+  }
+
+  // 4.5 Validate the generated schedule against the wizard's weekly volume budgets.
+  // One corrective retry; if the model still over-schedules, clamp deterministically
+  // so a week can never persist at a multiple of the athlete's chosen volume. (CW-316)
+  const weekTargets: WeekVolumeTarget[] = weekSchedules.map((schedule) => {
+    const original = block.weeks.find((w) => w.weekNumber === schedule.weekNumber)
+    return {
+      weekNumber: schedule.weekNumber,
+      volumeTargetMinutes: original?.volumeTargetMinutes ?? null,
+      isRecovery: original?.isRecovery,
+      allowedDaysOfWeek: schedule.validDays.map((d) => d.getUTCDay())
+    }
+  })
+
+  let volumeViolations = validateGeneratedBlockWeeks(result.weeks, weekTargets)
+  if (volumeViolations.length > 0) {
+    logger.warn('[GenerateBlock] Generated weeks violate volume budgets, retrying with feedback', {
+      blockId,
+      violations: volumeViolations.map((v) => v.message)
+    })
+
+    const retry = await generateWeeks(`${prompt}\n\n${formatViolationsFeedback(volumeViolations)}`)
+    if (retry.weeks && retry.weeks.length > 0) {
+      result.weeks = retry.weeks
+      volumeViolations = validateGeneratedBlockWeeks(result.weeks, weekTargets)
+    }
+
+    if (volumeViolations.length > 0) {
+      const { weeks: clampedWeeks, adjustments } = clampGeneratedBlockWeeks(
+        result.weeks,
+        weekTargets
+      )
+      result.weeks = clampedWeeks
+      logger.warn('[GenerateBlock] Retry still over budget - clamped weeks deterministically', {
+        blockId,
+        adjustments
+      })
+    }
   }
 
   logger.log('Persisting generated plan...', { weeksCount: result.weeks.length })
@@ -530,6 +575,10 @@ Return valid JSON matching the schema provided.`
 
           const focusLabel = weekData?.focus_label || weekData?.focus_key || 'Training Week'
 
+          // Wizard-defined targets are the source of truth; the AI's self-reported
+          // volume target can silently diverge from what it actually scheduled. (CW-316)
+          const originalWeek = block.weeks.find((w) => w.weekNumber === schedule.weekNumber)
+
           const createdWeek = await tx.trainingWeek.create({
             data: {
               blockId,
@@ -540,13 +589,15 @@ Return valid JSON matching the schema provided.`
               focusKey: focusKey,
               focusLabel: focusLabel,
               explanation: weekData?.explanation || 'Weekly progression.',
-              volumeTargetMinutes: weekData?.volumeTargetMinutes || 0,
+              volumeTargetMinutes:
+                originalWeek?.volumeTargetMinutes || weekData?.volumeTargetMinutes || 0,
               tssTarget:
                 weekData?.workouts?.reduce(
                   (acc: number, w: any) => acc + (w.tssEstimate || 0),
                   0
                 ) || 0,
-              isRecovery: focusKey === 'RECOVERY' || focusKey === 'TAPER'
+              isRecovery:
+                originalWeek?.isRecovery ?? (focusKey === 'RECOVERY' || focusKey === 'TAPER')
             }
           })
 


### PR DESCRIPTION
Fixes CW-316

## Problem

`generate-training-block` inserted Gemini's output verbatim. When the model over-scheduled — typically by filling **every availability slot every day** — athletes received weeks at a multiple of their chosen volume. Prod scan (ACTIVE non-template plans, last 90 days): **10 weeks across 8 users above 1.5x their volume target**, 6 of them recovery weeks; worst case all 3 weeks of a block at ~2x (919–990 min vs a 480 min target, 14–15 workouts/week) for an athlete actually training 2–5 h/week.

Two contributing defects:
- `TrainingWeek.volumeTargetMinutes` was persisted from the AI's *self-reported* number, which silently diverged from the sum of the workouts it generated in the same response (480 claimed vs 990 scheduled), and `isRecovery` was recomputed from the AI's focus key — destroying the wizard's targets on every regeneration.
- No sanity bounds on durations (prod example: a 6-minute strength session with TSS 35).

## Fix

- **New `server/utils/plans/block-volume.ts`** (pure, unit-tested): validates generated weeks against the wizard's weekly volume budgets (tolerance 1.2x) and duration bounds (15–420 min for non-Rest), and provides deterministic proportional clamping (durations + TSS scaled together to target × 1.1, 5-min rounding) as a last resort. Only workouts that can actually be scheduled (valid days) count toward volume.
- **`trigger/generate-training-block.ts`**: after generation, validate → one corrective retry with explicit violation feedback → clamp deterministically if still over budget. Persist the wizard's `volumeTargetMinutes`/`isRecovery` (fallback to AI values only when absent). Prompt hardened: volume targets are hard budgets; availability slots are windows, not sessions to fill.

## Testing

- `pnpm vitest run tests/unit/server/utils/plans/block-volume.test.ts tests/unit/trigger/generate-weekly-plan.test.ts tests/unit/trigger/imports.test.ts` — 61 passed
- `pnpm typecheck` — clean
- ESLint on touched files — clean

## Follow-ups filed

- CW-317 workout type taxonomy inconsistency between generators
- CW-318 `calculateWeekTargets` ignores `volumeHours` on replan
- CW-319 same validation gap in `generate-weekly-plan`
- CW-320 ramp-rate cap vs recent actual load (product decision)