### PR TITLE
fix(plans): share week-target computation; stop resetting replanned weeks to 450min default (CW-318)

### DIFF
--- a/server/api/plans/[id]/blocks/[blockId].patch.ts
+++ b/server/api/plans/[id]/blocks/[blockId].patch.ts
@@ -1,6 +1,11 @@
 import { requireAuth } from '../../../../utils/auth-guard'
 import { prisma } from '../../../../utils/db'
-import { shiftPlanDates, calculateWeekTargets } from '../../../../utils/plan-logic'
+import { shiftPlanDates } from '../../../../utils/plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../../../../utils/plans/week-targets'
 import { trainingBlockRepository } from '../../../../utils/repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../../../../utils/repositories/trainingWeekRepository'
 import { z } from 'zod/v3'
@@ -32,7 +37,7 @@ export default defineEventHandler(async (event) => {
   // Verify ownership and existence
   const existingBlock = await trainingBlockRepository.getById(blockId!, {
     include: {
-      plan: { select: { userId: true } },
+      plan: { select: { userId: true, recoveryRhythm: true } },
       weeks: { orderBy: { weekNumber: 'asc' } }
     }
   })
@@ -55,7 +60,15 @@ export default defineEventHandler(async (event) => {
         const lastWeek = existingBlock.weeks[existingBlock.weeks.length - 1]
         if (!lastWeek)
           throw createError({ statusCode: 500, message: 'Block has no weeks to extend from' })
-        const targets = calculateWeekTargets(type || existingBlock.type)
+
+        // Inherit the block's loading volume instead of resetting to defaults (CW-318)
+        const blockType = type || existingBlock.type
+        const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(existingBlock.weeks)
+        const recoveryRhythm =
+          recoveryWeekIndex ||
+          existingBlock.recoveryWeekIndex ||
+          (existingBlock.plan as any).recoveryRhythm ||
+          4
 
         for (let i = 1; i <= deltaWeeks; i++) {
           const newWeekNumber = existingBlock.durationWeeks + i
@@ -65,12 +78,22 @@ export default defineEventHandler(async (event) => {
           const endDate = new Date(startDate)
           endDate.setUTCDate(endDate.getUTCDate() + 6)
 
+          const isRecovery = isRecoveryWeek(newWeekNumber, recoveryRhythm, blockType)
+          const targets = calculateWeekTargets({
+            blockType,
+            weekNumber: newWeekNumber,
+            blockDurationWeeks: durationWeeks,
+            isRecovery,
+            baseVolumeMinutes
+          })
+
           await trainingWeekRepository.create(
             {
               blockId: existingBlock.id,
               weekNumber: newWeekNumber,
               startDate,
               endDate,
+              isRecovery,
               ...targets
             },
             tx

--- a/server/api/plans/[id]/blocks/index.post.ts
+++ b/server/api/plans/[id]/blocks/index.post.ts
@@ -1,6 +1,11 @@
 import { requireAuth } from '../../../../utils/auth-guard'
 import { prisma } from '../../../../utils/db'
-import { shiftPlanDates, calculateWeekTargets } from '../../../../utils/plan-logic'
+import { shiftPlanDates } from '../../../../utils/plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../../../../utils/plans/week-targets'
 import { trainingPlanRepository } from '../../../../utils/repositories/trainingPlanRepository'
 import { trainingBlockRepository } from '../../../../utils/repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../../../../utils/repositories/trainingWeekRepository'
@@ -32,7 +37,7 @@ export default defineEventHandler(async (event) => {
 
   const plan = await trainingPlanRepository.getById(planId!, user.id, {
     include: {
-      blocks: { orderBy: { order: 'asc' } }
+      blocks: { orderBy: { order: 'asc' }, include: { weeks: true } }
     }
   })
 
@@ -89,8 +94,12 @@ export default defineEventHandler(async (event) => {
       tx
     )
 
-    // 4. Create weeks for the new block
-    const targets = calculateWeekTargets(type)
+    // 4. Create weeks for the new block, inheriting the plan's loading volume (CW-318)
+    const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(
+      plan.blocks.flatMap((b: any) => b.weeks || [])
+    )
+    const recoveryRhythm = recoveryWeekIndex || (plan as any).recoveryRhythm || 4
+
     for (let i = 1; i <= durationWeeks; i++) {
       const weekStart = new Date(startDate)
       weekStart.setUTCDate(weekStart.getUTCDate() + (i - 1) * 7)
@@ -98,12 +107,22 @@ export default defineEventHandler(async (event) => {
       const weekEnd = new Date(weekStart)
       weekEnd.setUTCDate(weekEnd.getUTCDate() + 6)
 
+      const isRecovery = isRecoveryWeek(i, recoveryRhythm, type)
+      const targets = calculateWeekTargets({
+        blockType: type,
+        weekNumber: i,
+        blockDurationWeeks: durationWeeks,
+        isRecovery,
+        baseVolumeMinutes
+      })
+
       await trainingWeekRepository.create(
         {
           blockId: newBlock.id,
           weekNumber: i,
           startDate: weekStart,
           endDate: weekEnd,
+          isRecovery,
           ...targets
         },
         tx

--- a/server/api/plans/initialize.post.ts
+++ b/server/api/plans/initialize.post.ts
@@ -5,6 +5,11 @@ import { getUserTimezone, getUserLocalDate } from '../../utils/date'
 import { generateStructuredAnalysis } from '../../utils/gemini'
 
 import { trainingPlanRepository } from '../../utils/repositories/trainingPlanRepository'
+import {
+  baseWeeklyVolumeMinutes,
+  calculateWeekTargets,
+  isRecoveryWeek
+} from '../../utils/plans/week-targets'
 
 const initializePlanSchema = z.object({
   goalId: z.string(),
@@ -293,38 +298,22 @@ export default defineEventHandler(async (event) => {
                 // Determine recovery week based on rhythm
                 // e.g. Rhythm 4 (3:1) -> Weeks 4, 8, 12 are recovery
                 // But specifically for Taper/Race blocks, usually the whole thing is recovery/taper logic handled by workout generator
-                const isRecovery =
-                  (i + 1) % recoveryRhythm === 0 &&
-                  blockConfig.type !== 'PEAK' &&
-                  blockConfig.type !== 'RACE'
+                const isRecovery = isRecoveryWeek(i + 1, recoveryRhythm, blockConfig.type)
 
-                // Determine target volume
-                let targetMinutes = 450 // Default MID
-                if (volumeHours) {
-                  targetMinutes = volumeHours * 60
-                  if (isRecovery) targetMinutes = Math.round(targetMinutes * 0.6)
-                } else {
-                  if (volumePreference === 'LOW') targetMinutes = 240
-                  else if (volumePreference === 'HIGH') targetMinutes = 600
-                  if (isRecovery) targetMinutes = Math.round(targetMinutes * 0.6)
-                }
-
-                // Taper volume reduction
-                if (blockConfig.type === 'PEAK') {
-                  // Progressive reduction: Week 1 (70%), Week 2 (50%)
-                  const taperFactor = 1 - ((i + 1) / blockConfig.durationWeeks) * 0.5
-                  targetMinutes = Math.round(targetMinutes * taperFactor)
-                }
-
-                const tssTarget = Math.round((targetMinutes / 60) * 50)
+                const targets = calculateWeekTargets({
+                  blockType: blockConfig.type,
+                  weekNumber: i + 1,
+                  blockDurationWeeks: blockConfig.durationWeeks,
+                  isRecovery,
+                  baseVolumeMinutes: baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+                })
 
                 return {
                   weekNumber: i + 1,
                   startDate: weekStart,
                   endDate: weekEnd,
                   isRecovery,
-                  volumeTargetMinutes: targetMinutes,
-                  tssTarget: tssTarget
+                  ...targets
                 }
               })
             }

--- a/server/utils/plan-logic.ts
+++ b/server/utils/plan-logic.ts
@@ -62,21 +62,5 @@ export async function shiftPlanDates(planId: string, fromOrder: number, daysDelt
   }
 }
 
-/**
- * Calculates and updates targets for a week (Volume, TSS).
- * Simple heuristic for now.
- */
-export function calculateWeekTargets(blockType: string, volumePreference: string = 'MID') {
-  // Determine target volume
-  let targetMinutes = 450 // Default MID
-  if (volumePreference === 'LOW') targetMinutes = 240
-  else if (volumePreference === 'HIGH') targetMinutes = 600
-
-  // Default TSS estimation (0.6 IF avg => 36 TSS/hr)
-  const tssTarget = Math.round((targetMinutes / 60) * 50)
-
-  return {
-    volumeTargetMinutes: targetMinutes,
-    tssTarget: tssTarget
-  }
-}
+// calculateWeekTargets moved to server/utils/plans/week-targets.ts (CW-318),
+// which accounts for the athlete's chosen volume, recovery weeks, and taper.

--- a/server/utils/plans/week-targets.ts
+++ b/server/utils/plans/week-targets.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared computation of TrainingWeek volume/TSS targets.
+ *
+ * Historically the plan wizard (initialize endpoint) had the full logic inline
+ * (volumeHours, recovery reduction, taper factor) while every other call site
+ * (structure replan, add block, extend block) used a stripped-down helper that
+ * ignored the athlete's chosen volume and always reset new weeks to the 450min
+ * default. This module is the single source of truth for all of them. (CW-318)
+ */
+
+export const DEFAULT_WEEKLY_VOLUME_MINUTES = 450
+export const LOW_WEEKLY_VOLUME_MINUTES = 240
+export const HIGH_WEEKLY_VOLUME_MINUTES = 600
+export const RECOVERY_WEEK_FACTOR = 0.6
+/** Heuristic TSS per hour used for week targets across the app. */
+export const TSS_PER_HOUR = 50
+
+export interface WeekTargetOptions {
+  blockType: string
+  /** 1-based week number within the block. */
+  weekNumber: number
+  blockDurationWeeks: number
+  isRecovery: boolean
+  /** Weekly loading volume in minutes (athlete's wizard choice or derived). */
+  baseVolumeMinutes?: number | null
+}
+
+export function baseWeeklyVolumeMinutes(
+  volumeHours?: number | null,
+  volumePreference?: string | null
+): number {
+  if (volumeHours && volumeHours > 0) return Math.round(volumeHours * 60)
+  if (volumePreference === 'LOW') return LOW_WEEKLY_VOLUME_MINUTES
+  if (volumePreference === 'HIGH') return HIGH_WEEKLY_VOLUME_MINUTES
+  return DEFAULT_WEEKLY_VOLUME_MINUTES
+}
+
+/**
+ * Recovers the plan's loading-week volume from already-persisted weeks, since
+ * TrainingPlan does not store the wizard's volumeHours. The max non-recovery
+ * target is the loading volume (recovery/taper weeks are reduced from it).
+ */
+export function deriveBaseVolumeMinutesFromWeeks(
+  weeks: Array<{ volumeTargetMinutes?: number | null; isRecovery?: boolean | null }>
+): number | null {
+  const loadingTargets = weeks
+    .filter((w) => !w.isRecovery && (w.volumeTargetMinutes || 0) > 0)
+    .map((w) => w.volumeTargetMinutes!)
+  if (loadingTargets.length === 0) return null
+  return Math.max(...loadingTargets)
+}
+
+/** Standard recovery-week cadence: every Nth week, except in PEAK/RACE blocks. */
+export function isRecoveryWeek(
+  weekNumber: number,
+  recoveryRhythm: number,
+  blockType: string
+): boolean {
+  if (blockType === 'PEAK' || blockType === 'RACE') return false
+  return recoveryRhythm > 0 && weekNumber % recoveryRhythm === 0
+}
+
+export function calculateWeekTargets(options: WeekTargetOptions): {
+  volumeTargetMinutes: number
+  tssTarget: number
+} {
+  let targetMinutes = options.baseVolumeMinutes || DEFAULT_WEEKLY_VOLUME_MINUTES
+
+  if (options.isRecovery) {
+    targetMinutes = Math.round(targetMinutes * RECOVERY_WEEK_FACTOR)
+  }
+
+  if (options.blockType === 'PEAK') {
+    // Progressive taper: e.g. 2-week peak block -> week 1 at 75%, week 2 at 50%
+    const taperFactor = 1 - (options.weekNumber / options.blockDurationWeeks) * 0.5
+    targetMinutes = Math.round(targetMinutes * taperFactor)
+  }
+
+  return {
+    volumeTargetMinutes: targetMinutes,
+    tssTarget: Math.round((targetMinutes / 60) * TSS_PER_HOUR)
+  }
+}

--- a/server/utils/services/planService.ts
+++ b/server/utils/services/planService.ts
@@ -1,5 +1,9 @@
 import { prisma } from '../db'
-import { calculateWeekTargets } from '../plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../plans/week-targets'
 import { trainingPlanRepository } from '../repositories/trainingPlanRepository'
 import { trainingBlockRepository } from '../repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../repositories/trainingWeekRepository'
@@ -19,6 +23,12 @@ export const planService = {
     })
 
     if (!plan) throw new Error('Plan not found')
+
+    // TrainingPlan does not persist the wizard's volumeHours, so recover the
+    // athlete's loading volume from the weeks that already exist. (CW-318)
+    const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(
+      plan.blocks.flatMap((b) => (b as any).weeks || [])
+    )
 
     return await prisma.$transaction(async (tx) => {
       // 1. Delete blocks that are no longer in the plan
@@ -90,12 +100,21 @@ export const planService = {
         const newDuration = config.durationWeeks
 
         if (newDuration > oldDuration) {
-          const targets = calculateWeekTargets(config.type)
+          const recoveryRhythm = config.recoveryWeekIndex || plan.recoveryRhythm || 4
           for (let i = oldDuration + 1; i <= newDuration; i++) {
             const weekStart = new Date(blockStartDate)
             weekStart.setUTCDate(weekStart.getUTCDate() + (i - 1) * 7)
             const weekEnd = new Date(weekStart)
             weekEnd.setUTCDate(weekEnd.getUTCDate() + 6)
+
+            const isRecovery = isRecoveryWeek(i, recoveryRhythm, config.type)
+            const targets = calculateWeekTargets({
+              blockType: config.type,
+              weekNumber: i,
+              blockDurationWeeks: newDuration,
+              isRecovery,
+              baseVolumeMinutes
+            })
 
             await trainingWeekRepository.create(
               {
@@ -103,6 +122,7 @@ export const planService = {
                 weekNumber: i,
                 startDate: weekStart,
                 endDate: weekEnd,
+                isRecovery,
                 ...targets
               },
               tx

--- a/tests/unit/server/utils/plan-logic.test.ts
+++ b/tests/unit/server/utils/plan-logic.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import {
-  shiftPlanDates,
-  calculateWeekTargets
-} from '../../../../server/utils/plan-logic'
+import { shiftPlanDates } from '../../../../server/utils/plan-logic'
 import { prisma } from '../../../../server/utils/db'
 
 // Mock prisma
@@ -88,28 +85,6 @@ describe('Plan Logic Utils', () => {
     })
   })
 
-  describe('calculateWeekTargets', () => {
-    it('should calculate defaults (MID)', () => {
-      const result = calculateWeekTargets('Build', 'MID')
-      expect(result.volumeTargetMinutes).toBe(450)
-      expect(result.tssTarget).toBe(Math.round((450/60)*50)) // 375
-    })
-
-    it('should calculate LOW volume', () => {
-      const result = calculateWeekTargets('Base', 'LOW')
-      expect(result.volumeTargetMinutes).toBe(240)
-      expect(result.tssTarget).toBe(Math.round((240/60)*50)) // 200
-    })
-
-    it('should calculate HIGH volume', () => {
-      const result = calculateWeekTargets('Base', 'HIGH')
-      expect(result.volumeTargetMinutes).toBe(600)
-      expect(result.tssTarget).toBe(Math.round((600/60)*50)) // 500
-    })
-
-     it('should fallback to MID for unknown preference', () => {
-      const result = calculateWeekTargets('Base', 'UNKNOWN')
-      expect(result.volumeTargetMinutes).toBe(450)
-    })
-  })
+  // calculateWeekTargets moved to server/utils/plans/week-targets.ts (CW-318);
+  // see tests/unit/server/utils/plans/week-targets.test.ts
 })

--- a/tests/unit/server/utils/plans/week-targets.test.ts
+++ b/tests/unit/server/utils/plans/week-targets.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  baseWeeklyVolumeMinutes,
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek,
+  DEFAULT_WEEKLY_VOLUME_MINUTES,
+  RECOVERY_WEEK_FACTOR
+} from '../../../../../server/utils/plans/week-targets'
+
+describe('baseWeeklyVolumeMinutes', () => {
+  it('prefers explicit volumeHours over the preference bucket', () => {
+    expect(baseWeeklyVolumeMinutes(8, 'LOW')).toBe(480)
+    expect(baseWeeklyVolumeMinutes(3.5)).toBe(210)
+  })
+
+  it('maps preference buckets and falls back to MID default', () => {
+    expect(baseWeeklyVolumeMinutes(null, 'LOW')).toBe(240)
+    expect(baseWeeklyVolumeMinutes(null, 'HIGH')).toBe(600)
+    expect(baseWeeklyVolumeMinutes(null, 'MID')).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+    expect(baseWeeklyVolumeMinutes()).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+  })
+})
+
+describe('deriveBaseVolumeMinutesFromWeeks', () => {
+  it('returns the max non-recovery target (the loading volume)', () => {
+    expect(
+      deriveBaseVolumeMinutesFromWeeks([
+        { volumeTargetMinutes: 480, isRecovery: false },
+        { volumeTargetMinutes: 288, isRecovery: true },
+        { volumeTargetMinutes: 450, isRecovery: false }
+      ])
+    ).toBe(480)
+  })
+
+  it('returns null when no usable weeks exist', () => {
+    expect(deriveBaseVolumeMinutesFromWeeks([])).toBeNull()
+    expect(
+      deriveBaseVolumeMinutesFromWeeks([
+        { volumeTargetMinutes: 0 },
+        { isRecovery: true, volumeTargetMinutes: 200 }
+      ])
+    ).toBeNull()
+  })
+})
+
+describe('isRecoveryWeek', () => {
+  it('marks every Nth week per rhythm', () => {
+    expect(isRecoveryWeek(4, 4, 'BASE')).toBe(true)
+    expect(isRecoveryWeek(3, 4, 'BASE')).toBe(false)
+    expect(isRecoveryWeek(3, 3, 'BUILD')).toBe(true)
+  })
+
+  it('never marks recovery inside PEAK/RACE blocks', () => {
+    expect(isRecoveryWeek(4, 4, 'PEAK')).toBe(false)
+    expect(isRecoveryWeek(4, 4, 'RACE')).toBe(false)
+  })
+})
+
+describe('calculateWeekTargets', () => {
+  it('uses the athlete volume, not the 450min default (CW-318 regression)', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BUILD',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    expect(result.volumeTargetMinutes).toBe(480)
+    expect(result.tssTarget).toBe(400)
+  })
+
+  it('falls back to the default when no base volume is known', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: null
+    })
+    expect(result.volumeTargetMinutes).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+  })
+
+  it('reduces recovery weeks by the recovery factor', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 4,
+      blockDurationWeeks: 4,
+      isRecovery: true,
+      baseVolumeMinutes: 480
+    })
+    expect(result.volumeTargetMinutes).toBe(Math.round(480 * RECOVERY_WEEK_FACTOR))
+  })
+
+  it('applies the progressive taper in PEAK blocks', () => {
+    const week1 = calculateWeekTargets({
+      blockType: 'PEAK',
+      weekNumber: 1,
+      blockDurationWeeks: 2,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    const week2 = calculateWeekTargets({
+      blockType: 'PEAK',
+      weekNumber: 2,
+      blockDurationWeeks: 2,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    expect(week1.volumeTargetMinutes).toBe(360) // 75%
+    expect(week2.volumeTargetMinutes).toBe(240) // 50%
+    expect(week2.volumeTargetMinutes).toBeLessThan(week1.volumeTargetMinutes)
+  })
+})


### PR DESCRIPTION
Fixes CW-318

## Problem

`calculateWeekTargets` in `plan-logic.ts` ignored the athlete's wizard-chosen `volumeHours`/`volumePreference` and the block type. Every call site outside the wizard — structure replan, add block, extend block — silently reset new weeks to 450 min / TSS 375 (wizard range is 180–1200 min), with no recovery cadence and no taper. The correct logic existed only inline in `initialize.post.ts`.

## Fix

- New **`server/utils/plans/week-targets.ts`** — single source of truth: base volume resolution (`volumeHours` > preference bucket > default), recovery-week factor (×0.6), PEAK progressive taper, recovery cadence (`isRecoveryWeek`), and `deriveBaseVolumeMinutesFromWeeks` to recover the loading volume from persisted weeks (TrainingPlan doesn't store `volumeHours`).
- `initialize.post.ts` switched to the shared util — same output as before.
- `planService.replanStructure`, `POST /plans/:id/blocks`, and `PATCH /plans/:id/blocks/:blockId` now inherit the plan's existing loading volume and set `isRecovery` on newly created weeks (previously always false).

## Testing

- New `tests/unit/server/utils/plans/week-targets.test.ts` (incl. regression: athlete volume used instead of 450 default).
- `pnpm vitest run tests/unit/server/utils` — 1089 passed. `pnpm typecheck` — clean.