### PR TITLE
fix(workouts): time-weight peak effort averages and keep pace precision (CW-390)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -795,6 +795,94 @@ function detectIntervalsFromPlannedSteps(
   return intervals.filter((interval) => interval.duration > 0)
 }
 
+/** A gap has to be at least this long before it can count as a recording pause. */
+export const MIN_PAUSE_GAP_SEC = 30
+
+/** ...and also this many times the stream's typical sample spacing. */
+const PAUSE_GAP_MULTIPLE = 4
+
+/**
+ * Seconds after which a gap between two consecutive samples is a recording
+ * pause rather than a slow sample rate.
+ *
+ * Derived from the stream itself so that files recorded at 1Hz, with Garmin
+ * "smart recording", or at a fixed coarse interval are all judged against their
+ * own normal spacing instead of a single hardcoded number.
+ */
+export function estimatePauseGapSeconds(times: number[]): number {
+  const gaps: number[] = []
+  for (let i = 1; i < times.length; i++) {
+    const current = times[i]
+    const previous = times[i - 1]
+    if (!Number.isFinite(current) || !Number.isFinite(previous)) continue
+    const delta = (current as number) - (previous as number)
+    if (delta > 0) gaps.push(delta)
+  }
+
+  if (gaps.length === 0) return MIN_PAUSE_GAP_SEC
+
+  gaps.sort((a, b) => a - b)
+  const median = gaps[Math.floor(gaps.length / 2)] ?? 1
+  return Math.max(MIN_PAUSE_GAP_SEC, median * PAUSE_GAP_MULTIPLE)
+}
+
+/**
+ * Elapsed time, in seconds, that the sample at `index` represents when
+ * averaging over time. A recorded sample describes the interval since the
+ * previous sample, so its weight is that gap.
+ *
+ * Returns 0 for the first sample (it is the left boundary of a range and covers
+ * no time), for missing/non-monotonic timestamps, and for gaps that exceed
+ * `pauseGapSeconds` — those are recording pauses, and the value recorded when
+ * the athlete started again says nothing about the time they were stopped.
+ */
+export function sampleWeightSeconds(
+  times: number[],
+  index: number,
+  pauseGapSeconds: number = MIN_PAUSE_GAP_SEC
+): number {
+  if (index <= 0) return 0
+  const current = times[index]
+  const previous = times[index - 1]
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return 0
+  const delta = (current as number) - (previous as number)
+  if (!(delta > 0) || delta > pauseGapSeconds) return 0
+  return delta
+}
+
+/**
+ * Time-weighted mean of `values` over the inclusive sample range
+ * [`startIndex`, `endIndex`].
+ *
+ * Each sample is weighted by the time it covers instead of counting as one
+ * sample, so streams recorded at anything other than a steady 1Hz — or with
+ * recording pauses in them — average correctly. `startIndex` is the boundary of
+ * the range and contributes no weight; time inside a recording pause is
+ * excluded entirely rather than attributed to the value that follows it.
+ *
+ * Returns `null` when the range covers no elapsed time.
+ */
+export function timeWeightedMean(
+  times: number[],
+  values: number[],
+  startIndex = 0,
+  endIndex = values.length - 1
+): number | null {
+  const pauseGapSeconds = estimatePauseGapSeconds(times)
+  let weightedSum = 0
+  let totalSeconds = 0
+
+  for (let i = Math.max(1, startIndex + 1); i <= endIndex; i++) {
+    const weight = sampleWeightSeconds(times, i, pauseGapSeconds)
+    if (weight <= 0) continue
+    const value = values[i]
+    weightedSum += (Number.isFinite(value) ? (value as number) : 0) * weight
+    totalSeconds += weight
+  }
+
+  return totalSeconds > 0 ? weightedSum / totalSeconds : null
+}
+
 /**
  * Find peak efforts for standard durations (1min, 5min, 20min, etc.)
  */
