### PR TITLE
fix(recommendations): recover legacy workout targets

### DIFF
--- a/server/api/recommendations/[id]/accept.post.ts
+++ b/server/api/recommendations/[id]/accept.post.ts
@@ -66,13 +66,25 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'No suggested modifications found' })
   }
 
+  // Older recommendations may have a target snapshot but no persisted relation.
+  // Recover only the exact, owned target recorded at generation time; the normal
+  // guardrail validation below still rejects a changed, completed, or ambiguous workout.
+  const targetWorkout =
+    recommendation.plannedWorkout ||
+    (targetSnapshot?.id
+      ? await prisma.plannedWorkout.findFirst({
+          where: { id: targetSnapshot.id, userId },
+          include: { completedWorkouts: true }
+        })
+      : null)
+
   // Prepare the new description (completely replacing the old one)
   const newDescription = `${modifications.description || ''}${modifications.zone_adjustments ? `\n\nZone Adjustments: ${modifications.zone_adjustments}` : ''}`
   const type =
     modifications.new_type === 'Gym' ? 'WeightTraining' : modifications.new_type || 'Ride'
   const title =
     modifications.new_title?.trim() ||
-    (type === 'Rest' ? 'Rest Day' : recommendation.plannedWorkout?.title || 'Updated Workout')
+    (type === 'Rest' ? 'Rest Day' : targetWorkout?.title || 'Updated Workout')
   const durationSec =
     modifications.new_duration_min !== undefined && modifications.new_duration_min !== null
       ? Math.round(modifications.new_duration_min * 60)
