### PR TITLE
Release develop to master

### DIFF
--- a/app/components/nutrition/UpcomingFuelingFeed.vue
+++ b/app/components/nutrition/UpcomingFuelingFeed.vue
@@ -299,6 +299,7 @@
 
 <script setup lang="ts">
   import { format, parseISO } from 'date-fns'
+  import { resolveWindowKey } from '#shared/window-keys'
 
   const props = defineProps<{
     windows: any[]
@@ -407,7 +408,7 @@
       windowType: window.type,
       // Identity of this exact window. Without it a day with two pre-workout windows collapses
       // both onto one planned meal.
-      windowKey: window.windowKey || window.type,
+      windowKey: resolveWindowKey(window),
       slotName: window.slotName || window.label || '',
       label: window.label,
       targetCarbs: Number(window.targetCarbs || 0),
@@ -429,7 +430,7 @@
     const currentlyAssignedCarbs = day.windows
       .filter((candidate: any) =>
         windowAssignments.some(
-          (assignment: any) => assignment.windowKey === (candidate.windowKey || candidate.type)
+          (assignment: any) => assignment.windowKey === resolveWindowKey(candidate)
         )
       )
       .reduce((sum: number, candidate: any) => {

--- a/app/components/nutrition/WeeklyPlanDashboard.vue
+++ b/app/components/nutrition/WeeklyPlanDashboard.vue
@@ -130,6 +130,16 @@
       </div>
     </div>
 
+    <div
+      v-if="loadError"
+      class="m-3 flex items-center justify-between gap-3 rounded-lg border border-error-200 bg-error-50 p-3 text-sm text-error-700 dark:border-error-800 dark:bg-error-900/20 dark:text-error-300"
+    >
+      <span>Could not load the weekly plan. The grid below may be incomplete.</span>
+      <UButton size="xs" color="error" variant="soft" icon="i-lucide-refresh-cw" @click="refresh">
+        Retry
+      </UButton>
+    </div>
+
     <div class="overflow-x-auto">
       <table class="w-full border-collapse text-left">
         <thead>
@@ -568,6 +578,7 @@
 
 <script setup lang="ts">
   import { addDays, format, parseISO } from 'date-fns'
+  import { resolveWindowKey } from '#shared/window-keys'
   import { normalizeWindowLabel } from '~/utils/nutrition-window-label'
 
   const toast = useToast()
@@ -628,6 +639,8 @@
   const loading = ref(false)
   /** True once a fetch has settled, so the grid can distinguish "empty" from "not loaded yet". */
   const planLoaded = ref(false)
+  /** A failed fetch used to render as an authoritative-looking empty week; surface it instead. */
+  const loadError = ref(false)
   const plan = ref<any>(null)
   const workoutsByDate = ref<Record<string, DayWorkout[]>>({})
   const drawerOpen = ref(false)
@@ -635,25 +648,8 @@
   const selectedWindowKey = ref('')
   const expandedMealKeys = ref<string[]>([])
 
-  function toDailyBaseKey(slotName?: string) {
-    const normalized = (slotName || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-    return normalized ? `DAILY_BASE:${normalized}` : 'DAILY_BASE'
-  }
-
-  function getSlotNameFromWindow(window: any) {
-    return window?.slotName || window?.label || (window?.type === 'DAILY_BASE' ? 'Meal' : '')
-  }
-
-  function resolveWindowKey(window: any) {
-    if (!window) return ''
-    if (window.windowKey) return String(window.windowKey)
-    if (window.type === 'DAILY_BASE') return toDailyBaseKey(getSlotNameFromWindow(window))
-    return `${window.type}#1`
-  }
-
+  // Key derivation is shared with the server (shared/window-keys); a drifted local copy here
+  // once produced different keys for punctuated slot names and unlinked locked meals.
   function matchesMealToWindow(meal: any, window: any) {
     if (!meal || !window) return false
 
@@ -742,6 +738,7 @@
 
   async function fetchPlan() {
     loading.value = true
+    loadError.value = false
     try {
       const [planData, workoutsData] = await Promise.all([
         ($fetch as any)('/api/nutrition/plan', {
@@ -779,6 +776,7 @@
       workoutsByDate.value = mappedWorkouts
     } catch (e) {
       console.error('Failed to fetch weekly nutrition dashboard data:', e)
+      loadError.value = true
     } finally {
       loading.value = false
       planLoaded.value = true

--- a/app/pages/nutrition/index.vue
+++ b/app/pages/nutrition/index.vue
@@ -549,7 +549,14 @@
               </div>
 
               <div v-else-if="!groceryData.items.length" class="py-8 text-center text-gray-500">
-                No planned meal ingredients found for this range yet.
+                <p>No planned meal ingredients found for this range yet.</p>
+                <p class="mt-1 text-xs">
+                  {{
+                    groceryRange === 'week'
+                      ? `The Week range covers the plan week you are viewing (${weekStartDate} – ${weekEndDate}).`
+                      : 'The 24h/48h/7d ranges look forward from today — switch to Week to cover the plan week you are viewing.'
+                  }}
+                </p>
               </div>
 
               <ul v-else class="space-y-2">
@@ -699,7 +706,7 @@
   const upcomingPlan = ref<any>(null)
   const showGroceryList = ref(false)
   const groceryLoading = ref(false)
-  const groceryRange = ref<'24h' | '48h' | '7d'>('48h')
+  const groceryRange = ref<'week' | '24h' | '48h' | '7d'>('week')
   const groceryData = ref<{ items: any[]; totals: { ingredients: number; meals: number } }>({
     items: [],
     totals: { ingredients: 0, meals: 0 }
@@ -1069,20 +1076,26 @@
   }
 
   const groceryRangeOptions = [
+    { value: 'week', label: 'Week' },
     { value: '24h', label: '24h' },
     { value: '48h', label: '48h' },
     { value: '7d', label: '7d' }
   ] as const
 
   function getGroceryRangeDates() {
+    // 'week' covers the plan week currently shown in the dashboard; the hour-based
+    // options roll forward from today. The API treats `end` as inclusive end-of-day.
+    if (groceryRange.value === 'week') {
+      return { start: weekStartDate.value, end: weekEndDate.value }
+    }
     const start = format(new Date(), 'yyyy-MM-dd')
     if (groceryRange.value === '24h') {
-      return { start, end: format(addDays(new Date(), 1), 'yyyy-MM-dd') }
+      return { start, end: start }
     }
     if (groceryRange.value === '7d') {
       return { start, end: format(addDays(new Date(), 6), 'yyyy-MM-dd') }
     }
-    return { start, end: format(addDays(new Date(), 2), 'yyyy-MM-dd') }
+    return { start, end: format(addDays(new Date(), 1), 'yyyy-MM-dd') }
   }
 
   async function loadGroceryList() {

--- a/server/api/nutrition/plan/generate.post.ts
+++ b/server/api/nutrition/plan/generate.post.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import { defineEventHandler, readBody } from 'h3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { nutritionPlanService } from '../../../utils/services/nutritionPlanService'
@@ -35,6 +34,10 @@ export default defineEventHandler(async (event) => {
         new Date(start.getTime() + 6 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10) +
           'T23:59:59.999Z'
       )
+
+  if (end < start) {
+    throw createError({ statusCode: 400, message: 'endDate must not be before startDate' })
+  }
 
   try {
     const plan = await nutritionPlanService.generateDraftPlan(userId, start, end)

--- a/server/api/nutrition/plan/meal.post.ts
+++ b/server/api/nutrition/plan/meal.post.ts
@@ -2,15 +2,75 @@ import { z } from 'zod'
 import { requireAuth } from '../../../utils/auth-guard'
 import { nutritionPlanService } from '../../../utils/services/nutritionPlanService'
 
+// mealJson flows untouched into grocery aggregation, dashboards, and reconciliation, so the
+// shape is validated here while unknown extra fields still pass through.
+const numberLike = z.union([z.number(), z.string()])
+
+const ingredientSchema = z
+  .object({
+    item: z.string().optional(),
+    name: z.string().optional(),
+    quantity: numberLike.nullish(),
+    unit: z.string().nullish(),
+    category: z.string().nullish()
+  })
+  .passthrough()
+
+const mealSchema = z
+  .object({
+    title: z.string().optional(),
+    name: z.string().optional(),
+    totals: z
+      .object({
+        carbs: numberLike.nullish(),
+        protein: numberLike.nullish(),
+        kcal: numberLike.nullish(),
+        calories: numberLike.nullish(),
+        fat: numberLike.nullish()
+      })
+      .passthrough()
+      .optional(),
+    ingredients: z.array(ingredientSchema).optional()
+  })
+  .passthrough()
+
+const windowAssignmentSchema = z
+  .object({
+    windowType: z.string().min(1),
+    windowKey: z.string().optional(),
+    slotName: z.string().optional(),
+    label: z.string().optional(),
+    targetCarbs: z.number().optional(),
+    targetProtein: z.number().optional(),
+    targetKcal: z.number().optional()
+  })
+  .passthrough()
+
+const lockMealSchema = z.object({
+  date: z.string().min(8),
+  windowType: z.string().min(1),
+  meal: mealSchema,
+  slotName: z.string().optional(),
+  windowKey: z.string().optional(),
+  windowAssignments: z.array(windowAssignmentSchema).optional()
+})
+
 export default defineEventHandler(async (event) => {
   const authUser = await requireAuth(event, ['nutrition:write'])
 
   const userId = authUser.id
-  const body = await readBody(event)
+  const rawBody = await readBody(event)
 
-  if (!body.date || !body.windowType || !body.meal) {
-    throw createError({ statusCode: 400, message: 'Date, windowType, and meal are required' })
+  const parsed = lockMealSchema.safeParse(rawBody)
+  if (!parsed.success) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid lock meal payload',
+      data: parsed.error.issues
+    })
   }
+  const body = parsed.data
+
   console.log('[nutrition/plan/meal.post] request', {
     userId,
     date: body.date,
@@ -30,9 +90,7 @@ export default defineEventHandler(async (event) => {
       body.slotName,
       {
         windowKey: body.windowKey,
-        windowAssignments: Array.isArray(body.windowAssignments)
-          ? body.windowAssignments
-          : undefined
+        windowAssignments: body.windowAssignments
       }
     )
     console.log('[nutrition/plan/meal.post] locked', {

--- a/server/api/plans/[id]/blocks/[blockId].patch.ts
+++ b/server/api/plans/[id]/blocks/[blockId].patch.ts
@@ -1,6 +1,11 @@
 import { requireAuth } from '../../../../utils/auth-guard'
 import { prisma } from '../../../../utils/db'
-import { shiftPlanDates, calculateWeekTargets } from '../../../../utils/plan-logic'
+import { shiftPlanDates } from '../../../../utils/plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../../../../utils/plans/week-targets'
 import { trainingBlockRepository } from '../../../../utils/repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../../../../utils/repositories/trainingWeekRepository'
 import { z } from 'zod/v3'
@@ -32,7 +37,7 @@ export default defineEventHandler(async (event) => {
   // Verify ownership and existence
   const existingBlock = await trainingBlockRepository.getById(blockId!, {
     include: {
-      plan: { select: { userId: true } },
+      plan: { select: { userId: true, recoveryRhythm: true } },
       weeks: { orderBy: { weekNumber: 'asc' } }
     }
   })
@@ -55,7 +60,15 @@ export default defineEventHandler(async (event) => {
         const lastWeek = existingBlock.weeks[existingBlock.weeks.length - 1]
         if (!lastWeek)
           throw createError({ statusCode: 500, message: 'Block has no weeks to extend from' })
-        const targets = calculateWeekTargets(type || existingBlock.type)
+
+        // Inherit the block's loading volume instead of resetting to defaults (CW-318)
+        const blockType = type || existingBlock.type
+        const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(existingBlock.weeks)
+        const recoveryRhythm =
+          recoveryWeekIndex ||
+          existingBlock.recoveryWeekIndex ||
+          (existingBlock.plan as any).recoveryRhythm ||
+          4
 
         for (let i = 1; i <= deltaWeeks; i++) {
           const newWeekNumber = existingBlock.durationWeeks + i
@@ -65,12 +78,22 @@ export default defineEventHandler(async (event) => {
           const endDate = new Date(startDate)
           endDate.setUTCDate(endDate.getUTCDate() + 6)
 
+          const isRecovery = isRecoveryWeek(newWeekNumber, recoveryRhythm, blockType)
+          const targets = calculateWeekTargets({
+            blockType,
+            weekNumber: newWeekNumber,
+            blockDurationWeeks: durationWeeks,
+            isRecovery,
+            baseVolumeMinutes
+          })
+
           await trainingWeekRepository.create(
             {
               blockId: existingBlock.id,
               weekNumber: newWeekNumber,
               startDate,
               endDate,
+              isRecovery,
               ...targets
             },
             tx

--- a/server/api/plans/[id]/blocks/index.post.ts
+++ b/server/api/plans/[id]/blocks/index.post.ts
@@ -1,6 +1,11 @@
 import { requireAuth } from '../../../../utils/auth-guard'
 import { prisma } from '../../../../utils/db'
-import { shiftPlanDates, calculateWeekTargets } from '../../../../utils/plan-logic'
+import { shiftPlanDates } from '../../../../utils/plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../../../../utils/plans/week-targets'
 import { trainingPlanRepository } from '../../../../utils/repositories/trainingPlanRepository'
 import { trainingBlockRepository } from '../../../../utils/repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../../../../utils/repositories/trainingWeekRepository'
@@ -32,7 +37,7 @@ export default defineEventHandler(async (event) => {
 
   const plan = await trainingPlanRepository.getById(planId!, user.id, {
     include: {
-      blocks: { orderBy: { order: 'asc' } }
+      blocks: { orderBy: { order: 'asc' }, include: { weeks: true } }
     }
   })
 
@@ -89,8 +94,12 @@ export default defineEventHandler(async (event) => {
       tx
     )
 
-    // 4. Create weeks for the new block
-    const targets = calculateWeekTargets(type)
+    // 4. Create weeks for the new block, inheriting the plan's loading volume (CW-318)
+    const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(
+      plan.blocks.flatMap((b: any) => b.weeks || [])
+    )
+    const recoveryRhythm = recoveryWeekIndex || (plan as any).recoveryRhythm || 4
+
     for (let i = 1; i <= durationWeeks; i++) {
       const weekStart = new Date(startDate)
       weekStart.setUTCDate(weekStart.getUTCDate() + (i - 1) * 7)
@@ -98,12 +107,22 @@ export default defineEventHandler(async (event) => {
       const weekEnd = new Date(weekStart)
       weekEnd.setUTCDate(weekEnd.getUTCDate() + 6)
 
+      const isRecovery = isRecoveryWeek(i, recoveryRhythm, type)
+      const targets = calculateWeekTargets({
+        blockType: type,
+        weekNumber: i,
+        blockDurationWeeks: durationWeeks,
+        isRecovery,
+        baseVolumeMinutes
+      })
+
       await trainingWeekRepository.create(
         {
           blockId: newBlock.id,
           weekNumber: i,
           startDate: weekStart,
           endDate: weekEnd,
+          isRecovery,
           ...targets
         },
         tx

--- a/server/api/plans/initialize.post.ts
+++ b/server/api/plans/initialize.post.ts
@@ -5,6 +5,11 @@ import { getUserTimezone, getUserLocalDate } from '../../utils/date'
 import { generateStructuredAnalysis } from '../../utils/gemini'
 
 import { trainingPlanRepository } from '../../utils/repositories/trainingPlanRepository'
+import {
+  baseWeeklyVolumeMinutes,
+  calculateWeekTargets,
+  isRecoveryWeek
+} from '../../utils/plans/week-targets'
 
 const initializePlanSchema = z.object({
   goalId: z.string(),
@@ -293,38 +298,22 @@ export default defineEventHandler(async (event) => {
                 // Determine recovery week based on rhythm
                 // e.g. Rhythm 4 (3:1) -> Weeks 4, 8, 12 are recovery
                 // But specifically for Taper/Race blocks, usually the whole thing is recovery/taper logic handled by workout generator
-                const isRecovery =
-                  (i + 1) % recoveryRhythm === 0 &&
-                  blockConfig.type !== 'PEAK' &&
-                  blockConfig.type !== 'RACE'
+                const isRecovery = isRecoveryWeek(i + 1, recoveryRhythm, blockConfig.type)
 
-                // Determine target volume
-                let targetMinutes = 450 // Default MID
-                if (volumeHours) {
-                  targetMinutes = volumeHours * 60
-                  if (isRecovery) targetMinutes = Math.round(targetMinutes * 0.6)
-                } else {
-                  if (volumePreference === 'LOW') targetMinutes = 240
-                  else if (volumePreference === 'HIGH') targetMinutes = 600
-                  if (isRecovery) targetMinutes = Math.round(targetMinutes * 0.6)
-                }
-
-                // Taper volume reduction
-                if (blockConfig.type === 'PEAK') {
-                  // Progressive reduction: Week 1 (70%), Week 2 (50%)
-                  const taperFactor = 1 - ((i + 1) / blockConfig.durationWeeks) * 0.5
-                  targetMinutes = Math.round(targetMinutes * taperFactor)
-                }
-
-                const tssTarget = Math.round((targetMinutes / 60) * 50)
+                const targets = calculateWeekTargets({
+                  blockType: blockConfig.type,
+                  weekNumber: i + 1,
+                  blockDurationWeeks: blockConfig.durationWeeks,
+                  isRecovery,
+                  baseVolumeMinutes: baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+                })
 
                 return {
                   weekNumber: i + 1,
                   startDate: weekStart,
                   endDate: weekEnd,
                   isRecovery,
-                  volumeTargetMinutes: targetMinutes,
-                  tssTarget: tssTarget
+                  ...targets
                 }
               })
             }

--- a/server/api/plans/initialize.post.ts
+++ b/server/api/plans/initialize.post.ts
@@ -8,6 +8,7 @@ import { trainingPlanRepository } from '../../utils/repositories/trainingPlanRep
 import {
   baseWeeklyVolumeMinutes,
   calculateWeekTargets,
+  computeRampBaseMinutes,
   isRecoveryWeek
 } from '../../utils/plans/week-targets'
 
@@ -257,6 +258,24 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  // 4.5 Ramp-rate cap (CW-320): base the on-ramp on what the athlete actually
+  // trained in the last 4 weeks, so a plan can't jump straight to a multiple
+  // of their real load. The cap grows per loading week until it reaches the
+  // requested volume; it never raises targets.
+  const twentyEightDaysAgo = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000)
+  const recentLoad = await prisma.workout.aggregate({
+    _sum: { durationSec: true },
+    where: {
+      userId,
+      isDuplicate: false,
+      date: { gte: twentyEightDaysAgo }
+    }
+  })
+  const recentWeeklyAvgMinutes = (recentLoad._sum.durationSec || 0) / 60 / 4
+  const requestedBaseMinutes = baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+  const rampBaseMinutes = computeRampBaseMinutes(recentWeeklyAvgMinutes)
+  let loadingWeekOrdinal = 0
+
   // 5. Create Plan Skeleton
   const plan = await trainingPlanRepository.create(
     {
@@ -299,13 +318,16 @@ export default defineEventHandler(async (event) => {
                 // e.g. Rhythm 4 (3:1) -> Weeks 4, 8, 12 are recovery
                 // But specifically for Taper/Race blocks, usually the whole thing is recovery/taper logic handled by workout generator
                 const isRecovery = isRecoveryWeek(i + 1, recoveryRhythm, blockConfig.type)
+                if (!isRecovery) loadingWeekOrdinal++
 
                 const targets = calculateWeekTargets({
                   blockType: blockConfig.type,
                   weekNumber: i + 1,
                   blockDurationWeeks: blockConfig.durationWeeks,
                   isRecovery,
-                  baseVolumeMinutes: baseWeeklyVolumeMinutes(volumeHours, volumePreference)
+                  baseVolumeMinutes: requestedBaseMinutes,
+                  rampBaseMinutes,
+                  loadingWeekOrdinal: Math.max(1, loadingWeekOrdinal)
                 })
 
                 return {

--- a/server/utils/nutrition-domain/day-plan.ts
+++ b/server/utils/nutrition-domain/day-plan.ts
@@ -1,3 +1,4 @@
+import { slugifySlot } from '../../../shared/window-keys'
 import { extractWorkoutTemperatureC, getEstimatedSweatRateLph } from '../nutrition/sweat-rate'
 import { calculateDailyCalorieBreakdown, calculateMacroTargetCalories } from './energy'
 import type { FuelingProfile, SerializedFuelingPlan, SerializedFuelingWindow } from './types'
@@ -328,23 +329,13 @@ function extractSupplements(durationHours: number, intensity: number): string[] 
   return supplements
 }
 
-/** A name with no usable characters at all still needs a key it can be found by. */
-const FALLBACK_SLOT_SLUG = 'slot'
-
 /**
  * The stable half of a DAILY_BASE window key.
  *
- * Exported because `nutritionPlanService` derives the same key for legacy windows that predate
- * `windowKey`; two implementations of this drifted apart once already.
+ * The canonical implementation lives in `shared/window-keys` so server and app code derive
+ * identical keys; re-exported here because existing callers import it from this module.
  */
-export function slugifySlot(name: string) {
-  const slug = (name || '')
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  return slug || FALLBACK_SLOT_SLUG
-}
+export { slugifySlot }
 
 /**
  * Window keys for a day's meal slots, guaranteed unique.

--- a/server/utils/plan-logic.ts
+++ b/server/utils/plan-logic.ts
@@ -62,21 +62,5 @@ export async function shiftPlanDates(planId: string, fromOrder: number, daysDelt
   }
 }
 
-/**
- * Calculates and updates targets for a week (Volume, TSS).
- * Simple heuristic for now.
- */
-export function calculateWeekTargets(blockType: string, volumePreference: string = 'MID') {
-  // Determine target volume
-  let targetMinutes = 450 // Default MID
-  if (volumePreference === 'LOW') targetMinutes = 240
-  else if (volumePreference === 'HIGH') targetMinutes = 600
-
-  // Default TSS estimation (0.6 IF avg => 36 TSS/hr)
-  const tssTarget = Math.round((targetMinutes / 60) * 50)
-
-  return {
-    volumeTargetMinutes: targetMinutes,
-    tssTarget: tssTarget
-  }
-}
+// calculateWeekTargets moved to server/utils/plans/week-targets.ts (CW-318),
+// which accounts for the athlete's chosen volume, recovery weeks, and taper.

--- a/server/utils/plans/block-volume.ts
+++ b/server/utils/plans/block-volume.ts
@@ -1,0 +1,176 @@
+/**
+ * Validation and deterministic clamping for AI-generated training block weeks.
+ *
+ * The block generator prompts Gemini with per-week volume targets, but the model
+ * sometimes schedules far more than requested (e.g. filling every availability
+ * slot every day). These helpers verify the generated schedule against the
+ * wizard-defined week targets and, as a last resort, scale it down so a week can
+ * never be persisted at a multiple of what the athlete asked for. (CW-316)
+ */
+
+export interface GeneratedBlockWorkout {
+  dayOfWeek: number
+  title?: string
+  description?: string
+  type: string
+  durationMinutes?: number
+  tssEstimate?: number
+  intensity?: string
+}
+
+export interface GeneratedBlockWeek {
+  weekNumber: number
+  focus_key?: string
+  focus_label?: string
+  explanation?: string
+  volumeTargetMinutes?: number
+  workouts?: GeneratedBlockWorkout[]
+}
+
+export interface WeekVolumeTarget {
+  weekNumber: number
+  volumeTargetMinutes: number | null
+  isRecovery?: boolean
+  /** UTC days (0=Sun..6=Sat) that can actually receive workouts. When set, workouts on other days are ignored (they are dropped at insert time anyway). */
+  allowedDaysOfWeek?: number[]
+}
+
+export interface BlockVolumeViolation {
+  weekNumber: number
+  kind: 'over_volume' | 'invalid_duration'
+  message: string
+}
+
+/** A week is rejected when its scheduled minutes exceed target * VOLUME_TOLERANCE. */
+export const VOLUME_TOLERANCE = 1.2
+/** When clamping, scale down to target * CLAMP_RATIO. */
+export const CLAMP_RATIO = 1.1
+export const MIN_WORKOUT_MINUTES = 15
+export const MAX_WORKOUT_MINUTES = 420
+
+const REST_TYPES = new Set(['Rest'])
+
+function isRest(workout: GeneratedBlockWorkout): boolean {
+  return REST_TYPES.has(workout.type)
+}
+
+function countsForWeek(workout: GeneratedBlockWorkout, target: WeekVolumeTarget): boolean {
+  if (isRest(workout)) return false
+  if (target.allowedDaysOfWeek && !target.allowedDaysOfWeek.includes(workout.dayOfWeek)) {
+    return false
+  }
+  return true
+}
+
+export function weekScheduledMinutes(week: GeneratedBlockWeek, target: WeekVolumeTarget): number {
+  return (week.workouts || [])
+    .filter((w) => countsForWeek(w, target))
+    .reduce((sum, w) => sum + (w.durationMinutes || 0), 0)
+}
+
+export function validateGeneratedBlockWeeks(
+  weeks: GeneratedBlockWeek[],
+  targets: WeekVolumeTarget[]
+): BlockVolumeViolation[] {
+  const violations: BlockVolumeViolation[] = []
+
+  for (const week of weeks) {
+    const target = targets.find((t) => t.weekNumber === Number(week.weekNumber))
+    if (!target) continue
+
+    for (const workout of week.workouts || []) {
+      if (!countsForWeek(workout, target)) continue
+      const minutes = workout.durationMinutes || 0
+      if (minutes < MIN_WORKOUT_MINUTES || minutes > MAX_WORKOUT_MINUTES) {
+        violations.push({
+          weekNumber: week.weekNumber,
+          kind: 'invalid_duration',
+          message: `Week ${week.weekNumber}: "${workout.title || workout.type}" has an implausible duration of ${minutes} minutes (must be ${MIN_WORKOUT_MINUTES}-${MAX_WORKOUT_MINUTES} for a non-Rest session).`
+        })
+      }
+    }
+
+    if (!target.volumeTargetMinutes || target.volumeTargetMinutes <= 0) continue
+
+    const scheduled = weekScheduledMinutes(week, target)
+    if (scheduled > target.volumeTargetMinutes * VOLUME_TOLERANCE) {
+      violations.push({
+        weekNumber: week.weekNumber,
+        kind: 'over_volume',
+        message: `Week ${week.weekNumber}${target.isRecovery ? ' (RECOVERY week)' : ''}: scheduled ${scheduled} minutes but the volume target is ${target.volumeTargetMinutes} minutes. Reduce total scheduled time to within ±10% of the target — do not fill every availability slot.`
+      })
+    }
+  }
+
+  return violations
+}
+
+export function formatViolationsFeedback(violations: BlockVolumeViolation[]): string {
+  return [
+    'YOUR PREVIOUS RESPONSE WAS REJECTED FOR THE FOLLOWING VOLUME VIOLATIONS:',
+    ...violations.map((v) => `- ${v.message}`),
+    '',
+    "Regenerate the FULL block fixing every violation. The weekly volume targets are hard budgets: the sum of workout durations in each week MUST stay within ±10% of that week's target. Availability slots are windows when the athlete CAN train — schedule only as many sessions as the volume budget allows, never one per slot per day."
+  ].join('\n')
+}
+
+/**
+ * Deterministic fallback when the AI ignores corrective feedback: clamp
+ * implausible durations and proportionally scale down over-volume weeks
+ * (durations and TSS together) to target * CLAMP_RATIO.
+ * Mutates nothing; returns new week objects plus a log of adjustments.
+ */
+export function clampGeneratedBlockWeeks(
+  weeks: GeneratedBlockWeek[],
+  targets: WeekVolumeTarget[]
+): { weeks: GeneratedBlockWeek[]; adjustments: string[] } {
+  const adjustments: string[] = []
+
+  const clamped = weeks.map((week) => {
+    const target = targets.find((t) => t.weekNumber === Number(week.weekNumber))
+    if (!target) return week
+
+    let workouts = (week.workouts || []).map((w) => {
+      if (!countsForWeek(w, target)) return w
+      const minutes = w.durationMinutes || 0
+      if (minutes < MIN_WORKOUT_MINUTES || minutes > MAX_WORKOUT_MINUTES) {
+        const fixed = Math.min(Math.max(minutes, MIN_WORKOUT_MINUTES), MAX_WORKOUT_MINUTES)
+        adjustments.push(
+          `Week ${week.weekNumber}: "${w.title || w.type}" duration ${minutes}min -> ${fixed}min`
+        )
+        return { ...w, durationMinutes: fixed }
+      }
+      return w
+    })
+
+    if (target.volumeTargetMinutes && target.volumeTargetMinutes > 0) {
+      const scheduled = workouts
+        .filter((w) => countsForWeek(w, target))
+        .reduce((sum, w) => sum + (w.durationMinutes || 0), 0)
+
+      if (scheduled > target.volumeTargetMinutes * VOLUME_TOLERANCE) {
+        const factor = (target.volumeTargetMinutes * CLAMP_RATIO) / scheduled
+        workouts = workouts.map((w) => {
+          if (!countsForWeek(w, target)) return w
+          const minutes = w.durationMinutes || 0
+          const scaledMinutes = Math.max(
+            MIN_WORKOUT_MINUTES,
+            Math.round((minutes * factor) / 5) * 5
+          )
+          const scaled: GeneratedBlockWorkout = { ...w, durationMinutes: scaledMinutes }
+          if (typeof w.tssEstimate === 'number') {
+            scaled.tssEstimate = Math.round(w.tssEstimate * factor)
+          }
+          return scaled
+        })
+        adjustments.push(
+          `Week ${week.weekNumber}: scaled ${scheduled}min down to ~${Math.round(target.volumeTargetMinutes * CLAMP_RATIO)}min (target ${target.volumeTargetMinutes}min)`
+        )
+      }
+    }
+
+    return { ...week, workouts }
+  })
+
+  return { weeks: clamped, adjustments }
+}

--- a/server/utils/plans/week-targets.ts
+++ b/server/utils/plans/week-targets.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared computation of TrainingWeek volume/TSS targets.
+ *
+ * Historically the plan wizard (initialize endpoint) had the full logic inline
+ * (volumeHours, recovery reduction, taper factor) while every other call site
+ * (structure replan, add block, extend block) used a stripped-down helper that
+ * ignored the athlete's chosen volume and always reset new weeks to the 450min
+ * default. This module is the single source of truth for all of them. (CW-318)
+ */
+
+export const DEFAULT_WEEKLY_VOLUME_MINUTES = 450
+export const LOW_WEEKLY_VOLUME_MINUTES = 240
+export const HIGH_WEEKLY_VOLUME_MINUTES = 600
+export const RECOVERY_WEEK_FACTOR = 0.6
+/** Heuristic TSS per hour used for week targets across the app. */
+export const TSS_PER_HOUR = 50
+
+export interface WeekTargetOptions {
+  blockType: string
+  /** 1-based week number within the block. */
+  weekNumber: number
+  blockDurationWeeks: number
+  isRecovery: boolean
+  /** Weekly loading volume in minutes (athlete's wizard choice or derived). */
+  baseVolumeMinutes?: number | null
+}
+
+export function baseWeeklyVolumeMinutes(
+  volumeHours?: number | null,
+  volumePreference?: string | null
+): number {
+  if (volumeHours && volumeHours > 0) return Math.round(volumeHours * 60)
+  if (volumePreference === 'LOW') return LOW_WEEKLY_VOLUME_MINUTES
+  if (volumePreference === 'HIGH') return HIGH_WEEKLY_VOLUME_MINUTES
+  return DEFAULT_WEEKLY_VOLUME_MINUTES
+}
+
+/**
+ * Recovers the plan's loading-week volume from already-persisted weeks, since
+ * TrainingPlan does not store the wizard's volumeHours. The max non-recovery
+ * target is the loading volume (recovery/taper weeks are reduced from it).
+ */
+export function deriveBaseVolumeMinutesFromWeeks(
+  weeks: Array<{ volumeTargetMinutes?: number | null; isRecovery?: boolean | null }>
+): number | null {
+  const loadingTargets = weeks
+    .filter((w) => !w.isRecovery && (w.volumeTargetMinutes || 0) > 0)
+    .map((w) => w.volumeTargetMinutes!)
+  if (loadingTargets.length === 0) return null
+  return Math.max(...loadingTargets)
+}
+
+/** Standard recovery-week cadence: every Nth week, except in PEAK/RACE blocks. */
+export function isRecoveryWeek(
+  weekNumber: number,
+  recoveryRhythm: number,
+  blockType: string
+): boolean {
+  if (blockType === 'PEAK' || blockType === 'RACE') return false
+  return recoveryRhythm > 0 && weekNumber % recoveryRhythm === 0
+}
+
+export function calculateWeekTargets(options: WeekTargetOptions): {
+  volumeTargetMinutes: number
+  tssTarget: number
+} {
+  let targetMinutes = options.baseVolumeMinutes || DEFAULT_WEEKLY_VOLUME_MINUTES
+
+  if (options.isRecovery) {
+    targetMinutes = Math.round(targetMinutes * RECOVERY_WEEK_FACTOR)
+  }
+
+  if (options.blockType === 'PEAK') {
+    // Progressive taper: e.g. 2-week peak block -> week 1 at 75%, week 2 at 50%
+    const taperFactor = 1 - (options.weekNumber / options.blockDurationWeeks) * 0.5
+    targetMinutes = Math.round(targetMinutes * taperFactor)
+  }
+
+  return {
+    volumeTargetMinutes: targetMinutes,
+    tssTarget: Math.round((targetMinutes / 60) * TSS_PER_HOUR)
+  }
+}

--- a/server/utils/plans/week-targets.ts
+++ b/server/utils/plans/week-targets.ts
@@ -15,6 +15,36 @@ export const RECOVERY_WEEK_FACTOR = 0.6
 /** Heuristic TSS per hour used for week targets across the app. */
 export const TSS_PER_HOUR = 50
 
+/**
+ * Ramp-rate cap (CW-320): a brand-new plan must not prescribe a multiple of
+ * what the athlete has actually been training. Week 1's loading volume is
+ * capped at recent 4-week average x RAMP_BASE_MULTIPLIER (with an absolute
+ * floor so low-history athletes can still start), then the allowance grows
+ * RAMP_GROWTH_PER_LOADING_WEEK per loading week until the athlete's chosen
+ * volume is reached. The cap only ever lowers targets, never raises them.
+ */
+export const RAMP_BASE_MULTIPLIER = 1.2
+export const RAMP_GROWTH_PER_LOADING_WEEK = 1.1
+export const RAMP_FLOOR_MINUTES = 240
+
+export function computeRampBaseMinutes(recentWeeklyAvgMinutes: number): number {
+  return Math.round(
+    Math.max((recentWeeklyAvgMinutes || 0) * RAMP_BASE_MULTIPLIER, RAMP_FLOOR_MINUTES)
+  )
+}
+
+export function applyRampCap(
+  baseVolumeMinutes: number,
+  loadingWeekOrdinal: number,
+  rampBaseMinutes?: number | null
+): number {
+  if (!rampBaseMinutes || rampBaseMinutes <= 0) return baseVolumeMinutes
+  const cap = Math.round(
+    rampBaseMinutes * Math.pow(RAMP_GROWTH_PER_LOADING_WEEK, Math.max(0, loadingWeekOrdinal - 1))
+  )
+  return Math.min(baseVolumeMinutes, cap)
+}
+
 export interface WeekTargetOptions {
   blockType: string
   /** 1-based week number within the block. */
@@ -23,6 +53,10 @@ export interface WeekTargetOptions {
   isRecovery: boolean
   /** Weekly loading volume in minutes (athlete's wizard choice or derived). */
   baseVolumeMinutes?: number | null
+  /** When set, caps the loading volume by ramp allowance before recovery/taper factors. */
+  rampBaseMinutes?: number | null
+  /** 1-based count of loading weeks up to and including this week's position. */
+  loadingWeekOrdinal?: number
 }
 
 export function baseWeeklyVolumeMinutes(
@@ -65,6 +99,10 @@ export function calculateWeekTargets(options: WeekTargetOptions): {
   tssTarget: number
 } {
   let targetMinutes = options.baseVolumeMinutes || DEFAULT_WEEKLY_VOLUME_MINUTES
+
+  if (options.rampBaseMinutes && options.loadingWeekOrdinal) {
+    targetMinutes = applyRampCap(targetMinutes, options.loadingWeekOrdinal, options.rampBaseMinutes)
+  }
 
   if (options.isRecovery) {
     targetMinutes = Math.round(targetMinutes * RECOVERY_WEEK_FACTOR)

--- a/server/utils/plans/workout-type.ts
+++ b/server/utils/plans/workout-type.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalization of AI-generated workout types to the canonical types stored in
+ * the database and understood by integrations (Intervals.icu, UI icons, filters).
+ *
+ * The plan generators prompt the model with friendly type names ("Gym"), but the
+ * database convention is "WeightTraining". Historically only the weekly-plan
+ * generator normalized this, so block generation produced mixed taxonomies in
+ * the same plan ("Gym" and "WeightTraining" rows side by side). (CW-317)
+ */
+
+const AI_TYPE_TO_CANONICAL: Record<string, string> = {
+  Gym: 'WeightTraining'
+}
+
+export function normalizeGeneratedWorkoutType(aiType: string): string {
+  return AI_TYPE_TO_CANONICAL[aiType] || aiType
+}

--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -1,3 +1,4 @@
+import { dailyBaseWindowKey } from '../../../shared/window-keys'
 import { prisma } from '../db'
 import { nutritionRepository } from '../repositories/nutritionRepository'
 import { workoutRepository } from '../repositories/workoutRepository'
@@ -67,11 +68,9 @@ interface NutritionPlanSummary {
 
 export const metabolicService = {
   getDailyBaseWindowKey(slotName?: string) {
-    const normalized = (slotName || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-    return normalized ? `DAILY_BASE:${normalized}` : 'DAILY_BASE'
+    // Canonical slugifier shared with the generator and the app; a drifted local copy here once
+    // produced 'DAILY_BASE:lunch-' for 'Lunch!' and unlinked the stored meal.
+    return dailyBaseWindowKey(slotName)
   },
 
   /**

--- a/server/utils/services/nutritionPlanService.ts
+++ b/server/utils/services/nutritionPlanService.ts
@@ -1,8 +1,8 @@
 import { addDays, eachDayOfInterval, endOfDay, format, startOfWeek } from 'date-fns'
 import { prisma } from '../db'
 import { getUserTimezone, parseDateTimeInTimezone } from '../date'
+import { dailyBaseWindowKey } from '../../../shared/window-keys'
 import { nutritionRepository } from '../repositories/nutritionRepository'
-import { slugifySlot } from '../nutrition-domain/day-plan'
 import { bodyMetricResolver } from './bodyMetricResolver'
 import { metabolicService } from './metabolicService'
 import { mealRecommendationService } from './mealRecommendationService'
@@ -64,10 +64,9 @@ function toUpperList(value: unknown) {
 export const nutritionPlanService = {
   toDailyBaseWindowKey(slotName?: string) {
     // Legacy windows carry no windowKey, so their key is re-derived here. It has to be derived the
-    // same way the generator derives it - these two slugifiers disagreed on trailing punctuation
-    // ('Lunch!' -> 'lunch-' here, 'lunch' there), which silently unlinked the stored meal.
-    const raw = (slotName || '').trim()
-    return raw ? `DAILY_BASE:${slugifySlot(raw)}` : 'DAILY_BASE'
+    // same way the generator derives it - divergent slugifier copies silently unlinked stored
+    // meals once already, so the canonical implementation lives in shared/window-keys.
+    return dailyBaseWindowKey(slotName)
   },
 
   sanitizeMealTitle(value: unknown) {
@@ -443,6 +442,13 @@ export const nutritionPlanService = {
       }
     }
 
+    const nutrition = await prisma.nutrition.findUnique({
+      where: { userId_date: { userId, date: dayStartUtc } }
+    })
+    const dayWindows = Array.isArray((nutrition?.fuelingPlan as any)?.windows)
+      ? ((nutrition!.fuelingPlan as any).windows as any[])
+      : []
+
     const persistedPlanMeals: any[] = []
 
     for (const assignment of splitTotalsForAssignments) {
@@ -459,6 +465,32 @@ export const nutritionPlanService = {
         }
       }
 
+      // Without this, a re-lock that carries no explicit targets (the replace action does not)
+      // overwrote the window target with the meal's own totals, making every target-vs-planned
+      // comparison for the window self-referential.
+      const hasExplicitTarget =
+        assignment.targetCarbs != null ||
+        assignment.targetProtein != null ||
+        assignment.targetKcal != null
+      const targetJson = {
+        carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
+        protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
+        kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
+      }
+
+      // The window's clock time, so a manually locked meal doesn't sort to midnight while
+      // generated ones sit at their window start.
+      const sourceWindow = dayWindows.find(
+        (window: any) => this.resolveWindowKey(window) === assignment.normalizedWindowType
+      )
+      const windowStart = sourceWindow?.startTime ? new Date(sourceWindow.startTime) : null
+      const scheduledAt =
+        windowStart && !Number.isNaN(windowStart.getTime())
+          ? windowStart
+          : typeof date === 'string'
+            ? dayStartUtc
+            : date
+
       const planMeal = await prisma.nutritionPlanMeal.upsert({
         where: {
           planId_date_windowType: {
@@ -471,13 +503,9 @@ export const nutritionPlanService = {
           planId: plan.id,
           date: dayStartUtc,
           windowType: assignment.normalizedWindowType,
-          scheduledAt: typeof date === 'string' ? dayStartUtc : date,
+          scheduledAt,
           status: 'PLANNED',
-          targetJson: {
-            carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
-            protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
-            kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
-          },
+          targetJson,
           mealJson: mealForAssignment
         },
         update: {
@@ -486,21 +514,14 @@ export const nutritionPlanService = {
             replacedPreviousTitle: undefined
           },
           status: 'PLANNED',
-          targetJson: {
-            carbs: Number(assignment.targetCarbs ?? assignment.totals.carbs ?? 0),
-            protein: Number(assignment.targetProtein ?? assignment.totals.protein ?? 0),
-            kcal: Number(assignment.targetKcal ?? assignment.totals.kcal ?? 0)
-          },
+          scheduledAt,
+          ...(hasExplicitTarget ? { targetJson } : {}),
           actualNutritionItemId: null,
           updatedAt: new Date()
         }
       })
       persistedPlanMeals.push(planMeal)
     }
-
-    const nutrition = await prisma.nutrition.findUnique({
-      where: { userId_date: { userId, date: dayStartUtc } }
-    })
 
     if (nutrition) {
       const fuelingPlan = {
@@ -551,8 +572,13 @@ export const nutritionPlanService = {
   },
 
   async generateDraftPlan(userId: string, startDate: Date, endDate: Date) {
-    const days = eachDayOfInterval({ start: startDate, end: endDate })
     const plan = await this.getOrCreateWeeklyPlan(userId, startDate, 'DRAFT')
+    // The plan row always spans its full Monday-Sunday week. Persisting a caller-supplied
+    // endDate truncated the week when a sub-range was generated, which orphaned already-locked
+    // meals on the cut-off days; a range past the week overlapped the next week's plan.
+    const weekEnd = this.getWeekEndUtc(plan.startDate)
+    const rangeEnd = endDate > weekEnd ? weekEnd : endDate
+    const days = eachDayOfInterval({ start: startDate, end: rangeEnd })
     const existingMeals = new Map<string, any>(
       (plan.meals || []).map((meal: any) => [
         this.getWindowAssignmentKey(meal.date, meal.windowType),
@@ -689,13 +715,24 @@ export const nutritionPlanService = {
       })
     }
 
+    // A sub-range regeneration must not wipe the summary of the untouched days.
+    const existingSummaryDays = Array.isArray((plan.summaryJson as any)?.days)
+      ? ((plan.summaryJson as any).days as any[])
+      : []
+    const mergedSummaryDays = [
+      ...existingSummaryDays.filter(
+        (day: any) => !daySummaries.some((entry) => entry.date === day.date)
+      ),
+      ...daySummaries
+    ].sort((a: any, b: any) => String(a.date).localeCompare(String(b.date)))
+
     await prisma.nutritionPlan.update({
       where: { id: plan.id },
       data: {
         status: 'DRAFT',
-        endDate,
+        endDate: weekEnd,
         summaryJson: {
-          days: daySummaries,
+          days: mergedSummaryDays,
           generatedAt: new Date().toISOString()
         } as any,
         updatedAt: new Date()
@@ -707,7 +744,7 @@ export const nutritionPlanService = {
       include: {
         meals: {
           where: {
-            date: { gte: startDate, lte: endDate }
+            date: { gte: startDate, lte: rangeEnd }
           },
           orderBy: [{ date: 'asc' }, { scheduledAt: 'asc' }]
         }
@@ -756,8 +793,12 @@ export const nutritionPlanService = {
 
         if (!dailyBaseSlot) return true
 
+        // Logged items come from the plural Nutrition arrays ('snacks') while slot slugs are
+        // singular ('snack'), so the raw includes() check never matched a logged snack.
         const normalizedMealType = String(item.mealType || '').toLowerCase()
+        const singularMealType = normalizedMealType.replace(/s$/, '')
         if (dailyBaseSlot.includes(normalizedMealType)) return true
+        if (singularMealType && dailyBaseSlot.includes(singularMealType)) return true
 
         const itemName = String(item.name || '')
           .trim()

--- a/server/utils/services/planService.ts
+++ b/server/utils/services/planService.ts
@@ -1,5 +1,9 @@
 import { prisma } from '../db'
-import { calculateWeekTargets } from '../plan-logic'
+import {
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek
+} from '../plans/week-targets'
 import { trainingPlanRepository } from '../repositories/trainingPlanRepository'
 import { trainingBlockRepository } from '../repositories/trainingBlockRepository'
 import { trainingWeekRepository } from '../repositories/trainingWeekRepository'
@@ -19,6 +23,12 @@ export const planService = {
     })
 
     if (!plan) throw new Error('Plan not found')
+
+    // TrainingPlan does not persist the wizard's volumeHours, so recover the
+    // athlete's loading volume from the weeks that already exist. (CW-318)
+    const baseVolumeMinutes = deriveBaseVolumeMinutesFromWeeks(
+      plan.blocks.flatMap((b) => (b as any).weeks || [])
+    )
 
     return await prisma.$transaction(async (tx) => {
       // 1. Delete blocks that are no longer in the plan
@@ -90,12 +100,21 @@ export const planService = {
         const newDuration = config.durationWeeks
 
         if (newDuration > oldDuration) {
-          const targets = calculateWeekTargets(config.type)
+          const recoveryRhythm = config.recoveryWeekIndex || plan.recoveryRhythm || 4
           for (let i = oldDuration + 1; i <= newDuration; i++) {
             const weekStart = new Date(blockStartDate)
             weekStart.setUTCDate(weekStart.getUTCDate() + (i - 1) * 7)
             const weekEnd = new Date(weekStart)
             weekEnd.setUTCDate(weekEnd.getUTCDate() + 6)
+
+            const isRecovery = isRecoveryWeek(i, recoveryRhythm, config.type)
+            const targets = calculateWeekTargets({
+              blockType: config.type,
+              weekNumber: i,
+              blockDurationWeeks: newDuration,
+              isRecovery,
+              baseVolumeMinutes
+            })
 
             await trainingWeekRepository.create(
               {
@@ -103,6 +122,7 @@ export const planService = {
                 weekNumber: i,
                 startDate: weekStart,
                 endDate: weekEnd,
+                isRecovery,
                 ...targets
               },
               tx

--- a/shared/window-keys.test.ts
+++ b/shared/window-keys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { dailyBaseWindowKey, resolveWindowKey, slugifySlot } from './window-keys'
+
+describe('window-keys', () => {
+  describe('slugifySlot', () => {
+    it('strips leading and trailing punctuation the same way for every caller', () => {
+      // The drifted copies produced 'lunch-' here, which unlinked stored meals.
+      expect(slugifySlot('Lunch!')).toBe('lunch')
+      expect(slugifySlot('  Snack  ')).toBe('snack')
+      expect(slugifySlot('Post ride ')).toBe('post-ride')
+    })
+
+    it('falls back to a usable slug for names with no usable characters', () => {
+      expect(slugifySlot('!!!')).toBe('slot')
+      expect(slugifySlot('☕️')).toBe('slot')
+      expect(slugifySlot('')).toBe('slot')
+    })
+  })
+
+  describe('dailyBaseWindowKey', () => {
+    it('derives slot-specific keys', () => {
+      expect(dailyBaseWindowKey('Breakfast')).toBe('DAILY_BASE:breakfast')
+    })
+
+    it('keeps the legacy bare key when no slot name exists', () => {
+      expect(dailyBaseWindowKey('')).toBe('DAILY_BASE')
+      expect(dailyBaseWindowKey(undefined)).toBe('DAILY_BASE')
+    })
+  })
+
+  describe('resolveWindowKey', () => {
+    it('prefers an explicit window key', () => {
+      expect(resolveWindowKey({ type: 'PRE_WORKOUT', windowKey: 'PRE_WORKOUT#2' })).toBe(
+        'PRE_WORKOUT#2'
+      )
+    })
+
+    it('derives DAILY_BASE keys from slot name or label', () => {
+      expect(resolveWindowKey({ type: 'DAILY_BASE', slotName: 'Snack' })).toBe('DAILY_BASE:snack')
+      expect(resolveWindowKey({ type: 'DAILY_BASE', label: 'Lunch!' })).toBe('DAILY_BASE:lunch')
+    })
+
+    it('treats keyless typed windows as the first of their type', () => {
+      expect(resolveWindowKey({ type: 'PRE_WORKOUT' })).toBe('PRE_WORKOUT#1')
+    })
+
+    it('is defensive about empty input', () => {
+      expect(resolveWindowKey(null)).toBe('')
+      expect(resolveWindowKey({})).toBe('')
+    })
+  })
+})

--- a/shared/window-keys.ts
+++ b/shared/window-keys.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical DAILY_BASE window-key derivation, shared between server and app code.
+ *
+ * Three copies of this slugifier used to exist (day-plan generator, metabolicService, and
+ * WeeklyPlanDashboard) and they disagreed on edge punctuation — 'Lunch!' produced
+ * 'DAILY_BASE:lunch-' in two of them and 'DAILY_BASE:lunch' in the generator, which silently
+ * unlinked a locked meal from its window. Every layer must derive keys from this module only.
+ */
+
+/** A name with no usable characters at all still needs a key it can be found by. */
+export const FALLBACK_SLOT_SLUG = 'slot'
+
+export function slugifySlot(name: string) {
+  const slug = (name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || FALLBACK_SLOT_SLUG
+}
+
+/** Key for a DAILY_BASE window; windows with no slot at all keep the legacy bare key. */
+export function dailyBaseWindowKey(slotName?: string | null) {
+  const raw = (slotName || '').trim()
+  return raw ? `DAILY_BASE:${slugifySlot(raw)}` : 'DAILY_BASE'
+}
+
+/**
+ * Stable identity of a fueling window. Several windows of the same type can exist on one day
+ * (two sessions ⇒ two PRE_WORKOUT windows), so the bare type is not an identity; windows
+ * persisted before stable keys existed carry no ordinal and are treated as the first.
+ */
+export function resolveWindowKey(
+  window:
+    { windowKey?: unknown; type?: unknown; slotName?: unknown; label?: unknown } | null | undefined
+) {
+  if (!window) return ''
+  if (window.windowKey) return String(window.windowKey)
+  const type = String(window.type || '')
+  if (!type) return ''
+  if (type === 'DAILY_BASE') {
+    return dailyBaseWindowKey(String(window.slotName || window.label || ''))
+  }
+  return `${type}#1`
+}

--- a/tests/unit/server/utils/plan-logic.test.ts
+++ b/tests/unit/server/utils/plan-logic.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import {
-  shiftPlanDates,
-  calculateWeekTargets
-} from '../../../../server/utils/plan-logic'
+import { shiftPlanDates } from '../../../../server/utils/plan-logic'
 import { prisma } from '../../../../server/utils/db'
 
 // Mock prisma
@@ -88,28 +85,6 @@ describe('Plan Logic Utils', () => {
     })
   })
 
-  describe('calculateWeekTargets', () => {
-    it('should calculate defaults (MID)', () => {
-      const result = calculateWeekTargets('Build', 'MID')
-      expect(result.volumeTargetMinutes).toBe(450)
-      expect(result.tssTarget).toBe(Math.round((450/60)*50)) // 375
-    })
-
-    it('should calculate LOW volume', () => {
-      const result = calculateWeekTargets('Base', 'LOW')
-      expect(result.volumeTargetMinutes).toBe(240)
-      expect(result.tssTarget).toBe(Math.round((240/60)*50)) // 200
-    })
-
-    it('should calculate HIGH volume', () => {
-      const result = calculateWeekTargets('Base', 'HIGH')
-      expect(result.volumeTargetMinutes).toBe(600)
-      expect(result.tssTarget).toBe(Math.round((600/60)*50)) // 500
-    })
-
-     it('should fallback to MID for unknown preference', () => {
-      const result = calculateWeekTargets('Base', 'UNKNOWN')
-      expect(result.volumeTargetMinutes).toBe(450)
-    })
-  })
+  // calculateWeekTargets moved to server/utils/plans/week-targets.ts (CW-318);
+  // see tests/unit/server/utils/plans/week-targets.test.ts
 })

--- a/tests/unit/server/utils/plans/block-volume.test.ts
+++ b/tests/unit/server/utils/plans/block-volume.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  weekScheduledMinutes,
+  VOLUME_TOLERANCE,
+  CLAMP_RATIO,
+  MIN_WORKOUT_MINUTES,
+  type GeneratedBlockWeek,
+  type WeekVolumeTarget
+} from '../../../../../server/utils/plans/block-volume'
+
+const ride = (dayOfWeek: number, durationMinutes: number, tssEstimate?: number) => ({
+  dayOfWeek,
+  title: 'Ride',
+  type: 'Ride',
+  durationMinutes,
+  tssEstimate,
+  intensity: 'easy'
+})
+
+const target = (
+  weekNumber: number,
+  volumeTargetMinutes: number | null,
+  extra: Partial<WeekVolumeTarget> = {}
+): WeekVolumeTarget => ({ weekNumber, volumeTargetMinutes, ...extra })
+
+describe('weekScheduledMinutes', () => {
+  it('sums non-rest workout durations', () => {
+    const week: GeneratedBlockWeek = {
+      weekNumber: 1,
+      workouts: [ride(1, 90), ride(3, 60), { dayOfWeek: 2, type: 'Rest', durationMinutes: 0 }]
+    }
+    expect(weekScheduledMinutes(week, target(1, 480))).toBe(150)
+  })
+
+  it('ignores workouts on days outside allowedDaysOfWeek (they are dropped at insert)', () => {
+    const week: GeneratedBlockWeek = {
+      weekNumber: 1,
+      workouts: [ride(1, 90), ride(5, 120)]
+    }
+    expect(weekScheduledMinutes(week, target(1, 480, { allowedDaysOfWeek: [1, 2, 3] }))).toBe(90)
+  })
+})
+
+describe('validateGeneratedBlockWeeks', () => {
+  it('accepts a week within tolerance of its target', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 90), ride(3, 90), ride(6, 180)] }
+    ]
+    expect(validateGeneratedBlockWeeks(weeks, [target(1, 360)])).toEqual([])
+  })
+
+  it('flags a week scheduled beyond target * tolerance', () => {
+    // Reproduces CW-316: 480min target, ~919min scheduled
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [
+          ride(1, 90),
+          ride(2, 180),
+          ride(3, 180),
+          ride(4, 180),
+          ride(5, 180),
+          ride(6, 109)
+        ]
+      }
+    ]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ weekNumber: 1, kind: 'over_volume' })
+  })
+
+  it('mentions recovery in the violation for recovery weeks', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 3, workouts: [ride(1, 400), ride(3, 400)] }]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(3, 288, { isRecovery: true })])
+    expect(violations[0]!.message).toContain('RECOVERY')
+  })
+
+  it('flags implausible workout durations', () => {
+    // Prod example: 6-minute strength session with TSS 35
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [{ dayOfWeek: 2, title: 'Strength C', type: 'Gym', durationMinutes: 6 }]
+      }
+    ]
+    const violations = validateGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ kind: 'invalid_duration' })
+  })
+
+  it('skips weeks without a volume target and unmatched week numbers', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 400), ride(2, 400), ride(3, 400)] },
+      { weekNumber: 9, workouts: [ride(1, 400), ride(2, 400), ride(3, 400)] }
+    ]
+    expect(validateGeneratedBlockWeeks(weeks, [target(1, 0), target(2, 300)])).toEqual([])
+  })
+
+  it('does not count out-of-schedule workouts toward volume', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 300), ride(5, 300), ride(6, 300)] }
+    ]
+    // Only Monday is schedulable, so effective volume is 300 <= 360 * 1.2
+    expect(
+      validateGeneratedBlockWeeks(weeks, [target(1, 360, { allowedDaysOfWeek: [1] })])
+    ).toEqual([])
+  })
+})
+
+describe('clampGeneratedBlockWeeks', () => {
+  it('scales an over-volume week down to target * CLAMP_RATIO, durations and TSS together', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [ride(1, 300, 200), ride(3, 300, 200), ride(6, 300, 200)] }
+    ]
+    const { weeks: clamped, adjustments } = clampGeneratedBlockWeeks(weeks, [target(1, 450)])
+
+    const total = weekScheduledMinutes(clamped[0]!, target(1, 450))
+    expect(total).toBeLessThanOrEqual(450 * VOLUME_TOLERANCE)
+    // ~450 * 1.1 = 495, allow rounding slack from 5-minute steps
+    expect(total).toBeGreaterThanOrEqual(450 * CLAMP_RATIO * 0.9)
+    const w = clamped[0]!.workouts![0]!
+    expect(w.tssEstimate).toBeLessThan(200)
+    expect(adjustments.length).toBeGreaterThan(0)
+  })
+
+  it('clamps implausible durations into bounds', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      { weekNumber: 1, workouts: [{ dayOfWeek: 2, type: 'Gym', durationMinutes: 6 }] }
+    ]
+    const { weeks: clamped } = clampGeneratedBlockWeeks(weeks, [target(1, 480)])
+    expect(clamped[0]!.workouts![0]!.durationMinutes).toBe(MIN_WORKOUT_MINUTES)
+  })
+
+  it('leaves compliant weeks untouched', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 1, workouts: [ride(1, 90), ride(3, 90)] }]
+    const { weeks: clamped, adjustments } = clampGeneratedBlockWeeks(weeks, [target(1, 300)])
+    expect(clamped[0]!.workouts).toEqual(weeks[0]!.workouts)
+    expect(adjustments).toEqual([])
+  })
+
+  it('does not touch rest days or out-of-schedule workouts when scaling', () => {
+    const weeks: GeneratedBlockWeek[] = [
+      {
+        weekNumber: 1,
+        workouts: [
+          ride(1, 400),
+          ride(2, 400),
+          { dayOfWeek: 3, type: 'Rest', durationMinutes: 0 },
+          ride(6, 240)
+        ]
+      }
+    ]
+    const { weeks: clamped } = clampGeneratedBlockWeeks(weeks, [
+      target(1, 300, { allowedDaysOfWeek: [1, 2, 3] })
+    ])
+    const rest = clamped[0]!.workouts!.find((w) => w.type === 'Rest')!
+    const saturday = clamped[0]!.workouts!.find((w) => w.dayOfWeek === 6)!
+    expect(rest.durationMinutes).toBe(0)
+    expect(saturday.durationMinutes).toBe(240)
+  })
+})
+
+describe('formatViolationsFeedback', () => {
+  it('produces a corrective instruction listing each violation', () => {
+    const weeks: GeneratedBlockWeek[] = [{ weekNumber: 1, workouts: [ride(1, 400), ride(2, 400)] }]
+    const feedback = formatViolationsFeedback(validateGeneratedBlockWeeks(weeks, [target(1, 300)]))
+    expect(feedback).toContain('REJECTED')
+    expect(feedback).toContain('Week 1')
+    expect(feedback).toContain('windows')
+  })
+})

--- a/tests/unit/server/utils/plans/week-targets.test.ts
+++ b/tests/unit/server/utils/plans/week-targets.test.ts
@@ -4,8 +4,11 @@ import {
   calculateWeekTargets,
   deriveBaseVolumeMinutesFromWeeks,
   isRecoveryWeek,
+  computeRampBaseMinutes,
+  applyRampCap,
   DEFAULT_WEEKLY_VOLUME_MINUTES,
-  RECOVERY_WEEK_FACTOR
+  RECOVERY_WEEK_FACTOR,
+  RAMP_FLOOR_MINUTES
 } from '../../../../../server/utils/plans/week-targets'
 
 describe('baseWeeklyVolumeMinutes', () => {
@@ -110,5 +113,57 @@ describe('calculateWeekTargets', () => {
     expect(week1.volumeTargetMinutes).toBe(360) // 75%
     expect(week2.volumeTargetMinutes).toBe(240) // 50%
     expect(week2.volumeTargetMinutes).toBeLessThan(week1.volumeTargetMinutes)
+  })
+})
+
+describe('ramp-rate cap (CW-320)', () => {
+  it('bases the ramp on recent load with an absolute floor', () => {
+    expect(computeRampBaseMinutes(280)).toBe(336) // 280 * 1.2
+    expect(computeRampBaseMinutes(0)).toBe(RAMP_FLOOR_MINUTES)
+    expect(computeRampBaseMinutes(100)).toBe(RAMP_FLOOR_MINUTES)
+  })
+
+  it('caps week 1 at the ramp base and grows the allowance per loading week', () => {
+    // CW-316 prod case: athlete averaging ~280min/week requested 480min/week
+    expect(applyRampCap(480, 1, 336)).toBe(336)
+    expect(applyRampCap(480, 2, 336)).toBe(370) // 336 * 1.1
+    expect(applyRampCap(480, 4, 336)).toBe(447)
+    expect(applyRampCap(480, 5, 336)).toBe(480) // reached the requested volume
+  })
+
+  it('never raises targets above the requested volume', () => {
+    expect(applyRampCap(300, 1, 600)).toBe(300)
+    expect(applyRampCap(300, 10, 336)).toBe(300)
+  })
+
+  it('is a no-op when no ramp base is provided', () => {
+    expect(applyRampCap(480, 1, null)).toBe(480)
+  })
+
+  it('applies the cap before recovery reduction in calculateWeekTargets', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 4,
+      blockDurationWeeks: 4,
+      isRecovery: true,
+      baseVolumeMinutes: 480,
+      rampBaseMinutes: 336,
+      loadingWeekOrdinal: 3
+    })
+    // capped loading volume 336 * 1.1^2 = 407, then recovery x0.6
+    expect(result.volumeTargetMinutes).toBe(Math.round(407 * RECOVERY_WEEK_FACTOR))
+  })
+
+  it('leaves targets unchanged for athletes already training at the requested volume', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BUILD',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: 480,
+      rampBaseMinutes: computeRampBaseMinutes(450),
+      loadingWeekOrdinal: 1
+    })
+    expect(result.volumeTargetMinutes).toBe(480)
   })
 })

