### PR TITLE
fix(workouts): raise the pace work bar so recovery jogs are not counted as work (CW-401)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -165,6 +165,18 @@ export const HR_WORK_BAR_FRACTION_OF_MAX_HR = 0.7
 export const HR_WORK_BAR_FRACTION_OF_LTHR = 0.82
 
 /**
+ * Fraction of threshold pace (velocity, m/s) that marks the bottom of "work".
+ *
+ * ~80% of threshold velocity is the easy/steady boundary for running: recovery
+ * jogs in real interval sessions sit at 60-75% of threshold pace, while any
+ * deliberate rep - steady, tempo, threshold or faster - sits at 85%+. The bar
+ * used to be 0.65, which put a 4.0 m/s athlete's work bar at 2.6 m/s and made
+ * every recovery jog above ~65% read as work, welding reps and recoveries into
+ * one block (CW-401).
+ */
+export const PACE_WORK_BAR_FRACTION_OF_THRESHOLD = 0.8
+
+/**
  * Resolve the FINAL heart-rate work bar (in bpm) to hand to `detectIntervals`.
  *
  * `detectIntervals` deliberately applies no further multiplier to an HR
@@ -201,9 +213,13 @@ export function resolveHrWorkThreshold(refs: {
  * THRESHOLD CONTRACT (do not add a second discount on top of a scaled value):
  * - `power`:     `threshold` is the athlete's FTP. The work bar is derived here
  *                as 70% of FTP (the Z2/Z3 border).
- * - `pace`:      `threshold` is a reference velocity (usually omitted, in which
- *                case the stream's own median is used). The work bar is derived
- *                here as 65% of it.
+ * - `pace`:      `threshold` is a reference VELOCITY in m/s — the athlete's
+ *                threshold pace (omit it and the stream's own median is used
+ *                instead). The work bar is derived here as
+ *                `PACE_WORK_BAR_FRACTION_OF_THRESHOLD` (80%) of it, the
+ *                easy/steady boundary. Do not pre-scale it in the caller: pace
+ *                stays on the "caller passes the reference, engine scales it"
+ *                side of this contract, unlike heartrate.
  * - `heartrate`: `threshold` is ALREADY THE FINAL WORK BAR in bpm — build it
  *                with `resolveHrWorkThreshold()` from profile LTHR/max HR. No
  *                multiplier is applied here. Callers used to pass `maxHr * 0.7`
@@ -251,13 +267,14 @@ export function detectIntervals(
   //   (`resolveHrWorkThreshold`), so it is used verbatim. With no threshold at
   //   all the fallback baseline is the stream's own median HR, which is a
   //   sensible "above your typical effort = work" bar on its own.
-  // - pace: work is > 65% of the reference velocity
+  // - pace: work is > 80% of the reference velocity (the easy/steady boundary),
+  //   so a 60-75%-of-threshold recovery jog stays recovery (CW-401).
   const workThreshold =
     metricType === 'power'
       ? baseline * 0.7
       : metricType === 'heartrate'
         ? baseline
-        : baseline * 0.65
+        : baseline * PACE_WORK_BAR_FRACTION_OF_THRESHOLD
 
   let intervals: Interval[] = []
   let inInterval = false
@@ -350,7 +367,11 @@ export function detectIntervals(
   if (merged.length === 0 && times.length > 0) {
     const totalDuration = (times[times.length - 1] || 0) - (times[0] || 0)
     const avgValue = values.reduce((a, b) => a + (b || 0), 0) / values.length
-    // `baseline` is FTP for power and the work bar itself for HR/pace.
+    // `baseline` here is the caller's reference, NOT the work bar: FTP for
+    // power, threshold velocity for pace, the final work bar for HR (see the
+    // threshold contract above). Pace kept that meaning through CW-401 — only
+    // the work-bar factor moved — so "averaged at least half of threshold
+    // velocity for 15+ minutes" is still the right bar for a continuous run.
     const isSteady =
       totalDuration > 900 && // 15 mins
       (metricType === 'power' ? avgValue >= baseline * 0.4 : avgValue >= baseline * 0.5)

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -184,41 +184,69 @@ describe('resolveHrWorkThreshold', () => {
     expect(resolveHrWorkThreshold({})).toBeUndefined()
   })
 
-  it('separates run work reps from recovery jogs when the real threshold pace is supplied', () => {
-    // Threshold pace in m/s (same unit the app stores sportSettings.thresholdPace in).
-    const thresholdPace = 4.0
-    const workPace = 4.3 // ~108% of threshold — a typical rep pace
-    const recoveryPace = 2.4 // 60% of threshold — an easy recovery jog
-    const warmupPace = 2.3
-    const cooldownPace = 2.2
+  // Threshold pace in m/s (same unit the app stores sportSettings.thresholdPace in).
+  const THRESHOLD_PACE = 4.0
 
+  /** 5 x 3min reps with 3min jogs, bracketed by a warmup and a cooldown. */
+  const buildIntervalRun = (workFraction: number, recoveryFraction: number) => {
+    const workPace = THRESHOLD_PACE * workFraction
+    const recoveryPace = THRESHOLD_PACE * recoveryFraction
     const velocity = [
-      ...Array.from({ length: 600 }, () => warmupPace),
+      ...Array.from({ length: 600 }, () => 2.3), // warmup
       ...Array.from({ length: 5 }, () => [
         ...Array.from({ length: 180 }, () => workPace),
         ...Array.from({ length: 180 }, () => recoveryPace)
       ]).flat(),
-      ...Array.from({ length: 300 }, () => cooldownPace)
+      ...Array.from({ length: 300 }, () => 2.2) // cooldown
     ]
-    const time = velocity.map((_, index) => index)
+    return { velocity, time: velocity.map((_, index) => index), workPace }
+  }
 
