### PR TITLE
fix(ai): unify cadence units and add pace to interval rows (CW-387)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -290,6 +290,83 @@ describe('buildWorkoutAnalysisPrompt', () => {
     expect(prompt).toContain('- Average Speed: 3.00 m/s')
   })
 
+  it('uses one cadence convention across the session line and the interval rows for a run (CW-387)', () => {
+    // Same physical legs, three places in one prompt. Before CW-387 the session line
+    // said "176 spm", the Interval Breakdown said "180 rpm" for an equally doubled
+    // number, and the facts rows said "90rpm" for the undoubled one.
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-run-cadence',
+        date: new Date('2026-03-17T06:00:00Z'),
+        title: '3 x 1km Threshold',
+        type: 'Run',
+        durationSec: 3000,
+        distanceMeters: 9000,
+        averageSpeed: 3.0,
+        averageHr: 158,
+        maxHr: 176,
+        // One-legged, exactly as Strava / Intervals.icu store run cadence.
+        averageCadence: 88,
+        maxCadence: 95,
+        rawJson: {
+          icu_intervals: [
+            {
+              type: 'WORK',
+              label: 'Rep 1',
+              moving_time: 240,
+              distance: 1000,
+              average_heartrate: 168,
+              average_cadence: 90,
+              average_speed: 4.1667,
+              intensity: 101
+            },
+            {
+              type: 'RECOVERY',
+              label: 'Jog 1',
+              moving_time: 120,
+              distance: 400,
+              average_heartrate: 138,
+              average_cadence: 76,
+              average_speed: 3.0,
+              intensity: 68
+            }
+          ]
+        }
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      // HR-primary so the session cadence line is not condensed away; the
+      // Interval Breakdown prints cadence either way.
+      { loadPreference: 'HR' },
+      USER_PROFILE
+    )
+
+    // Session level: doubled and labelled spm.
+    expect(prompt).toContain('- Average Cadence: 176 spm')
+    expect(prompt).toContain('- Max Cadence: 190 spm')
+    // Interval Breakdown: same convention, same unit -- no hardcoded rpm.
+    expect(prompt).toContain('## Interval Breakdown')
+    expect(prompt).toContain('- Avg Cadence: 180 spm')
+    expect(prompt).toContain('- Avg Cadence: 152 spm')
+    // A run prompt must never mention rpm anywhere.
+    expect(prompt).not.toContain('rpm')
+    expect(prompt).not.toContain('RPM')
+  })
+
+  it('keeps rpm for a ride in both the session line and the interval rows (CW-387)', () => {
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(RIDE_WORKOUT),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('- Average Cadence: 88 rpm')
+    expect(prompt).toContain('- Avg Cadence: 90 rpm')
+    expect(prompt).not.toContain('spm')
+  })
+
   it('respects the athlete distanceUnits preference for strength set distances', () => {
     const workoutData = {
       date: new Date('2026-03-15T10:00:00Z'),

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -24,7 +24,12 @@ import {
   shouldCondenseHeartRateSection
 } from '../../../trigger/utils/workout-metric-priority'
 import { formatStructuredPlanForPrompt } from '../../../trigger/utils/planned-workout-targets'
-import type { WorkoutAnalysisFactsV2 } from '../workout-analysis-facts'
+import {
+  formatCadenceWithUnit,
+  isRunningCadenceFamily,
+  toCanonicalCadence,
+  type WorkoutAnalysisFactsV2
+} from '../workout-analysis-facts'
 import { summarizePowerFromWatts } from '../power-metrics'
 import type { JourneyEventCategory } from '@prisma/client'
 
@@ -52,18 +57,24 @@ export interface WorkoutAnalysisPromptRecentContext {
 /**
  * Running exports sometimes report "per-foot" cadence (< 120). Convert those into
  * total steps per minute so the model never reads a 85 spm run as a form problem.
+ *
+ * Thin alias for the shared {@link toCanonicalCadence}, which is the single
+ * implementation of the cadence convention (CW-387). Kept as a named export
+ * because `trigger/analyze-workout.ts` re-exports it.
  */
 export function normalizeRunningCadence(
   cadence: number | null | undefined,
   isRunningWorkout: boolean
 ): number | null | undefined {
-  if (!cadence) return cadence
-  return isRunningWorkout && cadence < 120 ? cadence * 2 : cadence
+  return toCanonicalCadence(cadence, isRunningWorkout)
 }
 
 export function buildWorkoutAnalysisData(workout: any) {
   const workoutType = String(workout.type || '')
-  const isRunningWorkout = workoutType.toLowerCase().includes('run')
+  const isRunningWorkout = isRunningCadenceFamily(workoutType)
+  // The ONLY place session and interval cadence gets converted to the canonical
+  // convention. Everything downstream of this payload -- including the
+  // "## Interval Breakdown" rows -- must only label, never re-scale.
   const normalizeCadence = (cadence: number | null | undefined) =>
     normalizeRunningCadence(cadence, isRunningWorkout)
 
@@ -911,11 +922,11 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     // Cadence is only relevant for cycling/running-like workouts
     if (isCadenceRelevant && !condensedHrSection) {
       if (workoutData.avg_cadence)
-        prompt += `- Average Cadence: ${workoutData.avg_cadence} ${workoutType.toLowerCase().includes('run') ? 'spm' : 'rpm'}\n`
+        prompt += `- Average Cadence: ${formatCadenceWithUnit(workoutData.avg_cadence, workoutType)}\n`
       else prompt += `- Average Cadence: N/A\n`
 
       if (workoutData.max_cadence)
-        prompt += `- Max Cadence: ${workoutData.max_cadence} ${workoutType.toLowerCase().includes('run') ? 'spm' : 'rpm'}\n`
+        prompt += `- Max Cadence: ${formatCadenceWithUnit(workoutData.max_cadence, workoutType)}\n`
     }
   }
 
@@ -1109,7 +1120,11 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
       if (interval.avg_power) prompt += `- Avg Power: ${interval.avg_power}W\n`
       if (interval.intensity) prompt += `- Intensity: ${formatMetric(interval.intensity, 2)}\n`
       if (interval.avg_hr) prompt += `- Avg HR: ${interval.avg_hr} bpm\n`
-      if (interval.avg_cadence) prompt += `- Avg Cadence: ${interval.avg_cadence} rpm\n`
+      // Values are already canonical (buildWorkoutAnalysisData normalised them);
+      // this only attaches the unit the workout family uses, so a run no longer
+      // reads "177 rpm" (CW-387).
+      if (interval.avg_cadence)
+        prompt += `- Avg Cadence: ${formatCadenceWithUnit(interval.avg_cadence, workoutType)}\n`
       if (interval.variability)
         prompt += `- Power Variability: ${formatMetric(interval.variability, 2)}\n`
     })

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   buildWorkoutAnalysisFacts,
   buildWorkoutAnalysisFactsV2,
+  formatActualIntervalsForPrompt,
+  formatCadenceWithUnit,
   getActualIntervalsForAnalysis,
-  getActualIntervalsSourceForAnalysis
+  getActualIntervalsSourceForAnalysis,
+  resolveCadenceUnit,
+  toCanonicalCadence
 } from './workout-analysis-facts'
 
 function makeWorkout(overrides: Record<string, unknown> = {}) {
@@ -1071,5 +1075,119 @@ describe('run pace interval detection refs (CW-384)', () => {
     })
 
     expect(intervals.filter((interval) => interval.classification === 'work')).toHaveLength(5)
+  })
+})
+
+describe('cadence units and pace in actual interval rows (CW-387)', () => {
+  const RUN_WITH_LAPS = makeWorkout({
+    title: '3 x 1km Threshold',
+    type: 'Run',
+    averageWatts: null,
+    rawJson: {
+      icu_intervals: [
+        {
+          type: 'WORK',
+          moving_time: 240,
+          distance: 1000,
+          average_heartrate: 168,
+          // One-legged, exactly as Strava / Intervals.icu store run cadence.
+          average_cadence: 88,
+          average_speed: 4.1667,
+          intensity: 101
+        },
+        {
+          type: 'RECOVERY',
+          moving_time: 120,
+          distance: 400,
+          average_heartrate: 138,
+          average_cadence: 76,
+          average_speed: 3.0,
+          intensity: 68
+        }
+      ]
+    }
+  })
+
+  it('doubles run cadence once and labels it spm, and adds min/km pace', () => {
+    const rows = formatActualIntervalsForPrompt(RUN_WITH_LAPS)
+
+    // 88 rpm one-legged -> 176 spm, and the unit agrees with the number.
+    expect(rows).toContain('176spm')
+    expect(rows).toContain('152spm')
+    expect(rows).not.toContain('rpm')
+    // 4.1667 m/s -> 240 s/km -> 4:00/km; 3.0 m/s -> 333 s/km -> 5:33/km.
+    expect(rows).toContain('4:00/km')
+    expect(rows).toContain('5:33/km')
+  })
+
+  it('leaves ride cadence untouched, keeps rpm and omits the pace column', () => {
+    const rows = formatActualIntervalsForPrompt(
+      makeWorkout({
+        type: 'Ride',
+        rawJson: {
+          icu_intervals: [
+            {
+              type: 'WORK',
+              moving_time: 720,
+              distance: 6400,
+              average_watts: 255,
+              average_heartrate: 155,
+              average_cadence: 88,
+              average_speed: 8.9,
+              intensity: 93
+            }
+          ]
+        }
+      })
+    )
+
+    expect(rows).toContain('88rpm')
+    expect(rows).not.toContain('spm')
+    expect(rows).not.toContain('/km')
+  })
+
+  it('emits N/A for pace on a pace-capable workout with no speed', () => {
+    const rows = formatActualIntervalsForPrompt(
+      makeWorkout({
+        type: 'Run',
+        averageWatts: null,
+        rawJson: {
+          icu_intervals: [
+            { type: 'WORK', moving_time: 300, average_heartrate: 160, average_cadence: 90 }
+          ]
+        }
+      })
+    )
+
+    expect(rows).toContain('180spm | N/A')
+  })
+})
+
+describe('cadence convention helpers (CW-387)', () => {
+  it('resolves the unit from the workout family, not from a hardcoded string', () => {
+    expect(resolveCadenceUnit('Run')).toBe('spm')
+    expect(resolveCadenceUnit('TrailRun')).toBe('spm')
+    expect(resolveCadenceUnit('Treadmill')).toBe('spm')
+    expect(resolveCadenceUnit('Ride')).toBe('rpm')
+    expect(resolveCadenceUnit('VirtualRide')).toBe('rpm')
+    expect(resolveCadenceUnit(null)).toBe('rpm')
+  })
+
+  it('doubles one-legged run cadence and is idempotent for realistic values', () => {
+    expect(toCanonicalCadence(88, true)).toBe(176)
+    // Already steps-per-minute (Garmin's averageRunCadenceInStepsPerMinute).
+    expect(toCanonicalCadence(176, true)).toBe(176)
+    expect(toCanonicalCadence(toCanonicalCadence(88, true), true)).toBe(176)
+    // Never scales cycling cadence.
+    expect(toCanonicalCadence(88, false)).toBe(88)
+    expect(toCanonicalCadence(null, true)).toBeNull()
+    expect(toCanonicalCadence(0, true)).toBe(0)
+  })
+
+  it('keeps the value and its unit together', () => {
+    expect(formatCadenceWithUnit(176, 'Run')).toBe('176 spm')
+    expect(formatCadenceWithUnit(88.4, 'Ride')).toBe('88 rpm')
+    expect(formatCadenceWithUnit(88, 'Ride', '')).toBe('88rpm')
+    expect(formatCadenceWithUnit(null, 'Run')).toBe('N/A')
   })
 })

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -6,6 +6,7 @@ import {
   resolveProviderIntervalTypes
 } from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
