### PR TITLE
fix(workouts): compare RPE-planned steps on the same intensity scale (CW-385)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -668,6 +668,114 @@ describe('buildWorkoutAnalysisFacts', () => {
     expect(facts.adherence.executionClassification).toBe('as_prescribed')
   })
 
+  it('scores RPE-target plans against provider laps on a single intensity scale', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'RPE Tempo Session',
+        type: 'Ride',
+        durationSec: 3600,
+        rawJson: {
+          // Intervals.icu reports lap `intensity` as a percent of threshold.
+          icu_intervals: [
+            { type: 'WORK', moving_time: 600, average_watts: 228, intensity: 91 },
+            { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 },
+            { type: 'WORK', moving_time: 600, average_watts: 230, intensity: 92 }
+          ]
+        }
+      }),
+      sportSettings: { ftp: 250 },
+      plannedWorkout: {
+        structuredWorkout: {
+          steps: [
+            { type: 'Interval', durationSeconds: 600, rpe: 9 },
+            { type: 'Rest', durationSeconds: 300, rpe: 5 },
+            { type: 'Interval', durationSeconds: 600, rpe: 9 }
+          ]
+        },
+        durationSec: 3600
+      }
+    })
+
+    expect(facts.adherence.adherenceAssessable).toBe(true)
+    expect(facts.adherence.structureMatched).toBe(true)
+    expect(facts.adherence.workIntervalHitRate).toBe(100)
+    expect(facts.adherence.recoveryHitRate).toBe(100)
+    // ~1-2% over an intensity factor of 0.9, not the ~11,000% the percent-vs-
+    // ratio comparison used to produce.
+    expect(facts.adherence.targetOvershootPct).not.toBeNull()
+    expect(facts.adherence.targetOvershootPct!).toBeLessThan(10)
+    expect(facts.adherence.targetUndershootPct).toBeNull()
+  })
+
+  it('does not call an on-target RPE session intensity_inflated', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'RPE Threshold Session',
+        type: 'Ride',
+        durationSec: 3600,
+        rawJson: {
+          icu_intervals: [
+            { type: 'WORK', moving_time: 600, average_watts: 250, intensity: 100 },
+            { type: 'REST', moving_time: 300, average_watts: 150, intensity: 60 },
+            { type: 'WORK', moving_time: 600, average_watts: 250, intensity: 100 }
+          ]
+        }
+      }),
+      sportSettings: { ftp: 250 },
+      plannedWorkout: {
+        structuredWorkout: {
+          steps: [
+            { type: 'Interval', durationSeconds: 600, rpe: 10 },
+            { type: 'Rest', durationSeconds: 300, rpe: 6 },
+            { type: 'Interval', durationSeconds: 600, rpe: 10 }
+          ]
+        },
+        durationSec: 3600
+      }
+    })
+
+    expect(facts.adherence.executionClassification).not.toBe('intensity_inflated')
+    expect(facts.adherence.executionClassification).toBe('as_prescribed')
+    expect(facts.adherence.targetOvershootPct).toBeNull()
+    expect(facts.adherence.workIntervalHitRate).toBe(100)
+  })
+
+  it('excludes RPE steps with no measurable intensity from the hit rate instead of scoring them as misses', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'RPE Session Without Lap Intensity',
+        type: 'Ride',
+        durationSec: 3600,
+        rawJson: {
+          // Laps carry no `intensity` at all — the same situation as
+          // engine-detected intervals, which never populate the field.
+          icu_intervals: [
+            { type: 'WORK', moving_time: 600, average_watts: 228 },
+            { type: 'REST', moving_time: 300, average_watts: 125 },
+            { type: 'WORK', moving_time: 600, average_watts: 230 }
+          ]
+        }
+      }),
+      sportSettings: { ftp: 250 },
+      plannedWorkout: {
+        structuredWorkout: {
+          steps: [
+            { type: 'Interval', durationSeconds: 600, rpe: 9 },
+            { type: 'Rest', durationSeconds: 300, rpe: 5 },
+            { type: 'Interval', durationSeconds: 600, rpe: 9 }
+          ]
+        },
+        durationSec: 3600
+      }
+    })
+
+    expect(facts.adherence.workIntervalHitRate).toBeNull()
+    expect(facts.adherence.recoveryHitRate).toBeNull()
+    expect(facts.adherence.targetOvershootPct).toBeNull()
+    expect(facts.adherence.targetUndershootPct).toBeNull()
+    expect(facts.adherence.executionClassification).not.toBe('intensity_inflated')
+  })
+
   it('falls back to stream-detected intervals when synced intervals are missing', () => {
     const facts = buildWorkoutAnalysisFactsV2({
       workout: makeWorkout({

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1114,6 +1114,13 @@ type ActualInterval = {
   avgHr: number | null
   avgSpeed: number | null
   avgCadence: number | null
+  /**
+   * Intensity factor — a fraction of threshold (~0.3–1.5), the same scale as
+   * `FlattenedPlannedStep.intensityFactor`. Normalised in `mapIntervalsToActual`
+   * (see `toIntervalIntensityFactor`); `null` when the source carries no
+   * intensity signal at all, which is always the case for engine-detected
+   * intervals.
+   */
   intensity: number | null
   matchScore: number | null
   confidence: number | null
@@ -1392,6 +1399,31 @@ function mapProviderIntervalsToActual(intervals: any[]): ActualInterval[] {
   )
 }
 
+/**
+ * Normalise a source interval's intensity onto ONE documented scale: an
+ * intensity factor (fraction of threshold, ~0.3–1.5).
+ *
+ * Provider laps keep Intervals.icu's `icu_intervals[].intensity` verbatim off
+ * `rawJson`, and that field is a PERCENTAGE of threshold (e.g. `101` for a lap
+ * ridden at 101% of FTP). The planned side of adherence is an intensity factor
+ * (`toIntensityFactorFromTarget`, and `rpe / 10` for RPE steps), so the two
+ * only compare if the provider percentage is divided by 100 first.
+ *
+ * The `> 5` heuristic is the same one the activity-level sync already applies
+ * (`normalizeIntensityValue` in `services/intervalsService.ts`): no lap sits at
+ * 500% of threshold, and no lap is meaningfully described as 5% of it, so the
+ * gap is unambiguous. Values already on the factor scale (older fixtures,
+ * providers that hand us a ratio) pass through untouched.
+ *
+ * Engine-detected intervals (`detectIntervals`) carry no intensity field at
+ * all, so they stay `null` — there is no second unit to reconcile.
+ */
+function toIntervalIntensityFactor(value: unknown): number | null {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return null
+  return numeric > 5 ? numeric / 100 : numeric
+}
+
 function mapIntervalsToActual(intervals: any[]): ActualInterval[] {
   return intervals
     .map((interval) => {
@@ -1428,7 +1460,7 @@ function mapIntervalsToActual(intervals: any[]): ActualInterval[] {
         avgCadence: Number.isFinite(Number(interval?.average_cadence ?? interval?.avg_cadence))
           ? Number(interval?.average_cadence ?? interval?.avg_cadence)
           : null,
-        intensity: Number.isFinite(Number(interval?.intensity)) ? Number(interval.intensity) : null,
+        intensity: toIntervalIntensityFactor(interval?.intensity),
         matchScore: Number.isFinite(Number(interval?.match_score))
           ? Number(interval.match_score)
           : null,
@@ -1796,6 +1828,7 @@ function getPlannedHardRepeats(plannedSteps: FlattenedPlannedStep[], refs: Analy
 function getActualHardRepeats(actualIntervals: ActualInterval[], refs: AnalysisRefs) {
   return actualIntervals.filter((interval) => {
     if (interval.classification !== 'work') return false
+    // `intensity` is an intensity factor, so 0.95 is 95% of threshold.
     if (interval.intensity !== null) return interval.intensity >= 0.95
     if (interval.avgPower !== null && refs.ftp > 0) return interval.avgPower >= refs.ftp * 0.95
     return false
@@ -2358,6 +2391,9 @@ function deriveDurabilitySignals(params: {
   if (actualIntervals.length >= 2) {
     const first = actualIntervals[0]!
     const last = actualIntervals[actualIntervals.length - 1]!
+    // The delta below is a ratio, so the units only need to agree between the
+    // two ends: an intensity factor scaled to a percent-of-threshold stands in
+    // when watts are missing.
     const firstMetric =
       family === 'run'
         ? (first.avgSpeed ?? null)
@@ -2634,23 +2670,28 @@ function deriveAdherence(params: {
   const cadencePlanned = plannedSteps.filter((step) => step.cadence !== null)
   const pairMetric = (
     planned: FlattenedPlannedStep,
-    actual: ActualInterval
-  ): { deltaPct: number | null; hit: boolean } => {
+    actual: ActualInterval | null
+  ): { deltaPct: number | null; hit: boolean; comparable: boolean } => {
     const target = resolveComparableTargetValue(planned, refs)
     const bounds = resolveComparableTargetBounds(planned, refs)
     let actualValue: number | null = null
     let threshold = 10
 
     if (planned.metric === 'power') {
-      actualValue = actual.avgPower
+      actualValue = actual?.avgPower ?? null
     } else if (planned.metric === 'pace') {
-      actualValue = actual.avgSpeed
+      actualValue = actual?.avgSpeed ?? null
       threshold = 8
     } else if (planned.metric === 'heartRate') {
-      actualValue = actual.avgHr
+      actualValue = actual?.avgHr ?? null
       threshold = 6
     } else if (planned.metric === 'rpe') {
-      actualValue = actual.intensity
+      // Both sides are intensity factors: `resolveComparableTargetValue`
+      // returns `planned.intensityFactor` (rpe / 10, clamped) and
+      // `ActualInterval.intensity` is normalised to the same fraction-of-
+      // threshold scale in `mapIntervalsToActual`. Comparing the raw provider
+      // percentage here produced deltas in the thousands of percent.
+      actualValue = actual?.intensity ?? null
       threshold = 10
     }
 
@@ -2662,12 +2703,12 @@ function deriveAdherence(params: {
       bounds.end > 0
     ) {
       if (actualValue >= bounds.start && actualValue <= bounds.end) {
-        return { deltaPct: 0, hit: true }
+        return { deltaPct: 0, hit: true, comparable: true }
       }
 
       const reference = actualValue < bounds.start ? bounds.start : bounds.end
       const deltaPct = ((actualValue - reference) / reference) * 100
-      return { deltaPct, hit: false }
+      return { deltaPct, hit: false, comparable: true }
     }
 
     if (
@@ -2675,30 +2716,60 @@ function deriveAdherence(params: {
       !Number.isFinite(target) ||
       target <= 0 ||
       actualValue === null ||
+      !Number.isFinite(actualValue) ||
       actualValue <= 0
     ) {
-      return { deltaPct: null, hit: false }
+      return { deltaPct: null, hit: false, comparable: false }
     }
 
     const deltaPct = ((actualValue - target) / target) * 100
-    return { deltaPct, hit: Math.abs(deltaPct) <= threshold }
+    return { deltaPct, hit: Math.abs(deltaPct) <= threshold, comparable: true }
   }
+
+  /**
+   * An RPE-planned step can only be scored when the actual side carries an
+   * intensity signal — engine-detected intervals never do, and not every
+   * provider lap does either. A missing measurement is not evidence of poor
+   * execution, so those steps drop out of the hit-rate denominator instead of
+   * being counted as misses. Other metrics keep their existing behaviour: an
+   * unmeasured power/pace/HR step still counts against the athlete.
+   */
+  const isUnmeasurableRpeStep = (planned: FlattenedPlannedStep, result: { comparable: boolean }) =>
+    planned.metric === 'rpe' && !result.comparable
 
   let workHits = 0
   let recoveryHits = 0
   let cadenceHits = 0
+  // Denominators start at every planned step and shrink only when an RPE step
+  // turns out to be unmeasurable (see `isUnmeasurableRpeStep`).
+  let scorableWorkSteps = plannedWork.length
+  let scorableRecoverySteps = plannedRecovery.length
   const overshoots: number[] = []
   const undershoots: number[] = []
 
-  for (let index = 0; index < workPairs; index++) {
-    const result = pairMetric(plannedWork[index]!, actualWork[index]!)
+  // Pairing stays index-based on purpose — reworking it is a separate concern.
+  // Planned steps past the end of the actual list simply have no counterpart.
+  for (let index = 0; index < plannedWork.length; index++) {
+    const planned = plannedWork[index]!
+    const actual = index < workPairs ? actualWork[index]! : null
+    const result = pairMetric(planned, actual)
+    if (isUnmeasurableRpeStep(planned, result)) {
+      scorableWorkSteps--
+      continue
+    }
     if (result.hit) workHits++
     if (result.deltaPct !== null && result.deltaPct > 0) overshoots.push(result.deltaPct)
     if (result.deltaPct !== null && result.deltaPct < 0) undershoots.push(Math.abs(result.deltaPct))
   }
 
-  for (let index = 0; index < recoveryPairs; index++) {
-    const result = pairMetric(plannedRecovery[index]!, actualRecovery[index]!)
+  for (let index = 0; index < plannedRecovery.length; index++) {
+    const planned = plannedRecovery[index]!
+    const actual = index < recoveryPairs ? actualRecovery[index]! : null
+    const result = pairMetric(planned, actual)
+    if (isUnmeasurableRpeStep(planned, result)) {
+      scorableRecoverySteps--
+      continue
+    }
     if (result.hit) recoveryHits++
   }
 
@@ -2712,9 +2783,9 @@ function deriveAdherence(params: {
   }
 
   const workIntervalHitRate =
-    plannedWork.length > 0 ? round((workHits / plannedWork.length) * 100, 1) : null
+    scorableWorkSteps > 0 ? round((workHits / scorableWorkSteps) * 100, 1) : null
   const recoveryHitRate =
-    plannedRecovery.length > 0 ? round((recoveryHits / plannedRecovery.length) * 100, 1) : null
+    scorableRecoverySteps > 0 ? round((recoveryHits / scorableRecoverySteps) * 100, 1) : null
   const cadenceHitRate =
     cadencePlanned.length > 0 ? round((cadenceHits / cadencePlanned.length) * 100, 1) : null
   const structureMatched =


### PR DESCRIPTION
Fixes CW-385

## Problem

`deriveAdherence`'s `pairMetric` compared an RPE-planned step's target (an **intensity factor**, `clamp(rpe / 10, 0.3, 1.5)`) against `actual.intensity`, which for provider-synced laps is Intervals.icu's `intensity` field — a **percentage of threshold** (`101` for a lap at 101% of FTP). The comparison was ~101 vs ~0.9, so `deltaPct` exploded to roughly +11,000%: the step never counted as a hit, `workIntervalHitRate` read 0%, that value poisoned `targetOvershootPct`, and `executionClassification` could flip to `intensity_inflated` for a session executed correctly. Every plan built on RPE targets rather than power/pace/HR was affected.

## Units: what each interval source actually holds (verified)

| Source | Field | Units before |
| --- | --- | --- |
| Provider laps (`rawJson.icu_intervals` / `rawJson.intervals` → `mapProviderIntervalsToActual` → `mapIntervalsToActual`) | Intervals.icu `intensity` | percent of threshold (e.g. `101`) |
| Engine-detected (`detectIntervals` → `buildDetectedIntervals` → `mapIntervalsToActual`) | — | never populated; `intensity` was always `null` |

So the two sources did not carry *conflicting* units — one carried a percentage and the other carried nothing — but `ActualInterval.intensity` had no documented meaning, and consumers disagreed about which scale it was on.

## Decision: normalise at the mapping layer

`ActualInterval.intensity` is now **always an intensity factor** (fraction of threshold, ~0.3–1.5), the same scale as `FlattenedPlannedStep.intensityFactor`. New `toIntervalIntensityFactor` in `mapIntervalsToActual` divides provider percentages by 100, reusing the exact `> 5` heuristic the activity-level sync already applies (`normalizeIntensityValue` in `server/utils/services/intervalsService.ts`, and the identical block in `server/utils/intervals.ts`). Values already on the factor scale pass through untouched; detected intervals stay `null`. The meaning is documented on the `ActualInterval.intensity` field and on the helper.

### Blast radius — every reader of `.intensity` on an `ActualInterval`

All four live inside `server/utils/workout-analysis-facts.ts`; the exported `getActualIntervalsForAnalysis` / `ActualIntervalForAnalysis` are only consumed by `cli/debug/workout-facts.ts` and `scripts/dump-intervals.ts`, neither of which reads `.intensity`.

- `pairMetric` (RPE branch) — the bug; now compares factor against factor.
- `getActualHardRepeats` — `interval.intensity >= 0.95` was silently broken for provider laps (every lap ≥ 0.95 when the value is a percentage, so every work lap counted as a hard repeat). Now correct. Comment added; **behaviour change**, in the correct direction.
- `deriveDurabilitySignals` (`firstVsLastIntervalDeltaPct`) — `intensity * 100`; the delta is a ratio between the two ends, so it was and remains scale-invariant. The `* 100` now genuinely means "intensity factor expressed as percent of threshold". Comment added, no behaviour change.
- `resolveProviderIntervalTypes` (`server/utils/interval-detection.ts`) — fed the **raw** provider values from `mapProviderIntervalsToActual`, before mapping, and every comparison there is a ratio against the other laps of the same session. Untouched, unaffected.

## Missing measurement is no longer scored as a miss

When an RPE-planned step has no comparable actual value (detected intervals carry no intensity; some provider laps omit it), the step is now **excluded from the hit-rate denominator** and from the overshoot/undershoot arrays instead of counting as a miss. `pairMetric` returns a `comparable` flag; the exclusion is gated on `planned.metric === 'rpe'`, so power/pace/HR steps keep their existing behaviour exactly. If no RPE step is measurable, the hit rate is `null` (not assessable) rather than 0%.

## Explicitly not changed

Planned↔actual pairing is still index-based. That is a known separate defect tracked in CW-386 and is deliberately untouched here — the work/recovery loops now iterate the full planned list rather than `Math.min(...)`, but a planned step past the end of the actual list gets `actual = null`, which yields the same non-hit / no-delta result the old bounded loop produced.

## Tests

Three new cases in `server/utils/workout-analysis-facts.test.ts`:

- RPE-target plan + provider laps carrying real icu percentages (`91`, `50`, `92`): `workIntervalHitRate` 100%, `recoveryHitRate` 100%, `targetOvershootPct` in single digits rather than thousands.
- On-target RPE session: `executionClassification` is `as_prescribed`, asserted **not** `intensity_inflated`, `targetOvershootPct` null.
- RPE plan against laps with no `intensity` at all: hit rates `null` (excluded from the denominator) instead of 0%.

## Verification

```
$ pnpm typecheck && pnpm test:unit server/utils/workout-analysis-facts.test.ts

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

Full unit suite also run as a regression check: **370 files / 2147 tests passed**.

## Files touched (vs Owned Paths — no drift)

- `server/utils/workout-analysis-facts.ts`
- `server/utils/workout-analysis-facts.test.ts`
