### PR TITLE
fix(nutrition): patch planning audit findings (CW-321, CW-322, CW-324, CW-325, CW-326)

### DIFF
--- a/app/components/nutrition/UpcomingFuelingFeed.vue
+++ b/app/components/nutrition/UpcomingFuelingFeed.vue
@@ -299,6 +299,7 @@
 
 <script setup lang="ts">
   import { format, parseISO } from 'date-fns'
+  import { resolveWindowKey } from '#shared/window-keys'
 
   const props = defineProps<{
     windows: any[]
@@ -407,7 +408,7 @@
       windowType: window.type,
       // Identity of this exact window. Without it a day with two pre-workout windows collapses
       // both onto one planned meal.
-      windowKey: window.windowKey || window.type,
+      windowKey: resolveWindowKey(window),
       slotName: window.slotName || window.label || '',
       label: window.label,
       targetCarbs: Number(window.targetCarbs || 0),
@@ -429,7 +430,7 @@
     const currentlyAssignedCarbs = day.windows
       .filter((candidate: any) =>
         windowAssignments.some(
-          (assignment: any) => assignment.windowKey === (candidate.windowKey || candidate.type)
+          (assignment: any) => assignment.windowKey === resolveWindowKey(candidate)
         )
       )
       .reduce((sum: number, candidate: any) => {

--- a/app/components/nutrition/WeeklyPlanDashboard.vue
+++ b/app/components/nutrition/WeeklyPlanDashboard.vue
@@ -130,6 +130,16 @@
       </div>
     </div>
 
+    <div
+      v-if="loadError"
+      class="m-3 flex items-center justify-between gap-3 rounded-lg border border-error-200 bg-error-50 p-3 text-sm text-error-700 dark:border-error-800 dark:bg-error-900/20 dark:text-error-300"
+    >
+      <span>Could not load the weekly plan. The grid below may be incomplete.</span>
+      <UButton size="xs" color="error" variant="soft" icon="i-lucide-refresh-cw" @click="refresh">
+        Retry
+      </UButton>
+    </div>
+
     <div class="overflow-x-auto">
       <table class="w-full border-collapse text-left">
         <thead>
@@ -568,6 +578,7 @@
 
 <script setup lang="ts">
   import { addDays, format, parseISO } from 'date-fns'
+  import { resolveWindowKey } from '#shared/window-keys'
   import { normalizeWindowLabel } from '~/utils/nutrition-window-label'
 
   const toast = useToast()
@@ -628,6 +639,8 @@
   const loading = ref(false)
   /** True once a fetch has settled, so the grid can distinguish "empty" from "not loaded yet". */
   const planLoaded = ref(false)
+  /** A failed fetch used to render as an authoritative-looking empty week; surface it instead. */
+  const loadError = ref(false)
   const plan = ref<any>(null)
   const workoutsByDate = ref<Record<string, DayWorkout[]>>({})
   const drawerOpen = ref(false)
@@ -635,25 +648,8 @@
   const selectedWindowKey = ref('')
   const expandedMealKeys = ref<string[]>([])
 
-  function toDailyBaseKey(slotName?: string) {
-    const normalized = (slotName || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-    return normalized ? `DAILY_BASE:${normalized}` : 'DAILY_BASE'
-  }
-
-  function getSlotNameFromWindow(window: any) {
-    return window?.slotName || window?.label || (window?.type === 'DAILY_BASE' ? 'Meal' : '')
-  }
-
-  function resolveWindowKey(window: any) {
-    if (!window) return ''
-    if (window.windowKey) return String(window.windowKey)
-    if (window.type === 'DAILY_BASE') return toDailyBaseKey(getSlotNameFromWindow(window))
-    return `${window.type}#1`
-  }
-
+  // Key derivation is shared with the server (shared/window-keys); a drifted local copy here
+  // once produced different keys for punctuated slot names and unlinked locked meals.
   function matchesMealToWindow(meal: any, window: any) {
     if (!meal || !window) return false
 
@@ -742,6 +738,7 @@
 
   async function fetchPlan() {
     loading.value = true
+    loadError.value = false
     try {
       const [planData, workoutsData] = await Promise.all([
         ($fetch as any)('/api/nutrition/plan', {
@@ -779,6 +776,7 @@
       workoutsByDate.value = mappedWorkouts
     } catch (e) {
       console.error('Failed to fetch weekly nutrition dashboard data:', e)
+      loadError.value = true
     } finally {
       loading.value = false
       planLoaded.value = true

--- a/server/api/nutrition/plan/generate.post.ts
+++ b/server/api/nutrition/plan/generate.post.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import { defineEventHandler, readBody } from 'h3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { nutritionPlanService } from '../../../utils/services/nutritionPlanService'
@@ -35,6 +34,10 @@ export default defineEventHandler(async (event) => {
         new Date(start.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10) +
           'T23:59:59.999Z'
       )
+
+  if (end < start) {
+    throw createError({ statusCode: 400, message: 'endDate must not be before startDate' })
+  }
 
   try {
     const plan = await nutritionPlanService.generateDraftPlan(userId, start, end)

--- a/server/api/nutrition/plan/meal.post.ts
+++ b/server/api/nutrition/plan/meal.post.ts
@@ -2,15 +2,75 @@ import { z } from 'zod'
 import { requireAuth } from '../../../utils/auth-guard'
 import { nutritionPlanService } from '../../../utils/services/nutritionPlanService'
 
+// mealJson flows untouched into grocery aggregation, dashboards, and reconciliation, so the
+// shape is validated here while unknown extra fields still pass through.
+const numberLike = z.union([z.number(), z.string()])
+
+const ingredientSchema = z
+  .object({
+    item: z.string().optional(),
+    name: z.string().optional(),
+    quantity: numberLike.nullish(),
+    unit: z.string().nullish(),
+    category: z.string().nullish()
+  })
+  .passthrough()
+
+const mealSchema = z
+  .object({
+    title: z.string().optional(),
+    name: z.string().optional(),
+    totals: z
+      .object({
+        carbs: numberLike.nullish(),
+        protein: numberLike.nullish(),
+        kcal: numberLike.nullish(),
+        calories: numberLike.nullish(),
+        fat: numberLike.nullish()
+      })
+      .passthrough()
+      .optional(),
+    ingredients: z.array(ingredientSchema).optional()
+  })
+  .passthrough()
+
+const windowAssignmentSchema = z
+  .object({
+    windowType: z.string().min(1),
+    windowKey: z.string().optional(),
+    slotName: z.string().optional(),
+    label: z.string().optional(),
+    targetCarbs: z.number().optional(),
+    targetProtein: z.number().optional(),
+    targetKcal: z.number().optional()
+  })
+  .passthrough()
+
+const lockMealSchema = z.object({
+  date: z.string().min(8),
+  windowType: z.string().min(1),
+  meal: mealSchema,
+  slotName: z.string().optional(),
+  windowKey: z.string().optional(),
+  windowAssignments: z.array(windowAssignmentSchema).optional()
+})
+
 export default defineEventHandler(async (event) => {
   const authUser = await requireAuth(event, ['nutrition:write'])
 
   const userId = authUser.id
-  const body = await readBody(event)
+  const rawBody = await readBody(event)
 
-  if (!body.date || !body.windowType || !body.meal) {
-    throw createError({ statusCode: 400, message: 'Date, windowType, and meal are required' })
+  const parsed = lockMealSchema.safeParse(rawBody)
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid lock meal payload',
+      data: parsed.error.issues
+    })
   }
+  const body = parsed.data
+
   console.log('[nutrition/plan/meal.post] request', {
     userId,
     date: body.date,
@@ -30,9 +90,7 @@ export default defineEventHandler(async (event) => {
       body.slotName,
       {
         windowKey: body.windowKey,
-        windowAssignments: Array.isArray(body.windowAssignments)
-          ? body.windowAssignments
-          : undefined
+        windowAssignments: body.windowAssignments
       }
     )
     console.log('[nutrition/plan/meal.post] locked', {

--- a/server/utils/nutrition-domain/day-plan.ts
+++ b/server/utils/nutrition-domain/day-plan.ts
@@ -1,3 +1,4 @@
+import { slugifySlot } from '../../../shared/window-keys'
 import { extractWorkoutTemperatureC, getEstimatedSweatRateLph } from '../nutrition/sweat-rate'
 import { calculateDailyCalorieBreakdown, calculateMacroTargetCalories } from './energy'
 import type { FuelingProfile, SerializedFuelingPlan, SerializedFuelingWindow } from './types'
@@ -328,23 +329,13 @@ function extractSupplements(durationHours: number, intensity: number): string[] 
   return supplements
 }
 
-/** A name with no usable characters at all still needs a key it can be found by. */
-const FALLBACK_SLOT_SLUG = 'slot'
-
 /**
  * The stable half of a DAILY_BASE window key.
  *
- * Exported because `nutritionPlanService` derives the same key for legacy windows that predate
- * `windowKey`; two implementations of this drifted apart once already.
+ * The canonical implementation lives in `shared/window-keys` so server and app code derive
+ * identical keys; re-exported here because existing callers import it from this module.
  */
-export function slugifySlot(name: string) {
-  const slug = (name || '')
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  return slug || FALLBACK_SLOT_SLUG
-}
+export { slugifySlot }
 
 /**
  * Window keys for a day's meal slots, guaranteed unique.

--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -1,3 +1,4 @@
+import { dailyBaseWindowKey } from '../../../shared/window-keys'
 import { prisma } from '../db'
 import { nutritionRepository } from '../repositories/nutritionRepository'
 import { workoutRepository } from '../repositories/workoutRepository'
@@ -67,11 +68,9 @@ interface NutritionPlanSummary {
 
 export const metabolicService = {
   getDailyBaseWindowKey(slotName?: string) {
-    const normalized = (slotName || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-    return normalized ? `DAILY_BASE:${normalized}` : 'DAILY_BASE'
+    // Canonical slugifier shared with the generator and the app; a drifted local copy here once
+    // produced 'DAILY_BASE:lunch-' for 'Lunch!' and unlinked the stored meal.
+    return dailyBaseWindowKey(slotName)
   },
 
   /**

--- a/server/utils/services/nutritionPlanService.ts
+++ b/server/utils/services/nutritionPlanService.ts
@@ -1,8 +1,8 @@
 import { addDays, eachDayOfInterval, endOfDay, format, startOfWeek } from 'date-fns'
 import { prisma } from '../db'
 import { getUserTimezone, parseDateTimeInTimezone } from '../date'
+import { dailyBaseWindowKey } from '../../../shared/window-keys'
 import { nutritionRepository } from '../repositories/nutritionRepository'
-import { slugifySlot } from '../nutrition-domain/day-plan'
 import { bodyMetricResolver } from './bodyMetricResolver'
 import { metabolicService } from './metabolicService'
 import { mealRecommendationService } from './mealRecommendationService'
@@ -64,10 +64,9 @@ function toUpperList(value: unknown) {
 export const nutritionPlanService = {
   toDailyBaseWindowKey(slotName?: string) {
     // Legacy windows carry no windowKey, so their key is re-derived here. It has to be derived the
-    // same way the generator derives it - these two slugifiers disagreed on trailing punctuation
-    // ('Lunch!' -> 'lunch-' here, 'lunch' there), which silently unlinked the stored meal.
-    const raw = (slotName || '').trim()
-    return raw ? `DAILY_BASE:${slugifySlot(raw)}` : 'DAILY_BASE'
+    // same way the generator derives it - divergent slugifier copies silently unlinked stored
+    // meals once already, so the canonical implementation lives in shared/window-keys.
+    return dailyBaseWindowKey(slotName)
   },
 
   sanitizeMealTitle(value: unknown) {
@@ -443,6 +442,13 @@ export const nutritionPlanService = {
       }
     }
 
+    const nutrition = await prisma.nutrition.findUnique({
+      where: { userId_date: { userId, date: dayStartUtc } }
+    })
+    const dayWindows = Array.isArray((nutrition?.fuelingPlan as any)?.windows)
+      ? ((nutrition!.fuelingPlan as any).windows as any[])
+      : []
+
     const persistedPlanMeals: any[] = []
 
     for (const assignment of splitTotalsForAssignments) {
@@ -459,6 +465,32 @@ export const nutritionPlanService = {
         }
       }
 
+      // Without this, a re-lock that carries no explicit targets (the replace action does not)
+      // overwrote the window target with the meal's own totals, making every target-vs-planned
+      // comparison for the window self-referential.
+      const hasExplicitTarget =
+        assignment.targetCarbs != null ||
+        assignment.targetProtein != null ||
+        assignment.targetKcal != null
+      const targetJson = {
+        carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
+        protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
+        kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
+      }
+
+      // The window's clock time, so a manually locked meal doesn't sort to midnight while
+      // generated ones sit at their window start.
+      const sourceWindow = dayWindows.find(
+        (window: any) => this.resolveWindowKey(window) === assignment.normalizedWindowType
+      )
+      const windowStart = sourceWindow?.startTime ? new Date(sourceWindow.startTime) : null
+      const scheduledAt =
+        windowStart && !Number.isNaN(windowStart.getTime())
+          ? windowStart
+          : typeof date === 'string'
+            ? dayStartUtc
+            : date
+
       const planMeal = await prisma.nutritionPlanMeal.upsert({
         where: {
           planId_date_windowType: {
@@ -471,13 +503,9 @@ export const nutritionPlanService = {
           planId: plan.id,
           date: dayStartUtc,
           windowType: assignment.normalizedWindowType,
-          scheduledAt: typeof date === 'string' ? dayStartUtc : date,
+          scheduledAt,
           status: 'PLANNED',
-          targetJson: {
-            carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
-            protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
-            kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
-          },
+          targetJson,
           mealJson: mealForAssignment
         },
         update: {
@@ -486,21 +514,14 @@ export const nutritionPlanService = {
             replacedPreviousTitle: undefined
           },
           status: 'PLANNED',
-          targetJson: {
-            carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
-            protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
-            kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
-          },
+          scheduledAt,
+          ...(hasExplicitTarget ? { targetJson } : {}),
           actualNutritionItemId: null,
           updatedAt: new Date()
         }
       })
       persistedPlanMeals.push(planMeal)
     }
-
-    const nutrition = await prisma.nutrition.findUnique({
-      where: { userId_date: { userId, date: dayStartUtc } }
-    })
 
     if (nutrition) {
       const fuelingPlan = {
@@ -551,8 +572,13 @@ export const nutritionPlanService = {
   },
 
   async generateDraftPlan(userId: string, startDate: Date, endDate: Date) {
-    const days = eachDayOfInterval({ start: startDate, end: endDate })
     const plan = await this.getOrCreateWeeklyPlan(userId, startDate, 'DRAFT')
+    // The plan row always spans its full Monday-Sunday week. Persisting a caller-supplied
+    // endDate truncated the week when a sub-range was generated, which orphaned already-locked
+    // meals on the cut-off days; a range past the week overlapped the next week's plan.
+    const weekEnd = this.getWeekEndUtc(plan.startDate)
+    const rangeEnd = endDate > weekEnd ? weekEnd : endDate
+    const days = eachDayOfInterval({ start: startDate, end: rangeEnd })
     const existingMeals = new Map<string, any>(
       (plan.meals || []).map((meal: any) => [
         this.getWindowAssignmentKey(meal.date, meal.windowType),
@@ -689,13 +715,24 @@ export const nutritionPlanService = {
       })
     }
 
+    // A sub-range regeneration must not wipe the summary of the untouched days.
+    const existingSummaryDays = Array.isArray((plan.summaryJson as any)?.days)
+      ? ((plan.summaryJson as any).days as any[])
+      : []
+    const mergedSummaryDays = [
+      ...existingSummaryDays.filter(
+        (day: any) => !daySummaries.some((entry) => entry.date === day.date)
+      ),
+      ...daySummaries
+    ].sort((a: any, b: any) => String(a.date).localeCompare(String(b.date)))
+
     await prisma.nutritionPlan.update({
       where: { id: plan.id },
       data: {
         status: 'DRAFT',
-        endDate,
+        endDate: weekEnd,
         summaryJson: {
-          days: daySummaries,
+          days: mergedSummaryDays,
           generatedAt: new Date().toISOString()
         } as any,
         updatedAt: new Date()
@@ -707,7 +744,7 @@ export const nutritionPlanService = {
       include: {
         meals: {
           where: {
-            date: { gte: startDate, lte: endDate }
+            date: { gte: startDate, lte: rangeEnd }
           },
           orderBy: [{ date: 'asc' }, { scheduledAt: 'asc' }]
         }
@@ -756,8 +793,12 @@ export const nutritionPlanService = {
 
         if (!dailyBaseSlot) return true
 
+        // Logged items come from the plural Nutrition arrays ('snacks') while slot slugs are
+        // singular ('snack'), so the raw includes() check never matched a logged snack.
         const normalizedMealType = String(item.mealType || '').toLowerCase()
+        const singularMealType = normalizedMealType.replace(/s$/, '')
         if (dailyBaseSlot.includes(normalizedMealType)) return true
+        if (singularMealType && dailyBaseSlot.includes(singularMealType)) return true
 
         const itemName = String(item.name || '')
           .trim()

--- a/shared/window-keys.test.ts
+++ b/shared/window-keys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { dailyBaseWindowKey, resolveWindowKey, slugifySlot } from './window-keys'
+
+describe('window-keys', () => {
+  describe('slugifySlot', () => {
+    it('strips leading and trailing punctuation the same way for every caller', () => {
+      // The drifted copies produced 'lunch-' here, which unlinked stored meals.
+      expect(slugifySlot('Lunch!')).toBe('lunch')
+      expect(slugifySlot('  Snack  ')).toBe('snack')
+      expect(slugifySlot('Post ride ')).toBe('post-ride')
+    })
+
+    it('falls back to a usable slug for names with no usable characters', () => {
+      expect(slugifySlot('!!!')).toBe('slot')
+      expect(slugifySlot('☕️')).toBe('slot')
+      expect(slugifySlot('')).toBe('slot')
+    })
+  })
+
+  describe('dailyBaseWindowKey', () => {
+    it('derives slot-specific keys', () => {
+      expect(dailyBaseWindowKey('Breakfast')).toBe('DAILY_BASE:breakfast')
+    })
+
+    it('keeps the legacy bare key when no slot name exists', () => {
+      expect(dailyBaseWindowKey('')).toBe('DAILY_BASE')
+      expect(dailyBaseWindowKey(undefined)).toBe('DAILY_BASE')
+    })
+  })
+
+  describe('resolveWindowKey', () => {
+    it('prefers an explicit window key', () => {
+      expect(resolveWindowKey({ type: 'PRE_WORKOUT', windowKey: 'PRE_WORKOUT#2' })).toBe(
+        'PRE_WORKOUT#2'
+      )
+    })
+
+    it('derives DAILY_BASE keys from slot name or label', () => {
+      expect(resolveWindowKey({ type: 'DAILY_BASE', slotName: 'Snack' })).toBe('DAILY_BASE:snack')
+      expect(resolveWindowKey({ type: 'DAILY_BASE', label: 'Lunch!' })).toBe('DAILY_BASE:lunch')
+    })
+
+    it('treats keyless typed windows as the first of their type', () => {
+      expect(resolveWindowKey({ type: 'PRE_WORKOUT' })).toBe('PRE_WORKOUT#1')
+    })
+
+    it('is defensive about empty input', () => {
+      expect(resolveWindowKey(null)).toBe('')
+      expect(resolveWindowKey({})).toBe('')
+    })
+  })
+})

--- a/shared/window-keys.ts
+++ b/shared/window-keys.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical DAILY_BASE window-key derivation, shared between server and app code.
+ *
+ * Three copies of this slugifier used to exist (day-plan generator, metabolicService, and
+ * WeeklyPlanDashboard) and they disagreed on edge punctuation — 'Lunch!' produced
+ * 'DAILY_BASE:lunch-' in two of them and 'DAILY_BASE:lunch' in the generator, which silently
+ * unlinked a locked meal from its window. Every layer must derive keys from this module only.
+ */
+
+/** A name with no usable characters at all still needs a key it can be found by. */
+export const FALLBACK_SLOT_SLUG = 'slot'
+
+export function slugifySlot(name: string) {
+  const slug = (name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || FALLBACK_SLOT_SLUG
+}
+
+/** Key for a DAILY_BASE window; windows with no slot at all keep the legacy bare key. */
+export function dailyBaseWindowKey(slotName?: string | null) {
+  const raw = (slotName || '').trim()
+  return raw ? `DAILY_BASE:${slugifySlot(raw)}` : 'DAILY_BASE'
+}
+
+/**
+ * Stable identity of a fueling window. Several windows of the same type can exist on one day
+ * (two sessions ⇒ two PRE_WORKOUT windows), so the bare type is not an identity; windows
+ * persisted before stable keys existed carry no ordinal and are treated as the first.
+ */
+export function resolveWindowKey(
+  window:
+    { windowKey?: unknown; type?: unknown; slotName?: unknown; label?: unknown } | null | undefined
+) {
+  if (!window) return ''
+  if (window.windowKey) return String(window.windowKey)
+  const type = String(window.type || '')
+  if (!type) return ''
+  if (type === 'DAILY_BASE') {
+    return dailyBaseWindowKey(String(window.slotName || window.label || ''))
+  }
+  return `${type}#1`
+}

--- a/tests/unit/server/utils/services/nutritionPlanService.test.ts
+++ b/tests/unit/server/utils/services/nutritionPlanService.test.ts
@@ -99,7 +99,8 @@ vi.mock('../../../../../server/utils/services/metabolicService', async (importOr
   return {
     metabolicService: {
       ...actual.metabolicService,
-      getNutritionDay: vi.fn()
+      getNutritionDay: vi.fn(),
+      getMealTargetContext: vi.fn()
     }
   }
 })
@@ -494,6 +495,173 @@ describe('nutritionPlanService', () => {
           })
         })
       )
+    })
+  })
+
+  describe('reconciliation matching', () => {
+    const snackWindow = {
+      type: 'DAILY_BASE',
+      windowKey: 'DAILY_BASE:snack',
+      slotName: 'Snack',
+      startTime: '2026-02-15T14:00:00.000Z',
+      endTime: '2026-02-15T16:00:00.000Z'
+    }
+
+    it('matches an item logged under the plural snacks array to a snack slot', () => {
+      // Logged items carry the Nutrition record's plural array name; slot slugs are singular.
+      // The raw includes() check never matched, so snack plan meals stayed PLANNED forever.
+      const planMeal = { windowType: 'DAILY_BASE:snack' }
+      const item = {
+        id: 'log-1',
+        mealType: 'snacks',
+        name: 'Apple',
+        at: new Date('2026-02-15T15:00:00.000Z')
+      }
+
+      expect(
+        nutritionPlanService.matchLoggedItemToPlanMeal(planMeal, [snackWindow], [item], new Set())
+      ).toBe(item)
+    })
+
+    it('still rejects items outside the window or of an unrelated meal type', () => {
+      const planMeal = { windowType: 'DAILY_BASE:snack' }
+      const outsideWindow = {
+        id: 'log-2',
+        mealType: 'snacks',
+        name: 'Apple',
+        at: new Date('2026-02-15T18:00:00.000Z')
+      }
+      const wrongMealType = {
+        id: 'log-3',
+        mealType: 'dinner',
+        name: 'Steak',
+        at: new Date('2026-02-15T15:00:00.000Z')
+      }
+
+      expect(
+        nutritionPlanService.matchLoggedItemToPlanMeal(
+          planMeal,
+          [snackWindow],
+          [outsideWindow, wrongMealType],
+          new Set()
+        )
+      ).toBeNull()
+    })
+  })
+
+  describe('lockMeal target and schedule handling', () => {
+    beforeEach(() => {
+      vi.mocked(prisma.nutritionPlan.findFirst).mockResolvedValue({ id: 'plan-1' } as any)
+      vi.mocked(prisma.nutritionPlan.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.nutrition.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.nutritionPlanMeal.upsert).mockResolvedValue({
+        id: 'plan-meal-1',
+        planId: 'plan-1',
+        date: new Date('2026-02-15T00:00:00.000Z'),
+        windowType: 'PRE_WORKOUT',
+        scheduledAt: new Date('2026-02-15T00:00:00.000Z')
+      } as any)
+    })
+
+    it('keeps the stored window target when a re-lock carries no explicit targets', async () => {
+      // The replace action re-locks without targets; writing the meal's own totals as the
+      // target made every target-vs-planned comparison self-referential.
+      await nutritionPlanService.lockMeal('user-1', '2026-02-15', 'PRE_WORKOUT', {
+        title: 'Rice Cakes',
+        totals: { carbs: 50 }
+      })
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.update.targetJson).toBeUndefined()
+      expect(upsertArgs.create.targetJson).toEqual({ carbs: 50, protein: 0, kcal: 0 })
+    })
+
+    it('writes the explicit window target when the assignment carries one', async () => {
+      await nutritionPlanService.lockMeal(
+        'user-1',
+        '2026-02-15',
+        'PRE_WORKOUT',
+        { title: 'Rice Cakes', totals: { carbs: 50 } },
+        undefined,
+        {
+          windowAssignments: [
+            {
+              windowType: 'PRE_WORKOUT',
+              windowKey: 'PRE_WORKOUT#1',
+              targetCarbs: 90,
+              targetProtein: 20,
+              targetKcal: 450
+            }
+          ]
+        }
+      )
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.update.targetJson).toEqual({ carbs: 90, protein: 20, kcal: 450 })
+    })
+
+    it('schedules a locked meal at its window start time instead of midnight', async () => {
+      vi.mocked(prisma.nutrition.findUnique).mockResolvedValue({
+        id: 'nutrition-1',
+        fuelingPlan: {
+          windows: [
+            {
+              type: 'PRE_WORKOUT',
+              windowKey: 'PRE_WORKOUT#1',
+              startTime: '2026-02-15T09:30:00.000Z'
+            }
+          ]
+        }
+      } as any)
+
+      await nutritionPlanService.lockMeal(
+        'user-1',
+        '2026-02-15',
+        'PRE_WORKOUT',
+        { title: 'Morning Oats', totals: { carbs: 60 } },
+        undefined,
+        { windowKey: 'PRE_WORKOUT#1' }
+      )
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.create.scheduledAt).toEqual(new Date('2026-02-15T09:30:00.000Z'))
+      expect(upsertArgs.update.scheduledAt).toEqual(new Date('2026-02-15T09:30:00.000Z'))
+    })
+  })
+
+  describe('generateDraftPlan', () => {
+    it('persists the full plan week even when a sub-range is generated', async () => {
+      // A caller-supplied endDate used to truncate the plan row, orphaning locked meals on the
+      // cut-off days, and the regenerated summary wiped the untouched days' entries.
+      const weekStart = new Date('2026-02-09T00:00:00.000Z')
+      vi.mocked(prisma.nutritionPlan.findFirst).mockResolvedValue({
+        id: 'plan-1',
+        startDate: weekStart,
+        summaryJson: {
+          days: [{ date: '2026-02-12', fuelingPlan: { windows: [] }, targets: {} }]
+        },
+        meals: []
+      } as any)
+      vi.mocked(prisma.userNutritionSettings.findUnique).mockResolvedValue(null as any)
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null as any)
+      vi.mocked(bodyMetricResolver.resolveEffectiveWeight).mockResolvedValue({ value: 75 } as any)
+      vi.mocked(metabolicService.getNutritionDay).mockResolvedValue({
+        fuelingPlan: { windows: [] },
+        targets: {}
+      } as any)
+      vi.mocked(metabolicService.getMealTargetContext).mockResolvedValue({} as any)
+
+      await nutritionPlanService.generateDraftPlan(
+        'user-1',
+        new Date('2026-02-09T00:00:00.000Z'),
+        new Date('2026-02-11T23:59:59.999Z')
+      )
+
+      const updateArgs = vi.mocked(prisma.nutritionPlan.update).mock.calls[0]?.[0] as any
+      expect(updateArgs.data.endDate).toEqual(new Date('2026-02-15T23:59:59.999Z'))
+
+      const summaryDates = updateArgs.data.summaryJson.days.map((day: any) => day.date)
+      expect(summaryDates).toEqual(['2026-02-09', '2026-02-10', '2026-02-11', '2026-02-12'])
     })
   })
 })


### PR DESCRIPTION
Fixes CW-321
Fixes CW-322
Fixes CW-324
Fixes CW-325
Fixes CW-326

Patches the defects found in the 2026-08-02 nutrition-planning audit. CW-323 (coach effective-user asymmetry) was re-verified and turned out to be a false positive — `requireAuth` resolves the same acting-as session as `getEffectiveUserId` — and is being canceled, not patched.

## Changes

### CW-321 — logged snacks never auto-completed snack plan meals
`matchLoggedItemToPlanMeal` compared the singular slot slug (`snack`) against the plural logged mealType (`snacks`) with a bare `includes()`, which never matched. The match now also checks the singular form, so items logged under Snacks reconcile snack windows to `DONE`.

### CW-322 — three drifted DAILY_BASE window-key slugifiers
New `shared/window-keys.ts` is the single canonical implementation (`slugifySlot`, `dailyBaseWindowKey`, `resolveWindowKey`), used by the day-plan generator, `nutritionPlanService`, `metabolicService`, `WeeklyPlanDashboard`, and `UpcomingFuelingFeed`. The two drifted copies (edge-punctuation handling) are deleted; `day-plan.ts` re-exports the shared slugifier for existing importers.

### CW-324 — generateDraftPlan clobbered the plan week
Generation is clamped to the plan's Monday–Sunday week, the persisted `endDate` is always the full week end (a sub-range regeneration no longer truncates the plan and orphans locked meals on cut-off days), and regenerated summary days merge with existing ones instead of wiping untouched days. `plan/generate.post` also rejects `endDate < startDate`.

### CW-325 — replace overwrote the window target with meal totals
`lockMeal`'s update path only writes `targetJson` when the assignment carries explicit targets; a target-less re-lock (the replace action) now preserves the stored window target.

### CW-326 — minor hardening batch
- Locked meals get `scheduledAt` from the actual fueling window's start time instead of midnight.
- `plan/meal.post` zod-validates the lock payload (meal shape, assignments) with passthrough for extra fields; unused zod import removed from `generate.post`.
- WeeklyPlanDashboard shows an error banner with retry when the plan fetch fails, instead of an authoritative-looking empty week.
- `UpcomingFuelingFeed` derives windowKey fallbacks via the shared resolver.

## Verification

- New tests: `shared/window-keys.test.ts` (9), plus reconciliation-matching, lockMeal target/schedule, and generateDraftPlan clamp suites in `nutritionPlanService.test.ts`.
- Full unit suite: 321 files / 1673 tests pass.
- `pnpm typecheck` clean; eslint clean on all changed files.