### PR TITLE
fix(workouts): require real threshold evidence before nominating a threshold pace

### DIFF
--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -6,12 +6,109 @@ import { queueThresholdUpdateEmail } from '../workout-insight-email'
 import { logger } from '@trigger.dev/sdk/v3'
 import { workoutStreamRepository } from '../repositories/workoutStreamRepository'
 import { formatPromptPace } from '../ai-prompt-format'
+import { calculateHrZones } from '../zones'
 
 /**
  * Threshold pace is taken directly off the best sustained 40 minute effort (no
  * scaling coefficient, unlike the 20 minute HR/power branches).
+ *
+ * The missing coefficient is deliberate and stays that way (CW-413 reviewed it):
+ * the 20 minute buckets are scaled by 0.95 because a maximal 20 minute effort
+ * sits *above* threshold, whereas an effort held at threshold intensity for 40
+ * minutes is, by definition, threshold pace. What the raw formula needs is not a
+ * discount but proof that the 40 minutes really were at threshold intensity —
+ * see `corroborateThresholdEffortWithHr`. Scaling instead would have been a
+ * blanket pessimism applied equally to real threshold efforts and to easy runs.
  */
 export const THRESHOLD_PACE_PEAK_DURATION_SEC = 2400
+
+/**
+ * Share of the peak window's samples that must carry a usable heart rate before
+ * the average is treated as evidence. A strap that dropped out for most of the
+ * effort corroborates nothing.
+ */
+const THRESHOLD_PACE_HR_COVERAGE_MIN = 0.8
+
+export interface ThresholdEffortHrEvidence {
+  corroborated: boolean
+  /** Machine-readable reason, for logs. */
+  reason:
+    | 'no_hr_stream'
+    | 'no_hr_reference'
+    | 'insufficient_hr_coverage'
+    | 'below_threshold_band'
+    | 'in_threshold_band'
+  avgHr?: number
+  floorHr?: number
+}
+
+/**
+ * Does the heart rate recorded over a peak effort's own window show the athlete
+ * was actually working at threshold?
+ *
+ * The bar is the floor of the athlete's Z4 band as `calculateHrZones` already
+ * defines it (0.93 x LTHR, or 0.8 x max HR when no LTHR is known) — no new
+ * coefficient is invented here. Note this is deliberately *not*
+ * `resolveHrWorkThreshold`: that is interval detection's easy/work boundary
+ * (0.82 x LTHR / 0.7 x max HR), which a steady easy run clears comfortably.
+ *
+ * The session's own max HR is likewise not accepted as a reference. On an easy
+ * run the session max is itself an easy heart rate, so anything measured
+ * relative to it passes — the gate would fail open exactly where it matters.
+ *
+ * Every "we cannot tell" path returns `corroborated: false`: a missing
+ * recommendation is invisible, a wrong one moves the athlete's training zones.
+ */
+export function corroborateThresholdEffortWithHr(args: {
+  times: number[]
+  heartrate?: number[] | null
+  startSec: number
+  endSec: number
+  lthr?: number | null
+  maxHr?: number | null
+}): ThresholdEffortHrEvidence {
+  const { times, heartrate, startSec, endSec, lthr, maxHr } = args
+
+  if (!Array.isArray(heartrate) || heartrate.length === 0) {
+    return { corroborated: false, reason: 'no_hr_stream' }
+  }
+
+  const floorHr = calculateHrZones(lthr || null, maxHr || null).find((zone) =>
+    zone.name.startsWith('Z4')
+  )?.min
+
+  if (!floorHr || floorHr <= 0) {
+    return { corroborated: false, reason: 'no_hr_reference' }
+  }
+
+  let inWindow = 0
+  let usable = 0
+  let sum = 0
+
+  for (let i = 0; i < times.length; i++) {
+    const t = times[i]
+    if (t === undefined || t < startSec || t > endSec) continue
+    inWindow++
+    const hr = heartrate[i]
+    if (typeof hr === 'number' && Number.isFinite(hr) && hr > 0) {
+      usable++
+      sum += hr
+    }
+  }
+
+  if (inWindow === 0 || usable / inWindow < THRESHOLD_PACE_HR_COVERAGE_MIN) {
+    return { corroborated: false, reason: 'insufficient_hr_coverage', floorHr }
+  }
+
+  const avgHr = sum / usable
+
+  return {
+    corroborated: avgHr >= floorHr,
+    reason: avgHr >= floorHr ? 'in_threshold_band' : 'below_threshold_band',
+    avgHr,
+    floorHr
+  }
+}
 
 export const thresholdDetectionService = {
   /**
@@ -297,17 +394,53 @@ export const thresholdDetectionService = {
         'pace',
         [{ sec: THRESHOLD_PACE_PEAK_DURATION_SEC, label: '40m' }]
       )
-      const peak40mPace = pacePeaks.find(
-        (p) => p.duration === THRESHOLD_PACE_PEAK_DURATION_SEC
-      )?.value // 40m
+      const peak40m = pacePeaks.find((p) => p.duration === THRESHOLD_PACE_PEAK_DURATION_SEC) // 40m
+      const peak40mPace = peak40m?.value
 
-      if (peak40mPace) {
+      if (peak40m && peak40mPace) {
         const detectedPacePerKm = 1000 / peak40mPace // s/km
         const effectiveOldPace =
           currentThresholdPace || (castWorkout.thresholdPace ? castWorkout.thresholdPace : null)
 
-        if (!effectiveOldPace || detectedPacePerKm < effectiveOldPace - 2) {
-          // 2s improvement
+        // Two different questions, so two different tests.
+        //
+        // The athlete who already has a threshold pace is vouched for by the
+        // improvement test: 40 minutes held faster than their known threshold is
+        // itself the evidence, and the value only ever ratchets upward.
+        //
+        // The first nomination has nothing to beat, so that test degenerates to
+        // "any 40 minute stretch qualifies" — and the longest steady stretch of a
+        // long *easy* run qualifies just as readily as a threshold effort. Since
+        // CW-384/CW-401 that would also drag interval detection's pace work bar
+        // (0.8 x thresholdPace) down with it. Make the first nomination prove the
+        // effort was near threshold before it counts (CW-413).
+        let accepted: boolean
+
+        if (effectiveOldPace) {
+          accepted = detectedPacePerKm < effectiveOldPace - 2 // 2s improvement
+        } else {
+          const evidence = corroborateThresholdEffortWithHr({
+            times: workout.streams.time as number[],
+            heartrate: workout.streams.heartrate as number[] | null,
+            startSec: peak40m.start_time,
+            endSec: peak40m.end_time,
+            lthr: currentLthr,
+            maxHr: currentMaxHr
+          })
+          accepted = evidence.corroborated
+
+          if (!accepted) {
+            logger.log('Threshold pace nomination rejected: no threshold-intensity evidence', {
+              workoutId: workout.id,
+              reason: evidence.reason,
+              avgHr: evidence.avgHr,
+              floorHr: evidence.floorHr,
+              detectedPacePerKm
+            })
+          }
+        }
+
+        if (accepted) {
           results.thresholdPace = {
             old: effectiveOldPace || 0,
             new: detectedPacePerKm,
@@ -329,7 +462,11 @@ export const thresholdDetectionService = {
             )
           }
         } else {
-          results.thresholdPace = { old: effectiveOldPace, new: detectedPacePerKm, detected: false }
+          results.thresholdPace = {
+            old: effectiveOldPace || 0,
+            new: detectedPacePerKm,
+            detected: false
+          }
         }
       }
     }

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -9,6 +9,7 @@ import {
 import { createUserNotification } from '../../../../../server/utils/notifications'
 import { queueThresholdUpdateEmail } from '../../../../../server/utils/workout-insight-email'
 import {
+  corroborateThresholdEffortWithHr,
   THRESHOLD_PACE_PEAK_DURATION_SEC,
   thresholdDetectionService
 } from '../../../../../server/utils/services/thresholdDetectionService'
@@ -80,6 +81,20 @@ function runWithSustained40mEffort(velocity: number) {
     effortValue: velocity
   })
   return { time, velocity: values }
+}
+
+/**
+ * The same run, with a heart rate stream that holds `effortHr` over exactly the
+ * 40 minutes the pace peak is read from.
+ */
+function runWithSustained40mEffortAndHr(options: {
+  velocity: number
+  warmupHr: number
+  effortHr: number
+}) {
+  const { time, velocity } = runWithSustained40mEffort(options.velocity)
+  const heartrate = time.map((t) => (t <= 300 ? options.warmupHr : options.effortHr))
+  return { time, velocity, heartrate }
 }
 
 describe('thresholdDetectionService', () => {
@@ -249,6 +264,180 @@ describe('thresholdDetectionService', () => {
 
     expect(results?.thresholdPace?.detected).toBe(false)
     expect(prisma.recommendation.create).not.toHaveBeenCalled()
+  })
+
+  // The athlete with no stored threshold pace has nothing for the 2 s/km
+  // improvement test to compare against, so before CW-413 any 40 minute stretch
+  // — including the steady middle of a long easy run — nominated a threshold
+  // pace. That value then feeds interval detection's pace work bar
+  // (0.8 x thresholdPace), so a too-slow nomination pushes recovery jogs back
+  // into WORK. The first nomination now has to be corroborated by heart rate.
+  describe('first threshold pace nomination (athlete has none)', () => {
+    it('does not nominate one from a long easy run', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running',
+        lthr: 170
+      } as any)
+
+      // 3 m/s for 40 minutes is 333 s/km at 132 bpm — 78% of LTHR, an easy
+      // aerobic heart rate nowhere near the Z4 band floor (159 bpm).
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-6',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Long Easy Run',
+        durationSec: 5400,
+        date: new Date('2025-03-01T07:30:00Z'),
+        streams: runWithSustained40mEffortAndHr({ velocity: 3, warmupHr: 110, effortHr: 132 }),
+        user: {}
+      })
+
+      expect(results?.thresholdPace?.detected).toBe(false)
+      expect(results?.thresholdPace?.old).toBe(0)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+    })
+
+    it('nominates one from a sustained 40 minute effort at threshold heart rate', async () => {
+      const workoutDate = new Date('2025-03-02T07:30:00Z')
+
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running',
+        lthr: 170
+      } as any)
+
+      // 4 m/s for 40 minutes is 250 s/km at 168 bpm — 99% of LTHR, comfortably
+      // inside the Z4 threshold band.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-7',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Threshold Test',
+        durationSec: 3000,
+        date: workoutDate,
+        streams: runWithSustained40mEffortAndHr({ velocity: 4, warmupHr: 120, effortHr: 168 }),
+        user: {}
+      })
+
+      expect(results?.thresholdPace?.detected).toBe(true)
+      expect(results?.thresholdPace?.new).toBeCloseTo(250, 5)
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ metric: 'THRESHOLD_PACE' })
+      })
+    })
+
+    it('does not nominate one when the run carries no heart rate stream', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running',
+        lthr: 170
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-8',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Unstrapped Run',
+        durationSec: 3000,
+        date: new Date('2025-03-03T07:30:00Z'),
+        streams: runWithSustained40mEffort(4),
+        user: {}
+      })
+
+      expect(results?.thresholdPace?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when the athlete has no LTHR or max HR reference', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running'
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-9',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Hard Run, No Profile',
+        durationSec: 3000,
+        date: new Date('2025-03-04T07:30:00Z'),
+        streams: runWithSustained40mEffortAndHr({ velocity: 4, warmupHr: 120, effortHr: 168 }),
+        user: {}
+      })
+
+      expect(results?.thresholdPace?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('leaves the improvement path ungated for an athlete who already has a pace', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running',
+        lthr: 170,
+        thresholdPace: 300
+      } as any)
+
+      // Easy heart rate, but 250 s/km beats the stored 300 s/km by far more than
+      // 2 s/km. Holding 40 minutes faster than a known threshold pace is its own
+      // evidence, so the HR gate deliberately does not apply here.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-10',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Steady Run',
+        durationSec: 3000,
+        date: new Date('2025-03-05T07:30:00Z'),
+        streams: runWithSustained40mEffortAndHr({ velocity: 4, warmupHr: 110, effortHr: 130 }),
+        user: {}
+      })
+
+      expect(results?.thresholdPace?.detected).toBe(true)
+      expect(results?.thresholdPace?.old).toBe(300)
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ metric: 'THRESHOLD_PACE' })
+      })
+    })
+  })
+
+  describe('corroborateThresholdEffortWithHr', () => {
+    const times = Array.from({ length: 601 }, (_, i) => i)
+
+    it('rejects a window whose heart rate mostly dropped out', () => {
+      // 160 bpm where it recorded — but only over a fifth of the window.
+      const heartrate = times.map((t) => (t > 480 ? 160 : 0))
+
+      expect(
+        corroborateThresholdEffortWithHr({
+          times,
+          heartrate,
+          startSec: 0,
+          endSec: 600,
+          lthr: 170
+        })
+      ).toMatchObject({ corroborated: false, reason: 'insufficient_hr_coverage' })
+    })
+
+    it('falls back to the max HR band when no LTHR is known', () => {
+      const maxHr = 190
+
+      // Z4 for a max-HR athlete starts at 0.8 x max HR (153 bpm).
+      expect(
+        corroborateThresholdEffortWithHr({
+          times,
+          heartrate: times.map(() => 165),
+          startSec: 0,
+          endSec: 600,
+          maxHr
+        })
+      ).toMatchObject({ corroborated: true, reason: 'in_threshold_band' })
+
+      expect(
+        corroborateThresholdEffortWithHr({
+          times,
+          heartrate: times.map(() => 140),
+          startSec: 0,
+          endSec: 600,
+          maxHr
+        })
+      ).toMatchObject({ corroborated: false, reason: 'below_threshold_band' })
+    })
   })
 
   it('logs running threshold pace history on the workout date', async () => {


### PR DESCRIPTION
Fixes CW-413

CW-405 revived threshold-pace auto-detection, so this branch is about to fire in production for the first time ever. For an athlete who already has a threshold pace it only fires on a genuine 2 s/km improvement, which is sound. For an athlete with **none**, `!effectiveOldPace` short-circuited the test entirely: any 40-minute stretch qualified, including the steady middle of a long easy run. Since CW-384/CW-401 that value also drives interval detection's pace work bar (`0.8 x thresholdPace`), so a too-slow nomination lowers the work bar and pushes recovery jogs back into WORK.

## Gate chosen: heart-rate corroboration of the peak window

The first nomination now has to prove the 40 minutes were actually near threshold. `corroborateThresholdEffortWithHr` averages the heart-rate stream over **the peak effort's own window** (`PeakEffort.start_time`/`end_time`, which `findPeakEfforts` already returns) and requires that average to reach the floor of the athlete's Z4 band.

Why this one, over the two alternatives the ticket offered:

- **Best-in-recent-window** fails open exactly where the bug lives: an athlete who only ever runs easy still has a best-ever easy 40 minutes, and it would be nominated. It also needs workout history the service does not load, which is a new query and a new failure mode for a guard.
- **An intensity floor relative to another reference** has no reference to use — the athlete has no threshold pace, and using the session's own statistics is circular.
- **HR corroboration** uses only data already resolved a few lines up in the same function (`currentLthr`, `currentMaxHr`, `workout.streams.heartrate`) and fails safe on every "cannot tell" path: no HR stream, no LTHR/max HR on the profile, or a strap that dropped out over more than 20% of the window all return "not corroborated", so no recommendation is emitted.

**No new coefficients.** The bar is the Z4 floor as `calculateHrZones` already defines it — `0.93 x LTHR`, or `0.8 x max HR` when no LTHR is known.

Two things it deliberately does **not** use:

- **`resolveHrWorkThreshold`** — that is interval detection's easy/work boundary (`0.82 x LTHR` / `0.7 x max HR`). A steady easy run clears it comfortably, so it would not have caught the reported case.
- **Session max HR** as a fallback reference — on an easy run the session max is itself an easy heart rate, so anything measured relative to it passes. `resolveHrWorkThreshold` accepts it; this gate must not.

## The missing coefficient: reviewed, and deliberately kept

The ticket asked whether taking the 40-minute peak as threshold pace with no coefficient is right at all. **The maths is unchanged** (`1000 / peak40mPace`), and the reasoning is now written down at the `THRESHOLD_PACE_PEAK_DURATION_SEC` declaration.

The 20-minute HR/power branches scale by 0.95 because a *maximal* 20-minute effort sits above threshold. An effort held at threshold intensity for 40 minutes is, by definition, threshold pace — nothing to discount. The real defect was never the missing coefficient; it was that nothing checked the 40 minutes were an effort at all. A coefficient would have been blanket pessimism applied equally to genuine threshold efforts and to easy runs, and it would still have nominated a bogus (merely slower) pace off an easy run. The gate removes the bad input instead of shrinking every output.

## Unchanged

- The improvement path (`effectiveOldPace` set, new detection at least 2 s/km faster) is textually and behaviourally untouched, and now has a test pinning that the HR gate does **not** apply to it.
- The LTHR, FTP and max-HR branches are untouched.
- `server/utils/interval-detection.ts` is untouched; the `vi.mock` on it stays removed, so the new tests drive real synthetic streams through the real `findPeakEfforts`.
- Recommendation copy is unchanged (the maths did not change).

## Tests

Six new cases plus two direct unit tests for the helper:

- long easy run (3 m/s, 132 bpm at 78% of LTHR), athlete with no threshold pace -> no `THRESHOLD_PACE` recommendation
- sustained 40 minutes at threshold HR (4 m/s, 168 bpm at 99% of LTHR) -> still nominated
- same fast effort with no HR stream -> no recommendation
- same fast effort with no LTHR/max HR on the profile -> no recommendation
- improvement path for an athlete who already has a pace -> unchanged, ungated
- helper: HR dropout over most of the window is rejected; the max-HR band is used when no LTHR is known

## Verification

```
$ pnpm typecheck && pnpm test:unit tests/unit/server/utils/services/thresholdDetectionService.test.ts
Test Files  1 passed (1)
     Tests  16 passed (16)
```

`pnpm lint`: 0 errors (116 pre-existing warnings, none in the touched files). Rebased onto `origin/develop` at `de357a3e` and re-verified.