--- a/tests/unit/server/utils/plans/week-targets.test.ts
+++ b/tests/unit/server/utils/plans/week-targets.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  baseWeeklyVolumeMinutes,
+  calculateWeekTargets,
+  deriveBaseVolumeMinutesFromWeeks,
+  isRecoveryWeek,
+  DEFAULT_WEEKLY_VOLUME_MINUTES,
+  RECOVERY_WEEK_FACTOR
+} from '../../../../../server/utils/plans/week-targets'
+
+describe('baseWeeklyVolumeMinutes', () => {
+  it('prefers explicit volumeHours over the preference bucket', () => {
+    expect(baseWeeklyVolumeMinutes(8, 'LOW')).toBe(480)
+    expect(baseWeeklyVolumeMinutes(3.5)).toBe(210)
+  })
+
+  it('maps preference buckets and falls back to MID default', () => {
+    expect(baseWeeklyVolumeMinutes(null, 'LOW')).toBe(240)
+    expect(baseWeeklyVolumeMinutes(null, 'HIGH')).toBe(600)
+    expect(baseWeeklyVolumeMinutes(null, 'MID')).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+    expect(baseWeeklyVolumeMinutes()).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+  })
+})
+
+describe('deriveBaseVolumeMinutesFromWeeks', () => {
+  it('returns the max non-recovery target (the loading volume)', () => {
+    expect(
+      deriveBaseVolumeMinutesFromWeeks([
+        { volumeTargetMinutes: 480, isRecovery: false },
+        { volumeTargetMinutes: 288, isRecovery: true },
+        { volumeTargetMinutes: 450, isRecovery: false }
+      ])
+    ).toBe(480)
+  })
+
+  it('returns null when no usable weeks exist', () => {
+    expect(deriveBaseVolumeMinutesFromWeeks([])).toBeNull()
+    expect(
+      deriveBaseVolumeMinutesFromWeeks([
+        { volumeTargetMinutes: 0 },
+        { isRecovery: true, volumeTargetMinutes: 200 }
+      ])
+    ).toBeNull()
+  })
+})
+
+describe('isRecoveryWeek', () => {
+  it('marks every Nth week per rhythm', () => {
+    expect(isRecoveryWeek(4, 4, 'BASE')).toBe(true)
+    expect(isRecoveryWeek(3, 4, 'BASE')).toBe(false)
+    expect(isRecoveryWeek(3, 3, 'BUILD')).toBe(true)
+  })
+
+  it('never marks recovery inside PEAK/RACE blocks', () => {
+    expect(isRecoveryWeek(4, 4, 'PEAK')).toBe(false)
+    expect(isRecoveryWeek(4, 4, 'RACE')).toBe(false)
+  })
+})
+
+describe('calculateWeekTargets', () => {
+  it('uses the athlete volume, not the 450min default (CW-318 regression)', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BUILD',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    expect(result.volumeTargetMinutes).toBe(480)
+    expect(result.tssTarget).toBe(400)
+  })
+
+  it('falls back to the default when no base volume is known', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 1,
+      blockDurationWeeks: 3,
+      isRecovery: false,
+      baseVolumeMinutes: null
+    })
+    expect(result.volumeTargetMinutes).toBe(DEFAULT_WEEKLY_VOLUME_MINUTES)
+  })
+
+  it('reduces recovery weeks by the recovery factor', () => {
+    const result = calculateWeekTargets({
+      blockType: 'BASE',
+      weekNumber: 4,
+      blockDurationWeeks: 4,
+      isRecovery: true,
+      baseVolumeMinutes: 480
+    })
+    expect(result.volumeTargetMinutes).toBe(Math.round(480 * RECOVERY_WEEK_FACTOR))
+  })
+
+  it('applies the progressive taper in PEAK blocks', () => {
+    const week1 = calculateWeekTargets({
+      blockType: 'PEAK',
+      weekNumber: 1,
+      blockDurationWeeks: 2,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    const week2 = calculateWeekTargets({
+      blockType: 'PEAK',
+      weekNumber: 2,
+      blockDurationWeeks: 2,
+      isRecovery: false,
+      baseVolumeMinutes: 480
+    })
+    expect(week1.volumeTargetMinutes).toBe(360) // 75%
+    expect(week2.volumeTargetMinutes).toBe(240) // 50%
+    expect(week2.volumeTargetMinutes).toBeLessThan(week1.volumeTargetMinutes)
+  })
+})

