### PR TITLE
fix(workouts): give planned-step detection real athlete refs (CW-402)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -1191,3 +1191,241 @@ describe('cadence convention helpers (CW-387)', () => {
     expect(formatCadenceWithUnit(null, 'Run')).toBe('N/A')
   })
 })
+
+describe('planned-step detection refs (CW-402)', () => {
+  // The RECOVERY -> WORK promotion in `toDetectionPlannedSteps` reads an intensity
+  // factor built from the athlete's references. When those were hardcoded to zero,
+  // an absolute watts target fell back to a fixed "assume 250 W" divisor and an
+  // absolute bpm target produced null, so the rule could not fire off real
+  // references at all. The FTP below is deliberately far from 250 W so the two
+  // paths give different answers for the same step.
+  const FTP = 200
+  const LTHR = 160
+  const STEP_SECONDS = 300
+
+  function repeat(value: number) {
+    return Array.from({ length: STEP_SECONDS }, () => value)
+  }
+
+  function powerPlan() {
+    return {
+      structuredWorkout: {
+        steps: [
+          {
+            name: 'Spin up',
+            type: 'Warmup',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 120, units: 'w' }
+          },
+          {
+            name: 'Effort 1',
+            type: 'Interval',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 240, units: 'w' }
+          },
+          // Labelled recovery, but 170 W is 85% of a 200 W FTP: this is work.
+          {
+            name: 'Float 1',
+            type: 'Recovery',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 170, units: 'w' }
+          },
+          {
+            name: 'Effort 2',
+            type: 'Interval',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 240, units: 'w' }
+          },
+          // Genuine recovery at 50% of FTP: must stay RECOVERY either way.
+          {
+            name: 'Easy spin',
+            type: 'Recovery',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 100, units: 'w' }
+          },
+          {
+            name: 'Wind down',
+            type: 'Cooldown',
+            durationSeconds: STEP_SECONDS,
+            power: { value: 110, units: 'w' }
+          }
+        ]
+      }
+    }
+  }
+
+  const powerStream = [
+    ...repeat(120),
+    ...repeat(240),
+    ...repeat(170),
+    ...repeat(240),
+    ...repeat(100),
+    ...repeat(110)
+  ]
+
+  const rideWorkout = makeWorkout({
+    title: '2 x 5min with tempo floats',
+    type: 'Ride',
+    durationSec: powerStream.length,
+    streams: {
+      time: powerStream.map((_, index) => index),
+      watts: powerStream
+    }
+  })
+
+  it('promotes a work-intensity RECOVERY step when refs carry a real FTP', () => {
+    const intervals = getActualIntervalsForAnalysis(rideWorkout, powerPlan(), {
+      ftp: FTP,
+      lthr: 0,
+      maxHr: 0,
+      thresholdPace: 0
+    })
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'WORK',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+    // The 100 W step is genuine recovery and must not be swept up by the promotion.
+    expect(intervals[4]?.classification).toBe('recovery')
+  })
+
+  it('leaves the same step as RECOVERY when no FTP reference exists', () => {
+    const intervals = getActualIntervalsForAnalysis(rideWorkout, powerPlan(), {
+      ftp: 0,
+      lthr: 0,
+      maxHr: 0,
+      thresholdPace: 0
+    })
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+
+  it('reads the FTP from sport settings when refs are not passed explicitly', () => {
+    const intervals = getActualIntervalsForAnalysis(
+      { ...rideWorkout, sportSettings: { ftp: FTP } },
+      powerPlan()
+    )
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'WORK',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+
+  function hrPlan() {
+    return {
+      structuredWorkout: {
+        steps: [
+          {
+            name: 'Ease in',
+            type: 'Warmup',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 120, units: 'bpm' }
+          },
+          {
+            name: 'Effort 1',
+            type: 'Interval',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 172, units: 'bpm' }
+          },
+          // 142 bpm is 89% of a 160 bpm LTHR: work, despite the label.
+          {
+            name: 'Float 1',
+            type: 'Recovery',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 142, units: 'bpm' }
+          },
+          {
+            name: 'Effort 2',
+            type: 'Interval',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 172, units: 'bpm' }
+          },
+          {
+            name: 'Easy spin',
+            type: 'Recovery',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 118, units: 'bpm' }
+          },
+          {
+            name: 'Wind down',
+            type: 'Cooldown',
+            durationSeconds: STEP_SECONDS,
+            heartRate: { value: 110, units: 'bpm' }
+          }
+        ]
+      }
+    }
+  }
+
+  const hrStream = [
+    ...repeat(120),
+    ...repeat(172),
+    ...repeat(142),
+    ...repeat(172),
+    ...repeat(118),
+    ...repeat(110)
+  ]
+
+  const hrWorkout = makeWorkout({
+    title: '2 x 5min HR-guided',
+    type: 'Ride',
+    durationSec: hrStream.length,
+    averageWatts: null,
+    streams: {
+      time: hrStream.map((_, index) => index),
+      heartrate: hrStream
+    }
+  })
+
+  it('promotes a work-intensity RECOVERY step from an absolute bpm target and a real LTHR', () => {
+    const intervals = getActualIntervalsForAnalysis(hrWorkout, hrPlan(), {
+      ftp: 0,
+      lthr: LTHR,
+      maxHr: 0,
+      thresholdPace: 0
+    })
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'WORK',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+
+  it('keeps the bpm step as RECOVERY when there is no LTHR or max HR to compare against', () => {
+    const intervals = getActualIntervalsForAnalysis(hrWorkout, hrPlan(), {
+      ftp: 0,
+      lthr: 0,
+      maxHr: 0,
+      thresholdPace: 0
+    })
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+})

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1577,7 +1577,23 @@ function normalizePlannedStepType(
   return 'WORK'
 }
 
-function toDetectionPlannedSteps(steps: any[]): Array<{
+/**
+ * Flatten a structured workout into the shape `detectIntervals` consumes.
+ *
+ * `refs` must be the athlete's resolved references (`resolveAnalysisRefs`), NOT
+ * a zeroed placeholder: they are what turns an ABSOLUTE target (watts, bpm,
+ * m/s) into an intensity factor, and that intensity factor is the sole input to
+ * the RECOVERY -> WORK promotion below. With zeroed refs an absolute target
+ * yields null or a clamped guess, so a plan whose "recovery" steps are actually
+ * work-intensity was segmented as recovery and the resulting facts described the
+ * wrong session shape (CW-402). Callers without references may still pass a
+ * zeroed refs object: the promotion then simply cannot fire, which is the
+ * pre-fix behaviour.
+ */
+function toDetectionPlannedSteps(
+  steps: any[],
+  refs: AnalysisRefs
+): Array<{
   name?: string
   durationSeconds?: number
   duration?: number
@@ -1612,26 +1628,11 @@ function toDetectionPlannedSteps(steps: any[]): Array<{
       const metric = resolvePlannedStepMetric(step)
       const intensity =
         metric === 'power'
-          ? toIntensityFactorFromTarget(step.power, 'power', {
-              ftp: 0,
-              lthr: 0,
-              maxHr: 0,
-              thresholdPace: 0
-            })
+          ? toIntensityFactorFromTarget(step.power, 'power', refs)
           : metric === 'pace'
-            ? toIntensityFactorFromTarget(step.pace, 'pace', {
-                ftp: 0,
-                lthr: 0,
-                maxHr: 0,
-                thresholdPace: 0
-              })
+            ? toIntensityFactorFromTarget(step.pace, 'pace', refs)
             : metric === 'heartRate'
-              ? toIntensityFactorFromTarget(step.heartRate || step.hr, 'heartRate', {
-                  ftp: 0,
-                  lthr: 0,
-                  maxHr: 0,
-                  thresholdPace: 0
-                })
+              ? toIntensityFactorFromTarget(step.heartRate || step.hr, 'heartRate', refs)
               : metric === 'rpe' && typeof step.rpe === 'number'
                 ? clamp(step.rpe / 10, 0.3, 1.5)
                 : null
@@ -1762,7 +1763,8 @@ function buildDetectedIntervals(
   const plannedSteps = toDetectionPlannedSteps(
     getStructuredSteps(
       plannedWorkout?.structuredWorkout || workout?.plannedWorkout?.structuredWorkout
-    )
+    ),
+    refs
   )
 
   let detected: Array<{


### PR DESCRIPTION
Fixes CW-402

## Problem

`toDetectionPlannedSteps` in `server/utils/workout-analysis-facts.ts` built the intensity factor for every planned step from a hardcoded `{ ftp: 0, lthr: 0, maxHr: 0, thresholdPace: 0 }`. That intensity factor is the sole input to the RECOVERY -> WORK promotion rule immediately below it, so with zeroed references:

- an absolute **watts** target fell back to a fixed "assume 250 W" divisor, i.e. the rule fired off a constant rather than the athlete's FTP;
- an absolute **bpm** target returned `null`, so the rule could never fire at all;
- an absolute **m/s** pace target returned `null` for the same reason.

The mis-typed steps then flow into `detectIntervals` as `plannedSteps` and drive plan-guided segmentation, so a plan whose "recovery" steps are actually work-intensity got segmented wrong and the resulting facts and AI prompt described the wrong session shape.

## Fix

CW-384 already added `resolveAnalysisRefs()` and `buildDetectedIntervals` already resolves `const refs = resolveAnalysisRefs(workout, refsInput)` three lines above the call site — the correct refs were simply not being passed.

- `toDetectionPlannedSteps(steps, refs)` now takes an `AnalysisRefs` and threads it into all three `toIntensityFactorFromTarget` calls. The four zeroed literals are gone.
- `buildDetectedIntervals` (the only caller) passes its already-resolved `refs`.
- No public signature changed, so `cli/debug/workout-facts.ts`, `scripts/dump-intervals.ts` and `trigger/analyze-plan-adherence.ts` are unaffected.
- Ref-less callers still route through `resolveAnalysisRefs`, and a genuinely zeroed refs object keeps exactly the pre-fix behaviour (promotion cannot fire, no crash).

## Behaviour change to be aware of

This makes the RECOVERY -> WORK promotion actually fire off real references, which will change plan-guided interval detection for real workouts that have absolute-target plans. The new tests pin both directions: a 170 W step labelled "Recovery" against a 200 W FTP (85% of threshold) is promoted to WORK, while a 100 W step against the same FTP stays RECOVERY.

## Tests

New `planned-step detection refs (CW-402)` block in `server/utils/workout-analysis-facts.test.ts`, five cases:

- absolute **watts** target promoted to WORK when refs carry a real FTP, with a genuine low-watt recovery step in the same plan staying RECOVERY;
- the same plan staying RECOVERY when no FTP reference exists (documents the unchanged ref-less path);
- FTP read from `sportSettings` when refs are not passed explicitly;
- absolute **bpm** target promoted to WORK against a real LTHR (this path was completely dead before);
- the same bpm step staying RECOVERY with no LTHR or max HR.

The three positive cases fail on `develop` and pass with the fix; the two negative cases pass either way by design.

## Verification

```
$ pnpm test:unit server/utils/workout-analysis-facts.test.ts
 Test Files  1 passed (1)
      Tests  42 passed (42)

$ pnpm test:unit
 Test Files  370 passed (370)
      Tests  2171 passed (2171)

$ pnpm typecheck   # exit 0
$ pnpm lint        # 116 problems (0 errors, 116 warnings) - all pre-existing vue/require-default-prop in email components
```