### PR TITLE
fix(workouts): pass real thresholdPace and sportSettings refs to interval detection (CW-384)

### DIFF
--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -2,6 +2,7 @@ import { defineEventHandler, createError, getRouterParam, getQuery } from 'h3'
 import { getServerSession } from '../../../utils/session'
 import { prisma } from '../../../utils/db'
 import { attachStreamToWorkout } from '../../../utils/repositories/workoutStreamRepository'
+import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import { calculateRollingNormalizedPower } from '../../../utils/power-metrics'
 import {
   detectIntervals,
@@ -14,7 +15,6 @@ import {
   resolveProviderIntervalTypes,
   resolveHrWorkThreshold
 } from '../../../utils/interval-detection'
-import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import {
   calculateWPrimeBalance,
   calculateEfficiencyFactorDecay,
@@ -129,6 +129,13 @@ export default defineEventHandler(async (event) => {
 
   const workout = await attachStreamToWorkout(workoutRecord)
 
+  // Athlete-level reference values (FTP / max HR / threshold pace) for the sport of this
+  // workout. Detection needs these so work reps can be separated from recovery blocks.
+  const sportSettings = await sportSettingsRepository.getForActivityType(
+    user.id,
+    workout.type || ''
+  )
+
   // Check if workout has stream data
   if (!workout.streams) {
     console.log(`[Intervals API] Workout ${workoutId} has no streams relation`)
@@ -174,7 +181,10 @@ export default defineEventHandler(async (event) => {
   const hasHr = !!(hrStream && hrStream.length > 0)
   const hasCadence = !!(cadenceStream && cadenceStream.length > 0)
 
-  const calculationFtp = workout.ftp || user?.ftp || 250
+  const calculationFtp = workout.ftp || sportSettings?.ftp || user?.ftp || 250
+  // Threshold pace is stored in m/s (same convention as calculatePaceZones), so it can be
+  // handed to the detection engine directly as the pace work/recovery reference.
+  const calculationThresholdPace = Number(sportSettings?.thresholdPace || 0) || undefined
 
   // 1. INTERVAL DETECTION LOGIC
 
@@ -242,21 +252,18 @@ export default defineEventHandler(async (event) => {
       time,
       velocityStream!,
       'pace',
-      undefined,
+      calculationThresholdPace,
       plannedSteps,
       undefined,
       cadenceStream || undefined
     )
   } else if (hasHr) {
     autoDetectionMetric = 'heartrate'
-    // Source the reference from the athlete's PROFILE. Using this workout's own
-    // max HR would make the bar self-referential and drift session to session,
-    // so it is only reached as an explicit last resort inside
-    // `resolveHrWorkThreshold` when the profile carries neither LTHR nor max HR.
-    const sportSettings = await sportSettingsRepository.getForActivityType(
-      user.id,
-      String(workout.type || '')
-    )
+    // Source the reference from the athlete's PROFILE (the `sportSettings`
+    // already loaded above, then the user record). Using this workout's own max
+    // HR would make the bar self-referential and drift session to session, so it
+    // is only reached as an explicit last resort inside `resolveHrWorkThreshold`
+    // when the profile carries neither LTHR nor max HR.
     const threshold = resolveHrWorkThreshold({
       lthr: sportSettings?.lthr ?? user.lthr,
       maxHr: sportSettings?.maxHr ?? user.maxHr,
@@ -426,6 +433,7 @@ export default defineEventHandler(async (event) => {
       plannedRaw: planned,
       plannedTitle: workout.plannedWorkout?.title || null,
       calculationFtp,
+      calculationThresholdPace: calculationThresholdPace ?? null,
       autoDetectionMetric
     }
 

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildWorkoutAnalysisFacts,
   buildWorkoutAnalysisFactsV2,
+  getActualIntervalsForAnalysis,
   getActualIntervalsSourceForAnalysis
 } from './workout-analysis-facts'
 
@@ -904,5 +905,63 @@ describe('buildWorkoutAnalysisFacts', () => {
     )
     expect(facts.performanceSignals.decoupling.interpretable).toBe(false)
     expect(facts.guardrails.suppressions.join(' ')).toContain('Stop-and-go motion pattern')
+  })
+})
+
+describe('run pace interval detection refs (CW-384)', () => {
+  const thresholdPace = 4.0 // m/s, as stored on sportSettings.thresholdPace
+  const velocity = [
+    ...Array.from({ length: 600 }, () => 2.3), // warmup
+    ...Array.from({ length: 5 }, () => [
+      ...Array.from({ length: 180 }, () => 4.3), // rep at ~108% of threshold pace
+      ...Array.from({ length: 180 }, () => 2.4) // recovery jog at 60% of threshold pace
+    ]).flat(),
+    ...Array.from({ length: 300 }, () => 2.2) // cooldown
+  ]
+
+  const runWorkout = makeWorkout({
+    title: '5 x 3min Threshold Run',
+    type: 'Run',
+    durationSec: velocity.length,
+    averageWatts: null,
+    averageSpeed: 3.1,
+    streams: {
+      time: velocity.map((_, index) => index),
+      velocity
+    }
+  })
+
+  it('splits reps from recovery jogs when sport-settings refs carry a real threshold pace', () => {
+    const intervals = getActualIntervalsForAnalysis(runWorkout, undefined, {
+      ftp: 0,
+      lthr: 0,
+      maxHr: 0,
+      thresholdPace
+    })
+
+    expect(intervals.filter((interval) => interval.classification === 'work')).toHaveLength(5)
+    expect(intervals.filter((interval) => interval.type === 'RECOVERY')).toHaveLength(4)
+  })
+
+  it('collapses the same run into one block when no threshold pace reference exists', () => {
+    // Documents the pre-fix behaviour: with thresholdPace 0 the detection engine falls back to
+    // 0.65 * median(stream), which a recovery jog clears, so nothing separates the reps.
+    const intervals = getActualIntervalsForAnalysis(runWorkout, undefined, {
+      ftp: 0,
+      lthr: 0,
+      maxHr: 0,
+      thresholdPace: 0
+    })
+
+    expect(intervals.filter((interval) => interval.classification === 'work')).toHaveLength(1)
+  })
+
+  it('reads the threshold pace from sport settings when refs are not passed explicitly', () => {
+    const intervals = getActualIntervalsForAnalysis({
+      ...runWorkout,
+      sportSettings: { thresholdPace }
+    })
+
+    expect(intervals.filter((interval) => interval.classification === 'work')).toHaveLength(5)
   })
 })

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1135,6 +1135,34 @@ type PlannedStepMetric = MetricTarget
 
 export type ActualIntervalForAnalysis = ActualInterval
 
+/**
+ * Resolve the reference values (FTP / LTHR / max HR / threshold pace) used by
+ * interval detection and source arbitration.
+ *
+ * Callers that already hold the athlete's sport settings (e.g.
+ * `buildWorkoutAnalysisFactsV2`) should always pass `refs` — those are the
+ * profile-level references. The fallback below only exists for the exported
+ * helpers that are still called from scripts/tasks without sport settings.
+ *
+ * Note on `workout.maxHr`: that is the SESSION max HR recorded for this single
+ * activity, not the athlete's profile max, so it is deliberately the last
+ * resort — it is only used when no profile value is available at all.
+ */
+function resolveAnalysisRefs(workout: any, refs?: AnalysisRefs): AnalysisRefs {
+  if (refs) return refs
+
+  return {
+    ftp: Number(workout?.sportSettings?.ftp || workout?.user?.ftp || workout?.ftp || 0),
+    lthr: Number(workout?.sportSettings?.lthr || workout?.user?.lthr || 0),
+    // Profile max HR first; session max HR (`workout.maxHr`) only as a last-resort fallback.
+    maxHr: Number(workout?.sportSettings?.maxHr || workout?.user?.maxHr || workout?.maxHr || 0),
+    thresholdPace: Number(workout?.sportSettings?.thresholdPace || 0),
+    hrZones: workout?.sportSettings?.hrZones || [],
+    powerZones: workout?.sportSettings?.powerZones || [],
+    paceZones: workout?.sportSettings?.paceZones || []
+  }
+}
+
 function getPromptFactValueByPath(value: unknown, path: string) {
   return path.split('.').reduce<unknown>((acc, key) => {
     if (!acc || typeof acc !== 'object') return undefined
@@ -1598,7 +1626,12 @@ function resolveComparableTargetValue(
   return planned.targetValue
 }
 
-function buildDetectedIntervals(workout: any, plannedWorkout?: any): ActualInterval[] {
+function buildDetectedIntervals(
+  workout: any,
+  plannedWorkout?: any,
+  refsInput?: AnalysisRefs
+): ActualInterval[] {
+  const refs = resolveAnalysisRefs(workout, refsInput)
   const time = asNumberArray(workout?.streams?.time)
   const power = asNumberArray(workout?.streams?.watts)
   const velocity = asNumberArray(workout?.streams?.velocity)
@@ -1625,24 +1658,37 @@ function buildDetectedIntervals(workout: any, plannedWorkout?: any): ActualInter
     velocity.length > 0 &&
     family === 'run'
   ) {
-    detected = detectIntervals(time, velocity, 'pace', undefined, plannedSteps, undefined, cadence)
+    // Threshold pace is stored in m/s (same convention as calculatePaceZones), so it can be
+    // handed to the detection engine directly as the work/recovery reference.
+    const thresholdPace = Number(refs.thresholdPace || 0) || undefined
+    detected = detectIntervals(
+      time,
+      velocity,
+      'pace',
+      thresholdPace,
+      plannedSteps,
+      undefined,
+      cadence
+    )
   } else if (time.length > 0 && power.length === time.length && power.length > 0) {
     detected = detectIntervals(
       time,
       power,
       'power',
-      Number(workout?.ftp || 0) || undefined,
+      Number(refs.ftp || workout?.ftp || 0) || undefined,
       plannedSteps,
       undefined,
       cadence
     )
   } else if (time.length > 0 && hr.length === time.length && hr.length > 0) {
-    // Profile-sourced reference (sportSettings, then the user record). This
+    // Profile-sourced reference, taken from the resolved analysis refs
+    // (sportSettings, then the user record) rather than off the workout object,
+    // which carries no user/sportSettings relation in the analysis path. This
     // workout's own max HR is only an explicit last-resort fallback — a bar
     // derived from it is self-referential and drifts session to session.
     const hrWorkThreshold = resolveHrWorkThreshold({
-      lthr: workout?.sportSettings?.lthr ?? workout?.user?.lthr,
-      maxHr: workout?.sportSettings?.maxHr ?? workout?.user?.maxHr,
+      lthr: refs.lthr,
+      maxHr: refs.maxHr,
       sessionMaxHr: workout?.maxHr
     })
     detected = detectIntervals(
@@ -1831,17 +1877,22 @@ function hasTerminalRecoveryPhase(workout: any, plannedWorkout: any, refs: Analy
     return true
   }
 
-  const lastActualInterval = extractActualIntervals(workout, plannedWorkout).at(-1)
+  const lastActualInterval = extractActualIntervals(workout, plannedWorkout, refs).at(-1)
   return Boolean(
     lastActualInterval?.classification === 'recovery' &&
     (lastActualInterval.durationSeconds || 0) >= 120
   )
 }
 
-function extractActualIntervals(workout: any, plannedWorkout?: any): ActualInterval[] {
+function extractActualIntervals(
+  workout: any,
+  plannedWorkout?: any,
+  refsInput?: AnalysisRefs
+): ActualInterval[] {
+  const refs = resolveAnalysisRefs(workout, refsInput)
   const rawIntervals = getRawIntervals(workout)
   const rawActual = mapProviderIntervalsToActual(rawIntervals)
-  const detectedActual = buildDetectedIntervals(workout, plannedWorkout)
+  const detectedActual = buildDetectedIntervals(workout, plannedWorkout, refs)
 
   if (rawActual.length === 0) return detectedActual
   if (detectedActual.length === 0) return rawActual
@@ -1850,22 +1901,11 @@ function extractActualIntervals(workout: any, plannedWorkout?: any): ActualInter
     getStructuredSteps(
       plannedWorkout?.structuredWorkout || workout?.plannedWorkout?.structuredWorkout
     ),
-    {
-      ftp: Number(workout?.ftp || 0),
-      lthr: 0,
-      maxHr: Number(workout?.maxHr || 0),
-      thresholdPace: 0
-    }
+    refs
   )
 
   if (plannedSteps.length === 0) return rawActual
 
-  const refs = {
-    ftp: Number(workout?.ftp || 0),
-    lthr: 0,
-    maxHr: Number(workout?.maxHr || 0),
-    thresholdPace: 0
-  }
   const source = chooseActualIntervalsSource(rawActual, detectedActual, plannedSteps, refs)
   return source === 'detected' ? detectedActual : rawActual
 }
@@ -1880,18 +1920,21 @@ export function getPlannedWorkIntervalsForAnalysis(
 
 export function getActualIntervalsForAnalysis(
   workout: any,
-  plannedWorkout?: any
+  plannedWorkout?: any,
+  refs?: AnalysisRefs
 ): ActualIntervalForAnalysis[] {
-  return extractActualIntervals(workout, plannedWorkout)
+  return extractActualIntervals(workout, plannedWorkout, refs)
 }
 
 export function getActualIntervalsSourceForAnalysis(
   workout: any,
-  plannedWorkout?: any
+  plannedWorkout?: any,
+  refsInput?: AnalysisRefs
 ): 'raw' | 'detected' | 'none' {
+  const refs = resolveAnalysisRefs(workout, refsInput)
   const rawIntervals = getRawIntervals(workout)
   const rawActual = mapProviderIntervalsToActual(rawIntervals)
-  const detectedActual = buildDetectedIntervals(workout, plannedWorkout)
+  const detectedActual = buildDetectedIntervals(workout, plannedWorkout, refs)
 
   if (rawActual.length === 0) return detectedActual.length > 0 ? 'detected' : 'none'
   if (detectedActual.length === 0) return 'raw'
@@ -1900,27 +1943,20 @@ export function getActualIntervalsSourceForAnalysis(
     getStructuredSteps(
       plannedWorkout?.structuredWorkout || workout?.plannedWorkout?.structuredWorkout
     ),
-    {
-      ftp: Number(workout?.ftp || 0),
-      lthr: 0,
-      maxHr: Number(workout?.maxHr || 0),
-      thresholdPace: 0
-    }
+    refs
   )
 
   if (plannedSteps.length === 0) return 'raw'
 
-  const refs = {
-    ftp: Number(workout?.ftp || 0),
-    lthr: 0,
-    maxHr: Number(workout?.maxHr || 0),
-    thresholdPace: 0
-  }
   return chooseActualIntervalsSource(rawActual, detectedActual, plannedSteps, refs)
 }
 
-export function formatActualIntervalsForPrompt(workout: any, plannedWorkout?: any): string {
-  const intervals = getActualIntervalsForAnalysis(workout, plannedWorkout)
+export function formatActualIntervalsForPrompt(
+  workout: any,
+  plannedWorkout?: any,
+  refs?: AnalysisRefs
+): string {
+  const intervals = getActualIntervalsForAnalysis(workout, plannedWorkout, refs)
   if (intervals.length === 0) return 'N/A'
 
   return intervals
@@ -1955,6 +1991,7 @@ function classifyArchetype(params: {
   powerSourceType: PowerSourceType
   hrUsable: boolean
   motionPattern: MotionPattern
+  refs: AnalysisRefs
 }): WorkoutAnalysisFactsV2['guardrails']['archetype'] {
   const {
     workout,
@@ -1964,20 +2001,19 @@ function classifyArchetype(params: {
     plannedWorkout,
     powerSourceType,
     hrUsable,
-    motionPattern
+    motionPattern,
+    refs
   } = params
   const rationale: string[] = []
   const titleContext = `${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
   const virtualContext =
     `${workout?.source || ''} ${workout?.type || ''} ${workout?.deviceName || ''} ${workout?.title || ''} ${workout?.description || ''}`.toLowerCase()
-  const plannedSteps = flattenPlannedSteps(getStructuredSteps(plannedWorkout?.structuredWorkout), {
-    ftp: Number(workout?.ftp || 0),
-    lthr: 0,
-    maxHr: 0,
-    thresholdPace: 0
-  })
+  const plannedSteps = flattenPlannedSteps(
+    getStructuredSteps(plannedWorkout?.structuredWorkout),
+    refs
+  )
   const workSteps = plannedSteps.filter((step) => step.classification === 'work')
-  const actualIntervals = extractActualIntervals(workout, plannedWorkout)
+  const actualIntervals = extractActualIntervals(workout, plannedWorkout, refs)
   const intervalCount = actualIntervals.filter(
     (interval) => interval.classification === 'work'
   ).length
@@ -2285,7 +2321,7 @@ function deriveDurabilitySignals(params: {
   workout: any
   family: ReturnType<typeof getWorkoutFamily>
   plannedWorkout?: any
-  refs: { ftp: number; lthr: number; maxHr: number; thresholdPace: number }
+  refs: AnalysisRefs
 }): WorkoutAnalysisFactsV2['performanceSignals']['durability'] {
   const { workout, family, plannedWorkout, refs } = params
   const time = asNumberArray(workout?.streams?.time)
@@ -2293,7 +2329,7 @@ function deriveDurabilitySignals(params: {
   const hr = asNumberArray(workout?.streams?.heartrate)
   const speed = asNumberArray(workout?.streams?.velocity)
   const cadence = asNumberArray(workout?.streams?.cadence)
-  const actualIntervals = extractActualIntervals(workout, plannedWorkout).filter(
+  const actualIntervals = extractActualIntervals(workout, plannedWorkout, refs).filter(
     (interval) => interval.classification === 'work'
   )
   const suppressLateFade = hasTerminalRecoveryPhase(workout, plannedWorkout, refs)
@@ -2509,7 +2545,7 @@ function deriveAdherence(params: {
   workout: any
   plannedWorkout: any
   family: ReturnType<typeof getWorkoutFamily>
-  refs: { ftp: number; lthr: number; maxHr: number; thresholdPace: number }
+  refs: AnalysisRefs
   metricOrder?: PlannedStepMetric[] | null
 }): WorkoutAnalysisFactsV2['adherence'] {
   const { workout, plannedWorkout, family, refs, metricOrder } = params
@@ -2543,7 +2579,7 @@ function deriveAdherence(params: {
     refs,
     metricOrder
   )
-  const actualIntervals = extractActualIntervals(workout, plannedWorkout)
+  const actualIntervals = extractActualIntervals(workout, plannedWorkout, refs)
   const plannedWork = plannedSteps.filter((step) => step.classification === 'work')
   const plannedRecovery = plannedSteps.filter((step) => step.classification === 'recovery')
   const actualWork = actualIntervals.filter((step) => step.classification === 'work')
@@ -3086,6 +3122,21 @@ export function buildWorkoutAnalysisFactsV2({
     hasPace,
     hasRpe: Boolean(rpe)
   })
+  // Reference values come from the athlete's sport settings (profile-level), not from the
+  // session row. They are resolved before archetype/interval work so every downstream
+  // consumer — including interval detection and raw-vs-detected arbitration — sees the
+  // same real FTP / LTHR / max HR / threshold pace instead of zeroed placeholders.
+  const refs: AnalysisRefs = {
+    ftp: Number(sportSettings?.ftp || workout?.ftp || 0),
+    lthr: Number(sportSettings?.lthr || 0),
+    // Profile max HR only; `workout.maxHr` is this session's max and would understate a
+    // fitter athlete's true ceiling, so it is not used as a stand-in here.
+    maxHr: Number(sportSettings?.maxHr || 0),
+    thresholdPace: Number(sportSettings?.thresholdPace || 0),
+    hrZones: sportSettings?.hrZones || [],
+    powerZones: sportSettings?.powerZones || [],
+    paceZones: sportSettings?.paceZones || []
+  }
   const warmupExcludedMinutes = clamp(Number(sportSettings?.warmupTime || 10), 10, 15)
   const erg = detectErg(workout, plannedWorkout)
   const lrBalance = deriveLrBalance(workout)
@@ -3098,7 +3149,8 @@ export function buildWorkoutAnalysisFactsV2({
     plannedWorkout,
     powerSourceType,
     hrUsable: hrStats.usable,
-    motionPattern
+    motionPattern,
+    refs
   })
   const decoupling = deriveDecouplingV2({
     workout,
@@ -3129,16 +3181,6 @@ export function buildWorkoutAnalysisFactsV2({
     suppressedMetrics.push(
       'Stop-and-go motion pattern detected; do not criticize lack of constant pace or invent steady-state drift narratives.'
     )
-
-  const refs = {
-    ftp: Number(sportSettings?.ftp || workout?.ftp || 0),
-    lthr: Number(sportSettings?.lthr || 0),
-    maxHr: Number(sportSettings?.maxHr || 0),
-    thresholdPace: Number(sportSettings?.thresholdPace || 0),
-    hrZones: sportSettings?.hrZones || [],
-    powerZones: sportSettings?.powerZones || [],
-    paceZones: sportSettings?.paceZones || []
-  }
 
   const adherence = deriveAdherence({
     workout,

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -181,6 +181,46 @@ describe('resolveHrWorkThreshold', () => {
     expect(resolveHrWorkThreshold({ sessionMaxHr: 175 })).toBeCloseTo(175 * 0.7, 5)
     expect(resolveHrWorkThreshold({})).toBeUndefined()
   })
+
+  it('separates run work reps from recovery jogs when the real threshold pace is supplied', () => {
+    // Threshold pace in m/s (same unit the app stores sportSettings.thresholdPace in).
+    const thresholdPace = 4.0
+    const workPace = 4.3 // ~108% of threshold — a typical rep pace
+    const recoveryPace = 2.4 // 60% of threshold — an easy recovery jog
+    const warmupPace = 2.3
+    const cooldownPace = 2.2
+
+    const velocity = [
+      ...Array.from({ length: 600 }, () => warmupPace),
+      ...Array.from({ length: 5 }, () => [
+        ...Array.from({ length: 180 }, () => workPace),
+        ...Array.from({ length: 180 }, () => recoveryPace)
+      ]).flat(),
+      ...Array.from({ length: 300 }, () => cooldownPace)
+    ]
+    const time = velocity.map((_, index) => index)
+
+    const withThreshold = detectIntervals(time, velocity, 'pace', thresholdPace)
+    const workIntervals = withThreshold.filter((interval) => interval.type === 'WORK')
+
+    expect(workIntervals).toHaveLength(5)
+    for (const interval of workIntervals) {
+      expect(interval.duration).toBeGreaterThan(150)
+      expect(interval.duration).toBeLessThan(210)
+      expect(interval.avg_pace || 0).toBeGreaterThan(4)
+    }
+    // The gaps between reps must come back as recovery, not be swallowed into the reps.
+    expect(withThreshold.filter((interval) => interval.type === 'RECOVERY')).toHaveLength(4)
+    expect(withThreshold[0]?.type).toBe('WARMUP')
+    expect(withThreshold.at(-1)?.type).toBe('COOLDOWN')
+
+    // Regression guard: this is what the pace branch used to do (CW-384). Without a threshold
+    // the engine falls back to 0.65 * median(stream); the median here sits at recovery pace, so
+    // the work bar lands at ~1.6 m/s and the entire run collapses into a single "work" block.
+    const withoutThreshold = detectIntervals(time, velocity, 'pace', undefined)
+    expect(withoutThreshold.filter((interval) => interval.type === 'WORK')).toHaveLength(1)
+    expect(withoutThreshold.filter((interval) => interval.type === 'RECOVERY')).toHaveLength(0)
+  })
 })
 
 describe('resolveProviderIntervalTypes', () => {


### PR DESCRIPTION
Fixes CW-384

## What

1. **Pace detection now gets a real threshold.** `buildDetectedIntervals` (server/utils/workout-analysis-facts.ts) and the pace branch of `server/api/workouts/[id]/intervals.get.ts` passed `threshold=undefined` for every `'pace'` call, so the engine fell back to `0.65 * median(stream)` as the work bar. Both now pass `sportSettings.thresholdPace` (m/s, same convention as `calculatePaceZones`). The intervals API now loads sport settings via `sportSettingsRepository.getForActivityType`, mirroring how the power branch sources FTP.

2. **Source arbitration no longer runs on zeroed refs.** `extractActualIntervals` and `getActualIntervalsSourceForAnalysis` each rebuilt `{ ftp: workout.ftp, lthr: 0, maxHr: workout.maxHr, thresholdPace: 0 }` internally. They now accept an optional `AnalysisRefs` parameter; `buildWorkoutAnalysisFactsV2` builds its sportSettings-derived refs earlier and threads them through `classifyArchetype`, `deriveAdherence`, `deriveDurabilitySignals`, `hasTerminalRecoveryPhase` and the detection call. A `resolveAnalysisRefs` helper keeps the existing 2-arg exported signatures working for script/task callers (trigger, cli/debug, scripts) and derives refs from `workout.sportSettings` / `workout.user` when none are passed.

3. **Session max HR demoted.** `workout.maxHr` is the max HR of that one activity, not the athlete's profile max. Everywhere touched, the profile value (`sportSettings.maxHr` / `user.maxHr`) is preferred and the session value is an explicitly commented last-resort fallback.

`server/utils/interval-detection.ts` is untouched (CW-383 owns the engine internals).

## Tests

- `tests/unit/server/utils/interval-detection.test.ts`: synthetic 5 x 3min run at ~108% of threshold pace with recovery jogs between them. With the real threshold it returns 5 WORK + 4 RECOVERY segments; the same stream with `threshold=undefined` collapses into a single WORK block (the pre-fix behaviour, kept as a regression guard).
- `server/utils/workout-analysis-facts.test.ts`: the same stream through `getActualIntervalsForAnalysis` — 5 work reps with refs carrying `thresholdPace`, 1 block with zeroed refs, and 5 again when the threshold is only reachable via `workout.sportSettings` (fallback resolver).

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server/utils/interval-detection.test.ts server/utils/workout-analysis-facts.test.ts
# typecheck: exit 0
# Test Files 2 passed (2) / Tests 35 passed (35)
```

Full unit suite also green: 369 files / 2122 tests. `pnpm lint`: 0 errors.

## Note for CW-383

The engine's work bar for non-power metrics is `0.65 * threshold`, so a recovery jog at 70% of threshold pace still clears it even with the correct threshold passed — separation only kicks in below ~65%. Raising/parameterising that factor lives inside `interval-detection.ts` and was deliberately left to CW-383.