--- a/tests/unit/server/utils/plans/workout-type.test.ts
+++ b/tests/unit/server/utils/plans/workout-type.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeGeneratedWorkoutType } from '../../../../../server/utils/plans/workout-type'
+
+describe('normalizeGeneratedWorkoutType', () => {
+  it('maps Gym to WeightTraining (DB/Intervals canonical type)', () => {
+    expect(normalizeGeneratedWorkoutType('Gym')).toBe('WeightTraining')
+  })
+
+  it('passes canonical types through unchanged', () => {
+    for (const type of ['Ride', 'Run', 'Swim', 'Rest', 'WeightTraining']) {
+      expect(normalizeGeneratedWorkoutType(type)).toBe(type)
+    }
+  })
+})

--- a/tests/unit/server/utils/services/nutritionPlanService.test.ts
+++ b/tests/unit/server/utils/services/nutritionPlanService.test.ts
@@ -99,7 +99,8 @@ vi.mock('../../../../../server/utils/services/metabolicService', async (importOr
   return {
     metabolicService: {
       ...actual.metabolicService,
-      getNutritionDay: vi.fn()
+      getNutritionDay: vi.fn(),
+      getMealTargetContext: vi.fn()
     }
   }
 })
@@ -494,6 +495,173 @@ describe('nutritionPlanService', () => {
           })
         })
       )
