### PR TITLE
fix(workouts): read power curve streams from WorkoutStreamV2 (CW-377)

### DIFF
--- a/server/api/workouts/power-curve.get.ts
+++ b/server/api/workouts/power-curve.get.ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, getQuery, createError } from 'h3'
 import { workoutRepository } from '../../utils/repositories/workoutRepository'
+import { workoutStreamRepository } from '../../utils/repositories/workoutStreamRepository'
 import { getServerSession } from '../../utils/session'
 import { subDays } from 'date-fns'
 import { getUserTimezone, getStartOfYearUTC } from '../../utils/date'
@@ -131,6 +132,8 @@ export default defineEventHandler(async (event) => {
   const sport = query.sport === 'all' ? undefined : (query.sport as string)
   const tags = parseTagQueryParam(query.tags)
 
+  const workoutSelect = { id: true, date: true }
+
   // 1. Fetch workouts for the selected period (Current Curve)
   const currentWorkouts = await workoutRepository.getForUser(userId, {
     startDate,
@@ -138,13 +141,7 @@ export default defineEventHandler(async (event) => {
     tags,
     includeDuplicates: false,
     where: sport ? { type: sport } : undefined,
-    include: {
-      streams: {
-        select: {
-          watts: true
-        }
-      }
-    }
+    select: workoutSelect
   })
 
   // 2. Fetch all-time bests (All-Time Curve)
@@ -155,14 +152,17 @@ export default defineEventHandler(async (event) => {
     tags,
     includeDuplicates: false,
     where: sport ? { type: sport } : undefined,
-    include: {
-      streams: {
-        select: {
-          watts: true
-        }
-      }
-    }
+    select: workoutSelect
   })
+
+  // Power streams live in WorkoutStreamV2 for anything ingested since the
+  // stream migration, with the legacy WorkoutStream table as fallback. Reading
+  // the `streams` relation directly would only ever see the legacy table and
+  // return an empty curve for V2-only athletes. The two workout sets overlap
+  // heavily, so resolve the union once instead of fetching streams twice.
+  const wattsByWorkoutId = await workoutStreamRepository.findWattsByWorkoutIds([
+    ...new Set([...currentWorkouts, ...allTimeWorkouts].map((workout: any) => workout.id))
+  ])
 
   const processWorkoutsToCurve = (
     workouts: any[],
@@ -178,11 +178,11 @@ export default defineEventHandler(async (event) => {
     })
 
     workouts.forEach((workout) => {
-      const watts = workout.streams?.watts
-      if (!Array.isArray(watts) || watts.length === 0) return
+      const watts = wattsByWorkoutId.get(workout.id)
+      if (!watts || watts.length === 0) return
 
       DURATIONS.forEach((duration) => {
-        const best = calculateBestPowerForDuration(watts as number[], duration)
+        const best = calculateBestPowerForDuration(watts, duration)
         if (best <= 0) return
 
         const current = bestByDuration.get(duration)

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -333,6 +333,64 @@ export const workoutStreamRepository = {
     return result
   },
 
+  /**
+   * Watts-only bulk read for aggregate power analytics.
+   *
+   * findManyByWorkoutIds() always fetches the REQUIRED_V2_SELECT baseline so
+   * hasUsableStreamData() can decide V2-vs-V1, which means ~6 parallel series
+   * per workout. Curve endpoints scan up to two years of workouts at once and
+   * only ever look at `watts`, so the baseline is the dominant cost there.
+   * This reads a single column and decides the V1 fallback from the presence
+   * of a non-empty watts series, which is the only signal that matters here.
+   *
+   * Workouts with no power data are simply absent from the returned map.
+   */
+  async findWattsByWorkoutIds(workoutIds: string[]): Promise<Map<string, number[]>> {
+    const result = new Map<string, number[]>()
+    if (workoutIds.length === 0) return result
+
+    const chunks = chunkArray(workoutIds, WORKOUT_ID_CHUNK_SIZE)
+
+    const v2Chunks = await Promise.all(
+      chunks.map((chunk) =>
+        (prisma as any).workoutStreamV2
+          .findMany({
+            where: { workoutId: { in: chunk } },
+            select: { workoutId: true, watts: true }
+          })
+          .catch(() => [])
+      )
+    )
+
+    for (const record of v2Chunks.flat() as Array<{ workoutId: string; watts: unknown }>) {
+      if (Array.isArray(record.watts) && record.watts.length > 0) {
+        result.set(record.workoutId, record.watts as number[])
+      }
+    }
+
+    const missingIds = workoutIds.filter((id) => !result.has(id))
+    if (missingIds.length === 0) return result
+
+    const v1Chunks = await Promise.all(
+      chunkArray(missingIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+        prisma.workoutStream
+          .findMany({
+            where: { workoutId: { in: chunk } },
+            select: { workoutId: true, watts: true }
+          })
+          .catch(() => [])
+      )
+    )
+
+    for (const record of v1Chunks.flat() as Array<{ workoutId: string; watts: unknown }>) {
+      if (Array.isArray(record.watts) && record.watts.length > 0) {
+        result.set(record.workoutId, record.watts as number[])
+      }
+    }
+
+    return result
+  },
+
   async updateMetadata(
     workoutId: string,
     data: { hrZoneTimes?: unknown; powerZoneTimes?: unknown }

--- a/tests/unit/server/api/workouts/power-curve.test.ts
+++ b/tests/unit/server/api/workouts/power-curve.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
+import { workoutStreamRepository } from '../../../../../server/utils/repositories/workoutStreamRepository'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {}
+}))
+
+vi.mock('../../../../../server/utils/repositories/workoutRepository', () => ({
+  workoutRepository: { getForUser: vi.fn() }
+}))
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  workoutStreamRepository: { findWattsByWorkoutIds: vi.fn() }
+}))
+
+vi.mock('../../../../../server/utils/date', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../server/utils/date')>(
+    '../../../../../server/utils/date'
+  )
+  return { ...actual, getUserTimezone: vi.fn().mockResolvedValue('UTC') }
+})
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/workouts/power-curve.get')).default
+
+/** A 10-minute ride at a flat `watts`, long enough to populate every duration bucket up to 10m. */
+const steadyRide = (watts: number, seconds = 700) => Array.from({ length: seconds }, () => watts)
+
+const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+
+describe('GET /api/workouts/power-curve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([] as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(new Map())
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const handler = await getHandler()
+    vi.mocked(getServerSession).mockResolvedValue(null as any)
+
+    await expect(handler({ query: {} } as any)).rejects.toMatchObject({ statusCode: 401 })
+  })
+
+  it('builds the curve from streams resolved through the repository (V2-aware read path)', async () => {
+    // Regression guard for CW-377: the handler used to read the legacy
+    // `streams` relation via a Prisma include, which returns nothing for
+    // athletes whose power data only exists in WorkoutStreamV2.
+    const handler = await getHandler()
+    const workouts = [{ id: 'workout-1', date: daysAgo(10) }]
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue(workouts as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([['workout-1', steadyRide(250)]])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    expect(result.current.length).toBeGreaterThan(0)
+    expect(result.allTime.length).toBeGreaterThan(0)
+    expect(result.current.find((p: any) => p.duration === 300)?.watts).toBe(250)
+    expect(result.current.find((p: any) => p.duration === 600)?.watts).toBe(250)
+    // No effort is long enough to fill the 20m+ buckets.
+    expect(result.current.find((p: any) => p.duration === 1200)).toBeUndefined()
+  })
+
+  it('never asks the repository for the raw `streams` relation', async () => {
+    const handler = await getHandler()
+
+    await handler({ query: { days: 90 } } as any)
+
+    for (const call of vi.mocked(workoutRepository.getForUser).mock.calls) {
+      expect((call[1] as any)?.include).toBeUndefined()
+      expect((call[1] as any)?.select).toEqual({ id: true, date: true })
+    }
+  })
+
+  it('resolves streams once for the union of the current and all-time workout sets', async () => {
+    const handler = await getHandler()
+    const recent = { id: 'workout-recent', date: daysAgo(10) }
+    const old = { id: 'workout-old', date: daysAgo(400) }
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([recent] as any) // current period (90d)
+      .mockResolvedValueOnce([recent, old] as any) // all-time (730d)
+
+    await handler({ query: { days: 90 } } as any)
+
+    expect(workoutStreamRepository.findWattsByWorkoutIds).toHaveBeenCalledTimes(1)
+    expect(workoutStreamRepository.findWattsByWorkoutIds).toHaveBeenCalledWith([
+      'workout-recent',
+      'workout-old'
+    ])
+  })
+
+  it('returns empty curves when the athlete has no power data at all', async () => {
+    const handler = await getHandler()
+    vi.mocked(workoutRepository.getForUser).mockResolvedValue([
+      { id: 'workout-1', date: daysAgo(5) }
+    ] as any)
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    expect(result.current).toEqual([])
+    expect(result.allTime).toEqual([])
+  })
+
+  it('reports an all-time best above the current period without inflating the current curve', async () => {
+    const handler = await getHandler()
+    const recent = { id: 'workout-recent', date: daysAgo(10) }
+    const old = { id: 'workout-old', date: daysAgo(400) }
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([recent] as any)
+      .mockResolvedValueOnce([recent, old] as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([
+        ['workout-recent', steadyRide(250)],
+        ['workout-old', steadyRide(320)]
+      ])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    expect(result.current.find((p: any) => p.duration === 300)?.watts).toBe(250)
+    expect(result.allTime.find((p: any) => p.duration === 300)?.watts).toBe(320)
+  })
+
+  it('marks a duration stale when nothing in the last two years came near the all-time best', async () => {
+    const handler = await getHandler()
+    const old = { id: 'workout-old', date: daysAgo(400) }
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([] as any) // nothing in the current 90-day window
+      .mockResolvedValueOnce([old] as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([['workout-old', steadyRide(320)]])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    expect(result.current).toEqual([])
+    const allTime300 = result.allTime.find((p: any) => p.duration === 300)
+    expect(allTime300?.watts).toBe(320)
+    expect(allTime300?.freshnessState).toBe('stale')
+    expect(allTime300?.daysSince).toBeGreaterThanOrEqual(399)
+  })
+})

--- a/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
@@ -264,4 +264,87 @@ describe('workoutStreamRepository', () => {
       expect(streams.get('workout-legacy')).toBeTruthy()
     })
   })
