### PR TITLE
fix(workouts): correct HR interval detection threshold and STEADY type (CW-383)

### DIFF
--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -11,8 +11,10 @@ import {
   calculateCoastingStats,
   detectSurgesAndFades,
   calculateRecoveryRateTrend,
-  resolveProviderIntervalTypes
+  resolveProviderIntervalTypes,
+  resolveHrWorkThreshold
 } from '../../../utils/interval-detection'
+import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import {
   calculateWPrimeBalance,
   calculateEfficiencyFactorDecay,
@@ -96,6 +98,7 @@ export default defineEventHandler(async (event) => {
       id: true,
       ftp: true,
       maxHr: true,
+      lthr: true,
       email: true
     }
   })
@@ -246,8 +249,19 @@ export default defineEventHandler(async (event) => {
     )
   } else if (hasHr) {
     autoDetectionMetric = 'heartrate'
-    const maxHr = workout.maxHr || user.maxHr
-    const threshold = maxHr ? maxHr * 0.7 : undefined
+    // Source the reference from the athlete's PROFILE. Using this workout's own
+    // max HR would make the bar self-referential and drift session to session,
+    // so it is only reached as an explicit last resort inside
+    // `resolveHrWorkThreshold` when the profile carries neither LTHR nor max HR.
+    const sportSettings = await sportSettingsRepository.getForActivityType(
+      user.id,
+      String(workout.type || '')
+    )
+    const threshold = resolveHrWorkThreshold({
+      lthr: sportSettings?.lthr ?? user.lthr,
+      maxHr: sportSettings?.maxHr ?? user.maxHr,
+      sessionMaxHr: workout.maxHr
+    })
     detectedEngineIntervals = detectIntervals(
       time,
       hrStream!,

--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -152,14 +152,70 @@ export function resolveProviderIntervalTypes(intervals: ProviderIntervalSummary[
 }
 
 /**
+ * Fraction of max HR that marks the bottom of "work" for interval detection.
+ * ~70% of max HR is the upper Z2 / lower Z3 border — an easy jog sits below it,
+ * a tempo or threshold effort clearly above it.
+ */
+export const HR_WORK_BAR_FRACTION_OF_MAX_HR = 0.7
+
+/**
+ * Fraction of LTHR that marks the same bar. LTHR sits at roughly 85% of max HR,
+ * so 0.82 * LTHR lands on the same bpm as 0.7 * maxHR for a typical athlete.
+ */
+export const HR_WORK_BAR_FRACTION_OF_LTHR = 0.82
+
+/**
+ * Resolve the FINAL heart-rate work bar (in bpm) to hand to `detectIntervals`.
+ *
+ * `detectIntervals` deliberately applies no further multiplier to an HR
+ * threshold (see the contract note on that function), so this is the one place
+ * the physiological scaling happens. Callers should source `lthr`/`maxHr` from
+ * the athlete's PROFILE (sportSettings, falling back to the user record).
+ *
+ * `sessionMaxHr` is an explicit last-resort fallback only: it is the max HR of
+ * the single workout being analysed, so a threshold derived from it is
+ * self-referential and drifts workout to workout. Pass it so a profile-less
+ * athlete still gets some segmentation, never as the preferred input.
+ */
+export function resolveHrWorkThreshold(refs: {
+  lthr?: number | null
+  maxHr?: number | null
+  sessionMaxHr?: number | null
+}): number | undefined {
+  const lthr = Number(refs.lthr || 0)
+  if (lthr > 0) return lthr * HR_WORK_BAR_FRACTION_OF_LTHR
+
+  const maxHr = Number(refs.maxHr || 0)
+  if (maxHr > 0) return maxHr * HR_WORK_BAR_FRACTION_OF_MAX_HR
+
+  const sessionMaxHr = Number(refs.sessionMaxHr || 0)
+  if (sessionMaxHr > 0) return sessionMaxHr * HR_WORK_BAR_FRACTION_OF_MAX_HR
+
+  return undefined
+}
+
+/**
  * Detect intervals in a workout based on power or heart rate data
  * Uses a moving average and threshold-based approach
+ *
+ * THRESHOLD CONTRACT (do not add a second discount on top of a scaled value):
+ * - `power`:     `threshold` is the athlete's FTP. The work bar is derived here
+ *                as 70% of FTP (the Z2/Z3 border).
+ * - `pace`:      `threshold` is a reference velocity (usually omitted, in which
+ *                case the stream's own median is used). The work bar is derived
+ *                here as 65% of it.
+ * - `heartrate`: `threshold` is ALREADY THE FINAL WORK BAR in bpm — build it
+ *                with `resolveHrWorkThreshold()` from profile LTHR/max HR. No
+ *                multiplier is applied here. Callers used to pass `maxHr * 0.7`
+ *                into a function that multiplied by 0.65 again, putting the work
+ *                bar at ~46% of max HR: every sample read as work and the merge
+ *                pass welded whole sessions into one interval (CW-383).
  */
 export function detectIntervals(
   times: number[],
   values: number[],
   metricType: 'power' | 'heartrate' | 'pace',
-  threshold?: number, // FTP or Threshold Pace/HR
+  threshold?: number, // FTP, reference pace, or the final HR work bar in bpm
   plannedSteps?: PlannedStep[],
   smoothedValues?: number[],
   cadenceValues?: number[]
@@ -189,9 +245,19 @@ export function detectIntervals(
   // If no manual threshold provided, estimate baseline
   const baseline = threshold || calculateBaseline(smoothed)
 
-  // For power, work is typically > 70% FTP (Zone 2/3 border)
-  // For HR, work is > 65% Max (approx Z2)
-  const workThreshold = metricType === 'power' ? baseline * 0.7 : baseline * 0.65
+  // Per the threshold contract above:
+  // - power: work is > 70% FTP (Zone 2/3 border)
+  // - heartrate: the caller already handed us the final work bar in bpm
+  //   (`resolveHrWorkThreshold`), so it is used verbatim. With no threshold at
+  //   all the fallback baseline is the stream's own median HR, which is a
+  //   sensible "above your typical effort = work" bar on its own.
+  // - pace: work is > 65% of the reference velocity
+  const workThreshold =
+    metricType === 'power'
+      ? baseline * 0.7
+      : metricType === 'heartrate'
+        ? baseline
+        : baseline * 0.65
 
   let intervals: Interval[] = []
   let inInterval = false
@@ -284,13 +350,17 @@ export function detectIntervals(
   if (merged.length === 0 && times.length > 0) {
     const totalDuration = (times[times.length - 1] || 0) - (times[0] || 0)
     const avgValue = values.reduce((a, b) => a + (b || 0), 0) / values.length
+    // `baseline` is FTP for power and the work bar itself for HR/pace.
     const isSteady =
       totalDuration > 900 && // 15 mins
       (metricType === 'power' ? avgValue >= baseline * 0.4 : avgValue >= baseline * 0.5)
 
     if (isSteady) {
+      // STEADY, not WORK: a continuous ride/run is one steady block, not a rep.
+      // Downstream consumers that count reps filter on `type === 'WORK'`, and
+      // labelling this WORK made every endurance session look like a 1x session.
       intervals = [
-        createIntervalObj(times, values, 0, times.length - 1, 'WORK', threshold, metricType)
+        createIntervalObj(times, values, 0, times.length - 1, 'STEADY', threshold, metricType)
       ]
     }
   } else {

--- a/server/utils/performance-metrics.ts
+++ b/server/utils/performance-metrics.ts
@@ -111,7 +111,10 @@ export function calculateStabilityMetrics(
   const overallCoV = getCoV(stream.filter((v) => v > 10))
 
   const intervalStability = intervals
-    .filter((interval) => interval.type === 'WORK')
+    // STEADY is the whole-session block emitted for a continuous ride/run
+    // (CW-383). Its coefficient of variation is exactly the number a steady
+    // session cares about, so it belongs here alongside WORK reps.
+    .filter((interval) => interval.type === 'WORK' || interval.type === 'STEADY')
     .map((interval, idx) => {
       const segment = stream.slice(interval.start_index, interval.end_index + 1)
       return {

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1,6 +1,10 @@
 import { calculateFatigueSensitivity, calculateStabilityMetrics } from './performance-metrics'
 import { toIntensityFactorFromTarget } from './structured-workout-persistence'
-import { detectIntervals, resolveProviderIntervalTypes } from './interval-detection'
+import {
+  detectIntervals,
+  resolveHrWorkThreshold,
+  resolveProviderIntervalTypes
+} from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
 
 type FactConfidence = 'low' | 'medium' | 'high'
@@ -1633,12 +1637,19 @@ function buildDetectedIntervals(workout: any, plannedWorkout?: any): ActualInter
       cadence
     )
   } else if (time.length > 0 && hr.length === time.length && hr.length > 0) {
-    const maxHr = Number(workout?.maxHr || 0) || undefined
+    // Profile-sourced reference (sportSettings, then the user record). This
+    // workout's own max HR is only an explicit last-resort fallback — a bar
+    // derived from it is self-referential and drifts session to session.
+    const hrWorkThreshold = resolveHrWorkThreshold({
+      lthr: workout?.sportSettings?.lthr ?? workout?.user?.lthr,
+      maxHr: workout?.sportSettings?.maxHr ?? workout?.user?.maxHr,
+      sessionMaxHr: workout?.maxHr
+    })
     detected = detectIntervals(
       time,
       hr,
       'heartrate',
-      maxHr ? maxHr * 0.7 : undefined,
+      hrWorkThreshold,
       plannedSteps,
       undefined,
       cadence

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   detectIntervals,
+  resolveHrWorkThreshold,
   resolveProviderIntervalTypes
 } from '../../../../server/utils/interval-detection'
 
@@ -88,6 +89,97 @@ describe('detectIntervals', () => {
     expect(intervals[6]?.avg_cadence).toBeGreaterThanOrEqual(78)
     expect(intervals[7]?.avg_cadence).toBeLessThan(intervals[6]?.avg_cadence || 999)
     expect(intervals[6]?.detection_confidence).toBeGreaterThan(0.35)
+  })
+
+  // Regression: the HR work bar used to end up at maxHr * 0.7 * 0.65 (~46% of
+  // max HR) because the caller scaled the threshold and detectIntervals scaled
+  // it again. Every sample read as "work" and the merge pass welded the whole
+  // session into one interval.
+  it('segments an HR interval session against a profile-sourced work bar', () => {
+    const block = (bpm: number, seconds: number) => Array.from({ length: seconds }, () => bpm)
+
+    const heartrate = [
+      ...block(112, 300), // warmup
+      ...block(165, 240), // work 1
+      ...block(120, 180), // recovery 1
+      ...block(165, 240), // work 2
+      ...block(120, 180), // recovery 2
+      ...block(165, 240), // work 3
+      ...block(120, 180), // recovery 3
+      ...block(165, 240), // work 4
+      ...block(105, 300) // cooldown
+    ]
+    const time = heartrate.map((_, index) => index)
+
+    // Athlete profile max HR, not this session's own max.
+    const threshold = resolveHrWorkThreshold({ maxHr: 190 })
+    expect(threshold).toBeCloseTo(133, 5)
+
+    const intervals = detectIntervals(time, heartrate, 'heartrate', threshold)
+
+    expect(intervals.length).toBeGreaterThan(1)
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'COOLDOWN'
+    ])
+
+    const workIntervals = intervals.filter((interval) => interval.type === 'WORK')
+    expect(workIntervals).toHaveLength(4)
+    workIntervals.forEach((interval) => {
+      expect(interval.avg_heartrate).toBeGreaterThan(threshold!)
+      // Nowhere near the full session length (2100s) — no mega-interval.
+      expect(interval.duration).toBeLessThan(300)
+    })
+
+    intervals
+      .filter((interval) => interval.type === 'RECOVERY')
+      .forEach((interval) => {
+        expect(interval.avg_heartrate).toBeLessThan(threshold!)
+      })
+  })
+
+  it('classifies a long steady HR session with no candidates as STEADY', () => {
+    const heartrate = Array.from({ length: 2400 }, (_, index) => 122 + (index % 3))
+    const time = heartrate.map((_, index) => index)
+
+    const threshold = resolveHrWorkThreshold({ maxHr: 190 })
+    const intervals = detectIntervals(time, heartrate, 'heartrate', threshold)
+
+    expect(intervals).toHaveLength(1)
+    expect(intervals[0]?.type).toBe('STEADY')
+    expect(intervals[0]?.duration).toBe(2399)
+  })
+
+  it('classifies a long steady power session with no candidates as STEADY', () => {
+    const watts = Array.from({ length: 2400 }, (_, index) => 130 + (index % 5))
+    const time = watts.map((_, index) => index)
+
+    const intervals = detectIntervals(time, watts, 'power', 250)
+
+    expect(intervals).toHaveLength(1)
+    expect(intervals[0]?.type).toBe('STEADY')
+  })
+})
+
+describe('resolveHrWorkThreshold', () => {
+  it('prefers LTHR, then max HR, and only then the session max as a last resort', () => {
+    expect(resolveHrWorkThreshold({ lthr: 160, maxHr: 190, sessionMaxHr: 175 })).toBeCloseTo(
+      160 * 0.82,
+      5
+    )
+    expect(resolveHrWorkThreshold({ lthr: null, maxHr: 190, sessionMaxHr: 175 })).toBeCloseTo(
+      190 * 0.7,
+      5
+    )
+    expect(resolveHrWorkThreshold({ sessionMaxHr: 175 })).toBeCloseTo(175 * 0.7, 5)
+    expect(resolveHrWorkThreshold({})).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Fixes CW-383

## Problem

HR-based interval detection could not segment anything. Callers passed `maxHr * 0.7` as the `threshold` argument, and `detectIntervals` multiplied every non-power threshold by `0.65` again — putting the work bar at `maxHr * 0.7 * 0.65` ≈ **45.5% of max HR**, below easy-jog HR. Every sample read as "work" and the merge pass welded the whole session into one giant interval.

Two related defects in the same path:
- The `maxHr` both HR callers used was `workout.maxHr` — that single session's own max, not the athlete's profile max — so the bar was self-referential and drifted workout to workout.
- The "long steady session, no candidates" special case pushed `type: 'WORK'` despite its own comment (and the `Interval['type']` union) saying `'STEADY'`, so every steady endurance ride/run counted as one work rep downstream.

## Threshold contract (chosen: option b)

**Callers pass the FINAL HR work bar in bpm; `detectIntervals` applies no additional multiplier for heart rate.** Documented in a block comment on `detectIntervals` and inline at the `workThreshold` calculation.

Why (b) over (a): the two HR call sites that are *outside* this ticket's owned paths (`server/api/workouts/[id]/streams.get.ts`, `server/api/share/workouts/[token]/intervals.get.ts`) already pass `maxHr * 0.7`. Under contract (b) that value becomes exactly right — a 70%-of-max-HR work bar — so those endpoints are fixed with zero edits and zero conflict surface. Under contract (a) they would have needed edits outside the ticket's scope to avoid a *new* miscalculation. `detectIntervals` also cannot tell whether an HR reference it receives is LTHR or max HR, so pushing the physiological scaling to one named helper is the less ambiguous contract.

Power (`0.7 * FTP`) and pace (`0.65 * baseline`) are unchanged — CW-384 owns pace logic in `workout-analysis-facts.ts` and nothing pace-related was touched.

## Changes

- `server/utils/interval-detection.ts`
  - New exported `resolveHrWorkThreshold({ lthr, maxHr, sessionMaxHr })` plus the named constants `HR_WORK_BAR_FRACTION_OF_LTHR` (0.82) and `HR_WORK_BAR_FRACTION_OF_MAX_HR` (0.7). Preference order LTHR → profile max HR → session max HR, the last documented as an explicit last resort.
  - `workThreshold` no longer discounts a heart-rate threshold; contract documented so it does not regress.
  - The long-steady special case now emits `type: 'STEADY'`.
- `server/api/workouts/[id]/intervals.get.ts` — HR branch resolves LTHR/max HR from `sportSettingsRepository.getForActivityType()` for the workout's activity type, falling back to the user record; `workout.maxHr` is only the last-resort fallback. Added `lthr` to the user selection.
- `server/utils/workout-analysis-facts.ts` — HR branch of `buildDetectedIntervals` only: same profile-sourced resolution via `resolveHrWorkThreshold`. No other line in the file touched.
- `server/utils/performance-metrics.ts` — `calculateStabilityMetrics` now includes `STEADY` alongside `WORK`. Direct consequence of the type fix: CoV of a steady block is exactly the number a steady session cares about, and it would otherwise have silently disappeared from the response.
- `tests/unit/server/utils/interval-detection.test.ts` — four new tests (HR interval session segments into 4 WORK + 3 RECOVERY against a profile-sourced bar instead of one mega-interval; long steady HR session returns STEADY; long steady power session returns STEADY; `resolveHrWorkThreshold` preference order).

## STEADY-type consequence grep

- `performance-metrics.ts` `calculateStabilityMetrics` — would have silently dropped steady sessions. Fixed here.
- `workout-analysis-facts.ts` `mapIntervalsToActual` classifies by substring (anything not rest/recovery/warm/cool is `work`), so `STEADY` still classifies as `work`; `getActualHardRepeats` and `scoreIntervalStructure` read that classification, not the raw type — unaffected.
- `interval-detection.ts` `calculateRecoveryRateTrend` filters `type === 'WORK'`; a whole-session STEADY block has no post-interval recovery window, so excluding it is correct.

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server/utils/interval-detection.test.ts
```

```
$ NODE_OPTIONS='--max-old-space-size=8192' nuxt typecheck --checker=vue-tsc
[sidebase-auth] ✔ nuxt-auth setup done
[nuxt:icon] ✔ Nuxt Icon discovered local-installed 6 collections
$ vitest run tests/unit/server/utils/interval-detection.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
EXIT=0
```

`tests/unit/server/utils/performance-metrics.test.ts` and `workout-analysis-enqueue.test.ts` also run green (15 passed).
