### PR TITLE
feat(plans): cap new-plan volume ramp against athlete's recent actual load (CW-320)

### DIFF
--- a/server/api/plans/initialize.post.ts
+++ b/server/api/plans/initialize.post.ts
@@ -8,6 +8,7 @@ import { trainingPlanRepository } from '../../utils/repositories/trainingPlanRep
 import {
   baseWeeklyVolumeMinutes,
   calculateWeekTargets,
+  computeRampBaseMinutes,
   isRecoveryWeek
 } from '../../utils/plans/week-targets'
 
@@ -257,6 +258,24 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // 4.5 Ramp-rate cap (CW-320): base the on-ramp on what the athlete actually
+  // trained in the last 4 weeks, so a plan can't jump straight to a multiple
+  // of their real load. The cap grows per loading week until it reaches the
+  // requested volume; it never raises targets.
+  const twentyEightDaysAgo = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000)
+  const recentLoad = await prisma.workout.aggregate({
+    _sum: { durationSec: true },
+    where: {
+      userId,
+      isDuplicate: false,
+      date: { gte: twentyEightDaysAgo }
+    }
+  })
+  const recentWeeklyAvgMinutes = (recentLoad._sum.durationSec || 0) / 60 / 4
+  const requestedBaseMinutes = baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+  const rampBaseMinutes = computeRampBaseMinutes(recentWeeklyAvgMinutes)
+  let loadingWeekOrdinal = 0
+
   // 5. Create Plan Skeleton
   const plan = await trainingPlanRepository.create(
     {
@@ -299,13 +318,16 @@ export default defineEventHandler(async (event) => {
                 // e.g. Rhythm 4 (3:1) -> Weeks 4, 8, 12 are recovery
                 // But specifically for Taper/Race blocks, usually the whole thing is recovery/taper logic handled by workout generator
                 const isRecovery = isRecoveryWeek(i + 1, recoveryRhythm, blockConfig.type)
+                if (!isRecovery) loadingWeekOrdinal++
 
                 const targets = calculateWeekTargets({
                   blockType: blockConfig.type,
                   weekNumber: i + 1,
                   blockDurationWeeks: blockConfig.durationWeeks,
                   isRecovery,
-                  baseVolumeMinutes: baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+                  baseVolumeMinutes: requestedBaseMinutes,
+                  rampBaseMinutes,
+                  loadingWeekOrdinal: Math.max(1, loadingWeekOrdinal)
                 })
 
                 return {

--- a/server/utils/plans/week-targets.ts
+++ b/server/utils/plans/week-targets.ts
@@ -15,6 +15,36 @@ export const RECOVERY_WEEK_FACTOR = 0.6
 /** Heuristic TSS per hour used for week targets across the app. */
 export const TSS_PER_HOUR = 50
 
+/**
+ * Ramp-rate cap (CW-320): a brand-new plan must not prescribe a multiple of
+ * what the athlete has actually been training. Week 1's loading volume is
+ * capped at recent 4-week average x RAMP_BASE_MULTIPLIER (with an absolute
+ * floor so low-history athletes can still start), then the allowance grows
+ * RAMP_GROWTH_PER_LOADING_WEEK per loading week until the athlete's chosen
+ * volume is reached. The cap only ever lowers targets, never raises them.
+ */
+export const RAMP_BASE_MULTIPLIER = 1.2
+export const RAMP_GROWTH_PER_LOADING_WEEK = 1.1
+export const RAMP_FLOOR_MINUTES = 240
+
+export function computeRampBaseMinutes(recentWeeklyAvgMinutes: number): number {
+  return Math.round(
+    Math.max((recentWeeklyAvgMinutes || 0) * RAMP_BASE_MULTIPLIER, RAMP_FLOOR_MINUTES)
+  )
+}
+
+export function applyRampCap(
+  baseVolumeMinutes: number,
+  loadingWeekOrdinal: number,
+  rampBaseMinutes?: number | null
+): number {
+  if (!rampBaseMinutes || rampBaseMinutes <= 0) return baseVolumeMinutes
+  const cap = Math.round(
+    rampBaseMinutes * Math.pow(RAMP_GROWTH_PER_LOADING_WEEK, Math.max(0, loadingWeekOrdinal - 1))
+  )
+  return Math.min(baseVolumeMinutes, cap)
+}
+
 export interface WeekTargetOptions {
   blockType: string
   /** 1-based week number within the block. */
@@ -23,6 +53,10 @@ export interface WeekTargetOptions {
   isRecovery: boolean
   /** Weekly loading volume in minutes (athlete's wizard choice or derived). */
   baseVolumeMinutes?: number | null
+  /** When set, caps the loading volume by ramp allowance before recovery/taper factors. */
+  rampBaseMinutes?: number | null
+  /** 1-based count of loading weeks up to and including this week's position. */
+  loadingWeekOrdinal?: number
 }
 
 export function baseWeeklyVolumeMinutes(
@@ -65,6 +99,10 @@ export function calculateWeekTargets(options: WeekTargetOptions): {
   tssTarget: number
 } {
   let targetMinutes = options.baseVolumeMinutes || DEFAULT_WEEKLY_VOLUME_MINUTES
+
+  if (options.rampBaseMinutes && options.loadingWeekOrdinal) {
+    targetMinutes = applyRampCap(targetMinutes, options.loadingWeekOrdinal, options.rampBaseMinutes)
+  }
 
   if (options.isRecovery) {
     targetMinutes = Math.round(targetMinutes * RECOVERY_WEEK_FACTOR)

--- a/tests/unit/server/utils/plans/week-targets.test.ts
+++ b/tests/unit/server/utils/plans/week-targets.test.ts
@@ -4,8 +4,11 @@ import {
   calculateWeekTargets,
   deriveBaseVolumeMinutesFromWeeks,
   isRecoveryWeek,
+  computeRampBaseMinutes,
+  applyRampCap,
   DEFAULT_WEEKLY_VOLUME_MINUTES,
-  RECOVERY_WEEK_FACTOR
+  RECOVERY_WEEK_FACTOR,
+  RAMP_FLOOR_MINUTES
 } from '../../../../../server/utils/plans/week-targets'
 
 describe('baseWeeklyVolumeMinutes', () => {
@@ -110,5 +113,57 @@ describe('calculateWeekTargets', () => {
     expect(week1.volumeTargetMinutes).toBe(360) // 75%
     expect(week2.volumeTargetMinutes).toBe(240) // 50%
     expect(week2.volumeTargetMinutes).toBeLessThan(week1.volumeTargetMinutes)
+  })
+})
+
+describe('ramp-rate cap (CW-320)', () => {
+  it('bases the ramp on recent load with an absolute floor', () => {
+    expect(computeRampBaseMinutes(280)).toBe(336) // 280 * 1.2
+    expect(computeRampBaseMinutes(0)).toBe(RAMP_FLOOR_MINUTES)
+    expect(computeRampBaseMinutes(100)).toBe(RAMP_FLOOR_MINUTES)
+  })
+
+  it('caps week 1 at the ramp base and grows the allowance per loading week', () => {
+    // CW-316 prod case: athlete averaging ~280min/week requested 480min/week
+    expect(applyRampCap(480, 1, 336)).toBe(336)
+    expect(applyRampCap(480, 2, 336)).toBe(370) // 336 * 1.1
+    expect(applyRampCap(480, 4, 336)).toBe(447)
+    expect(applyRampCap(480, 5, 336)).toBe(480) // reached the requested volume
+  })
+
+  it('never raises targets above the requested volume', () => {
+    expect(applyRampCap(300, 1, 600)).toBe(300)
+    expect(applyRampCap(300, 10, 336)).toBe(300)
+  })
+
+  it('is a no-op when no ramp base is provided', () => {
+    expect(applyRampCap(480, 1, null)).toBe(480)
+  })
+
+  it('applies the cap before recovery reduction in calculateWeekTargets', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 4,
+      blockDurationWeeks: 4,
+      isRecovery: true,
+      baseVolumeMinutes: 480,
+      rampBaseMinutes: 336,
+      loadingWeekOrdinal: 3
+    })
+    // capped loading volume 336 * 1.1^2 = 407, then recovery x0.6
+    expect(result.volumeTargetMinutes).toBe(Math.round(407 * RECOVERY_WEEK_FACTOR))
+  })
+
+  it('leaves targets unchanged for athletes already training at the requested volume', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BUILD',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: 480,
+      rampBaseMinutes: computeRampBaseMinutes(450),
+      loadingWeekOrdinal: 1
+    })
+    expect(result.volumeTargetMinutes).toBe(480)
   })
 })


### PR DESCRIPTION
Fixes CW-320

Stacked on #459 (GitHub retargets to `develop` when it merges).

## Decision

Ticket asked for a product decision on ramp policy; implemented the conservative option that needs no new UX:

- **Ramp base** = recent 4-week average weekly duration × **1.2**, floored at **240 min** (so low/no-history athletes can still start a reasonable plan).
- **Per-loading-week growth ×1.1** until the athlete's requested volume is reached; the requested volume is a ceiling — the cap only ever lowers targets.
- Recovery (×0.6) and PEAK taper factors apply to the capped loading volume, preserving cadence shape.
- Applied at plan initialization (week-target computation). Since #456 makes block generation enforce stored week targets, the on-ramp propagates to generated workouts with no generator changes.
- Wizard-side warning UX deliberately deferred (would need design input).

Example (the CW-316 prod case — athlete at ~280 min/week asking for 480): weeks now ramp 336 → 370 → recovery → 407 → 447 → 480 instead of jumping straight to 480 (or the 919 actually generated).

## Testing

- New unit tests in `week-targets.test.ts` covering ramp base/floor, growth, ceiling, no-op, recovery interaction.
- `pnpm vitest run tests/unit/server/utils/plans` — 20 passed. `pnpm typecheck` — clean.