+
+  describe('findWattsByWorkoutIds', () => {
+    beforeEach(() => {
+      workoutStreamV2.findMany.mockResolvedValue([])
+      vi.mocked(prisma.workoutStream.findMany).mockResolvedValue([] as any)
+    })
+
+    it('returns an empty map without querying when given no IDs', async () => {
+      const watts = await workoutStreamRepository.findWattsByWorkoutIds([])
+
+      expect(watts.size).toBe(0)
+      expect(workoutStreamV2.findMany).not.toHaveBeenCalled()
+      expect(prisma.workoutStream.findMany).not.toHaveBeenCalled()
+    })
+
+    it('reads watts from WorkoutStreamV2 and selects only the watts column', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([
+        { workoutId: 'workout-1', watts: [100, 110, 120] }
+      ])
+
+      const watts = await workoutStreamRepository.findWattsByWorkoutIds(['workout-1'])
+
+      expect(workoutStreamV2.findMany).toHaveBeenCalledWith({
+        where: { workoutId: { in: ['workout-1'] } },
+        select: { workoutId: true, watts: true }
+      })
+      expect(watts.get('workout-1')).toEqual([100, 110, 120])
+      // V2 covered every ID, so the legacy table is never touched.
+      expect(prisma.workoutStream.findMany).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the legacy V1 table for workouts with no usable V2 watts', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([
+        { workoutId: 'workout-v2', watts: [200] },
+        // Present in V2 but with no power series -- must still fall back.
+        { workoutId: 'workout-empty-v2', watts: [] }
+      ])
+      vi.mocked(prisma.workoutStream.findMany).mockResolvedValue([
+        { workoutId: 'workout-empty-v2', watts: [150] },
+        { workoutId: 'workout-v1-only', watts: [175] }
+      ] as any)
+
+      const watts = await workoutStreamRepository.findWattsByWorkoutIds([
+        'workout-v2',
+        'workout-empty-v2',
+        'workout-v1-only'
+      ])
+
+      expect(prisma.workoutStream.findMany).toHaveBeenCalledWith({
+        where: { workoutId: { in: ['workout-empty-v2', 'workout-v1-only'] } },
+        select: { workoutId: true, watts: true }
+      })
+      expect(watts.get('workout-v2')).toEqual([200])
+      expect(watts.get('workout-empty-v2')).toEqual([150])
+      expect(watts.get('workout-v1-only')).toEqual([175])
+    })
+
+    it('omits workouts that have no power data in either table', async () => {
+      workoutStreamV2.findMany.mockResolvedValue([{ workoutId: 'workout-hr-only', watts: [] }])
+      vi.mocked(prisma.workoutStream.findMany).mockResolvedValue([
+        { workoutId: 'workout-hr-only', watts: null }
+      ] as any)
+
+      const watts = await workoutStreamRepository.findWattsByWorkoutIds([
+        'workout-hr-only',
+        'workout-no-streams'
+      ])
+
+      expect(watts.size).toBe(0)
+    })
+
+    it('splits a large IN(...) clause into chunks of at most 200 IDs', async () => {
+      const workoutIds = Array.from({ length: 450 }, (_, i) => `workout-${i}`)
+
+      await workoutStreamRepository.findWattsByWorkoutIds(workoutIds)
+
+      expect(workoutStreamV2.findMany).toHaveBeenCalledTimes(3)
+      const callSizes = workoutStreamV2.findMany.mock.calls.map(
+        (call: any[]) => call[0].where.workoutId.in.length
+      )
+      expect(callSizes).toEqual([200, 200, 50])
+    })
+  })
 })