+    })
+  })
+
+  describe('reconciliation matching', () => {
+    const snackWindow = {
+      type: 'DAILY_BASE',
+      windowKey: 'DAILY_BASE:snack',
+      slotName: 'Snack',
+      startTime: '2026-02-15T14:00:00.000Z',
+      endTime: '2026-02-15T16:00:00.000Z'
+    }
+
+    it('matches an item logged under the plural snacks array to a snack slot', () => {
+      // Logged items carry the Nutrition record's plural array name; slot slugs are singular.
+      // The raw includes() check never matched, so snack plan meals stayed PLANNED forever.
+      const planMeal = { windowType: 'DAILY_BASE:snack' }
+      const item = {
+        id: 'log-1',
+        mealType: 'snacks',
+        name: 'Apple',
+        at: new Date('2026-02-15T15:00:00.000Z')
+      }
+
+      expect(
+        nutritionPlanService.matchLoggedItemToPlanMeal(planMeal, [snackWindow], [item], new Set())
+      ).toBe(item)
+    })
+
+    it('still rejects items outside the window or of an unrelated meal type', () => {
+      const planMeal = { windowType: 'DAILY_BASE:snack' }
+      const outsideWindow = {
+        id: 'log-2',
+        mealType: 'snacks',
+        name: 'Apple',
+        at: new Date('2026-02-15T18:00:00.000Z')
+      }
+      const wrongMealType = {
+        id: 'log-3',
+        mealType: 'dinner',
+        name: 'Steak',
+        at: new Date('2026-02-15T15:00:00.000Z')
+      }
+
+      expect(
+        nutritionPlanService.matchLoggedItemToPlanMeal(
+          planMeal,
+          [snackWindow],
+          [outsideWindow, wrongMealType],
+          new Set()
+        )
+      ).toBeNull()
+    })
+  })
+
+  describe('lockMeal target and schedule handling', () => {
+    beforeEach(() => {
+      vi.mocked(prisma.nutritionPlan.findFirst).mockResolvedValue({ id: 'plan-1' } as any)
+      vi.mocked(prisma.nutritionPlan.findMany).mockResolvedValue([] as any)
+      vi.mocked(prisma.nutrition.findUnique).mockResolvedValue(null)
+      vi.mocked(prisma.nutritionPlanMeal.upsert).mockResolvedValue({
+        id: 'plan-meal-1',
+        planId: 'plan-1',
+        date: new Date('2026-02-15T00:00:00.000Z'),
+        windowType: 'PRE_WORKOUT',
+        scheduledAt: new Date('2026-02-15T00:00:00.000Z')
+      } as any)
+    })
+
+    it('keeps the stored window target when a re-lock carries no explicit targets', async () => {
+      // The replace action re-locks without targets; writing the meal's own totals as the
+      // target made every target-vs-planned comparison self-referential.
+      await nutritionPlanService.lockMeal('user-1', '2026-02-15', 'PRE_WORKOUT', {
+        title: 'Rice Cakes',
+        totals: { carbs: 50 }
+      })
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.update.targetJson).toBeUndefined()
+      expect(upsertArgs.create.targetJson).toEqual({ carbs: 50, protein: 0, kcal: 0 })
+    })
+
+    it('writes the explicit window target when the assignment carries one', async () => {
+      await nutritionPlanService.lockMeal(
+        'user-1',
+        '2026-02-15',
+        'PRE_WORKOUT',
+        { title: 'Rice Cakes', totals: { carbs: 50 } },
+        undefined,
+        {
+          windowAssignments: [
+            {
+              windowType: 'PRE_WORKOUT',
+              windowKey: 'PRE_WORKOUT#1',
+              targetCarbs: 90,
+              targetProtein: 20,
+              targetKcal: 450
+            }
+          ]
+        }
+      )
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.update.targetJson).toEqual({ carbs: 90, protein: 20, kcal: 450 })
+    })
+
+    it('schedules a locked meal at its window start time instead of midnight', async () => {
+      vi.mocked(prisma.nutrition.findUnique).mockResolvedValue({
+        id: 'nutrition-1',
+        fuelingPlan: {
+          windows: [
+            {
+              type: 'PRE_WORKOUT',
+              windowKey: 'PRE_WORKOUT#1',
+              startTime: '2026-02-15T09:30:00.000Z'
+            }
+          ]
+        }
+      } as any)
+
+      await nutritionPlanService.lockMeal(
+        'user-1',
+        '2026-02-15',
+        'PRE_WORKOUT',
+        { title: 'Morning Oats', totals: { carbs: 60 } },
+        undefined,
+        { windowKey: 'PRE_WORKOUT#1' }
+      )
+
+      const upsertArgs = vi.mocked(prisma.nutritionPlanMeal.upsert).mock.calls[0]?.[0] as any
+      expect(upsertArgs.create.scheduledAt).toEqual(new Date('2026-02-15T09:30:00.000Z'))
+      expect(upsertArgs.update.scheduledAt).toEqual(new Date('2026-02-15T09:30:00.000Z'))
+    })
+  })
+
+  describe('generateDraftPlan', () => {
+    it('persists the full plan week even when a sub-range is generated', async () => {
+      // A caller-supplied endDate used to truncate the plan row, orphaning locked meals on the
+      // cut-off days, and the regenerated summary wiped the untouched days' entries.
+      const weekStart = new Date('2026-02-09T00:00:00.000Z')
+      vi.mocked(prisma.nutritionPlan.findFirst).mockResolvedValue({
+        id: 'plan-1',
+        startDate: weekStart,
+        summaryJson: {
+          days: [{ date: '2026-02-12', fuelingPlan: { windows: [] }, targets: {} }]
+        },
+        meals: []
+      } as any)
+      vi.mocked(prisma.userNutritionSettings.findUnique).mockResolvedValue(null as any)
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(null as any)
+      vi.mocked(bodyMetricResolver.resolveEffectiveWeight).mockResolvedValue({ value: 75 } as any)
+      vi.mocked(metabolicService.getNutritionDay).mockResolvedValue({
+        fuelingPlan: { windows: [] },
+        targets: {}
+      } as any)
+      vi.mocked(metabolicService.getMealTargetContext).mockResolvedValue({} as any)
+
+      await nutritionPlanService.generateDraftPlan(
+        'user-1',
+        new Date('2026-02-09T00:00:00.000Z'),
+        new Date('2026-02-11T23:59:59.999Z')
+      )
+
+      const updateArgs = vi.mocked(prisma.nutritionPlan.update).mock.calls[0]?.[0] as any
+      expect(updateArgs.data.endDate).toEqual(new Date('2026-02-15T23:59:59.999Z'))
+
+      const summaryDates = updateArgs.data.summaryJson.days.map((day: any) => day.date)
+      expect(summaryDates).toEqual(['2026-02-09', '2026-02-10', '2026-02-11', '2026-02-12'])
     })
   })
 })

