### PR TITLE
fix(ai): stop dividing stored m/s average speed by 3.6 (CW-382)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -40,7 +40,8 @@ const RIDE_WORKOUT = {
   maxHr: 176,
   averageCadence: 88,
   maxCadence: 121,
-  averageSpeed: 32,
+  // m/s, as every sync writer stores it (48000 m / 5400 s = 8.889 m/s).
+  averageSpeed: 8.9,
   tss: 96,
   trainingLoad: 101,
   intensity: 0.9,
@@ -125,7 +126,7 @@ describe('buildWorkoutAnalysisData', () => {
     expect(data.avg_power).toBe(231)
     expect(data.normalized_power).toBe(248)
     expect(data.avg_cadence).toBe(88)
-    expect(data.avg_speed_ms).toBeCloseTo(8.889, 2)
+    expect(data.avg_speed_ms).toBe(8.9)
     // Provider lap labels are re-derived rather than trusted (CW-376).
     expect(data.intervals).toHaveLength(2)
     expect(data.intervals[0].type).toBe('WORK')
@@ -142,6 +143,19 @@ describe('buildWorkoutAnalysisData', () => {
 
     expect(data.avg_cadence).toBe(174)
     expect(data.max_cadence).toBe(190)
+  })
+
+  it('passes the stored m/s average speed through untouched (CW-382)', () => {
+    // Every sync writer persists `averageSpeed` in m/s. The payload used to divide it by
+    // 3.6 as if it were km/h, so a 3.0 m/s run (5:33/km) reached the model as 0.83 m/s.
+    const data = buildWorkoutAnalysisData({
+      type: 'Run',
+      durationSec: 3333,
+      distanceMeters: 10000,
+      averageSpeed: 3.0
+    })
+
+    expect(data.avg_speed_ms).toBe(3.0)
   })
 })
 
@@ -246,6 +260,34 @@ describe('buildWorkoutAnalysisPrompt', () => {
     )
 
     expect(prompt).toMatchSnapshot()
+  })
+
+  it('reports an average speed that agrees with the derived average pace (CW-382)', () => {
+    // The two lines in the "Pace & Speed" block are derived independently: the pace from
+    // distance_m / duration_s, the speed from the stored `averageSpeed` column. They only
+    // agree once the bogus /3.6 conversion is gone.
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-run',
+        date: new Date('2026-03-16T06:00:00Z'),
+        title: 'Steady 10k',
+        type: 'Run',
+        durationSec: 3333,
+        distanceMeters: 10000,
+        averageSpeed: 3.0,
+        averageHr: 152,
+        maxHr: 171
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('## Pace & Speed (Primary Metric)')
+    // 10000 m / 3333 s = 3.0 m/s = 333 s/km = 5:33/km.
+    expect(prompt).toContain('- Average Pace: 5:33/km')
+    expect(prompt).toContain('- Average Speed: 3.00 m/s')
   })
 
   it('respects the athlete distanceUnits preference for strength set distances', () => {

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -116,7 +116,11 @@ export function buildWorkoutAnalysisData(workout: any) {
   }
 
   // Speed
-  if (workout.averageSpeed) data.avg_speed_ms = workout.averageSpeed / 3.6 // km/h to m/s
+  // `workout.averageSpeed` is stored in m/s by every sync writer (Intervals.icu, Strava,
+  // Polar, Rouvy, FIT, Garmin, Wahoo), so it is passed through untouched. This used to be
+  // divided by 3.6 as if it were km/h, which told the model the athlete moved 3.6x slower
+  // than they did -- badly corrupting pace commentary for runs (CW-382).
+  if (workout.averageSpeed) data.avg_speed_ms = workout.averageSpeed
 
   // Training metrics
   if (workout.tss) data.tss = workout.tss

--- a/server/utils/workoutExplorer.ts
+++ b/server/utils/workoutExplorer.ts
@@ -39,6 +39,9 @@ export const workoutExplorerMetricUnits: Record<string, string> = {
   averageHr: 'bpm',
   maxHr: 'bpm',
   averageCadence: 'rpm',
+  // Correct as-is: `Workout.averageSpeed` is stored in m/s, but
+  // `normalizeWorkoutMetricValue` converts it to km/h before it ever reaches a consumer,
+  // so the unit that goes with the emitted value really is km/h (CW-382).
   averageSpeed: 'km/h',
   intensity: '',
   efficiencyFactor: '',
@@ -58,6 +61,7 @@ export function normalizeWorkoutMetricValue(field: string, value: unknown) {
   if (value === null || value === undefined || value === '') return null
   const numeric = Number(value)
   if (Number.isNaN(numeric)) return null
+  // averageSpeed is persisted in m/s; the explorer charts it in km/h.
   if (field === 'averageSpeed') return Number((numeric * 3.6).toFixed(1))
   return numeric
 }


### PR DESCRIPTION
Fixes CW-382

## Problem

`buildWorkoutAnalysisData` divided `workout.averageSpeed` by 3.6 with the comment `// km/h to m/s`, but the column is stored in **m/s** by every sync writer. The model was told the athlete moved 3.6x slower than they did — a 3.0 m/s run (5:33/km) reached it as `Average Speed: 0.84 m/s` (~20 min/km) in the `## Pace & Speed (Primary Metric)` block, exactly where pace is the primary metric.

## Verified the m/s premise before changing it

All seven writers read as m/s — no conflict, no writer stores km/h:

| Writer | Assignment |
| --- | --- |
| `server/utils/intervals.ts:1035` | `activity.average_speed` (Intervals.icu m/s) |
| `server/utils/strava.ts:368` | `activity.average_speed` (Strava m/s) |
| `server/utils/polar.ts:337` | `exercise.distance / durationSec` (metres / seconds) |
| `server/utils/rouvy.ts:278` | `activity.aggregates.speedMetersPerSecond.avg` |
| `server/utils/fit.ts:335` | `session.avg_speed, // m/s` |
| `server/utils/services/garminService.ts:765` | `record.averageSpeedInMetersPerSecond` |
| `server/utils/wahoo.ts:247` | `summary.speed_avg` |

Corroborating read-side evidence: `server/utils/gemini.ts:699` renders the same column as `(w.averageSpeed * 3.6).toFixed(1) km/h`, i.e. it treats the stored value as m/s too.

## The `workoutExplorer.ts` label is correct as-is — deliberately NOT changed

The ticket suggested flipping `averageSpeed: 'km/h'` to `'m/s'` in `workoutExplorerMetricUnits`. Grepping the consumers shows that would have introduced a bug rather than fixed one:

- The only consumer of the map's sibling functions is `server/api/analytics/workout-explorer/summary.post.ts:526`, which emits the value through `normalizeWorkoutMetricValue(field, ...)`.
- `normalizeWorkoutMetricValue` special-cases this field: `if (field === 'averageSpeed') return Number((numeric * 3.6).toFixed(1))` — it converts m/s to km/h **before** the value reaches any consumer.
- The client page `app/pages/analytics/workout-explorer.vue:142` independently labels `averageSpeed` as `km/h`, matching the converted value.

So the emitted number really is km/h and the label is right. (`workoutExplorerMetricUnits` itself currently has no importers at all — it is exported but unconsumed.) Instead of flipping the label, this PR documents both halves of the conversion so the next reader doesn't have to re-derive it.

## Derived pace vs. corrected speed — they now agree

The prompt's `- Average Pace:` line is derived independently from `duration_s / (distance_m / 1000)`, never from `avg_speed_ms`. A new prompt-level test pins both lines for the same fixture (10000 m in 3333 s):

- `- Average Pace: 5:33/km`
- `- Average Speed: 3.00 m/s`

3.00 m/s == 333 s/km == 5:33/km — agreement to rounding. **Before this fix those two lines disagreed by exactly 3.6x on real data**, which is what made the bug visible in run analyses.

## Changes

- `server/utils/services/workout-analysis-prompt.ts` — pass the stored m/s value through untouched; replace the misleading comment with the writer-unit rationale.
- `server/utils/services/workout-analysis-prompt.test.ts` —
  - New regression test: `averageSpeed: 3.0` produces `avg_speed_ms: 3.0` (not `0.83`).
  - New prompt test asserting the derived pace and the reported speed agree.
  - The `RIDE_WORKOUT` fixture's `averageSpeed` was `32`, a value authored under the wrong km/h assumption (it happened to be self-consistent only because `32 / 3.6 = 8.889 = 48000 m / 5400 s`). Corrected to `8.9` m/s so the fixture matches what a real writer would persist, and the assertion tightened from `toBeCloseTo(8.889, 2)` to `toBe(8.9)`.
- `server/utils/workoutExplorer.ts` — comments only, per the analysis above.

The CW-392 snapshot is **unchanged**: the `RIDE_WORKOUT` fixture's primary metric is POWER, so the `## Pace & Speed` block is not emitted for it and no speed line appears in the snapshot.

## Verification

```
$ pnpm typecheck && pnpm test:unit server/utils/services
...
 Test Files  24 passed (24)
      Tests  225 passed (225)
   Duration  7.61s
EXIT=0
```

## Risk

Low, and it is a behaviour change by design: every future AI workout analysis now sees an average speed 3.6x higher (and correct). Already-generated analyses are unaffected. No schema, API, or UI change.
