### PR TITLE
fix(workouts): let threshold pace detection request the 40m peak bucket (CW-405)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -904,26 +904,47 @@ export function timeWeightedMean(
   return totalSeconds > 0 ? weightedSum / totalSeconds : null
 }
 
+/** One duration bucket `findPeakEfforts` searches for. */
+export interface PeakDuration {
+  sec: number
+  label: string
+}
+
 /**
- * Find peak efforts for standard durations (1min, 5min, 20min, etc.)
+ * The standard duration buckets every peak consumer shares.
+ *
+ * This list is load-bearing well beyond the peaks themselves: `pbDetectionService`
+ * mints a `POWER_<LABEL>` personal-best type from every entry, and both intervals
+ * endpoints return the buckets verbatim as rows in the UI peaks table. Adding a
+ * bucket here therefore invents a new PB type and a new UI row for every athlete.
+ * A caller that needs an off-list duration for its own maths should pass it via
+ * `findPeakEfforts`' `durations` argument instead of extending this list.
+ */
+export const DEFAULT_PEAK_DURATIONS: readonly PeakDuration[] = [
+  { sec: 5, label: '5s' },
+  { sec: 30, label: '30s' },
+  { sec: 60, label: '1m' },
+  { sec: 300, label: '5m' },
+  { sec: 600, label: '10m' },
+  { sec: 1200, label: '20m' },
+  { sec: 3600, label: '60m' }
+]
+
+/**
+ * Find peak efforts for standard durations (1min, 5min, 20min, etc.).
+ *
+ * `durations` defaults to {@link DEFAULT_PEAK_DURATIONS}. Pass an explicit list
+ * only when the caller consumes the result itself — anything handed to the PB
+ * detector or to the intervals endpoints must keep the default buckets.
  */
 export function findPeakEfforts(
   times: number[],
   values: number[],
-  metric: 'power' | 'heartrate' | 'pace'
+  metric: 'power' | 'heartrate' | 'pace',
+  durations: readonly PeakDuration[] = DEFAULT_PEAK_DURATIONS
 ): PeakEffort[] {
   if (!values || values.length === 0) return []
   if (!times || times.length < 2) return []
-
-  const durations = [
-    { sec: 5, label: '5s' },
-    { sec: 30, label: '30s' },
-    { sec: 60, label: '1m' },
-    { sec: 300, label: '5m' },
-    { sec: 600, label: '10m' },
-    { sec: 1200, label: '20m' },
-    { sec: 3600, label: '60m' }
-  ]
 
   const peaks: PeakEffort[] = []
 

--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -7,6 +7,12 @@ import { logger } from '@trigger.dev/sdk/v3'
 import { workoutStreamRepository } from '../repositories/workoutStreamRepository'
 import { formatPromptPace } from '../ai-prompt-format'
 
+/**
+ * Threshold pace is taken directly off the best sustained 40 minute effort (no
+ * scaling coefficient, unlike the 20 minute HR/power branches).
+ */
+export const THRESHOLD_PACE_PEAK_DURATION_SEC = 2400
+
 export const thresholdDetectionService = {
   /**
    * Detect potential new thresholds (LTHR, FTP) from workout data
@@ -281,12 +287,19 @@ export const thresholdDetectionService = {
       Array.isArray(workout.streams.velocity) &&
       Array.isArray(workout.streams.time)
     ) {
+      // Threshold pace is read off a 40 minute effort, which is deliberately not
+      // one of the shared DEFAULT_PEAK_DURATIONS buckets: adding it there would
+      // mint a POWER_40M personal-best type and a "40m" row in the UI peaks
+      // table. Ask for the one bucket this branch consumes instead.
       const pacePeaks = findPeakEfforts(
         workout.streams.time as number[],
         workout.streams.velocity as number[],
-        'pace'
+        'pace',
+        [{ sec: THRESHOLD_PACE_PEAK_DURATION_SEC, label: '40m' }]
       )
-      const peak40mPace = pacePeaks.find((p) => p.duration === 2400)?.value // 40m
+      const peak40mPace = pacePeaks.find(
+        (p) => p.duration === THRESHOLD_PACE_PEAK_DURATION_SEC
+      )?.value // 40m
 
       if (peak40mPace) {
         const detectedPacePerKm = 1000 / peak40mPace // s/km

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_PEAK_DURATIONS,
   detectIntervals,
   findPeakEfforts,
   resolveHrWorkThreshold,
@@ -447,5 +448,58 @@ describe('findPeakEfforts', () => {
   it('returns nothing for streams that are too short or empty', () => {
     expect(findPeakEfforts([], [], 'power')).toEqual([])
     expect(findPeakEfforts([0, 1, 2], [200, 200, 200], 'power')).toEqual([])
+  })
+
+  it('emits exactly the shared default buckets when no durations are requested', () => {
+    // pbDetectionService mints a POWER_<LABEL> personal-best type per bucket and
+    // both intervals endpoints render one peaks-table row per bucket, so this
+    // list is a product contract: changing it invents PB types and UI rows.
+    const times = Array.from({ length: 3601 }, (_, index) => index)
+    const watts = times.map(() => 250)
+
+    const peaks = findPeakEfforts(times, watts, 'power')
+
+    expect(peaks.map((p) => p.duration)).toEqual([5, 30, 60, 300, 600, 1200, 3600])
+    expect(peaks.map((p) => p.duration_label)).toEqual([
+      '5s',
+      '30s',
+      '1m',
+      '5m',
+      '10m',
+      '20m',
+      '60m'
+    ])
+    expect(DEFAULT_PEAK_DURATIONS.map((d) => d.sec)).toEqual([5, 30, 60, 300, 600, 1200, 3600])
+
+    // The 40 minute bucket thresholdDetectionService asks for must stay opt-in.
+    expect(peaks.find((p) => p.duration === 2400)).toBeUndefined()
+  })
+
+  it('emits only the requested buckets when durations are passed explicitly', () => {
+    const times = Array.from({ length: 2401 }, (_, index) => index)
+    const velocity = times.map(() => 4)
+
+    const peaks = findPeakEfforts(times, velocity, 'pace', [{ sec: 2400, label: '40m' }])
+
+    expect(peaks).toHaveLength(1)
+    expect(peaks[0]).toMatchObject({ duration: 2400, duration_label: '40m', metric: 'pace' })
+    expect(peaks[0]?.value).toBeCloseTo(4, 5)
+  })
+
+  it('applies the same pause and time-weighting rules to a requested bucket', () => {
+    // 20 minutes at 4 m/s, a 10 minute recording pause, then 20 more minutes.
+    // The activity spans 50 minutes of wall time but holds no continuous 40.
+    const times: number[] = []
+    const velocity: number[] = []
+    for (let t = 0; t <= 1199; t++) {
+      times.push(t)
+      velocity.push(4)
+    }
+    for (let t = 1800; t <= 2999; t++) {
+      times.push(t)
+      velocity.push(4)
+    }
+
+    expect(findPeakEfforts(times, velocity, 'pace', [{ sec: 2400, label: '40m' }])).toEqual([])
   })
 })

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -2,10 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { prisma } from '../../../../../server/utils/db'
 import { sportSettingsRepository } from '../../../../../server/utils/repositories/sportSettingsRepository'
-import { findPeakEfforts } from '../../../../../server/utils/interval-detection'
+import {
+  DEFAULT_PEAK_DURATIONS,
+  findPeakEfforts
+} from '../../../../../server/utils/interval-detection'
 import { createUserNotification } from '../../../../../server/utils/notifications'
 import { queueThresholdUpdateEmail } from '../../../../../server/utils/workout-insight-email'
-import { thresholdDetectionService } from '../../../../../server/utils/services/thresholdDetectionService'
+import {
+  THRESHOLD_PACE_PEAK_DURATION_SEC,
+  thresholdDetectionService
+} from '../../../../../server/utils/services/thresholdDetectionService'
 
 vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
@@ -27,9 +33,12 @@ vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () =
   }
 }))
 
-vi.mock('../../../../../server/utils/interval-detection', () => ({
-  findPeakEfforts: vi.fn()
-}))
+// `interval-detection` is deliberately NOT mocked. It used to be, and the stub
+// handed the service a synthetic `{ duration: 2400 }` peak bucket that the real
+// `findPeakEfforts` never produced — so threshold pace detection was dead code
+// for every athlete while the suite stayed green (CW-405). Driving the service
+// with real streams through the real implementation is what keeps the bucket
+// the service asks for and the bucket the detector emits from drifting apart.
 
 vi.mock('../../../../../server/utils/notifications', () => ({
   createUserNotification: vi.fn()
@@ -46,6 +55,33 @@ vi.mock('@trigger.dev/sdk/v3', () => ({
   }
 }))
 
+/** A 1Hz stream: `warmupSec` seconds easy, then `effortSec` seconds steady. */
+function steadyEffortStream(options: {
+  warmupSec: number
+  warmupValue: number
+  effortSec: number
+  effortValue: number
+}) {
+  const time: number[] = []
+  const values: number[] = []
+  for (let t = 0; t <= options.warmupSec + options.effortSec; t++) {
+    time.push(t)
+    values.push(t <= options.warmupSec ? options.warmupValue : options.effortValue)
+  }
+  return { time, values }
+}
+
+/** A run whose best sustained 40 minutes average exactly `velocity` m/s. */
+function runWithSustained40mEffort(velocity: number) {
+  const { time, values } = steadyEffortStream({
+    warmupSec: 300,
+    warmupValue: 2.5,
+    effortSec: THRESHOLD_PACE_PEAK_DURATION_SEC,
+    effortValue: velocity
+  })
+  return { time, velocity: values }
+}
+
 describe('thresholdDetectionService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -55,6 +91,25 @@ describe('thresholdDetectionService', () => {
     vi.mocked(prisma.metricHistory.createMany).mockResolvedValue({ count: 0 } as any)
   })
 
+  it('asks for a pace bucket the real findPeakEfforts actually produces', () => {
+    const { time, velocity } = runWithSustained40mEffort(4)
+
+    // The bucket the service requests is real...
+    const requested = findPeakEfforts(time, velocity, 'pace', [
+      { sec: THRESHOLD_PACE_PEAK_DURATION_SEC, label: '40m' }
+    ])
+    expect(requested.find((p) => p.duration === THRESHOLD_PACE_PEAK_DURATION_SEC)?.value).toBe(4)
+
+    // ...and it stays off the shared default list, so no POWER_40M personal-best
+    // type and no extra "40m" row in the UI peaks table appear as a side effect.
+    expect(DEFAULT_PEAK_DURATIONS.map((d) => d.sec)).not.toContain(THRESHOLD_PACE_PEAK_DURATION_SEC)
+    expect(
+      findPeakEfforts(time, velocity, 'pace').find(
+        (p) => p.duration === THRESHOLD_PACE_PEAK_DURATION_SEC
+      )
+    ).toBeUndefined()
+  })
+
   it('logs FTP history on the triggering workout date and stores the sport profile', async () => {
     const workoutDate = new Date('2025-02-05T10:00:00Z')
 
@@ -62,7 +117,13 @@ describe('thresholdDetectionService', () => {
       name: 'Cycling',
       ftp: 250
     } as any)
-    vi.mocked(findPeakEfforts).mockReturnValue([{ duration: 1200, value: 280 } as any])
+
+    const { time, values } = steadyEffortStream({
+      warmupSec: 300,
+      warmupValue: 150,
+      effortSec: 1200,
+      effortValue: 280
+    })
 
     await thresholdDetectionService.detectThresholdIncreases({
       id: 'workout-1',
@@ -72,8 +133,8 @@ describe('thresholdDetectionService', () => {
       durationSec: 3600,
       date: workoutDate,
       streams: {
-        watts: [200, 260, 300],
-        time: [0, 600, 1200]
+        watts: values,
+        time
       },
       user: {
         ftp: 250
@@ -104,6 +165,92 @@ describe('thresholdDetectionService', () => {
     )
   })
 
+  it('detects a threshold pace improvement from a real 40 minute effort', async () => {
+    const workoutDate = new Date('2025-01-10T07:30:00Z')
+
+    vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+      name: 'Running',
+      thresholdPace: 300
+    } as any)
+
+    const results = await thresholdDetectionService.detectThresholdIncreases({
+      id: 'workout-2a',
+      userId: 'user-1',
+      type: 'Run',
+      title: 'Threshold Run',
+      durationSec: 2700,
+      date: workoutDate,
+      streams: runWithSustained40mEffort(4),
+      user: {}
+    })
+
+    // 4 m/s sustained for 40 minutes is 250 s/km, comfortably faster than the
+    // athlete's stored 300 s/km threshold pace.
+    expect(results?.thresholdPace?.detected).toBe(true)
+    expect(results?.thresholdPace?.old).toBe(300)
+    expect(results?.thresholdPace?.new).toBeCloseTo(250, 5)
+    expect(prisma.recommendation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ metric: 'THRESHOLD_PACE' })
+    })
+  })
+
+  it('does not detect a threshold pace when no 40 minute effort exists', async () => {
+    const workoutDate = new Date('2025-01-11T07:30:00Z')
+
+    vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+      name: 'Running',
+      thresholdPace: 300
+    } as any)
+
+    // A brisk 35 minute run: fast enough to beat the stored threshold pace, but
+    // too short to hold a 40 minute effort.
+    const { time, values } = steadyEffortStream({
+      warmupSec: 300,
+      warmupValue: 2.5,
+      effortSec: 1800,
+      effortValue: 4.5
+    })
+
+    const results = await thresholdDetectionService.detectThresholdIncreases({
+      id: 'workout-2b',
+      userId: 'user-1',
+      type: 'Run',
+      title: 'Short Tempo',
+      durationSec: 2100,
+      date: workoutDate,
+      streams: { time, velocity: values },
+      user: {}
+    })
+
+    expect(results?.thresholdPace).toBeNull()
+    expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+  })
+
+  it('reports no improvement when the 40 minute effort is slower than the stored pace', async () => {
+    const workoutDate = new Date('2025-01-12T07:30:00Z')
+
+    vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+      name: 'Running',
+      thresholdPace: 240
+    } as any)
+
+    // 3.2 m/s over 40 minutes is 312.5 s/km, slower than the stored 240 s/km.
+    const results = await thresholdDetectionService.detectThresholdIncreases({
+      id: 'workout-2c',
+      userId: 'user-1',
+      type: 'Run',
+      title: 'Easy Long Run',
+      durationSec: 2700,
+      date: workoutDate,
+      streams: runWithSustained40mEffort(3.2),
+      user: {}
+    })
+
+    expect(results?.thresholdPace?.detected).toBe(false)
+    expect(prisma.recommendation.create).not.toHaveBeenCalled()
+  })
+
   it('logs running threshold pace history on the workout date', async () => {
     const workoutDate = new Date('2025-01-10T07:30:00Z')
 
@@ -111,7 +258,6 @@ describe('thresholdDetectionService', () => {
       name: 'Running',
       thresholdPace: 260
     } as any)
-    vi.mocked(findPeakEfforts).mockReturnValue([{ duration: 2400, value: 4 } as any])
 
     await thresholdDetectionService.detectThresholdIncreases({
       id: 'workout-2',
@@ -120,10 +266,7 @@ describe('thresholdDetectionService', () => {
       title: 'Tempo Run',
       durationSec: 3600,
       date: workoutDate,
-      streams: {
-        velocity: [3.8, 4, 4.1],
-        time: [0, 1200, 2400]
-      },
+      streams: runWithSustained40mEffort(4),
       user: {}
     })
 
@@ -143,7 +286,6 @@ describe('thresholdDetectionService', () => {
       name: 'Running',
       thresholdPace: 260
     } as any)
-    vi.mocked(findPeakEfforts).mockReturnValue([{ duration: 2400, value: 4 } as any])
 
     await thresholdDetectionService.detectThresholdIncreases({
       id: 'workout-3',
@@ -152,10 +294,7 @@ describe('thresholdDetectionService', () => {
       title: 'Tempo Run',
       durationSec: 3600,
       date: workoutDate,
-      streams: {
-        velocity: [3.8, 4, 4.1],
-        time: [0, 1200, 2400]
-      },
+      streams: runWithSustained40mEffort(4),
       user: { distanceUnits: 'Kilometers' }
     })
 
@@ -174,7 +313,6 @@ describe('thresholdDetectionService', () => {
       name: 'Running',
       thresholdPace: 260
     } as any)
-    vi.mocked(findPeakEfforts).mockReturnValue([{ duration: 2400, value: 4 } as any])
 
     await thresholdDetectionService.detectThresholdIncreases({
       id: 'workout-4',
@@ -183,10 +321,7 @@ describe('thresholdDetectionService', () => {
       title: 'Tempo Run',
       durationSec: 3600,
       date: workoutDate,
-      streams: {
-        velocity: [3.8, 4, 4.1],
-        time: [0, 1200, 2400]
-      },
+      streams: runWithSustained40mEffort(4),
       user: {}
     })
 
@@ -205,7 +340,6 @@ describe('thresholdDetectionService', () => {
       name: 'Running',
       thresholdPace: 260
     } as any)
-    vi.mocked(findPeakEfforts).mockReturnValue([{ duration: 2400, value: 4 } as any])
 
     await thresholdDetectionService.detectThresholdIncreases({
       id: 'workout-5',
@@ -214,10 +348,7 @@ describe('thresholdDetectionService', () => {
       title: 'Tempo Run',
       durationSec: 3600,
       date: workoutDate,
-      streams: {
-        velocity: [3.8, 4, 4.1],
-        time: [0, 1200, 2400]
-      },
+      streams: runWithSustained40mEffort(4),
       user: { distanceUnits: 'Miles' }
     })
 


### PR DESCRIPTION
Fixes CW-405

## Problem

`thresholdDetectionService` looked up `pacePeaks.find((p) => p.duration === 2400)`, but `findPeakEfforts` only ever emitted `[5, 30, 60, 300, 600, 1200, 3600]`. The `find()` always returned `undefined`, the guard never opened, and **threshold pace has never been auto-detected for any athlete** — silently.

It stayed invisible because the service's test mocked `interval-detection` wholesale and fed the service a synthetic `{ duration: 2400, value: 4 }` bucket. The mock and the implementation had never been compared.

## Fix

`findPeakEfforts` gains an optional fourth argument, `durations`, defaulting to a new exported `DEFAULT_PEAK_DURATIONS` (the same seven buckets as before). `thresholdDetectionService` passes `[{ sec: 2400, label: '40m' }]` for its pace call only.

The 40 minute bucket was deliberately **not** added to the shared list. That list is a product contract:

- `pbDetectionService.ts:73` mints a `POWER_<LABEL>` personal-best type per bucket — adding 40m would create a brand-new `POWER_40M` PB for every athlete.
- `server/api/workouts/[id]/intervals.get.ts` and `server/api/share/workouts/[token]/intervals.get.ts` return the buckets verbatim to the UI — adding 40m would add a "40m" row to the peaks table.

Every other caller still calls with three arguments and is byte-for-byte unchanged in behaviour.

## Proving the constraint held

- `DEFAULT_PEAK_DURATIONS` is unchanged; a test asserts a default `findPeakEfforts` call emits exactly `[5, 30, 60, 300, 600, 1200, 3600]` with labels `5s/30s/1m/5m/10m/20m/60m`, and explicitly that no `2400` bucket appears.
- A test in the service suite asserts `DEFAULT_PEAK_DURATIONS` does not contain the duration the service requests, and that a default call on the very same stream yields no 2400 bucket.
- `grep` confirms all four other call sites (`pbDetectionService`, both intervals endpoints, `cli/debug/intervals.ts`) pass three arguments and therefore take the default.
- The full unit suite passes: 370 files, 2158 tests.

## Test changes

`interval-detection` is no longer mocked in `thresholdDetectionService.test.ts`. All five pre-existing tests now drive the service with real 1Hz synthetic streams through the real `findPeakEfforts`, so mock and implementation cannot drift apart again. Added: the drift guard above, an end-to-end detection test (40 min at 4 m/s vs a stored 300 s/km threshold -> `detected: true`, 250 s/km), a negative test (35 min run -> `thresholdPace` null, no recommendation), and a no-improvement test (40 min at 3.2 m/s vs a stored 240 s/km -> `detected: false`).

Reverting only the service change makes 6 of the 9 service tests fail, confirming the new coverage actually catches the bug.

## Verification

```
pnpm test:unit tests/unit/server/utils/services/thresholdDetectionService.test.ts tests/unit/server/utils/interval-detection.test.ts
 Test Files  2 passed (2)
      Tests  33 passed (33)
```

`pnpm typecheck` clean, `eslint` clean, full `pnpm test:unit` green.

Backend only, no user-visible surface — UX critique round skipped by design.