--- a/tests/unit/trigger/generate-weekly-plan.test.ts
+++ b/tests/unit/trigger/generate-weekly-plan.test.ts
@@ -14,8 +14,13 @@ vi.mock('../../../server/utils/db', () => ({
   prisma: {
     user: { findUnique: vi.fn() },
     userProfile: { findUnique: vi.fn(), findFirst: vi.fn() },
-    plannedWorkout: { findMany: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
-    trainingWeek: { findUnique: vi.fn(), update: vi.fn() },
+    plannedWorkout: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      createMany: vi.fn(),
+      updateMany: vi.fn()
+    },
+    trainingWeek: { findUnique: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
     weeklyTrainingPlan: { findFirst: vi.fn(), create: vi.fn(), upsert: vi.fn(), update: vi.fn() },
 
     report: { findFirst: vi.fn() },
@@ -25,7 +30,7 @@ vi.mock('../../../server/utils/db', () => ({
     workout: { findMany: vi.fn(), findFirst: vi.fn() },
     wellness: { findMany: vi.fn(), findFirst: vi.fn() },
 
-    sportSettings: { findMany: vi.fn() },
+    sportSettings: { findMany: vi.fn(), upsert: vi.fn() },
     integration: { findMany: vi.fn(), findUnique: vi.fn() }
   }
 }))
@@ -95,5 +100,107 @@ describe('generateWeeklyPlan task', () => {
         daysToPlan: 7
       })
     ).rejects.toThrow('User not found')
+  })
+
+  describe('volume validation (CW-319)', () => {
+    const user = { id: 'user-1', timezone: 'UTC', language: 'English' }
+    const trainingWeek = {
+      id: 'week-1',
+      startDate: new Date('2026-03-16T00:00:00Z'),
+      endDate: new Date('2026-03-22T00:00:00Z'),
+      volumeTargetMinutes: 300,
+      tssTarget: 250,
+      weekNumber: 1,
+      focus: 'Base',
+      block: {
+        name: 'Base 1',
+        type: 'BASE',
+        primaryFocus: 'AEROBIC_ENDURANCE',
+        durationWeeks: 3,
+        plan: { name: 'Plan', goal: null }
+      }
+    }
+
+    const day = (date: string, durationMinutes: number, targetTSS = 50) => ({
+      date,
+      dayOfWeek: 1,
+      workoutType: 'Ride',
+      title: 'Ride',
+      description: 'desc',
+      durationMinutes,
+      targetTSS,
+      intensity: 'easy',
+      reasoningText: 'because'
+    })
+
+    const overBudgetDays = [day('2026-03-16', 180), day('2026-03-17', 180), day('2026-03-18', 180)] // 540 min vs 300 target
+    const compliantDays = [day('2026-03-16', 150), day('2026-03-18', 150)]
+
+    beforeEach(async () => {
+      vi.mocked(prisma.user.findUnique).mockResolvedValue(user as any)
+      vi.mocked(prisma.sportSettings.upsert).mockResolvedValue({
+        id: 'ss-1',
+        userId: 'user-1',
+        isDefault: true,
+        types: [],
+        name: 'Default'
+      } as any)
+      vi.mocked(prisma.trainingWeek.findUnique).mockResolvedValue(trainingWeek as any)
+      vi.mocked(prisma.trainingWeek.findFirst).mockResolvedValue(null as any)
+      vi.mocked(prisma.weeklyTrainingPlan.create).mockImplementation(
+        async ({ data }: any) => ({ id: 'wtp-1', ...data }) as any
+      )
+      vi.mocked(prisma.plannedWorkout.updateMany).mockResolvedValue({ count: 0 } as any)
+      vi.mocked(prisma.plannedWorkout.deleteMany).mockResolvedValue({ count: 0 } as any)
+      vi.mocked(prisma.plannedWorkout.createMany).mockResolvedValue({ count: 2 } as any)
+    })
+
+    it('retries once with corrective feedback when the generated week exceeds the volume budget', async () => {
+      const { generateStructuredAnalysis } = await import('../../../server/utils/gemini')
+      vi.mocked(generateStructuredAnalysis)
+        .mockResolvedValueOnce({ days: overBudgetDays, weekSummary: 's', totalTSS: 150 } as any)
+        .mockResolvedValueOnce({ days: compliantDays, weekSummary: 's', totalTSS: 100 } as any)
+
+      const result = await runGenerateWeeklyPlan({
+        userId: 'user-1',
+        trainingWeekId: 'week-1',
+        daysToPlan: 7
+      })
+
+      expect(result.success).toBe(true)
+      expect(generateStructuredAnalysis).toHaveBeenCalledTimes(2)
+      const retryPrompt = vi.mocked(generateStructuredAnalysis).mock.calls[1]![0] as string
+      expect(retryPrompt).toContain('REJECTED')
+      // The compliant retry result is the one persisted
+      const createArg = vi.mocked(prisma.plannedWorkout.createMany).mock.calls[0]![0] as any
+      expect(createArg.data).toHaveLength(2)
+      expect(createArg.data[0].durationSec).toBe(150 * 60)
+    })
+
+    it('clamps deterministically when the retry is still over budget', async () => {
+      const { generateStructuredAnalysis } = await import('../../../server/utils/gemini')
+      vi.mocked(generateStructuredAnalysis).mockResolvedValue({
+        days: overBudgetDays,
+        weekSummary: 's',
+        totalTSS: 150
+      } as any)
+
+      const result = await runGenerateWeeklyPlan({
+        userId: 'user-1',
+        trainingWeekId: 'week-1',
+        daysToPlan: 7
+      })
+
+      expect(result.success).toBe(true)
+      expect(generateStructuredAnalysis).toHaveBeenCalledTimes(2)
+      const createArg = vi.mocked(prisma.plannedWorkout.createMany).mock.calls[0]![0] as any
+      const totalMinutes = createArg.data.reduce(
+        (sum: number, w: any) => sum + w.durationSec / 60,
+        0
+      )
+      // 540 scheduled vs 300 target -> scaled to ~300 * 1.1
+      expect(totalMinutes).toBeLessThanOrEqual(300 * 1.2)
+      expect(totalMinutes).toBeGreaterThan(250)
+    })
   })
 })

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -19,6 +19,12 @@ import { TRAINING_BLOCK_TYPES, TRAINING_BLOCK_FOCUSES } from '../app/utils/train
 import { availabilityRepository } from '../server/utils/repositories/availabilityRepository'
 import { enqueuePlannedWorkoutStructureGeneration } from '../server/utils/planned-workout-structure-trigger'
 import { registerTaskHandler } from '../server/utils/task-registry'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  type WeekVolumeTarget