### PR DESCRIPTION
Fixes CW-377

## Problem

`GET /api/workouts/power-curve` — the aggregate curve behind the **Power Duration Curve** card on `/performance` — resolved power data through the raw Prisma relation:

```ts
include: { streams: { select: { watts: true } } }
```

`Workout.streams` is the **legacy V1** `WorkoutStream` table. Stream writes were migrated to `WorkoutStreamV2`; `workoutStreamRepository.upsert()` writes only to V2, and reads are meant to go through `workoutStreamRepository`, which prefers V2 and falls back to V1. This endpoint was missed in that migration, so any athlete whose streams are V2-only got `{ current: [], allTime: [] }` and the chart rendered its "Power Telemetry Unavailable" empty state.

Reported via support ticket `7f9ffa34`. For the reporting athlete, production has **0** V1 stream rows and **285** V2 rows, 134 of them with a power series. The data was intact the whole time — this is a read-path bug, not data loss, so no backfill is required.

The two per-workout endpoints (`/api/workouts/[id]/power-curve`, `/api/share/workouts/[token]/power-curve`) already used `attachStreamToWorkout` and were unaffected.

## Change

- `workoutStreamRepository.findWattsByWorkoutIds()` — a new watts-only bulk read, V2-first with V1 fallback, chunked at 200 IDs per `IN (...)` like its sibling.
  - Deliberately not `findManyByWorkoutIds({ fields: [] })`: that has to fetch the `REQUIRED_V2_SELECT` baseline (~6 parallel series) so `hasUsableStreamData()` can pick V2 vs V1. This endpoint scans up to two years of workouts and reads nothing but `watts`, so the baseline would dominate the cost.
- The endpoint now selects `{ id, date }` for its workout rows and resolves streams **once** for the union of the current-period and all-time sets, replacing two full stream reads with one.

## Verification

```
npx vitest run tests/unit/server/api/workouts/power-curve.test.ts \
               tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
#  Test Files  2 passed (2)
#       Tests  26 passed (26)

npx vue-tsc --noEmit -p .nuxt/tsconfig.server.json   # clean
npx eslint <changed files>                            # clean
```

Full `tests/unit/server` run: 250/253 files pass. The 3 failures (`wellness-analysis.test.ts`, two `oauth/authorize*.nuxt.test.ts`) reproduce identically on a clean `develop` checkout with these changes stashed — pre-existing, not from this PR.

Replayed the before/after curve against the reporting athlete's production data:

| | current (90d) | all-time (730d) |
|---|---|---|
| before (V1-only read) | 0 points | 0 points |
| after (V2-first) | 5s=1196W … 1h=285W | 5s=1196W … 1h=290W |

No UX critique round: this changes no UI, copy, or layout — only whether the existing chart receives data.