-    const withThreshold = detectIntervals(time, velocity, 'pace', thresholdPace)
+  it('separates run work reps from a realistic 70%-of-threshold recovery jog', () => {
+    // The case that failed before CW-401: with the old 0.65 work bar a 70% jog
+    // (2.8 m/s against a 2.6 m/s bar) read as work and the session welded into
+    // one block. The bar is now 0.8 * threshold pace, so it sits at 3.2 m/s.
+    const { velocity, time, workPace } = buildIntervalRun(1.05, 0.7)
+
+    const withThreshold = detectIntervals(time, velocity, 'pace', THRESHOLD_PACE)
     const workIntervals = withThreshold.filter((interval) => interval.type === 'WORK')
 
     expect(workIntervals).toHaveLength(5)
     for (const interval of workIntervals) {
       expect(interval.duration).toBeGreaterThan(150)
       expect(interval.duration).toBeLessThan(210)
-      expect(interval.avg_pace || 0).toBeGreaterThan(4)
+      expect(interval.avg_pace || 0).toBeGreaterThan(THRESHOLD_PACE)
+      expect(interval.avg_pace || 0).toBeLessThanOrEqual(workPace)
     }
     // The gaps between reps must come back as recovery, not be swallowed into the reps.
-    expect(withThreshold.filter((interval) => interval.type === 'RECOVERY')).toHaveLength(4)
+    const recoveries = withThreshold.filter((interval) => interval.type === 'RECOVERY')
+    expect(recoveries).toHaveLength(4)
+    for (const interval of recoveries) {
+      expect(interval.avg_pace || 0).toBeLessThan(THRESHOLD_PACE * 0.8)
+    }
     expect(withThreshold[0]?.type).toBe('WARMUP')
     expect(withThreshold.at(-1)?.type).toBe('COOLDOWN')
+  })
 
