### PR TITLE
fix(workouts): compute intensity zones for heart-rate intervals (CW-400)

### DIFF
--- a/cli/debug/intervals.ts
+++ b/cli/debug/intervals.ts
@@ -295,6 +295,9 @@ const intervalsDebugCommand = new Command('intervals')
         metric = 'heartrate'
         const maxHr = workout.maxHr || workout.user?.maxHr
         const threshold = maxHr ? maxHr * 0.7 : undefined
+        // Zone reference is the athlete's PROFILE LTHR/max HR, not the work bar
+        // above and not this session's own max HR (CW-400).
+        const hrRefs = { lthr: workout.user?.lthr, maxHr: workout.user?.maxHr }
         detected = detectIntervals(
           time,
           hr,
@@ -302,7 +305,8 @@ const intervalsDebugCommand = new Command('intervals')
           threshold,
           plannedSteps,
           undefined,
-          cadence
+          cadence,
+          hrRefs
         )
       }
 

--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -264,9 +264,12 @@ export default defineEventHandler(async (event) => {
     // HR would make the bar self-referential and drift session to session, so it
     // is only reached as an explicit last resort inside `resolveHrWorkThreshold`
     // when the profile carries neither LTHR nor max HR.
-    const threshold = resolveHrWorkThreshold({
+    const hrRefs = {
       lthr: sportSettings?.lthr ?? user.lthr,
-      maxHr: sportSettings?.maxHr ?? user.maxHr,
+      maxHr: sportSettings?.maxHr ?? user.maxHr
+    }
+    const threshold = resolveHrWorkThreshold({
+      ...hrRefs,
       sessionMaxHr: workout.maxHr
     })
     detectedEngineIntervals = detectIntervals(
@@ -276,7 +279,9 @@ export default defineEventHandler(async (event) => {
       threshold,
       plannedSteps,
       undefined,
-      cadenceStream || undefined
+      cadenceStream || undefined,
+      // Zone reference, kept separate from the work bar above (CW-400).
+      hrRefs
     )
   }
 

--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -1,4 +1,4 @@
-import { calculatePowerZones, calculateHrZones, identifyZone } from './zones'
+import { calculatePowerZones, calculateHrZones, identifyZone, type Zone } from './zones'
 
 /**
  * Utility for detecting intervals and peak efforts in workout stream data
@@ -207,6 +207,25 @@ export function resolveHrWorkThreshold(refs: {
 }
 
 /**
+ * The athlete's PROFILE heart-rate references, used to build HR training zones.
+ *
+ * Deliberately separate from the `threshold` argument. For `heartrate` that
+ * argument is the final work BAR in bpm (`resolveHrWorkThreshold`: 0.82 * LTHR
+ * or 0.7 * max HR), which is a segmentation bar, not a zone reference —
+ * `calculateHrZones` wants LTHR/max HR themselves. The bar cannot be turned
+ * back into them either: it carries no record of which of the two fractions
+ * produced it, so dividing by one of them would silently invent the other
+ * athlete's physiology (CW-400).
+ *
+ * Optional throughout: with neither value the HR zone stays `undefined` rather
+ * than being guessed off the work bar.
+ */
+export interface HrZoneRefs {
+  lthr?: number | null
+  maxHr?: number | null
+}
+
+/**
  * Detect intervals in a workout based on power or heart rate data
  * Uses a moving average and threshold-based approach
  *
@@ -226,6 +245,10 @@ export function resolveHrWorkThreshold(refs: {
  *                into a function that multiplied by 0.65 again, putting the work
  *                bar at ~46% of max HR: every sample read as work and the merge
  *                pass welded whole sessions into one interval (CW-383).
+ *
+ * `hrRefs` is the separate, optional channel for the athlete's profile LTHR/max
+ * HR. It exists only so HR intervals can be assigned an `intensity_zone`, and is
+ * never used for segmentation — see `HrZoneRefs`.
  */
 export function detectIntervals(
   times: number[],
@@ -234,7 +257,8 @@ export function detectIntervals(
   threshold?: number, // FTP, reference pace, or the final HR work bar in bpm
   plannedSteps?: PlannedStep[],
   smoothedValues?: number[],
-  cadenceValues?: number[]
+  cadenceValues?: number[],
+  hrRefs?: HrZoneRefs
 ): Interval[] {
   if (!times || !values || times.length !== values.length || times.length === 0) {
     return []
@@ -251,7 +275,8 @@ export function detectIntervals(
     threshold,
     plannedSteps,
     smoothed,
-    cadenceValues
+    cadenceValues,
+    hrRefs
   )
   if (plannedGuided.length > 0) {
     return plannedGuided
@@ -381,7 +406,17 @@ export function detectIntervals(
       // Downstream consumers that count reps filter on `type === 'WORK'`, and
       // labelling this WORK made every endurance session look like a 1x session.
       intervals = [
-        createIntervalObj(times, values, 0, times.length - 1, 'STEADY', threshold, metricType)
+        createIntervalObj(
+          times,
+          values,
+          0,
+          times.length - 1,
+          'STEADY',
+          threshold,
+          metricType,
+          undefined,
+          hrRefs
+        )
       ]
     }
   } else {
@@ -399,7 +434,8 @@ export function detectIntervals(
               type,
               threshold,
               metricType,
-              cadenceValues
+              cadenceValues,
+              hrRefs
             )
           )
         }
@@ -416,7 +452,8 @@ export function detectIntervals(
             'WORK',
             threshold,
             metricType,
-            cadenceValues
+            cadenceValues,
+            hrRefs
           )
         )
       }
@@ -439,7 +476,8 @@ export function detectIntervals(
           'COOLDOWN',
           threshold,
           metricType,
-          cadenceValues
+          cadenceValues,
+          hrRefs
         )
       )
     }
@@ -451,9 +489,18 @@ export function detectIntervals(
     const plannedWorkSteps = plannedSteps.filter((s) => s.type === 'WORK' || !s.type)
     const detectedWorkIntervals = intervals.filter((i) => i.type === 'WORK')
 
-    if (plannedWorkSteps.length > 0 && detectedWorkIntervals.length > 0) {
-      detectedWorkIntervals.forEach((interval, idx) => {
-        const plannedStep = plannedWorkSteps[idx]
+    // A STEADY session has no WORK interval at all, so the WORK-only pairing
+    // above left it with no label and no match score even when the athlete had
+    // linked a planned workout. Fall back to the unfiltered lists whenever
+    // either side of the WORK pairing is empty — when both sides have WORK the
+    // pairing is unchanged (CW-400).
+    const canPairWork = plannedWorkSteps.length > 0 && detectedWorkIntervals.length > 0
+    const stepsToMatch = canPairWork ? plannedWorkSteps : plannedSteps
+    const intervalsToMatch = canPairWork ? detectedWorkIntervals : intervals
+
+    if (stepsToMatch.length > 0 && intervalsToMatch.length > 0) {
+      intervalsToMatch.forEach((interval, idx) => {
+        const plannedStep = stepsToMatch[idx]
         if (plannedStep) {
           interval.label = plannedStep.name
           // Calculate match score based on duration
@@ -704,7 +751,8 @@ function detectIntervalsFromPlannedSteps(
   threshold?: number,
   plannedSteps?: PlannedStep[],
   smoothedValues?: number[],
-  cadenceValues?: number[]
+  cadenceValues?: number[],
+  hrRefs?: HrZoneRefs
 ): Interval[] {
   const flattened = flattenPlannedStepsForDetection(plannedSteps, metricType)
   if (flattened.length < 2) return []
@@ -792,7 +840,8 @@ function detectIntervalsFromPlannedSteps(
       step.type,
       threshold,
       metricType,
-      cadenceValues
+      cadenceValues,
+      hrRefs
     )
     interval.label = step.name
     interval.planned_step_id = step.id
@@ -1052,6 +1101,19 @@ function calculateBaseline(data: number[]): number {
   return median !== undefined ? median : 0
 }
 
+/**
+ * Zone number from a zone definition list: "Z2 Endurance" -> 2. HR zones split
+ * the top zone into Z5a/Z5b/Z5c, which all collapse to 5. Returns `undefined`
+ * for an empty zone list or a value outside every band.
+ */
+function resolveZoneNumber(value: number, zones: Zone[]): number | undefined {
+  const zone = identifyZone(value, zones)
+  if (!zone) return undefined
+  const match = zone.name.match(/^Z(\d+)/)
+  if (!match || !match[1]) return undefined
+  return parseInt(match[1])
+}
+
 function createIntervalObj(
   times: number[],
   values: number[],
@@ -1060,7 +1122,8 @@ function createIntervalObj(
   type: Interval['type'],
   threshold?: number,
   metricType?: 'power' | 'heartrate' | 'pace',
-  cadenceValues?: number[]
+  cadenceValues?: number[],
+  hrRefs?: HrZoneRefs
 ): Interval {
   const segmentValues = values.slice(startIdx, endIdx + 1)
   const sum = segmentValues.reduce((a, b) => a + (b || 0), 0)
@@ -1076,24 +1139,18 @@ function createIntervalObj(
 
   let intensity_zone: number | undefined
 
-  if (threshold && metricType) {
-    if (metricType === 'power') {
-      const zones = calculatePowerZones(threshold)
-      const zone = identifyZone(avg, zones)
-      if (zone) {
-        // Extract zone number from name "Z2 Endurance" -> 2
-        const match = zone.name.match(/^Z(\d+)/)
-        if (match && match[1]) intensity_zone = parseInt(match[1])
-      }
-    } else if (metricType === 'heartrate') {
-      // Estimate maxHR roughly if threshold is LTHR
-      // Or assume threshold passed IS MaxHR? The function signature says "FTP or Threshold Pace/HR"
-      // Let's assume for HR detection, threshold passed is usually MaxHR or LTHR.
-      // The identifyZone logic expects LTHR for HrZones usually.
-      // This is a bit ambiguous in the original code.
-      // For now, let's skip zone detection for HR here to avoid breakage,
-      // or implement a simple check if we want.
-    }
+  if (metricType === 'power' && threshold) {
+    // `threshold` is the athlete's FTP here, which IS the power zone reference.
+    intensity_zone = resolveZoneNumber(avg, calculatePowerZones(threshold))
+  } else if (metricType === 'heartrate') {
+    // HR zones do NOT come from `threshold`: for heartrate that argument is the
+    // final work bar in bpm (CW-383), a segmentation bar rather than a zone
+    // reference. Zones come from the athlete's profile LTHR/max HR, handed in
+    // separately as `hrRefs`. With neither available `calculateHrZones` returns
+    // an empty list and the zone stays undefined - the work bar is never used
+    // as a stand-in for LTHR (CW-400).
+    const zones = calculateHrZones(hrRefs?.lthr ?? null, hrRefs?.maxHr ?? null)
+    if (zones.length > 0) intensity_zone = resolveZoneNumber(avg, zones)
   }
 
   const startTimeValue = times[startIdx] || 0

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -160,6 +160,96 @@ describe('detectIntervals', () => {
     expect(intervals[0]?.duration).toBe(2399)
   })
 
+  // CW-400: the HR branch of createIntervalObj used to be an empty block, so
+  // every HR-detected interval came back with intensity_zone undefined. Zones
+  // come from the PROFILE refs, never from the work bar (which is already
+  // scaled - 0.82 * LTHR - and would put every effort a zone or two too high).
+  describe('heart-rate intensity zones', () => {
+    const block = (bpm: number, seconds: number) => Array.from({ length: seconds }, () => bpm)
+    const heartrate = [
+      ...block(112, 300), // warmup
+      ...block(155, 240), // work 1
+      ...block(115, 180), // recovery 1
+      ...block(155, 240), // work 2
+      ...block(115, 180), // recovery 2
+      ...block(155, 240), // work 3
+      ...block(105, 300) // cooldown
+    ]
+    const time = heartrate.map((_, index) => index)
+    const LTHR = 160
+    const threshold = resolveHrWorkThreshold({ lthr: LTHR })
+
+    it('assigns zones from a profile LTHR, not from the work bar', () => {
+      const intervals = detectIntervals(
+        time,
+        heartrate,
+        'heartrate',
+        threshold,
+        undefined,
+        undefined,
+        undefined,
+        { lthr: LTHR }
+      )
+
+      expect(intervals.length).toBeGreaterThan(1)
+      // Friel LTHR bands at LTHR 160: Z1 <= 130, Z4 150-158.
+      const workIntervals = intervals.filter((interval) => interval.type === 'WORK')
+      expect(workIntervals.length).toBeGreaterThan(0)
+      workIntervals.forEach((interval) => {
+        expect(interval.intensity_zone).toBe(4)
+      })
+      intervals
+        .filter((interval) => interval.type !== 'WORK')
+        .forEach((interval) => {
+          expect(interval.intensity_zone).toBe(1)
+        })
+    })
+
+    it('falls back to the max-HR zone model when only max HR is known', () => {
+      // Max-HR bands at 190: Z2 115-133, Z4 153-171.
+      const intervals = detectIntervals(
+        time,
+        heartrate,
+        'heartrate',
+        resolveHrWorkThreshold({ maxHr: 190 }),
+        undefined,
+        undefined,
+        undefined,
+        { maxHr: 190 }
+      )
+
+      const workIntervals = intervals.filter((interval) => interval.type === 'WORK')
+      expect(workIntervals.length).toBeGreaterThan(0)
+      workIntervals.forEach((interval) => {
+        expect(interval.intensity_zone).toBe(4)
+      })
+    })
+
+    it('leaves the zone undefined when the profile carries neither LTHR nor max HR', () => {
+      const intervals = detectIntervals(time, heartrate, 'heartrate', threshold)
+
+      expect(intervals.length).toBeGreaterThan(1)
+      intervals.forEach((interval) => {
+        expect(interval.intensity_zone).toBeUndefined()
+      })
+
+      // ...and passing empty refs must not guess off the work bar either.
+      const withEmptyRefs = detectIntervals(
+        time,
+        heartrate,
+        'heartrate',
+        threshold,
+        undefined,
+        undefined,
+        undefined,
+        { lthr: null, maxHr: null }
+      )
+      withEmptyRefs.forEach((interval) => {
+        expect(interval.intensity_zone).toBeUndefined()
+      })
+    })
+  })
+
   it('classifies a long steady power session with no candidates as STEADY', () => {
     const watts = Array.from({ length: 2400 }, (_, index) => 130 + (index % 5))
     const time = watts.map((_, index) => index)
@@ -168,6 +258,51 @@ describe('detectIntervals', () => {
 
     expect(intervals).toHaveLength(1)
     expect(intervals[0]?.type).toBe('STEADY')
+  })
+
+  // CW-400: plan-guided labelling paired planned WORK steps with detected WORK
+  // intervals only, so a STEADY session (which has no WORK interval at all) came
+  // back unlabelled even with a planned workout linked to it.
+  it('labels a STEADY session against its planned step', () => {
+    const watts = Array.from({ length: 2400 }, (_, index) => 130 + (index % 5))
+    const time = watts.map((_, index) => index)
+    const plannedSteps = [{ type: 'STEADY', name: 'Endurance ride', durationSeconds: 2400 }]
+
+    const intervals = detectIntervals(time, watts, 'power', 250, plannedSteps)
+
+    expect(intervals).toHaveLength(1)
+    expect(intervals[0]?.type).toBe('STEADY')
+    expect(intervals[0]?.label).toBe('Endurance ride')
+    expect(intervals[0]?.match_score).toBeGreaterThan(0.99)
+  })
+
+  it('still pairs planned WORK steps with detected WORK intervals only', () => {
+    const block = (value: number, seconds: number) => Array.from({ length: seconds }, () => value)
+    const watts = [
+      ...block(120, 600), // warmup
+      ...block(260, 300), // work 1
+      ...block(120, 300), // recovery 1
+      ...block(260, 300), // work 2
+      ...block(110, 300) // cooldown
+    ]
+    const time = watts.map((_, index) => index)
+    // A single planned step keeps plan-guided detection out of it (it needs two
+    // or more), so the tail matching block runs on a session that does have WORK
+    // intervals - the case the STEADY fallback must not disturb.
+    const plannedSteps = [{ type: 'WORK', durationSeconds: 300, name: 'Rep 1' }]
+
+    const intervals = detectIntervals(time, watts, 'power', 250, plannedSteps)
+    const workIntervals = intervals.filter((interval) => interval.type === 'WORK')
+
+    expect(workIntervals).toHaveLength(2)
+    expect(workIntervals[0]?.label).toBe('Rep 1')
+    expect(workIntervals[1]?.label).toBeUndefined()
+    // The label must not leak onto the warmup/recovery/cooldown blocks.
+    intervals
+      .filter((interval) => interval.type !== 'WORK')
+      .forEach((interval) => {
+        expect(interval.label).toBeUndefined()
+      })
   })
 })
 


### PR DESCRIPTION
Fixes CW-400

`createIntervalObj`'s heart-rate branch was an empty block holding only unresolved commentary about whether the `threshold` argument was LTHR or max HR, so every HR-detected interval came back with `intensity_zone: undefined` and `calculateHrZones` sat imported but unused.

## The work-bar vs zone-reference problem

CW-383 settled the ambiguity in the other direction than the original author guessed: for `heartrate`, `detectIntervals`' `threshold` is the FINAL work bar in bpm (`resolveHrWorkThreshold` -> `0.82 * LTHR` or `0.7 * maxHR`). That is a segmentation bar, not a zone reference — feeding it to `calculateHrZones(lthr, maxHr)` would treat ~82% of LTHR as LTHR itself and shift every effort a zone or two too high.

Back-deriving the reference out of the bar with the exported `HR_WORK_BAR_FRACTION_OF_LTHR` / `HR_WORK_BAR_FRACTION_OF_MAX_HR` constants was rejected: the bar carries no record of which of the two fractions produced it, so dividing by one of them silently invents a physiology the athlete does not have (a 190 max-HR athlete's 133 bpm bar would read back as LTHR 162), and it also picks the wrong zone MODEL — Friel LTHR bands vs the standard max-HR 5-zone bands are different shapes, not a rescaling of each other.

**Chosen approach:** thread the profile references separately as a new optional last parameter `hrRefs?: HrZoneRefs` (`{ lthr?, maxHr? }`) on `detectIntervals` -> `detectIntervalsFromPlannedSteps` -> `createIntervalObj`. The work bar keeps its CW-383 meaning and is never used for zones; the zone reference keeps its `calculateHrZones` meaning and is never used for segmentation.

**Trade-off:** `detectIntervals` now takes 8 positional parameters, which is one more than it should have. It was kept positional and optional deliberately so that all existing call sites (including `server/utils/workout-analysis-facts.ts`, concurrently edited under CW-386) compile and behave exactly as before — a params-object refactor would have touched every caller in the repo for a P4 correctness fix. If the signature grows again it should be converted to an options object in one deliberate pass.

## Changes

- `server/utils/interval-detection.ts`
  - new exported `HrZoneRefs` interface with the contract documented on it, threaded through as an optional 8th argument
  - HR branch now computes `intensity_zone` via `calculateHrZones(hrRefs.lthr, hrRefs.maxHr)` + `identifyZone`; with neither reference `calculateHrZones` returns `[]` and the zone stays `undefined` (no guessing off the work bar, nothing throws)
  - the zone-name parse (`"Z2 Endurance"` -> `2`) is extracted into `resolveZoneNumber` and shared by both branches, so the power path is behaviourally identical (`Z5a`/`Z5b`/`Z5c` all collapse to `5`)
  - plan-guided label matching falls back to the unfiltered planned-step/interval lists when either side of the `WORK`-only pairing is empty, so a STEADY session with a linked plan now gets its label and match score. When both sides have `WORK` the pairing is untouched.
- `server/api/workouts/[id]/intervals.get.ts`, `cli/debug/intervals.ts` — pass the profile refs alongside the work bar. `cli/debug/intervals.ts` is the only consumer of `intensity_zone` repo-wide, so this is what makes the fix observable.

Not wired (deliberately out of scope, noted for follow-up): `server/utils/workout-analysis-facts.ts` (concurrent CW-386 work; also does not read `intensity_zone`), and `server/api/workouts/[id]/streams.get.ts` / `server/api/share/workouts/[token]/intervals.get.ts`, which still build the HR bar inline as `maxHr * 0.7` instead of calling `resolveHrWorkThreshold`.

## Verification

```
$ pnpm test:unit tests/unit/server/utils/interval-detection.test.ts
 Test Files  1 passed (1)
      Tests  29 passed (29)
```

`pnpm typecheck` clean. `pnpm lint`: 0 errors (116 pre-existing warnings, all `vue/require-default-prop` in email components, none in touched files).

New tests: HR session with a profile LTHR -> work intervals carry `intensity_zone: 4` and the easy blocks `1`; max-HR-only refs -> correct 5-zone model; no refs / null refs -> `undefined` everywhere; STEADY session labelled from its planned step; and a guard that the WORK-only pairing still applies when WORK intervals exist.

## Risk

Low. `intensity_zone` has one consumer (the debug CLI table), is not persisted, not returned to the UI and not in any AI prompt. Power and pace paths are unchanged; the new parameter is optional so untouched callers are byte-identical.
