### PR TITLE
fix(plans): validate weekly plan generation against week volume budget (CW-319)

### DIFF
--- a/tests/unit/trigger/generate-weekly-plan.test.ts
+++ b/tests/unit/trigger/generate-weekly-plan.test.ts
@@ -14,8 +14,13 @@ vi.mock('../../../server/utils/db', () => ({
   prisma: {
     user: { findUnique: vi.fn() },
     userProfile: { findUnique: vi.fn(), findFirst: vi.fn() },
-    plannedWorkout: { findMany: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
-    trainingWeek: { findUnique: vi.fn(), update: vi.fn() },
+    plannedWorkout: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+      updateMany: vi.fn()
+    },
+    trainingWeek: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
     weeklyTrainingPlan: { findFirst: vi.fn(), create: vi.fn(), upsert: vi.fn(), update: vi.fn() },
 
     report: { findFirst: vi.fn() },
@@ -25,7 +30,7 @@ vi.mock('../../../server/utils/db', () => ({
     workout: { findMany: vi.fn(), findFirst: vi.fn() },
     wellness: { findMany: vi.fn(), findFirst: vi.fn() },
 
-    sportSettings: { findMany: vi.fn() },
+    sportSettings: { findMany: vi.fn(), upsert: vi.fn() },
     integration: { findMany: vi.fn(), findUnique: vi.fn() }
   }
 }))
@@ -95,5 +100,107 @@ describe('generateWeeklyPlan task', () => {
         daysToPlan: 7
       })
     ).rejects.toThrow('User not found')
+  })
+
+  describe('volume validation (CW-319)', () => {
+    const user = { id: 'user-1', timezone: 'UTC', language: 'English' }
+    const trainingWeek = {
+      id: 'week-1',
+      startDate: new Date('2026-03-16T00:00:00Z'),
+      endDate: new Date('2026-03-22T00:00:00Z'),
+      volumeTargetMinutes: 300,
+      tssTarget: 250,
+      weekNumber: 1,
+      focus: 'Base',
+      block: {
+        name: 'Base 1',
+        type: 'BASE',
+        primaryFocus: 'AEROBIC_ENDURANCE',
+        durationWeeks: 3,
+        plan: { name: 'Plan', goal: null }
+      }
+    }
+
+    const day = (date: string, durationMinutes: number, targetTSS = 50) => ({
+      date,
+      dayOfWeek: 1,
+      workoutType: 'Ride',
+      title: 'Ride',
+      description: 'desc',
+      durationMinutes,
+      targetTSS,
+      intensity: 'easy',
+      reasoningText: 'because'
+    })
+
+    const overBudgetDays = [day('2026-03-16', 180), day('2026-03-17', 180), day('2026-03-18', 180)] // 540 min vs 300 target
+    const compliantDays = [day('2026-03-16', 150), day('2026-03-18', 150)]
+
+    beforeEach(async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(user as any)
+      vi.mocked(prisma.sportSettings.upsert).mockResolvedValue({
+        id: 'ss-1',
+        userId: 'user-1',
+        isDefault: true,
+        types: [],
+        name: 'Default'
+      } as any)
+      vi.mocked(prisma.trainingWeek.findUnique).mockResolvedValue(trainingWeek as any)
+      vi.mocked(prisma.trainingWeek.findFirst).mockResolvedValue(null as any)
+      vi.mocked(prisma.weeklyTrainingPlan.create).mockImplementation(
+        async ({ data }: any) => ({ id: 'wtp-1', ...data }) as any
+      )
+      vi.mocked(prisma.plannedWorkout.updateMany).mockResolvedValue({ count: 0 } as any)
+      vi.mocked(prisma.plannedWorkout.deleteMany).mockResolvedValue({ count: 0 } as any)
+      vi.mocked(prisma.plannedWorkout.createMany).mockResolvedValue({ count: 2 } as any)
+    })
+
+    it('retries once with corrective feedback when the generated week exceeds the volume budget', async () => {
+      const { generateStructuredAnalysis } = await import('../../../server/utils/gemini')
+      vi.mocked(generateStructuredAnalysis)
+        .mockResolvedValueOnce({ days: overBudgetDays, weekSummary: 's', totalTSS: 150 } as any)
+        .mockResolvedValueOnce({ days: compliantDays, weekSummary: 's', totalTSS: 100 } as any)
+
+      const result = await runGenerateWeeklyPlan({
+        userId: 'user-1',
+        trainingWeekId: 'week-1',
+        daysToPlan: 7
+      })
+
+      expect(result.success).toBe(true)
+      expect(generateStructuredAnalysis).toHaveBeenCalledTimes(2)
+      const retryPrompt = vi.mocked(generateStructuredAnalysis).mock.calls[1]![0] as string
+      expect(retryPrompt).toContain('REJECTED')
+      // The compliant retry result is the one persisted
+      const createArg = vi.mocked(prisma.plannedWorkout.createMany).mock.calls[0]![0] as any
+      expect(createArg.data).toHaveLength(2)
+      expect(createArg.data[0].durationSec).toBe(150 * 60)
+    })
+
+    it('clamps deterministically when the retry is still over budget', async () => {
+      const { generateStructuredAnalysis } = await import('../../../server/utils/gemini')
+      vi.mocked(generateStructuredAnalysis).mockResolvedValue({
+        days: overBudgetDays,
+        weekSummary: 's',
+        totalTSS: 150
+      } as any)
+
+      const result = await runGenerateWeeklyPlan({
+        userId: 'user-1',
+        trainingWeekId: 'week-1',
+        daysToPlan: 7
+      })
+
+      expect(result.success).toBe(true)
+      expect(generateStructuredAnalysis).toHaveBeenCalledTimes(2)
+      const createArg = vi.mocked(prisma.plannedWorkout.createMany).mock.calls[0]![0] as any
+      const totalMinutes = createArg.data.reduce(
+        (sum: number, w: any) => sum + w.durationSec / 60,
+        0
+      )
+      // 540 scheduled vs 300 target -> scaled to ~300 * 1.1
+      expect(totalMinutes).toBeLessThanOrEqual(300 * 1.2)
+      expect(totalMinutes).toBeGreaterThan(250)
+    })
   })
 })