-    // Regression guard: this is what the pace branch used to do (CW-384). Without a threshold
-    // the engine falls back to 0.65 * median(stream); the median here sits at recovery pace, so
-    // the work bar lands at ~1.6 m/s and the entire run collapses into a single "work" block.
+  it('holds the work/recovery split across the realistic 60-75% recovery-jog range', () => {
+    // Real recovery jogs land anywhere in this band; none of them is work.
+    for (const recoveryFraction of [0.6, 0.65, 0.7, 0.75]) {
+      const { velocity, time } = buildIntervalRun(1.05, recoveryFraction)
+      const detected = detectIntervals(time, velocity, 'pace', THRESHOLD_PACE)
+      expect({
+        recoveryFraction,
+        work: detected.filter((interval) => interval.type === 'WORK').length,
+        recovery: detected.filter((interval) => interval.type === 'RECOVERY').length
+      }).toEqual({ recoveryFraction, work: 5, recovery: 4 })
+    }
+  })
+
+  it('still collapses into one block when no threshold pace is available', () => {
+    // Regression guard for CW-384's fix at the CALL SITES: without a threshold the engine
+    // falls back to 0.8 * median(stream), and the median of an interval run sits at recovery
+    // pace — so the work bar lands below the jog and the run reads as one work block. This is
+    // why callers must pass the athlete's real thresholdPace; the engine cannot infer it.
+    const { velocity, time } = buildIntervalRun(1.05, 0.7)
     const withoutThreshold = detectIntervals(time, velocity, 'pace', undefined)
     expect(withoutThreshold.filter((interval) => interval.type === 'WORK')).toHaveLength(1)
     expect(withoutThreshold.filter((interval) => interval.type === 'RECOVERY')).toHaveLength(0)


### PR DESCRIPTION
Fixes CW-401

CW-384 fixed the pace call sites so `detectIntervals` receives the athlete's real `thresholdPace` (m/s), but the engine still derived the work bar as `baseline * 0.65`. Against a 4.0 m/s threshold that put the bar at 2.6 m/s, so any recovery jog above ~65% of threshold pace still classified as WORK — and real recovery jogs sit at 60-75%.

## Approach chosen: (a) raise the pace work-bar factor

Approach (b) — a `resolvePaceWorkThreshold()` helper with the caller passing the final bar — would have required editing the pace call sites in `server/utils/workout-analysis-facts.ts` and `server/api/workouts/[id]/intervals.get.ts`, which are outside this ticket's Owned Paths and may be under concurrent edit. Per the ticket's instruction, approach (a) it is: a minimal, self-contained diff inside the engine.

- New exported constant `PACE_WORK_BAR_FRACTION_OF_THRESHOLD = 0.8`, mirroring the named HR constants from CW-383.
- **Why 0.80:** ~80% of threshold velocity is the easy/steady boundary for running. It clears the whole realistic recovery-jog band (60-75%) with margin, while still sitting below any deliberate rep — steady, tempo, threshold or faster all land at 85%+ of threshold pace.
- The `detectIntervals` threshold contract comment now documents the pace entry alongside power and heartrate, and states explicitly that pace stays on the "caller passes the reference velocity, engine scales it" side of the contract — unlike heartrate, callers must **not** pre-scale it.

Power (`baseline * 0.7` of FTP) and heartrate (caller-supplied final bar, no multiplier) are untouched.

## `isSteady` special case — checked, no change needed

`baseline` semantics for pace did **not** shift: it is still the caller's reference velocity, and only the work-bar factor moved. So `avgValue >= baseline * 0.5` for pace still means "averaged at least half of threshold velocity for 15+ minutes", which is the right bar for calling a continuous run STEADY. The stale comment above it claimed `baseline` was "the work bar itself for HR/pace" — that was already wrong for pace, and is now corrected to name the reference per metric.

## Tests

The CW-384 pace test was rewritten rather than left passing:

- The primary assertion now uses a **70%**-of-threshold recovery jog (the case that fails on `develop`) with reps at 105% of threshold, and additionally asserts each detected RECOVERY averages below the work bar.
- A new case sweeps the realistic **60-75%** recovery band and asserts 5 WORK / 4 RECOVERY throughout.
- The no-threshold fallback guard is kept and relabelled honestly: without a threshold the engine falls back to `0.8 * median(stream)`, the median of an interval run sits at recovery pace, and the run still collapses into one WORK block. That is why callers must pass the athlete's real `thresholdPace` — the engine cannot infer it.

Falsification check: both new pace cases fail with the factor set back to 0.65 and pass at 0.80.

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server/utils/interval-detection.test.ts
```

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Full unit suite also green locally: 370 files, 2151 tests passed.
