### PR TITLE
fix(e2e): stop nutrition-fueling REST_DAY colliding with today (CW-333)

### DIFF
--- a/e2e/tests/nutrition-fueling.spec.ts
+++ b/e2e/tests/nutrition-fueling.spec.ts
@@ -1,4 +1,4 @@
-import { startOfWeek } from 'date-fns'
+import { differenceInCalendarDays, startOfWeek } from 'date-fns'
 import { test, expect } from '../fixtures/test-fixtures.ts'
 import { E2E_ATHLETE_EMAIL } from '../seed.ts'
 import { createE2ePrisma } from '../helpers/db.ts'
@@ -33,9 +33,18 @@ test.describe('Nutrition fueling plan', () => {
 
   // Keep this suite away from the current and next day. Other parallel E2E specs create
   // workouts there, which would otherwise change the number of generated fueling windows.
-  const STACKED_DAY = () => dayOffset(4) // two sessions back to back
-  const SPLIT_DAY = () => dayOffset(5) // morning and evening sessions
-  const REST_DAY = () => dayOffset(6) // no training at all
+  // A fixed offset (e.g. "Monday + 6") lands on a different weekday depending on which day the
+  // suite actually runs, so it can silently collide with "today" - pick offsets fresh each run,
+  // excluding whichever two of the week's seven days are today/tomorrow.
+  const todayOffset = ((differenceInCalendarDays(new Date(), getWeekStart()) % 7) + 7) % 7
+  const excludedOffsets = new Set([todayOffset, (todayOffset + 1) % 7])
+  const [stackedOffset, splitOffset, restOffset] = [0, 1, 2, 3, 4, 5, 6].filter(
+    (offset) => !excludedOffsets.has(offset)
+  )
+
+  const STACKED_DAY = () => dayOffset(stackedOffset) // two sessions back to back
+  const SPLIT_DAY = () => dayOffset(splitOffset) // morning and evening sessions
+  const REST_DAY = () => dayOffset(restOffset) // no training at all
 
   async function clearDay(date: Date) {
     const key = dateKey(date)


### PR DESCRIPTION
## Summary
- `nutrition-fueling.spec.ts` picked `STACKED_DAY`/`SPLIT_DAY`/`REST_DAY` via fixed offsets (Monday+4/5/6), so which weekday each lands on depends on when CI happens to run.
- On a Sunday, `REST_DAY` (Monday+6) *is* today, and `workout-analysis.spec.ts` seeds a `Workout` dated `new Date()` for the same shared E2E athlete in a parallel worker, bleeding a PRE/POST/INTRA window into the rest-day assertion. Caused `Playwright E2E` to fail on PR #462 (release develop→master), forcing an admin-override merge.
- Fix: compute the three offsets fresh each run, excluding whichever two of the week's seven days are today/tomorrow, so the suite can never land on either regardless of the day it runs.
- Verified the exclusion logic against all 7 possible weekday starting points (always 3 distinct valid offsets remain); lint/typecheck pass on the changed file. No production code touched.

Fixes CW-333

## Test plan
- [ ] CI `Playwright E2E` passes (including on the Sunday this PR was opened)