@@ -93,7 +105,7 @@ export default defineEventHandler(async (event) => {
   if (!canCreateWorkoutFromUntargetedRecommendation) {
     const validation = validateRecommendationAcceptanceTarget({
       recommendationDate: recommendation.date,
-      currentWorkout: recommendation.plannedWorkout,
+      currentWorkout: targetWorkout,
       targetSnapshot,
       activeWorkoutCountForDate
     })
@@ -106,7 +118,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  let targetPlannedWorkoutId = recommendation.plannedWorkoutId
+  let targetPlannedWorkoutId = targetWorkout?.id || recommendation.plannedWorkoutId
   const nextSyncStatus = (syncStatus: string | null | undefined) =>
     syncStatus === 'LOCAL_ONLY' ? 'LOCAL_ONLY' : 'PENDING'
 
@@ -122,7 +134,7 @@ export default defineEventHandler(async (event) => {
         tss: modifications.new_tss,
         description: newDescription,
         modifiedLocally: true,
-        syncStatus: nextSyncStatus(recommendation.plannedWorkout?.syncStatus),
+        syncStatus: nextSyncStatus(targetWorkout?.syncStatus),
         syncError: null
       }
     })

--- a/server/utils/recommendation-actions.ts
+++ b/server/utils/recommendation-actions.ts
@@ -32,12 +32,24 @@ export async function acceptActivityRecommendation(userId: string, recommendatio
     return { error: 'No suggested modifications found' }
   }
 
+  // Recommendations created before the planned-workout relation was persisted
+  // can still carry an exact guardrail snapshot. Resolve that owned target and
+  // let the existing guardrails decide whether it remains safe to change.
+  const targetWorkout =
+    recommendation.plannedWorkout ||
+    (targetSnapshot?.id
+      ? await prisma.plannedWorkout.findFirst({
+          where: { id: targetSnapshot.id, userId },
+          include: { completedWorkouts: true }
+        })
+      : null)
+
   const newDescription = `${modifications.description || ''}${modifications.zone_adjustments ? `\n\nZone Adjustments: ${modifications.zone_adjustments}` : ''}`
   const type =
     modifications.new_type === 'Gym' ? 'WeightTraining' : modifications.new_type || 'Ride'
   const title =
     modifications.new_title?.trim() ||
-    (type === 'Rest' ? 'Rest Day' : recommendation.plannedWorkout?.title || 'Updated Workout')
+    (type === 'Rest' ? 'Rest Day' : targetWorkout?.title || 'Updated Workout')
   const durationSec =
     modifications.new_duration_min !== undefined && modifications.new_duration_min !== null
       ? Math.round(modifications.new_duration_min * 60)
@@ -58,7 +70,7 @@ export async function acceptActivityRecommendation(userId: string, recommendatio
   if (!canCreateWorkoutFromUntargetedRecommendation) {
     const validation = validateRecommendationAcceptanceTarget({
       recommendationDate: recommendation.date,
-      currentWorkout: recommendation.plannedWorkout,
+      currentWorkout: targetWorkout,
       targetSnapshot,
       activeWorkoutCountForDate
     })
@@ -68,7 +80,7 @@ export async function acceptActivityRecommendation(userId: string, recommendatio
     }
   }
 
-  let targetPlannedWorkoutId = recommendation.plannedWorkoutId
+  let targetPlannedWorkoutId = targetWorkout?.id || recommendation.plannedWorkoutId
   const nextSyncStatus = (syncStatus: string | null | undefined) =>
     syncStatus === 'LOCAL_ONLY' ? 'LOCAL_ONLY' : 'PENDING'
 
@@ -84,7 +96,7 @@ export async function acceptActivityRecommendation(userId: string, recommendatio
         tss: modifications.new_tss,
         description: newDescription,
         modifiedLocally: true,
-        syncStatus: nextSyncStatus(recommendation.plannedWorkout?.syncStatus),
+        syncStatus: nextSyncStatus(targetWorkout?.syncStatus),
         syncError: null
       }
     })

--- a/tests/unit/server/api/recommendations/accept.post.test.ts
+++ b/tests/unit/server/api/recommendations/accept.post.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../../../server/utils/db', () => ({
     },
     plannedWorkout: {
       count: vi.fn(),
+      findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
       findUnique: vi.fn()
@@ -140,6 +141,69 @@ describe('POST /api/recommendations/[id]/accept', () => {
     expect(result).toEqual({
       success: true,
       message: 'Workout updated successfully'
+    })
+  })
+
+  it('recovers the saved target for legacy recommendations missing the workout relation', async () => {
+    const handler = await getHandler()
+
+    vi.mocked(prisma.activityRecommendation.findUnique).mockResolvedValue({
+      id: 'rec-legacy',
+      userId: 'user-1',
+      date: new Date('2026-03-12T00:00:00Z'),
+      userAccepted: false,
+      plannedWorkoutId: null,
+      analysisJson: {
+        guardrails: {
+          targetPlannedWorkout: { id: 'planned-1', updatedAt: '2026-03-12T06:00:00.000Z' }
+        },
+        suggested_modifications: {
+          description: 'Take the rest of the day off.',
+          new_type: 'Rest',
+          new_duration_min: 0,
+          new_tss: 0
+        }
+      },
+      plannedWorkout: null
+    } as any)
+    vi.mocked(prisma.plannedWorkout.findFirst).mockResolvedValue({
+      id: 'planned-1',
+      title: 'Long Endurance Ride',
+      completed: false,
+      completionStatus: 'PENDING',
+      completedWorkouts: [],
+      updatedAt: new Date('2026-03-12T06:00:00.000Z'),
+      syncStatus: 'LOCAL_ONLY'
+    } as any)
+    vi.mocked(prisma.plannedWorkout.update).mockResolvedValue({
+      id: 'planned-1',
+      type: 'Rest',
+      syncStatus: 'LOCAL_ONLY',
+      externalId: 'ai_gen_user-1_2026-03-12_1',
+      date: new Date('2026-03-12T00:00:00Z'),
+      title: 'Rest Day',
+      description: 'Take the rest of the day off.',
+      durationSec: 0,
+      tss: 0,
+      managedBy: 'COACH_WATTS'
+    } as any)
+
+    await expect(handler({ context: { params: { id: 'rec-legacy' } } } as any)).resolves.toEqual({
+      success: true,
+      message: 'Workout updated successfully'
+    })
+
+    expect(prisma.plannedWorkout.findFirst).toHaveBeenCalledWith({
+      where: { id: 'planned-1', userId: 'user-1' },
+      include: { completedWorkouts: true }
+    })
+    expect(prisma.plannedWorkout.update).toHaveBeenCalledWith({
+      where: { id: 'planned-1' },
+      data: expect.objectContaining({ type: 'Rest' })
+    })
+    expect(prisma.activityRecommendation.update).toHaveBeenCalledWith({
+      where: { id: 'rec-legacy' },
+      data: { userAccepted: true, plannedWorkoutId: 'planned-1' }
     })
   })
 


### PR DESCRIPTION
Fixes CW-375

Recovers a legacy activity-recommendation target only when its guardrail snapshot identifies an owned planned workout. Existing safety checks still reject completed, changed, or ambiguous workouts.

Verification:
- pnpm test:unit tests/unit/server/api/recommendations/accept.post.test.ts (6 passed)
- pnpm typecheck