--- a/trigger/generate-weekly-plan.ts
+++ b/trigger/generate-weekly-plan.ts
@@ -30,6 +30,13 @@ import { buildWorkoutCleanupQuery } from '../server/utils/plans/cleanup'
 import { filterGoalsForContext } from '../server/utils/goal-context'
 import { autoUploadPlannedWorkoutToIntervalsIfEnabled } from '../server/utils/intervals-sync'
 import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  type GeneratedBlockWeek,
+  type WeekVolumeTarget
+} from '../server/utils/plans/block-volume'
 
 import { registerTaskHandler } from '../server/utils/task-registry'
 
@@ -427,6 +434,7 @@ export async function runGenerateWeeklyPlan(payload: {
 
   // Fetch full Plan context if available (via trainingWeekId)
   let planContext = ''
+  let weekVolumeTargetMinutes: number | null = null
   if (trainingWeekId) {
     const fullContext = await prisma.trainingWeek.findUnique({
       where: { id: trainingWeekId },
@@ -442,6 +450,7 @@ export async function runGenerateWeeklyPlan(payload: {
     })
 
     if (fullContext) {
+      weekVolumeTargetMinutes = fullContext.volumeTargetMinutes || null
       planContext = `
 CONTEXT FROM MASTER PLAN:
 - Plan Name: ${fullContext.block.plan.name || fullContext.block.plan.goal?.title || 'Custom Plan'}
@@ -668,7 +677,7 @@ INSTRUCTIONS:
    - "Gym" means strength training.
 5. **PROGRESSION**:
    - If User Instructions are absent/minimal, aim for progressive overload based on the current phase.
-   - Weekly TSS target: ${Math.round(currentWeeklyTSS)} - ${targetMaxTSS} (unless overridden by instructions).
+   - Weekly TSS target: ${targetMinTSS} - ${targetMaxTSS} (unless overridden by instructions).
 6. **INTENSITY DISTRIBUTION**:
    - Keep the week polarized or pyramidal unless user constraints dictate otherwise.
    - Avoid stacking hard days back-to-back unless explicitly requested.
@@ -730,17 +739,70 @@ Maintain your **${aiSettings.aiPersona}** persona throughout the plan's reasonin
     userInstructions: userInstructions || 'None'
   })
 
-  const plan = await generateStructuredAnalysis(
-    prompt,
-    weeklyPlanSchema,
-    aiSettings.aiModelPreference,
-    {
+  const generatePlan = (promptText: string) =>
+    generateStructuredAnalysis(promptText, weeklyPlanSchema, aiSettings.aiModelPreference, {
       userId,
       operation: 'weekly_plan_generation',
       entityType: 'WeeklyTrainingPlan',
       entityId: undefined
+    })
+
+  let plan = await generatePlan(prompt)
+
+  // Validate the generated week against the plan week's volume budget (when linked)
+  // and duration sanity bounds. One corrective retry, then deterministic clamping,
+  // mirroring generate-training-block. (CW-319)
+  const daysToBlockWeek = (days: any[]): GeneratedBlockWeek => ({
+    weekNumber: 1,
+    workouts: days.map((d: any) => ({
+      dayOfWeek: d.dayOfWeek ?? 0,
+      title: d.title,
+      type: d.workoutType,
+      durationMinutes: d.durationMinutes,
+      tssEstimate: d.targetTSS
+    }))
+  })
+  const weekTargets: WeekVolumeTarget[] = [
+    { weekNumber: 1, volumeTargetMinutes: weekVolumeTargetMinutes }
+  ]
+
+  let planDays: any[] = Array.isArray((plan as any)?.days) ? (plan as any).days : []
+  let volumeViolations = validateGeneratedBlockWeeks([daysToBlockWeek(planDays)], weekTargets)
+  if (volumeViolations.length > 0) {
+    logger.warn('Generated week violates volume budget, retrying with feedback', {
+      violations: volumeViolations.map((v) => v.message)
+    })
+
+    const retryPlan = await generatePlan(
+      `${prompt}\n\n${formatViolationsFeedback(volumeViolations)}`
+    )
+    if (Array.isArray((retryPlan as any)?.days) && (retryPlan as any).days.length > 0) {
+      plan = retryPlan
+      planDays = (plan as any).days
+      volumeViolations = validateGeneratedBlockWeeks([daysToBlockWeek(planDays)], weekTargets)
     }
-  )
+
+    if (volumeViolations.length > 0) {
+      const { weeks: clampedWeeks, adjustments } = clampGeneratedBlockWeeks(
+        [daysToBlockWeek(planDays)],
+        weekTargets
+      )
+      const clampedWorkouts = clampedWeeks[0]?.workouts || []
+      planDays.forEach((d: any, i: number) => {
+        const clamped = clampedWorkouts[i]
+        if (!clamped) return
+        d.durationMinutes = clamped.durationMinutes
+        if (typeof clamped.tssEstimate === 'number') d.targetTSS = clamped.tssEstimate
+      })
+      ;(plan as any).totalTSS = planDays.reduce(
+        (sum: number, d: any) => sum + (d.targetTSS || 0),
+        0
+      )
+      logger.warn('Retry still over budget - clamped generated week deterministically', {
+        adjustments
+      })
+    }
+  }
 
   logger.log('Plan generated from AI', {
     daysPlanned: (plan as any).days?.length,


### PR DESCRIPTION
Fixes CW-319

Stacked on #457 → #456 (GitHub retargets as they merge).

## Problem

`generate-weekly-plan` prompted the AI with a TSS range but inserted the generated days verbatim — no check against the linked `TrainingWeek.volumeTargetMinutes` and no duration sanity bounds. Same gap CW-316 fixed for block generation. `targetMinTSS` was computed and never used.

## Fix

- Reuse `server/utils/plans/block-volume.ts` from #456: validate the generated week (volume budget when linked to a plan week, duration bounds always) → one corrective retry with violation feedback → deterministic proportional clamp of durations + TSS; `totalTSS` recomputed after clamping.
- `targetMinTSS` now serves as the prompt's lower TSS bound (it was always intended as the 5% progressive floor).

## Testing

- New regression tests in the existing harness: retry-then-accept path (asserts corrective feedback prompt + retry result persisted) and clamp-fallback path (asserts persisted durations scaled to budget).
- `pnpm vitest run tests/unit/trigger tests/unit/server/utils/plans` — all passed