### PR TITLE
fix(workouts): re-derive provider lap types instead of trusting WORK (CW-376)

### DIFF
--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -197,7 +197,7 @@ export default defineEventHandler(async (event) => {
       start_time: i.start_time,
       end_time: i.end_time,
       duration: i.duration || i.end_time - i.start_time,
-      type: resolvedTypes[index],
+      type: resolvedTypes[index] ?? i.type,
       avg_power: i.average_watts,
       max_power: i.max_watts,
       avg_heartrate: i.average_heartrate,

--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -10,7 +10,8 @@ import {
   calculateAerobicDecoupling,
   calculateCoastingStats,
   detectSurgesAndFades,
-  calculateRecoveryRateTrend
+  calculateRecoveryRateTrend,
+  resolveProviderIntervalTypes
 } from '../../../utils/interval-detection'
 import {
   calculateWPrimeBalance,
@@ -180,13 +181,23 @@ export default defineEventHandler(async (event) => {
 
   const mapSyncedIntervals = (intervals: any[]) => {
     if (!intervals || !Array.isArray(intervals)) return []
-    return intervals.map((i: any) => ({
+    // Providers (Intervals.icu especially) label almost every lap WORK, so the
+    // recovery jogs of an interval session would otherwise render as reps.
+    const resolvedTypes = resolveProviderIntervalTypes(
+      intervals.map((i: any) => ({
+        type: i.type,
+        intensity: Number(i.intensity),
+        avgPower: Number(i.average_watts),
+        avgSpeed: Number(i.average_speed)
+      }))
+    )
+    return intervals.map((i: any, index: number) => ({
       start_index: i.start_index,
       end_index: i.end_index,
       start_time: i.start_time,
       end_time: i.end_time,
       duration: i.duration || i.end_time - i.start_time,
-      type: i.type,
+      type: resolvedTypes[index],
       avg_power: i.average_watts,
       max_power: i.max_watts,
       avg_heartrate: i.average_heartrate,

--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -49,6 +49,108 @@ export interface PeakEffort {
   metric: 'power' | 'heartrate' | 'pace'
 }
 
+export interface ProviderIntervalSummary {
+  type?: string | null
+  /** Provider intensity as a percentage of threshold (Intervals.icu `intensity`) */
+  intensity?: number | null
+  avgPower?: number | null
+  avgSpeed?: number | null
+}
+
+const PROVIDER_RECOVERY_TOKENS = [
+  'rest',
+  'recover',
+  'recuper',
+  'warm',
+  'cool',
+  'calentamiento',
+  'enfriamiento',
+  'descanso'
+]
+
+/**
+ * Providers label synced laps inconsistently. Intervals.icu in particular marks
+ * nearly every lap `WORK` — warmups, recovery jogs and cooldowns included — so
+ * trusting the string verbatim makes a 4x4min threshold session look like ten
+ * work reps of wildly different intensity.
+ *
+ * Re-derive the type from the intensity profile of the session itself: a lap
+ * well below the session's own work band is recovery, and a low-intensity lap
+ * at either end is a warmup/cooldown. Explicit recovery-ish labels are always
+ * honoured — this only ever demotes a generic WORK lap, never promotes one.
+ */
+export function resolveProviderIntervalTypes(intervals: ProviderIntervalSummary[]): string[] {
+  const originalTypes = intervals.map((interval) => String(interval?.type || 'WORK'))
+  if (intervals.length < 3) return originalTypes
+
+  const isExplicitRecovery = originalTypes.map((type) => {
+    const lower = type.toLowerCase()
+    return PROVIDER_RECOVERY_TOKENS.some((token) => lower.includes(token))
+  })
+
+  // Prefer the provider's own intensity (% of threshold); fall back to raw
+  // power, then speed. Units do not matter — every comparison is a ratio
+  // against the other laps of the same workout.
+  const useIntensity = intervals.some((i) => Number.isFinite(Number(i?.intensity)))
+  const usePower = !useIntensity && intervals.some((i) => Number.isFinite(Number(i?.avgPower)))
+  const useSpeed =
+    !useIntensity && !usePower && intervals.some((i) => Number.isFinite(Number(i?.avgSpeed)))
+  if (!useIntensity && !usePower && !useSpeed) return originalTypes
+
+  const levels = intervals.map((interval) => {
+    const value = Number(
+      useIntensity ? interval?.intensity : usePower ? interval?.avgPower : interval?.avgSpeed
+    )
+    return Number.isFinite(value) && value > 0 ? value : null
+  })
+
+  const known = levels.filter((level): level is number => level !== null)
+  if (known.length < 3) return originalTypes
+
+  // Work band = median of the top third of laps, so a single short spike does
+  // not define "hard" for the whole session.
+  const sorted = [...known].sort((a, b) => b - a)
+  const topCount = Math.max(1, Math.round(sorted.length / 3))
+  const top = sorted.slice(0, topCount)
+  const workBand = top[Math.floor(top.length / 2)]!
+  if (!(workBand > 0)) return originalTypes
+
+  const RECOVERY_RATIO = 0.75
+  const EDGE_RATIO = 0.85
+
+  const demoted = levels.map((level, index) => {
+    if (level === null || isExplicitRecovery[index]) return false
+    const ratio = level / workBand
+    if (ratio < RECOVERY_RATIO) return true
+    // A first/last lap that sits clearly below the work band is a warmup or
+    // cooldown even when it is not deep in recovery territory.
+    const isEdge = index === 0 || index === intervals.length - 1
+    return isEdge && ratio < EDGE_RATIO
+  })
+
+  const resolved = originalTypes.map((type, index) => (demoted[index] ? 'RECOVERY' : type))
+
+  // Name the outermost demoted lap at each end for what it is. Trailing stubs
+  // the provider already flagged as recovery are skipped over, and only the
+  // first demoted lap reached is renamed — anything further in is a genuine
+  // between-reps recovery, not part of the warmup/cooldown.
+  const isRecoveryish = (index: number) => isExplicitRecovery[index] || demoted[index]
+  for (let index = 0; index < resolved.length && isRecoveryish(index); index++) {
+    if (demoted[index]) {
+      resolved[index] = 'WARMUP'
+      break
+    }
+  }
+  for (let index = resolved.length - 1; index >= 0 && isRecoveryish(index); index--) {
+    if (demoted[index]) {
+      resolved[index] = 'COOLDOWN'
+      break
+    }
+  }
+
+  return resolved
+}
+
 /**
  * Detect intervals in a workout based on power or heart rate data
  * Uses a moving average and threshold-based approach

--- a/server/utils/services/workoutAnalysisService.ts
+++ b/server/utils/services/workoutAnalysisService.ts
@@ -35,6 +35,7 @@ import {
   type WorkoutAnalysisFactsV2
 } from '../workout-analysis-facts'
 import { summarizePowerFromWatts } from '../power-metrics'
+import { resolveProviderIntervalTypes } from '../interval-detection'
 import type { JourneyEventCategory } from '@prisma/client'
 import { registerTaskHandler } from '../task-registry'
 
@@ -338,8 +339,19 @@ export function buildWorkoutAnalysisData(workout: any) {
         ? raw.intervals
         : null
     if (rawIntervals) {
-      data.intervals = rawIntervals.map((interval: any) => ({
-        type: interval.type,
+      // Provider lap labels are unreliable (Intervals.icu marks nearly every
+      // lap WORK); re-derive them so the model does not read recovery jogs as
+      // work reps.
+      const resolvedTypes = resolveProviderIntervalTypes(
+        rawIntervals.map((interval: any) => ({
+          type: interval.type,
+          intensity: Number(interval.intensity),
+          avgPower: Number(interval.average_watts),
+          avgSpeed: Number(interval.average_speed)
+        }))
+      )
+      data.intervals = rawIntervals.map((interval: any, index: number) => ({
+        type: resolvedTypes[index],
         label: interval.label,
         duration_s: interval.moving_time ?? interval.elapsed_time,
         distance_m: interval.distance,

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1,6 +1,6 @@
 import { calculateFatigueSensitivity, calculateStabilityMetrics } from './performance-metrics'
 import { toIntensityFactorFromTarget } from './structured-workout-persistence'
-import { detectIntervals } from './interval-detection'
+import { detectIntervals, resolveProviderIntervalTypes } from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
 
 type FactConfidence = 'low' | 'medium' | 'high'
@@ -1341,6 +1341,25 @@ function getRawIntervals(workout: any): any[] {
   return []
 }
 
+/**
+ * Provider-synced laps come with unreliable type labels (Intervals.icu marks
+ * nearly everything `WORK`), so re-derive them from the session's own intensity
+ * profile before they reach adherence facts or the AI prompt.
+ */
+function mapProviderIntervalsToActual(intervals: any[]): ActualInterval[] {
+  const resolvedTypes = resolveProviderIntervalTypes(
+    intervals.map((interval) => ({
+      type: interval?.type,
+      intensity: Number(interval?.intensity),
+      avgPower: Number(interval?.average_watts ?? interval?.avg_power),
+      avgSpeed: Number(interval?.average_speed ?? interval?.avg_pace)
+    }))
+  )
+  return mapIntervalsToActual(
+    intervals.map((interval, index) => ({ ...interval, type: resolvedTypes[index] }))
+  )
+}
+
 function mapIntervalsToActual(intervals: any[]): ActualInterval[] {
   return intervals
     .map((interval) => {
@@ -1810,7 +1829,7 @@ function hasTerminalRecoveryPhase(workout: any, plannedWorkout: any, refs: Analy
 
 function extractActualIntervals(workout: any, plannedWorkout?: any): ActualInterval[] {
   const rawIntervals = getRawIntervals(workout)
-  const rawActual = mapIntervalsToActual(rawIntervals)
+  const rawActual = mapProviderIntervalsToActual(rawIntervals)
   const detectedActual = buildDetectedIntervals(workout, plannedWorkout)
 
   if (rawActual.length === 0) return detectedActual
@@ -1860,7 +1879,7 @@ export function getActualIntervalsSourceForAnalysis(
   plannedWorkout?: any
 ): 'raw' | 'detected' | 'none' {
   const rawIntervals = getRawIntervals(workout)
-  const rawActual = mapIntervalsToActual(rawIntervals)
+  const rawActual = mapProviderIntervalsToActual(rawIntervals)
   const detectedActual = buildDetectedIntervals(workout, plannedWorkout)
 
   if (rawActual.length === 0) return detectedActual.length > 0 ? 'detected' : 'none'

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { detectIntervals } from '../../../../server/utils/interval-detection'
+import {
+  detectIntervals,
+  resolveProviderIntervalTypes
+} from '../../../../server/utils/interval-detection'
 
 describe('detectIntervals', () => {
   it('preserves the final recovery block before cooldown for plan-guided detection', () => {
@@ -85,5 +88,79 @@ describe('detectIntervals', () => {
     expect(intervals[6]?.avg_cadence).toBeGreaterThanOrEqual(78)
     expect(intervals[7]?.avg_cadence).toBeLessThan(intervals[6]?.avg_cadence || 999)
     expect(intervals[6]?.detection_confidence).toBeGreaterThan(0.35)
+  })
+})
+
+describe('resolveProviderIntervalTypes', () => {
+  // Intervals.icu labels nearly every synced lap WORK, including the recovery
+  // jogs of a threshold session.
+  const thresholdSession = [
+    { type: 'WORK', intensity: 83, avgPower: 220 },
+    { type: 'WORK', intensity: 101, avgPower: 270 },
+    { type: 'WORK', intensity: 52, avgPower: 139 },
+    { type: 'WORK', intensity: 103, avgPower: 275 },
+    { type: 'WORK', intensity: 52, avgPower: 138 },
+    { type: 'WORK', intensity: 105, avgPower: 280 },
+    { type: 'WORK', intensity: 52, avgPower: 139 },
+    { type: 'WORK', intensity: 109, avgPower: 291 },
+    { type: 'WORK', intensity: 52, avgPower: 140 },
+    { type: 'WORK', intensity: 69, avgPower: 184 },
+    { type: 'RECOVERY', intensity: 38, avgPower: 103 }
+  ]
+
+  it('demotes recovery jogs and end blocks that the provider labelled WORK', () => {
+    expect(resolveProviderIntervalTypes(thresholdSession)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN',
+      'RECOVERY'
+    ])
+  })
+
+  it('falls back to average power when the provider reports no intensity', () => {
+    const withoutIntensity = thresholdSession.map(({ type, avgPower }) => ({ type, avgPower }))
+    expect(resolveProviderIntervalTypes(withoutIntensity)).toEqual(
+      resolveProviderIntervalTypes(thresholdSession)
+    )
+  })
+
+  it('leaves an evenly paced endurance run untouched', () => {
+    const steadyLaps = [62, 64, 63, 65, 64, 63, 66, 64].map((intensity) => ({
+      type: 'WORK',
+      intensity
+    }))
+    expect(resolveProviderIntervalTypes(steadyLaps)).toEqual(steadyLaps.map(() => 'WORK'))
+  })
+
+  it('never promotes an explicit recovery label to work', () => {
+    const laps = [
+      { type: 'WARMUP', intensity: 60 },
+      { type: 'RECOVERY', intensity: 104 },
+      { type: 'WORK', intensity: 105 },
+      { type: 'RECOVERY', intensity: 103 },
+      { type: 'WORK', intensity: 106 }
+    ]
+    expect(resolveProviderIntervalTypes(laps)).toEqual([
+      'WARMUP',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'WORK'
+    ])
+  })
+
+  it('keeps provider types when there is nothing to compare', () => {
+    expect(resolveProviderIntervalTypes([{ type: 'WORK' }, { type: 'WORK' }])).toEqual([
+      'WORK',
+      'WORK'
+    ])
+    expect(resolveProviderIntervalTypes([])).toEqual([])
   })
 })

--- a/trigger/analyze-workout.ts
+++ b/trigger/analyze-workout.ts
@@ -29,6 +29,7 @@ import {
   formatPromptPace
 } from '../server/utils/ai-prompt-format'
 import { isWorkoutEligibleForAutomaticInsights } from '../server/utils/automatic-workout-insights'
+import { resolveProviderIntervalTypes } from '../server/utils/interval-detection'
 import {
   buildAnalysisRequestMetricRules,
   buildMetricPriorityPromptBlock,
@@ -780,8 +781,19 @@ export function buildWorkoutAnalysisData(workout: any) {
         ? raw.intervals
         : null
     if (rawIntervals) {
-      data.intervals = rawIntervals.map((interval: any) => ({
-        type: interval.type,
+      // Provider lap labels are unreliable (Intervals.icu marks nearly every
+      // lap WORK); re-derive them so the model does not read recovery jogs as
+      // work reps.
+      const resolvedTypes = resolveProviderIntervalTypes(
+        rawIntervals.map((interval: any) => ({
+          type: interval.type,
+          intensity: Number(interval.intensity),
+          avgPower: Number(interval.average_watts),
+          avgSpeed: Number(interval.average_speed)
+        }))
+      )
+      data.intervals = rawIntervals.map((interval: any, index: number) => ({
+        type: resolvedTypes[index],
         label: interval.label,
         // Prefer moving time for pace analysis (elapsed_time can include pauses/stops and distort run interval pace).
         duration_s: interval.moving_time ?? interval.elapsed_time,


### PR DESCRIPTION
Fixes CW-376

Intervals.icu returns `icu_intervals` with `type: "WORK"` on nearly every lap, so warmups, recovery jogs and cooldowns reached interval analysis as work reps. Reproduced on two of the reporting athlete's threshold sessions (support ticket 882b8687): 4x4min @ ~105% FTP with 2min recoveries at ~52% all came back classified as work, which is what corrupted the AI summary and the lap markers.

## What changed
- `resolveProviderIntervalTypes()` in `server/utils/interval-detection.ts` re-derives each lap's type from the intensity profile of the session itself: the work band is the median of the top third of laps, anything below 75% of it is recovery, and a first/last lap below 85% is a warmup/cooldown. Explicit recovery labels are always honoured — the pass only ever demotes a generic WORK lap.
- Applied at every site that consumes provider laps: adherence facts (`workout-analysis-facts.ts`), the intervals API that draws the lap markers, and both AI prompt builders (`workoutAnalysisService.ts`, `trigger/analyze-workout.ts`).

## Verification
- Both reported workouts now read warmup / 4x work / recoveries / cooldown against the production data.
- 6 new unit tests, including an evenly paced endurance run that must stay untouched and a no-promotion case; `vitest` over `tests/unit/server/utils` + analysis suites: 1005 passed. `tsc --noEmit` clean.