### PR TITLE
fix(workouts): give the STEADY interval its cadence stream (CW-417)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -414,7 +414,7 @@ export function detectIntervals(
           'STEADY',
           threshold,
           metricType,
-          undefined,
+          cadenceValues,
           hrRefs
         )
       ]

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -260,6 +260,37 @@ describe('detectIntervals', () => {
     expect(intervals[0]?.type).toBe('STEADY')
   })
 
+  // CW-417: the STEADY branch was the only createIntervalObj call site that
+  // passed `undefined` instead of the cadence stream, so exactly the session
+  // type where one steady cadence figure means the most reported none.
+  it('carries the cadence stream onto a STEADY interval', () => {
+    const watts = Array.from({ length: 2400 }, (_, index) => 130 + (index % 5))
+    const time = watts.map((_, index) => index)
+    const cadence = Array.from({ length: 2400 }, (_, index) => 88 + (index % 3))
+
+    const intervals = detectIntervals(time, watts, 'power', 250, undefined, undefined, cadence)
+
+    expect(intervals).toHaveLength(1)
+    expect(intervals[0]?.type).toBe('STEADY')
+    // Cadence cycles 88/89/90 across the whole session, so the mean is 89.
+    expect(intervals[0]?.avg_cadence).toBeCloseTo(89, 5)
+    expect(intervals[0]?.cadence_start).toBe(88)
+    expect(intervals[0]?.cadence_end).toBe(cadence[cadence.length - 1])
+  })
+
+  it('leaves STEADY cadence fields absent when no cadence stream is supplied', () => {
+    const watts = Array.from({ length: 2400 }, (_, index) => 130 + (index % 5))
+    const time = watts.map((_, index) => index)
+
+    const intervals = detectIntervals(time, watts, 'power', 250)
+
+    expect(intervals).toHaveLength(1)
+    expect(intervals[0]?.type).toBe('STEADY')
+    expect(intervals[0]?.avg_cadence).toBeUndefined()
+    expect(intervals[0]?.cadence_start).toBeUndefined()
+    expect(intervals[0]?.cadence_end).toBeUndefined()
+  })
+
   // CW-400: plan-guided labelling paired planned WORK steps with detected WORK
   // intervals only, so a STEADY session (which has no WORK interval at all) came
   // back unlabelled even with a planned workout linked to it.


### PR DESCRIPTION
Fixes CW-417

## What

`detectIntervals`'s STEADY special case (the branch that fires when no interval candidates were found and the session is long and continuous) called `createIntervalObj` with `undefined` in the `cadenceValues` position, while every other call site in the function passes the real stream. A long steady ride or run therefore came back as a single STEADY interval with `avg_cadence`, `cadence_start` and `cadence_end` all undefined even when a complete cadence stream was supplied.

One-argument fix: `undefined` -> `cadenceValues`.

## Side-by-side argument comparison (requested by AC 5)

Compared the STEADY call against the WARMUP/RECOVERY, WORK and COOLDOWN calls in the same function, and against the plan-guided call further down. `createIntervalObj(times, values, startIdx, endIdx, type, threshold?, metricType?, cadenceValues?, hrRefs?)`.

| arg | STEADY (before) | WARMUP/RECOVERY | WORK | COOLDOWN | plan-guided |
|---|---|---|---|---|---|
| times | `times` | `times` | `times` | `times` | `times` |
| values | `values` | `values` | `values` | `values` | `values` |
| startIdx | `0` | `lastEndIndex` | `candidate.start` | `lastEndIndex` | `currentStartIdx` |
| endIdx | `times.length - 1` | `candidate.start` | `candidate.end` | `times.length - 1` | `endIdx` |
| type | `'STEADY'` | `type` | `'WORK'` | `'COOLDOWN'` | `step.type` |
| threshold | `threshold` | `threshold` | `threshold` | `threshold` | `threshold` |
| metricType | `metricType` | `metricType` | `metricType` | `metricType` | `metricType` |
| cadenceValues | **`undefined`** | `cadenceValues` | `cadenceValues` | `cadenceValues` | `cadenceValues` |
| hrRefs | `hrRefs` | `hrRefs` | `hrRefs` | `hrRefs` | `hrRefs` |

**Result: `cadenceValues` was the only omission.** `threshold`, `metricType` and `hrRefs` were already passed correctly (`hrRefs` came in with CW-400 and did include the STEADY branch), and the index/type arguments are branch-specific by design. Nothing else needed fixing.

## Tests

Two tests added to `tests/unit/server/utils/interval-detection.test.ts`, alongside the existing CW-383 STEADY cases:

- `carries the cadence stream onto a STEADY interval` — a 2400s steady power stream with a cadence stream returns a STEADY interval with `avg_cadence` 89 and the expected `cadence_start` / `cadence_end`. Confirmed this test fails on the pre-fix code (`expected undefined to be close to 89`).
- `leaves STEADY cadence fields absent when no cadence stream is supplied` — same stream with no cadence: STEADY interval still returned, cadence fields absent, no crash and no zero-filling.

The 29 pre-existing tests in the file are untouched and still pass, so WORK / RECOVERY / WARMUP / COOLDOWN and the plan-guided path are unaffected.

## Verification

```
$ pnpm typecheck
exit 0

$ pnpm test:unit tests/unit/server/utils/interval-detection.test.ts
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

`pnpm lint`: 0 errors (116 pre-existing `vue/require-default-prop` warnings in unrelated email components).

Files touched: `server/utils/interval-detection.ts`, `tests/unit/server/utils/interval-detection.test.ts` — both within the ticket's Owned Paths, nothing outside.

Unblocks CW-399's STEADY row, which would otherwise render a blank cadence.