+} from '../server/utils/plans/block-volume'
 
 const trainingBlockSchema = {
   type: 'object',
@@ -124,7 +130,8 @@ export async function runGenerateTrainingBlock(payload: {
         select: {
           weekNumber: true,
           volumeTargetMinutes: true,
-          tssTarget: true
+          tssTarget: true,
+          isRecovery: true
         },
         orderBy: { weekNumber: 'asc' }
       }
@@ -381,7 +388,7 @@ CURRENT BLOCK CONTEXT:
 
 VOLUME TARGETS (Baseline from Plan Wizard):
 ${volumeTargets}
-*Use these targets as a guide. You may adjust slightly (+/- 10%) based on the phase and progression needs, but aim to hit these durations.*
+*These are HARD weekly duration budgets chosen by the athlete. The sum of all workout durations in a week MUST be within ±10% of that week's target. Never exceed it, and reduce recovery weeks accordingly.*
 
 WEEKLY SCHEDULE CONSTRAINTS (Explicit Dates):
 ${calendarContext}
@@ -389,6 +396,7 @@ ${calendarContext}
 
 TRAINING AVAILABILITY (when athlete can train):
 ${availabilitySummary || 'No availability set - assume flexible schedule'}
+*Availability slots are windows when the athlete CAN train — they are NOT sessions to fill. Schedule only as many sessions as the weekly volume budget allows; most days should use at most one slot.*
 
 LOCKED/ANCHOR WORKOUTS (DO NOT CHANGE OR REPLACE):
 ${
@@ -442,21 +450,58 @@ Return valid JSON matching the schema provided.`
     blockId,
     userId
   })
-  const result = await generateStructuredAnalysis<any>(
-    prompt,
-    trainingBlockSchema,
-    aiSettings.aiModelPreference,
-    {
+  const generateWeeks = (promptText: string) =>
+    generateStructuredAnalysis<any>(promptText, trainingBlockSchema, aiSettings.aiModelPreference, {
       userId,
       operation: 'generate_training_block',
       entityType: 'TrainingBlock',
       entityId: blockId
-    }
-  )
+    })
+
+  const result = await generateWeeks(prompt)
 
   // 5. Persist Results
   if (!result.weeks || result.weeks.length === 0) {
     throw new Error('AI returned no weeks for the block')
+  }
+
+  // 4.5 Validate the generated schedule against the wizard's weekly volume budgets.
+  // One corrective retry; if the model still over-schedules, clamp deterministically
+  // so a week can never persist at a multiple of the athlete's chosen volume. (CW-316)
+  const weekTargets: WeekVolumeTarget[] = weekSchedules.map((schedule) => {
+    const original = block.weeks.find((w) => w.weekNumber === schedule.weekNumber)
+    return {
+      weekNumber: schedule.weekNumber,
+      volumeTargetMinutes: original?.volumeTargetMinutes ?? null,
+      isRecovery: original?.isRecovery,
+      allowedDaysOfWeek: schedule.validDays.map((d) => d.getUTCDay())
+    }
+  })
+
+  let volumeViolations = validateGeneratedBlockWeeks(result.weeks, weekTargets)
+  if (volumeViolations.length > 0) {
+    logger.warn('[GenerateBlock] Generated weeks violate volume budgets, retrying with feedback', {
+      blockId,
+      violations: volumeViolations.map((v) => v.message)
+    })
+
+    const retry = await generateWeeks(`${prompt}\n\n${formatViolationsFeedback(volumeViolations)}`)
+    if (retry.weeks && retry.weeks.length > 0) {
+      result.weeks = retry.weeks
+      volumeViolations = validateGeneratedBlockWeeks(result.weeks, weekTargets)
+    }
+
+    if (volumeViolations.length > 0) {
+      const { weeks: clampedWeeks, adjustments } = clampGeneratedBlockWeeks(
+        result.weeks,
+        weekTargets
+      )
+      result.weeks = clampedWeeks
+      logger.warn('[GenerateBlock] Retry still over budget - clamped weeks deterministically', {
+        blockId,
+        adjustments
+      })
+    }
   }
 
   logger.log('Persisting generated plan...', { weeksCount: result.weeks.length })
@@ -530,6 +575,10 @@ Return valid JSON matching the schema provided.`
 
           const focusLabel = weekData?.focus_label || weekData?.focus_key || 'Training Week'
 
+          // Wizard-defined targets are the source of truth; the AI's self-reported
+          // volume target can silently diverge from what it actually scheduled. (CW-316)
+          const originalWeek = block.weeks.find((w) => w.weekNumber === schedule.weekNumber)
+
           const createdWeek = await tx.trainingWeek.create({
             data: {
               blockId,
@@ -540,13 +589,15 @@ Return valid JSON matching the schema provided.`
               focusKey: focusKey,
               focusLabel: focusLabel,
               explanation: weekData?.explanation || 'Weekly progression.',
-              volumeTargetMinutes: weekData?.volumeTargetMinutes || 0,
+              volumeTargetMinutes:
+                originalWeek?.volumeTargetMinutes || weekData?.volumeTargetMinutes || 0,
               tssTarget:
                 weekData?.workouts?.reduce(
                   (acc: number, w: any) => acc + (w.tssEstimate || 0),
                   0
                 ) || 0,
-              isRecovery: focusKey === 'RECOVERY' || focusKey === 'TAPER'
+              isRecovery:
+                originalWeek?.isRecovery ?? (focusKey === 'RECOVERY' || focusKey === 'TAPER')
             }
           })
 

--- a/trigger/generate-training-block.ts
+++ b/trigger/generate-training-block.ts
@@ -19,6 +19,7 @@ import { TRAINING_BLOCK_TYPES, TRAINING_BLOCK_FOCUSES } from '../app/utils/train
 import { availabilityRepository } from '../server/utils/repositories/availabilityRepository'
 import { enqueuePlannedWorkoutStructureGeneration } from '../server/utils/planned-workout-structure-trigger'
 import { registerTaskHandler } from '../server/utils/task-registry'
+import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
 import {
   validateGeneratedBlockWeeks,
   clampGeneratedBlockWeeks,
@@ -62,7 +63,9 @@ const trainingBlockSchema = {
                 },
                 type: {
                   type: 'string',
-                  enum: ['Ride', 'Run', 'Swim', 'Gym', 'Rest', 'Active Recovery']
+                  description:
+                    'Type of workout. DO NOT use generic terms like "Active Recovery" - map recovery sessions to a light "Ride"/"Run" or "Rest". "Gym" means strength training.',
+                  enum: ['Ride', 'Run', 'Swim', 'Gym', 'Rest']
                 },
                 durationMinutes: { type: 'integer' },
                 tssEstimate: { type: 'integer' },
@@ -427,7 +430,7 @@ Generate a detailed daily training plan for each week in this block (${block.dur
 - Ensure the recovery week (if applicable) has clearly reduced volume and intensity versus prior loading weeks.
 - Quantify recovery intent in your rationale (what was reduced and why).
 - For "Ride" workouts, provide realistic TSS estimates based on duration and intensity.
-- Workout types: ${allowedTypesString}, Rest, Active Recovery.
+- Workout types: ${allowedTypesString}, Rest. DO NOT use generic types like "Active Recovery" - map recovery sessions to a light Ride/Run or Rest.
 - Start each week on a Monday.
 - Provide a summary for each week explaining the focus and volume.
 - Explicitly connect each week focus to event demands and phase goals (base/build/peak/taper).
@@ -644,7 +647,7 @@ Return valid JSON matching the schema provided.`
                   date: targetDate,
                   title: workout.title,
                   description: workout.description,
-                  type: workout.type,
+                  type: normalizeGeneratedWorkoutType(workout.type),
                   durationSec: (workout.durationMinutes || 0) * 60,
                   tss: workout.tssEstimate,
                   workIntensity: getIntensityScore(workout.intensity),

--- a/trigger/generate-weekly-plan.ts
+++ b/trigger/generate-weekly-plan.ts
@@ -29,6 +29,7 @@ import { bodyMetricResolver } from '../server/utils/services/bodyMetricResolver'
 import { buildWorkoutCleanupQuery } from '../server/utils/plans/cleanup'
 import { filterGoalsForContext } from '../server/utils/goal-context'
 import { autoUploadPlannedWorkoutToIntervalsIfEnabled } from '../server/utils/intervals-sync'
+import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
 
 import { registerTaskHandler } from '../server/utils/task-registry'
 
@@ -901,12 +902,8 @@ Maintain your **${aiSettings.aiPersona}** persona throughout the plan's reasonin
           date: workoutDate, // Stored as UTC start of day for user
           title: d.title,
           description: d.description + (d.reasoningText ? `\n\nReasoning: ${d.reasoningText}` : ''),
-          // Map AI "Gym" type to "WeightTraining" which is standard in Intervals/our DB
-          // "Rest" is preserved. Everything else is passed through.
-          // AI has been instructed NOT to use "Workout" or "Active Recovery".
-          // If it still does, we map Active Recovery to a light Ride or Run based on user profile would be better,
-          // but for now let's map to "Workout" as a fallback so it doesn't crash, but log it.
-          type: d.workoutType === 'Gym' ? 'WeightTraining' : d.workoutType,
+          // "Rest" is preserved, "Gym" becomes "WeightTraining"; everything else passes through.
+          type: normalizeGeneratedWorkoutType(d.workoutType),
           durationSec: (d.durationMinutes || 0) * 60,
           distanceMeters: d.distanceMeters,
           tss: d.targetTSS,

--- a/trigger/generate-weekly-plan.ts
+++ b/trigger/generate-weekly-plan.ts
@@ -30,6 +30,13 @@ import { buildWorkoutCleanupQuery } from '../server/utils/plans/cleanup'
 import { filterGoalsForContext } from '../server/utils/goal-context'
 import { autoUploadPlannedWorkoutToIntervalsIfEnabled } from '../server/utils/intervals-sync'
 import { normalizeGeneratedWorkoutType } from '../server/utils/plans/workout-type'
+import {
+  validateGeneratedBlockWeeks,
+  clampGeneratedBlockWeeks,
+  formatViolationsFeedback,
+  type GeneratedBlockWeek,
+  type WeekVolumeTarget
+} from '../server/utils/plans/block-volume'
 
 import { registerTaskHandler } from '../server/utils/task-registry'
 
@@ -427,6 +434,7 @@ export async function runGenerateWeeklyPlan(payload: {
 
   // Fetch full Plan context if available (via trainingWeekId)
   let planContext = ''
+  let weekVolumeTargetMinutes: number | null = null
   if (trainingWeekId) {
     const fullContext = await prisma.trainingWeek.findUnique({
       where: { id: trainingWeekId },
@@ -442,6 +450,7 @@ export async function runGenerateWeeklyPlan(payload: {
     })
 
     if (fullContext) {
+      weekVolumeTargetMinutes = fullContext.volumeTargetMinutes || null
       planContext = `
 CONTEXT FROM MASTER PLAN:
 - Plan Name: ${fullContext.block.plan.name || fullContext.block.plan.goal?.title || 'Custom Plan'}
@@ -668,7 +677,7 @@ INSTRUCTIONS:
    - "Gym" means strength training.
 5. **PROGRESSION**:
    - If User Instructions are absent/minimal, aim for progressive overload based on the current phase.
-   - Weekly TSS target: ${Math.round(currentWeeklyTSS)} - ${targetMaxTSS} (unless overridden by instructions).
+   - Weekly TSS target: ${targetMinTSS} - ${targetMaxTSS} (unless overridden by instructions).
 6. **INTENSITY DISTRIBUTION**:
    - Keep the week polarized or pyramidal unless user constraints dictate otherwise.
    - Avoid stacking hard days back-to-back unless explicitly requested.
@@ -730,17 +739,70 @@ Maintain your **${aiSettings.aiPersona}** persona throughout the plan's reasonin
     userInstructions: userInstructions || 'None'
   })
 
-  const plan = await generateStructuredAnalysis(
-    prompt,
-    weeklyPlanSchema,
-    aiSettings.aiModelPreference,
-    {
+  const generatePlan = (promptText: string) =>
+    generateStructuredAnalysis(promptText, weeklyPlanSchema, aiSettings.aiModelPreference, {
       userId,
       operation: 'weekly_plan_generation',
       entityType: 'WeeklyTrainingPlan',
       entityId: undefined
+    })
+
+  let plan = await generatePlan(prompt)
+
+  // Validate the generated week against the plan week's volume budget (when linked)
+  // and duration sanity bounds. One corrective retry, then deterministic clamping,
+  // mirroring generate-training-block. (CW-319)
+  const daysToBlockWeek = (days: any[]): GeneratedBlockWeek => ({
+    weekNumber: 1,
+    workouts: days.map((d: any) => ({
+      dayOfWeek: d.dayOfWeek ?? 0,
+      title: d.title,
+      type: d.workoutType,
+      durationMinutes: d.durationMinutes,
+      tssEstimate: d.targetTSS
+    }))
+  })
+  const weekTargets: WeekVolumeTarget[] = [
+    { weekNumber: 1, volumeTargetMinutes: weekVolumeTargetMinutes }
+  ]
+
+  let planDays: any[] = Array.isArray((plan as any)?.days) ? (plan as any).days : []
+  let volumeViolations = validateGeneratedBlockWeeks([daysToBlockWeek(planDays)], weekTargets)
+  if (volumeViolations.length > 0) {
+    logger.warn('Generated week violates volume budget, retrying with feedback', {
+      violations: volumeViolations.map((v) => v.message)
+    })
+
+    const retryPlan = await generatePlan(
+      `${prompt}\n\n${formatViolationsFeedback(volumeViolations)}`
+    )
+    if (Array.isArray((retryPlan as any)?.days) && (retryPlan as any).days.length > 0) {
+      plan = retryPlan
+      planDays = (plan as any).days
+      volumeViolations = validateGeneratedBlockWeeks([daysToBlockWeek(planDays)], weekTargets)
     }
-  )
+
+    if (volumeViolations.length > 0) {
+      const { weeks: clampedWeeks, adjustments } = clampGeneratedBlockWeeks(
+        [daysToBlockWeek(planDays)],
+        weekTargets
+      )
+      const clampedWorkouts = clampedWeeks[0]?.workouts || []
+      planDays.forEach((d: any, i: number) => {
+        const clamped = clampedWorkouts[i]
+        if (!clamped) return
+        d.durationMinutes = clamped.durationMinutes
+        if (typeof clamped.tssEstimate === 'number') d.targetTSS = clamped.tssEstimate
+      })
+      ;(plan as any).totalTSS = planDays.reduce(
+        (sum: number, d: any) => sum + (d.targetTSS || 0),
+        0
+      )
+      logger.warn('Retry still over budget - clamped generated week deterministically', {
+        adjustments
+      })
+    }
+  }
 
   logger.log('Plan generated from AI', {
     daysPlanned: (plan as any).days?.length,


### PR DESCRIPTION
## Summary
- fix(nutrition): add Week grocery range anchored to viewed plan week (CW-315)
- fix(plans): validate and clamp AI block generation against weekly volume targets (CW-316)
- fix(plans): normalize AI workout types consistently across both generators (CW-317)
- fix(plans): validate weekly plan generation against week volume budget (CW-319)
- fix(plans): share week-target computation; stop resetting replanned weeks to 450min default (CW-318)
- feat(plans): cap new-plan volume ramp against athlete's recent actual load (CW-320)
- fix(nutrition): patch planning audit findings (CW-321 CW-322 CW-324 CW-325 CW-326)

## Test plan
- [ ] CI passes on develop
- [ ] Spot-check nutrition grocery list "Week" range in staging
- [ ] Spot-check training plan generation volume clamping in staging