### PR TITLE
fix(plans): normalize AI workout types consistently across both generators (CW-317)

### DIFF
--- a/server/utils/plans/workout-type.ts
+++ b/server/utils/plans/workout-type.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalization of AI-generated workout types to the canonical types stored in
+ * the database and understood by integrations (Intervals.icu, UI icons, filters).
+ *
+ * The plan generators prompt the model with friendly type names ("Gym"), but the
+ * database convention is "WeightTraining". Historically only the weekly-plan
+ * generator normalized this, so block generation produced mixed taxonomies in
+ * the same plan ("Gym" and "WeightTraining" rows side by side). (CW-317)
+ */
+
+const AI_TYPE_TO_CANONICAL: Record<string, string> = {
+  Gym: 'WeightTraining'
+}
+
+export function normalizeGeneratedWorkoutType(aiType: string): string {
+  return AI_TYPE_TO_CANONICAL[aiType] || aiType
+}

--- a/tests/unit/server/utils/plans/workout-type.test.ts
+++ b/tests/unit/server/utils/plans/workout-type.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeGeneratedWorkoutType } from '../../../../../server/utils/plans/workout-type'
+
+describe('normalizeGeneratedWorkoutType', () => {
+  it('maps Gym to WeightTraining (DB/Intervals canonical type)', () => {
+    expect(normalizeGeneratedWorkoutType('Gym')).toBe('WeightTraining')
+  })
+
+  it('passes canonical types through unchanged', () => {
+    for (const type of ['Ride', 'Run', 'Swim', 'Rest', 'WeightTraining']) {
+      expect(normalizeGeneratedWorkoutType(type)).toBe(type)
+    }
+  })
+})

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -19,6 +19,7 @@ import { TRAINING_BLOCK_TYPES, TRAINING_BLOCK_FOCUSES } from '../app/utils/train
 import { availabilityRepository } from '../server/utils/repositories/availabilityRepository'
 import { enqueuePlannedWorkoutStructureGeneration } from '../server/utils/planned-workout-structure-trigger'
 import { registerTaskHandler } from '../server/utils/task-registry'
+import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
 import {
   validateGeneratedBlockWeeks,
   clampGeneratedBlockWeeks,
@@ -62,7 +63,9 @@ const trainingBlockSchema = {
                 },
                 type: {
                   type: 'string',
-                  enum: ['Ride', 'Run', 'Swim', 'Gym', 'Rest', 'Active Recovery']
+                  description:
+                    'Type of workout. DO NOT use generic terms like "Active Recovery" - map recovery sessions to a light "Ride"/"Run" or "Rest". "Gym" means strength training.',
+                  enum: ['Ride', 'Run', 'Swim', 'Gym', 'Rest']
                 },
                 durationMinutes: { type: 'integer' },
                 tssEstimate: { type: 'integer' },
@@ -427,7 +430,7 @@ Generate a detailed daily training plan for each week in this block (${block.dur
 - Ensure the recovery week (if applicable) has clearly reduced volume and intensity versus prior loading weeks.
 - Quantify recovery intent in your rationale (what was reduced and why).
 - For "Ride" workouts, provide realistic TSS estimates based on duration and intensity.
-- Workout types: ${allowedTypesString}, Rest, Active Recovery.
+- Workout types: ${allowedTypesString}, Rest. DO NOT use generic types like "Active Recovery" - map recovery sessions to a light Ride/Run or Rest.
 - Start each week on a Monday.
 - Provide a summary for each week explaining the focus and volume.
 - Explicitly connect each week focus to event demands and phase goals (base/build/peak/taper).
@@ -644,7 +647,7 @@ Return valid JSON matching the schema provided.`
                   date: targetDate,
                   title: workout.title,
                   description: workout.description,
-                  type: workout.type,
+                  type: normalizeGeneratedWorkoutType(workout.type),
                   durationSec: (workout.durationMinutes || 0) * 60,
                   tss: workout.tssEstimate,
                   workIntensity: getIntensityScore(workout.intensity),

--- a/trigger/generate-weekly-plan.ts
+++ b/trigger/generate-weekly-plan.ts
@@ -29,6 +29,7 @@ import { bodyMetricResolver } from '../server/utils/services/bodyMetricResolver'
 import { buildWorkoutCleanupQuery } from '../server/utils/plans/cleanup'
 import { filterGoalsForContext } from '../server/utils/goal-context'
 import { autoUploadPlannedWorkoutToIntervalsIfEnabled } from '../server/utils/intervals-sync'
+import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
 
 import { registerTaskHandler } from '../server/utils/task-registry'
 
@@ -901,12 +902,8 @@ Maintain your **${aiSettings.aiPersona}** persona throughout the plan's reasonin
           date: workoutDate, // Stored as UTC start of day for user
           title: d.title,
           description: d.description + (d.reasoningText ? `\n\nReasoning: ${d.reasoningText}` : ''),
-          // Map AI "Gym" type to "WeightTraining" which is standard in Intervals/our DB
-          // "Rest" is preserved. Everything else is passed through.
-          // AI has been instructed NOT to use "Workout" or "Active Recovery".
-          // If it still does, we map Active Recovery to a light Ride or Run based on user profile would be better,
-          // but for now let's map to "Workout" as a fallback so it doesn't crash, but log it.
-          type: d.workoutType === 'Gym' ? 'WeightTraining' : d.workoutType,
+          // "Rest" is preserved, "Gym" becomes "WeightTraining"; everything else passes through.
+          type: normalizeGeneratedWorkoutType(d.workoutType),
           durationSec: (d.durationMinutes || 0) * 60,
           distanceMeters: d.distanceMeters,
           tss: d.targetTSS,


### PR DESCRIPTION
Fixes CW-317

Stacked on #456 (base is its branch; GitHub will retarget to `develop` when it merges).

## Problem

`generate-training-block` stored Gemini's raw workout types while `generate-weekly-plan` normalized them, so a single plan ended up with both `Gym` and `WeightTraining` rows plus `Active Recovery` rows the weekly generator explicitly forbids (confirmed in prod plan `414dc079`). Type-based filters, Intervals.icu sync mapping, and UI icons treat these as distinct types.

## Fix

- New shared `server/utils/plans/workout-type.ts` — `normalizeGeneratedWorkoutType` maps `Gym` → `WeightTraining`; both generators now use it.
- Block schema enum drops `Active Recovery`; the prompt instructs a light Ride/Run or Rest instead (mirrors the weekly generator). The legacy `notIn: ['Rest','Active Recovery']` DB filter stays for existing rows.

## Testing

- `pnpm vitest run tests/unit/server/utils/plans tests/unit/trigger` — 142 passed