+import { formatPromptPace } from './ai-prompt-format'
 
 type FactConfidence = 'low' | 'medium' | 'high'
 type FactSeverity = 'low' | 'moderate' | 'high' | 'unknown'
@@ -277,6 +278,94 @@ function getWorkoutFamily(workoutType: string | null | undefined) {
     return 'nonimpact_cardio'
   }
   return 'other'
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cadence convention (CW-387)                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The canonical cadence convention for every AI prompt in this codebase:
+ *
+ * - running-family workouts are expressed in **steps per minute (`spm`)**;
+ * - everything else (cycling and friends) is expressed in **revolutions per
+ *   minute (`rpm`)** and is never scaled.
+ *
+ * Only the helpers below implement that convention, and `formatCadenceWithUnit`
+ * is the only thing that ever prints a unit — so a value and its label cannot
+ * drift apart the way they did before CW-387 (session line said `spm`, the
+ * Interval Breakdown said `rpm` for the same doubled number, and the facts
+ * interval rows said `rpm` for the *undoubled* number).
+ */
+export function isRunningCadenceFamily(workoutType: string | null | undefined): boolean {
+  return getWorkoutFamily(workoutType) === 'run'
+}
+
+/**
+ * Convert a stored cadence value into the canonical convention.
+ *
+ * Running exports arrive in two different shapes depending on the sync writer:
+ *
+ * - `server/utils/services/garminService.ts` reads Garmin's
+ *   `averageRunCadenceInStepsPerMinute`, which is already both feet (~166);
+ * - `strava.ts`, `intervals.ts`, `wahoo.ts` and `fit.ts` store the provider's
+ *   `average_cadence` verbatim, and for runs those providers report *one leg*
+ *   (~83).
+ *
+ * There is no provenance flag on the workout row that distinguishes the two, so
+ * the magnitude heuristic below is what disambiguates them: a one-legged run
+ * cadence lives in ~60-100, an already-doubled one in ~140-200. See the
+ * threshold note on {@link CANONICAL_RUN_CADENCE_THRESHOLD}.
+ *
+ * Applying this twice is not harmful for realistic running cadences (the second
+ * pass sees a value >= the threshold and leaves it alone), but callers should
+ * still normalise exactly once, at the point where the workout row is turned
+ * into prompt data.
+ */
+export function toCanonicalCadence(
+  cadence: number | null | undefined,
+  isRunningFamily: boolean
+): number | null | undefined {
+  if (!cadence) return cadence
+  return isRunningFamily && cadence < CANONICAL_RUN_CADENCE_THRESHOLD ? cadence * 2 : cadence
+}
+
+/**
+ * Below this, a running cadence is read as one-legged and doubled.
+ *
+ * Safety review (CW-387): the value has to sit above the fastest realistic
+ * one-legged cadence (~110, i.e. a 220 spm sprint) and below the slowest
+ * already-doubled running cadence a provider will emit. Steady running is
+ * 150-190 spm and even a very slow shuffle is ~140 spm, so 120 clears both
+ * sides for *running*. The residual (accepted) risk is a Garmin-sourced "Run"
+ * that is mostly walking: walking is ~100-120 spm, so such a session can be
+ * reported below the threshold in real spm and would then be doubled. That is
+ * rare, only affects sessions whose primary activity is not running, and the
+ * alternative -- trusting per-source provenance -- is not reliable either,
+ * because Intervals.icu re-syncs Garmin activities and does not document which
+ * convention it forwards. Revisit if a provenance flag ever lands on the
+ * workout row.
+ */
+const CANONICAL_RUN_CADENCE_THRESHOLD = 120
+
+/** `spm` for running-family workouts, `rpm` for everything else. */
+export function resolveCadenceUnit(workoutType: string | null | undefined): 'spm' | 'rpm' {
+  return isRunningCadenceFamily(workoutType) ? 'spm' : 'rpm'
+}
+
+/**
+ * Render an already-canonical cadence together with the unit its workout family
+ * uses. Always pair a value with its label through this helper rather than
+ * concatenating a literal `rpm`/`spm`.
+ */
+export function formatCadenceWithUnit(
+  canonicalCadence: number | null | undefined,
+  workoutType: string | null | undefined,
+  separator = ' '
+): string {
+  if (canonicalCadence === null || canonicalCadence === undefined) return 'N/A'
+  if (!Number.isFinite(canonicalCadence)) return 'N/A'
+  return `${Math.round(canonicalCadence)}${separator}${resolveCadenceUnit(workoutType)}`
 }
 
 function inferImpactProfile(
@@ -1984,6 +2073,14 @@ export function getActualIntervalsSourceForAnalysis(
   return chooseActualIntervalsSource(rawActual, detectedActual, plannedSteps, refs)
 }
 
+/**
+ * Render the detected/synced actual intervals as compact prompt rows.
+ *
+ * The workout-family context needed for cadence units and pace comes off the
+ * `workout` row this function already receives, so the exported signature is
+ * unchanged for `cli/debug/workout-facts.ts`, `scripts/dump-intervals.ts` and
+ * `trigger/analyze-plan-adherence.ts` (CW-387).
+ */
 export function formatActualIntervalsForPrompt(
   workout: any,
   plannedWorkout?: any,
@@ -1992,6 +2089,13 @@ export function formatActualIntervalsForPrompt(
   const intervals = getActualIntervalsForAnalysis(workout, plannedWorkout, refs)
   if (intervals.length === 0) return 'N/A'
 
+  const workoutType = workout?.type
+  const family = getWorkoutFamily(workoutType)
+  const isRunningFamily = family === 'run'
+  // Pace is the leading metric for runs and useful for the other distance
+  // sports; it is noise for indoor/strength work and for power-primary rides.
+  const paceCapable = family !== 'ride' && family !== 'strength'
+
   return intervals
     .map((interval, idx) => {
       const minutes = Math.floor(interval.durationSeconds / 60)
@@ -1999,12 +2103,25 @@ export function formatActualIntervalsForPrompt(
       const duration = `${minutes}m ${seconds}s`
       const avgPower = interval.avgPower != null ? `${Math.round(interval.avgPower)}W` : 'N/A'
       const avgHr = interval.avgHr != null ? `${Math.round(interval.avgHr)}bpm` : 'N/A'
-      const avgCadence =
-        interval.avgCadence != null ? `${Math.round(interval.avgCadence)}rpm` : 'N/A'
+      // Doubled here (once) so a run's legs read as steps per minute, matching
+      // the unit label and the session-level cadence line.
+      const avgCadence = formatCadenceWithUnit(
+        toCanonicalCadence(interval.avgCadence, isRunningFamily),
+        workoutType,
+        ''
+      )
+      // `ActualInterval.avgSpeed` is m/s; 1000 / (m/s) is seconds per km.
+      const avgPace = paceCapable
+        ? ` | ${
+            interval.avgSpeed != null && Number.isFinite(interval.avgSpeed) && interval.avgSpeed > 0
+              ? formatPromptPace(1000 / interval.avgSpeed)
+              : 'N/A'
+          }`
+        : ''
       const confidence =
         interval.confidence != null ? ` | conf ${(interval.confidence * 100).toFixed(0)}%` : ''
       const note = interval.ambiguityNote ? ` | note ${interval.ambiguityNote}` : ''
-      return `Int ${idx + 1}: ${duration} | ${interval.type} | ${avgPower} | ${avgHr} | ${avgCadence}${confidence}${note}`
+      return `Int ${idx + 1}: ${duration} | ${interval.type} | ${avgPower} | ${avgHr} | ${avgCadence}${avgPace}${confidence}${note}`
     })
     .join('\n      ')
 }


### PR DESCRIPTION
Fixes CW-387

The same physical quantity reached the model three different ways in one analysis prompt. This unifies them behind a single cadence convention and adds the missing pace column to the facts interval rows.

## One convention, one implementation

`server/utils/workout-analysis-facts.ts` now owns the convention:

- `isRunningCadenceFamily(type)` / `resolveCadenceUnit(type)` — running family is `spm`, everything else `rpm`.
- `toCanonicalCadence(cadence, isRunningFamily)` — the single doubling implementation.
- `formatCadenceWithUnit(canonicalCadence, type, separator?)` — the **only** thing that prints a unit, so a value and its label can no longer disagree.

`normalizeRunningCadence` in `workout-analysis-prompt.ts` is now a thin alias for `toCanonicalCadence` (kept as a named export because `trigger/analyze-workout.ts` re-exports it, and the CW-392 identity test pins it). Dependency direction is prompt → facts, so no new module is pulled into the facts graph and no auto-import name is exported twice.

Fixes per site:

1. **Session level** — unchanged behaviour, now labelled via `formatCadenceWithUnit` instead of an inline `includes('run') ? 'spm' : 'rpm'` ternary. `buildWorkoutAnalysisData` is documented as the single normalisation point for that payload, and its family test widened from `.includes('run')` to the shared family resolver (so `Treadmill` is now covered too).
2. **`## Interval Breakdown`** — was hardcoded `rpm` on already-doubled values, so a run read "177 rpm". Now labels by family; values are still normalised exactly once, upstream in `buildWorkoutAnalysisData`.
3. **Facts interval rows** (`formatActualIntervalsForPrompt`, feeding `trigger/analyze-plan-adherence.ts`) — was printing the **undoubled** value with a hardcoded `rpm`, so the same legs read "83rpm". Now normalised once and labelled by family.

**No signature change.** `formatActualIntervalsForPrompt` already receives the `workout` row, so `workout.type` supplies all the context needed. `cli/debug/workout-facts.ts`, `scripts/dump-intervals.ts` and `trigger/analyze-plan-adherence.ts` are untouched and compile clean.

## Pace in the facts interval rows

Rows for pace-capable workouts (everything except the `ride` and `strength` families) now carry average pace in `min/km`, derived from `ActualInterval.avgSpeed` (m/s) via the existing `formatPromptPace`. `N/A` when speed is missing. Ride rows are byte-identical to before — no pace column, so the adherence prompt for power-primary sessions is unchanged.

```
run:  Int 1: 4m 0s | WORK | N/A | 168bpm | 176spm | 4:00/km | conf 100%
ride: Int 1: 12m 0s | WORK | 255W | 155bpm | 88rpm | conf 100%
```

## Doubling-threshold safety review (AC 5)

Checked every sync writer. Provenance is genuinely mixed, which is why the heuristic exists:

- `services/garminService.ts` reads `averageRunCadenceInStepsPerMinute` — **already both feet** (~166).
- `strava.ts`, `intervals.ts`, `wahoo.ts`, `fit.ts` store the provider's `average_cadence` verbatim, and for runs those report **one leg** (~83).
- `rouvy.ts` is `cadenceRPM` (cycling).

There is no provenance flag on the workout row separating the two, so magnitude is what disambiguates them. `< 120` is safe for *running*: the fastest realistic one-legged cadence is ~110 (a 220 spm sprint) and the slowest already-doubled running cadence is ~140 spm, so the threshold clears both sides.

**Residual accepted risk, stated explicitly:** a Garmin-sourced `Run` that is mostly *walking* (walking is ~100–120 spm) can be reported below the threshold in genuine spm and would then be doubled. It is rare, only hits sessions whose primary activity is not running, and a per-source provenance rule is not a reliable fix either — Intervals.icu re-syncs Garmin activities and does not document which convention it forwards. The heuristic is therefore retained, with the reasoning and the revisit condition recorded in a doc comment on `CANONICAL_RUN_CADENCE_THRESHOLD`.

## Snapshot

The CW-392 prompt snapshot is **byte-identical** — deliberately. Its fixture is a `Ride`, and the ride path produces exactly the same strings under the new convention (`88 rpm`, `90 rpm`). Confirmed with `git diff --stat` on `__snapshots__/`. New assertions cover the run path instead of re-snapshotting.

## Tests

- `workout-analysis-prompt.test.ts` — a Run prompt asserting the session line **and** the Interval Breakdown rows agree (`176 spm` / `190 spm` / `180 spm` / `152 spm`) and that the prompt never says `rpm`; plus the mirror-image ride test asserting `rpm` everywhere and no `spm`.
- `workout-analysis-facts.test.ts` — `formatActualIntervalsForPrompt` for a run (doubled + `spm` + `min/km` pace present), for a ride (untouched + `rpm` + no pace column), the no-speed `N/A` case, and unit tests for the three convention helpers including idempotency of `toCanonicalCadence`.

## Verification

```
pnpm typecheck && pnpm test:unit server/utils/services server/utils/workout-analysis-facts.test.ts
```

```
typecheck: exit 0

 Test Files  25 passed (25)
      Tests  264 passed (264)
   Duration  3.76s
```