@@ -804,6 +892,7 @@ export function findPeakEfforts(
   metric: 'power' | 'heartrate' | 'pace'
 ): PeakEffort[] {
   if (!values || values.length === 0) return []
+  if (!times || times.length < 2) return []
 
   const durations = [
     { sec: 5, label: '5s' },
@@ -820,59 +909,65 @@ export function findPeakEfforts(
   // Optimization: Pre-calculate prefix sums for O(1) range sum queries?
   // Since we need max average, a simple sliding window is O(N) per duration.
 
+  const pauseGapSeconds = estimatePauseGapSeconds(times)
+
   for (const dur of durations) {
     const lastTime = times[times.length - 1]
     if (lastTime === undefined || lastTime < dur.sec) continue
 
-    // Find approximate number of data points for this duration
-    // Assuming 1Hz sampling for simplicity, or we check timestamps
-    // Robust approach: Sliding window on time
+    // Sliding window over time. The window is both advanced *and* averaged by
+    // elapsed time: each sample contributes the seconds it covers, so a file
+    // with non-1Hz sampling (or gaps) is not mis-averaged by sample count.
 
-    let maxSum = -Infinity
+    let maxAvg = -Infinity
     let bestStartIdx = -1
     let bestEndIdx = -1
 
-    let currentSum = 0
+    // Weighted sum of value*seconds over (startPtr, endPtr], and the seconds
+    // those samples cover. `startPtr` is the window's left boundary and carries
+    // no weight of its own.
+    let weightedSum = 0
+    let windowSeconds = 0
     let startPtr = 0
 
-    for (let endPtr = 0; endPtr < values.length; endPtr++) {
-      const val = values[endPtr]
-      if (val !== undefined) currentSum += val
+    for (let endPtr = 1; endPtr < values.length; endPtr++) {
+      const weight = sampleWeightSeconds(times, endPtr, pauseGapSeconds)
 
-      // Shrink window from left until duration is approx correct
-      // We want times[endPtr] - times[startPtr] approx dur.sec
-
-      while (times[endPtr] !== undefined && times[startPtr] !== undefined) {
-        const tEnd = times[endPtr]
-        const tStart = times[startPtr]
-        if (tEnd !== undefined && tStart !== undefined && tEnd - tStart > dur.sec) {
-          const startVal = values[startPtr]
-          if (startVal !== undefined) currentSum -= startVal
-          startPtr++
-        } else {
-          break
-        }
+      if (weight <= 0) {
+        // Recording pause (or an unusable timestamp): a peak window may not
+        // span it, so restart the window on the far side of the break.
+        weightedSum = 0
+        windowSeconds = 0
+        startPtr = endPtr
+        continue
       }
 
-      // Check if window is valid duration (close enough)
-      const tEnd = times[endPtr]
-      const tStart = times[startPtr]
+      const val = values[endPtr]
+      weightedSum += (Number.isFinite(val) ? (val as number) : 0) * weight
+      windowSeconds += weight
 
-      if (tEnd !== undefined && tStart !== undefined) {
-        const windowDuration = tEnd - tStart
-        if (windowDuration >= dur.sec * 0.95) {
-          // Allow slight tolerance
-          const avg = currentSum / (endPtr - startPtr + 1)
-          if (avg > maxSum) {
-            maxSum = avg
-            bestStartIdx = startPtr
-            bestEndIdx = endPtr
-          }
+      // Shrink from the left until the window is no longer than the target.
+      while (startPtr < endPtr && windowSeconds > dur.sec) {
+        const dropIdx = startPtr + 1
+        const dropWeight = sampleWeightSeconds(times, dropIdx, pauseGapSeconds)
+        const dropVal = values[dropIdx]
+        weightedSum -= (Number.isFinite(dropVal) ? (dropVal as number) : 0) * dropWeight
+        windowSeconds -= dropWeight
+        startPtr = dropIdx
+      }
+
+      // Allow slight tolerance so coarse sampling still yields a peak.
+      if (windowSeconds >= dur.sec * 0.95) {
+        const avg = weightedSum / windowSeconds
+        if (avg > maxAvg) {
+          maxAvg = avg
+          bestStartIdx = startPtr
+          bestEndIdx = endPtr
         }
       }
     }
 
-    if (bestStartIdx !== -1 && bestEndIdx !== -1) {
+    if (bestStartIdx !== -1 && bestEndIdx !== -1 && Number.isFinite(maxAvg)) {
       const startTimeValue = times[bestStartIdx]
       const endTimeValue = times[bestEndIdx]
       if (startTimeValue !== undefined && endTimeValue !== undefined) {
@@ -881,7 +976,9 @@ export function findPeakEfforts(
           duration_label: dur.label,
           start_time: startTimeValue,
           end_time: endTimeValue,
-          value: Math.round(maxSum),
+          // Pace is a velocity in m/s (typically 2-6), so whole-number rounding
+          // would destroy the curve. Watts and bpm stay integers.
+          value: metric === 'pace' ? Math.round(maxAvg * 100) / 100 : Math.round(maxAvg),
           metric
         })
       }

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   detectIntervals,
+  findPeakEfforts,
   resolveHrWorkThreshold,
-  resolveProviderIntervalTypes
+  resolveProviderIntervalTypes,
+  timeWeightedMean
 } from '../../../../server/utils/interval-detection'
 
 describe('detectIntervals', () => {
@@ -294,5 +296,128 @@ describe('resolveProviderIntervalTypes', () => {
       'WORK'
     ])
     expect(resolveProviderIntervalTypes([])).toEqual([])
+  })
+})
+
+/**
+ * A minute of riding recorded at two different rates: 50 seconds sampled every
+ * 10s at 100W, then the last 10 seconds sampled at 1Hz at 400W.
+ *
+ * Time-weighted mean over the minute: (50 * 100 + 10 * 400) / 60 = 150.
+ * Counting samples instead of seconds gives 4600 / 16 = 287.5 — the old bug.
+ */
+function mixedRateMinute() {
+  const times = [0, 10, 20, 30, 40, 50]
+  const values = [100, 100, 100, 100, 100, 100]
+  for (let t = 51; t <= 60; t++) {
+    times.push(t)
+    values.push(400)
+  }
+  return { times, values }
+}
+
+describe('timeWeightedMean', () => {
+  it('weights each sample by the time it covers, not by sample count', () => {
+    const { times, values } = mixedRateMinute()
+    expect(timeWeightedMean(times, values)).toBe(150)
+  })
+
+  it('drops the time spent inside a recording pause', () => {
+    // 60s at 100, a 10 minute pause, then 20s at 400.
+    const times: number[] = []
+    const values: number[] = []
+    for (let t = 0; t <= 59; t++) {
+      times.push(t)
+      values.push(100)
+    }
+    for (let t = 660; t <= 679; t++) {
+      times.push(t)
+      values.push(400)
+    }
+
+    // The paused 600s carries no value at all: only the recorded seconds count
+    // (59 in the first block, 19 in the second — the sample that reopens
+    // recording is a boundary). Charging the pause to the 400W sample that
+    // follows it would give ~372.
+    expect(timeWeightedMean(times, values)).toBeCloseTo((59 * 100 + 19 * 400) / 78, 10)
+  })
+
+  it('returns null when the range covers no elapsed time', () => {
+    expect(timeWeightedMean([5], [250])).toBeNull()
+    expect(timeWeightedMean([], [])).toBeNull()
+  })
+})
+
+describe('findPeakEfforts', () => {
+  it('averages a steady effort to its actual value', () => {
+    const times = Array.from({ length: 400 }, (_, index) => index)
+    const watts = times.map(() => 250)
+
+    const peaks = findPeakEfforts(times, watts, 'power')
+
+    expect(peaks.find((p) => p.duration === 60)?.value).toBe(250)
+    expect(peaks.find((p) => p.duration === 300)?.value).toBe(250)
+    expect(peaks.find((p) => p.duration === 600)).toBeUndefined()
+  })
+
+  it('averages by elapsed time when the sample rate is not 1Hz', () => {
+    const { times, values } = mixedRateMinute()
+
+    const peak = findPeakEfforts(times, values, 'power').find((p) => p.duration === 60)
+
+    // Sample-count averaging reported 288W for this minute.
+    expect(peak?.value).toBe(150)
+    expect(peak?.start_time).toBe(0)
+    expect(peak?.end_time).toBe(60)
+  })
+
+  it('does not let a peak window borrow time from across a recording pause', () => {
+    // 15 minutes at 200W, a 10 minute pause, then 15 minutes at 400W.
+    const times: number[] = []
+    const watts: number[] = []
+    for (let t = 0; t <= 899; t++) {
+      times.push(t)
+      watts.push(200)
+    }
+    for (let t = 1500; t <= 2399; t++) {
+      times.push(t)
+      watts.push(400)
+    }
+
+    const peaks = findPeakEfforts(times, watts, 'power')
+
+    // The best continuous 10 minutes is inside the second block.
+    const peak10m = peaks.find((p) => p.duration === 600)
+    expect(peak10m?.value).toBe(400)
+    expect(peak10m?.start_time).toBeGreaterThanOrEqual(1500)
+    expect(peaks.find((p) => p.duration === 300)?.start_time).toBeGreaterThanOrEqual(1500)
+
+    // No continuous 20 minute effort exists: the activity spans 40 minutes of
+    // wall time but only two 15 minute blocks were recorded. Sample-count
+    // averaging happily reported a 20m peak of 400W here.
+    expect(peaks.find((p) => p.duration === 1200)).toBeUndefined()
+  })
+
+  it('keeps decimal precision for pace peaks and whole numbers for power', () => {
+    const times = Array.from({ length: 301 }, (_, index) => index)
+    // A fast half at 3.42 m/s, then an easy half at 2.61 m/s. Rounded to whole
+    // numbers both collapse to 3, which is what made the pace curve useless.
+    const velocity = times.map((_, index) => (index <= 150 ? 3.42 : 2.61))
+    const watts = times.map((_, index) => 200 + (index % 10))
+
+    const pacePeaks = findPeakEfforts(times, velocity, 'pace')
+    const pacePeak = pacePeaks.find((p) => p.duration === 60)
+    const powerPeak = findPeakEfforts(times, watts, 'power').find((p) => p.duration === 60)
+
+    expect(pacePeak?.metric).toBe('pace')
+    expect(pacePeak?.value).toBe(3.42)
+    expect(pacePeaks.every((p) => Number.isInteger(p.value))).toBe(false)
+
+    expect(powerPeak?.value).toBe(Math.round(powerPeak?.value ?? 0))
+  })
+
+  it('returns nothing for streams that are too short or empty', () => {
+    expect(findPeakEfforts([], [], 'power')).toEqual([])
+    expect(findPeakEfforts([0, 1, 2], [200, 200, 200], 'power')).toEqual([])
   })
 })


### PR DESCRIPTION
Fixes CW-390

## Problem

`findPeakEfforts` advanced its rolling window by timestamp but averaged by sample count (`currentSum / (endPtr - startPtr + 1)`). On any file that is not a clean 1Hz stream — recording pauses, mixed sample rates, smart recording — the sample count no longer matches the window's time span, so reported peaks were inflated (or deflated). Separately, `value: Math.round(maxSum)` quantized `metric: 'pace'` peaks: pace is a velocity in m/s (typically 2-6), so 3.4 and 2.6 m/s both collapsed to `3` and the whole pace peak curve became useless integers.

## Change

Scoped to `findPeakEfforts` plus a small shared helper. `detectIntervals`, `resolveProviderIntervalTypes` and `resolveHrWorkThreshold` are untouched.

New exported helpers in `server/utils/interval-detection.ts`:

- `sampleWeightSeconds(times, index, pauseGapSeconds)` — the elapsed time a sample represents (the gap since the previous sample). Returns 0 for the range boundary, unusable timestamps, and gaps that count as a recording pause.
- `estimatePauseGapSeconds(times)` — derives the pause threshold from the stream's own median sample spacing (`max(30s, 4 × median gap)`), so 1Hz files, smart-recording files and coarse fixed-interval files are each judged against their own normal spacing instead of a hardcoded number.
- `timeWeightedMean(times, values, startIndex?, endIndex?)` — time-weighted mean over a sample range, for reuse.

`findPeakEfforts` now accumulates `value × seconds` and divides by the seconds the window actually covers. A gap large enough to be a recording pause restarts the window, so a peak can no longer borrow elapsed time (or values) from across a break — previously a 40-minute activity made of two 15-minute blocks either side of a 10-minute pause reported a bogus 20-minute peak. Pace peaks keep 2 decimals; power and heart rate stay whole numbers, which is correct for W and bpm.

## Consumers checked

- `server/api/workouts/[id]/intervals.get.ts` and `server/api/share/workouts/[token]/intervals.get.ts` — pass the `peaks` payload straight through; the UI (`app/components/IntervalsAnalysis.vue`) formats pace as `1000 / mps`, so extra precision flows through as a better min/km value with no formatting change needed.
- `server/utils/services/pbDetectionService.ts` — only consumes **power** peaks, which remain integers. No change needed there (and it is outside this ticket's owned paths).
- `server/utils/services/thresholdDetectionService.ts` — consumes HR (integer), power (integer) and pace peaks; the pace path divides `1000 / peak` for threshold pace, so decimals strictly improve it. Its suite (197 tests across `tests/unit/server/utils/services/`) passes unchanged.

## Tests

`tests/unit/server/utils/interval-detection.test.ts` gains:

- time-weighted mean weights by seconds, not sample count (mixed 10s/1s sampling: 150 W, where sample counting gave 287.5 W)
- time inside a recording pause is dropped rather than charged to the sample that reopens recording
- steady 1Hz stream still averages to its exact value (no regression)
- a 15min/pause/15min stream reports the right 10m peak inside the second block and **no** 20m peak — the old code reported a 20m peak of 400 W that never happened
- pace peaks keep 2 decimals (3.42 m/s, not 3) while power peaks stay whole numbers
- empty / too-short streams return `[]`

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server/utils/interval-detection.test.ts
```

Both green: typecheck exits 0, `Test Files 1 passed (1) / Tests 19 passed (19)`. Rebased onto `develop` (includes CW-384 and CW-392) with no conflicts and re-verified after the rebase.

## Follow-up (not done here, deliberately)

`server/utils/workout-analysis-facts.ts` has the same class of bug and can now reuse `timeWeightedMean` / `sampleWeightSeconds`:

- `computeZoneTimesFromSamples` counts each sample as one second regardless of gaps.
- `getTimeAboveThresholdPct` hardcodes `values.slice(3)` as "above threshold", which is wrong for any non-7-zone scheme.

Left untouched because CW-384 had in-flight changes in that file.
