### PR TITLE
fix(workouts): render STEADY intervals in the analysis UI (CW-399)

### DIFF
--- a/app/components/IntervalTable.vue
+++ b/app/components/IntervalTable.vue
@@ -57,7 +57,13 @@
           <tr
             v-for="(interval, index) in intervals"
             :key="index"
-            :class="interval.type === 'WORK' ? `bg-${props.color}-500/[0.02]` : ''"
+            :class="
+              interval.type === 'WORK'
+                ? `bg-${props.color}-500/[0.02]`
+                : interval.type === 'STEADY'
+                  ? 'bg-cyan-500/[0.02]'
+                  : ''
+            "
             class="hover:bg-white/[0.02] transition-colors cursor-pointer"
             @mouseenter="$emit('interval-hover', interval)"
             @mouseleave="$emit('interval-leave', interval)"
@@ -68,9 +74,11 @@
                 :class="[
                   interval.type === 'WORK'
                     ? `border-${props.color}-500/30 text-${props.color}-500 bg-${props.color}-500/5`
-                    : interval.type === 'RECOVERY'
-                      ? 'border-blue-500/30 text-blue-400 bg-blue-500/5'
-                      : 'border-zinc-500/30 text-zinc-400 bg-zinc-500/5'
+                    : interval.type === 'STEADY'
+                      ? 'border-cyan-500/30 text-cyan-700 dark:text-cyan-400 bg-cyan-500/5'
+                      : interval.type === 'RECOVERY'
+                        ? 'border-blue-500/30 text-blue-400 bg-blue-500/5'
+                        : 'border-zinc-500/30 text-zinc-400 bg-zinc-500/5'
                 ]"
               >
                 {{ interval.type }}

--- a/app/components/IntervalsAnalysis.vue
+++ b/app/components/IntervalsAnalysis.vue
@@ -47,17 +47,30 @@
           class="bg-white/[0.02] dark:bg-black rounded-2xl p-6 border border-white/5 shadow-inner group transition-all hover:bg-white/[0.04]"
         >
           <div
-            class="font-mono text-[9px] font-black uppercase tracking-[0.3em] text-primary-500 mb-4"
+            class="font-mono text-[9px] font-black uppercase tracking-[0.3em] mb-4"
+            :class="isSteadySession ? 'text-cyan-700 dark:text-cyan-400' : 'text-primary-500'"
           >
-            Work Intervals
+            {{ effortCardLabel }}
           </div>
+          <!-- A steady session always has exactly one block, so "1" would be a useless
+               headline. Lead with the duration instead - that is the number the athlete
+               actually cares about on a continuous ride. -->
           <div
             class="text-4xl font-black text-gray-900 dark:text-white tabular-nums tracking-tighter"
           >
-            {{ workIntervals.length }}
+            {{ isSteadySession ? formatBlockDuration(effortCardDuration) : effortCardCount }}
           </div>
-          <div class="font-mono text-[9px] font-bold text-zinc-500 uppercase tracking-widest mt-2">
-            Duration: {{ formatDuration(totalWorkDuration) }}
+          <div
+            v-if="!isSteadySession"
+            class="font-mono text-[9px] font-bold text-zinc-500 uppercase tracking-widest mt-2"
+          >
+            Duration: {{ formatDuration(effortCardDuration) }}
+          </div>
+          <div
+            v-else
+            class="font-mono text-[9px] font-bold text-cyan-700 dark:text-cyan-400 uppercase tracking-widest mt-2"
+          >
+            {{ steadySubLabel }}
           </div>
         </div>
 
@@ -180,7 +193,13 @@
               <tr
                 v-for="(interval, index) in data.intervals"
                 :key="index"
-                :class="interval.type === 'WORK' ? 'bg-primary-500/[0.02]' : ''"
+                :class="
+                  interval.type === 'WORK'
+                    ? 'bg-primary-500/[0.02]'
+                    : interval.type === 'STEADY'
+                      ? 'bg-cyan-500/[0.02]'
+                      : ''
+                "
                 class="hover:bg-white/[0.02] transition-colors"
               >
                 <td class="px-6 py-4 whitespace-nowrap">
@@ -189,9 +208,11 @@
                     :class="[
                       interval.type === 'WORK'
                         ? 'border-primary-500/30 text-primary-500 bg-primary-500/5'
-                        : interval.type === 'RECOVERY'
-                          ? 'border-blue-500/30 text-blue-400 bg-blue-500/5'
-                          : 'border-zinc-500/30 text-zinc-400 bg-zinc-500/5'
+                        : interval.type === 'STEADY'
+                          ? 'border-cyan-500/30 text-cyan-700 dark:text-cyan-400 bg-cyan-500/5'
+                          : interval.type === 'RECOVERY'
+                            ? 'border-blue-500/30 text-blue-400 bg-blue-500/5'
+                            : 'border-zinc-500/30 text-zinc-400 bg-zinc-500/5'
                     ]"
                   >
                     {{ interval.type }}
@@ -362,17 +383,51 @@
       unit = 'm/s'
     }
 
-    // Create annotations for intervals
+    // Create annotations for intervals.
+    // The chart series is downsampled, and `formatTime` collapses everything past the
+    // first hour to whole minutes, so label strings are ambiguous/duplicated and the
+    // annotation plugin cannot resolve them. Resolve the category index instead.
+    const chartTimes: number[] = data.value.chartData.time || []
+    const indexForTime = (seconds: number) => {
+      if (!chartTimes.length) return 0
+      let lo = 0
+      let hi = chartTimes.length - 1
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1
+        if ((chartTimes[mid] as number) < seconds) lo = mid + 1
+        else hi = mid
+      }
+      return lo
+    }
+
     const annotations: any = {}
 
     if (data.value.intervals) {
       data.value.intervals.forEach((interval: any, index: number) => {
-        if (interval.type === 'WORK') {
+        // STEADY is the whole-session block emitted for a continuous ride/run; it is
+        // the athlete's entire effort, so it has to be shaded too - just in its own
+        // hue so it never reads as a work rep.
+        const shading =
+          interval.type === 'WORK'
+            ? isDark
+              ? 'rgba(74, 222, 128, 0.1)'
+              : 'rgba(74, 222, 128, 0.2)' // Green tint
+            : interval.type === 'STEADY'
+              ? isDark
+                ? 'rgba(34, 211, 238, 0.18)'
+                : 'rgba(34, 211, 238, 0.22)' // Cyan tint - a STEADY box covers the whole
+              : null // trace, so it needs enough alpha to read against the black panel
+
+        if (shading) {
           annotations[`box${index}`] = {
             type: 'box',
-            xMin: formatTime(interval.start_time),
-            xMax: formatTime(interval.end_time),
-            backgroundColor: isDark ? 'rgba(74, 222, 128, 0.1)' : 'rgba(74, 222, 128, 0.2)', // Green tint
+            xMin: indexForTime(interval.start_time),
+            xMax: indexForTime(interval.end_time),
+            backgroundColor: shading,
+            // `ensureChartJsAnnotationDefaults` replaces the plugin's own defaults, which
+            // drops its default `drawTime`. Without this every annotation resolves to no
+            // draw phase and silently never paints - the state the WORK boxes shipped in.
+            drawTime: 'afterDatasetsDraw',
             borderWidth: 0
           }
         }
@@ -424,16 +479,22 @@
                 const time = data.value.chartData.time[index]
 
                 const interval = data.value.intervals.find(
-                  (i: any) => i.start_time <= time && i.end_time >= time && i.type === 'WORK'
+                  (i: any) =>
+                    i.start_time <= time &&
+                    i.end_time >= time &&
+                    (i.type === 'WORK' || i.type === 'STEADY')
                 )
 
                 if (interval) {
-                  return [
+                  const lines = [
                     '',
-                    `Interval: ${formatDuration(interval.duration)}`,
-                    `Avg Power: ${Math.round(interval.avg_power || 0)}W`,
-                    `Avg HR: ${Math.round(interval.avg_heartrate || 0)} bpm`
+                    `${interval.type === 'STEADY' ? 'Steady block' : 'Interval'}: ${formatDuration(interval.duration)}`
                   ]
+                  if (interval.avg_power)
+                    lines.push(`Avg Power: ${Math.round(interval.avg_power)}W`)
+                  if (interval.avg_heartrate)
+                    lines.push(`Avg HR: ${Math.round(interval.avg_heartrate)} bpm`)
+                  return lines
                 }
                 return []
               }
@@ -472,6 +533,43 @@
     return workIntervals.value.reduce((sum: number, i: any) => sum + i.duration, 0)
   })
 
+  // STEADY is the single whole-session block the engine emits for a continuous
+  // endurance ride/run. It is deliberately counted separately from WORK (folding it
+  // in would undo CW-383) but it must not leave the summary reading "0 intervals".
+  const steadyIntervals = computed(() => {
+    return data.value?.intervals?.filter((i: any) => i.type === 'STEADY') || []
+  })
+
+  const totalSteadyDuration = computed(() => {
+    return steadyIntervals.value.reduce((sum: number, i: any) => sum + i.duration, 0)
+  })
+
+  const isSteadySession = computed(
+    () => workIntervals.value.length === 0 && steadyIntervals.value.length > 0
+  )
+
+  const effortCardLabel = computed(() =>
+    isSteadySession.value
+      ? steadyIntervals.value.length === 1
+        ? 'Steady Block'
+        : 'Steady Blocks'
+      : 'Work Intervals'
+  )
+
+  const effortCardCount = computed(() =>
+    isSteadySession.value ? steadyIntervals.value.length : workIntervals.value.length
+  )
+
+  const effortCardDuration = computed(() =>
+    isSteadySession.value ? totalSteadyDuration.value : totalWorkDuration.value
+  )
+
+  const steadySubLabel = computed(() =>
+    steadyIntervals.value.length > 1
+      ? `${steadyIntervals.value.length} Continuous Blocks`
+      : 'Continuous Effort — No Reps'
+  )
+
   const bestEffort = computed(() => {
     if (!data.value?.peaks) return null
 
@@ -505,6 +603,8 @@
     switch (type) {
       case 'WORK':
         return 'primary'
+      case 'STEADY':
+        return 'cyan'
       case 'RECOVERY':
         return 'neutral'
       case 'WARMUP':
@@ -520,6 +620,17 @@
     const mins = Math.floor(seconds / 60)
     const secs = Math.round(seconds % 60)
     return `${mins}:${secs.toString().padStart(2, '0')}`
+  }
+
+  /**
+   * Headline duration for the steady card. `formatTime` floors the minutes, which makes a
+   * 1:14:59 block read "1h 14m" next to the workout header's "1:15:00"; round instead.
+   */
+  function formatBlockDuration(seconds: number) {
+    const totalMins = Math.round(seconds / 60)
+    const hours = Math.floor(totalMins / 60)
+    const mins = totalMins % 60
+    return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
   }
 
   function formatTime(seconds: number) {

--- a/app/pages/workouts/[id]/map.vue
+++ b/app/pages/workouts/[id]/map.vue
@@ -229,7 +229,13 @@
                   >
                     <td class="px-4 py-2.5 text-xs font-black">
                       <span
-                        :class="interval.type === 'WORK' ? 'text-primary-600' : 'text-gray-400'"
+                        :class="
+                          interval.type === 'WORK'
+                            ? 'text-primary-600'
+                            : interval.type === 'STEADY'
+                              ? 'text-cyan-700 dark:text-cyan-400'
+                              : 'text-gray-400'
+                        "
                       >
                         {{ interval.type }}
                       </span>


### PR DESCRIPTION
Fixes CW-399

The interval engine emits a single `STEADY` block for a continuous endurance ride/run (CW-383), but nothing in the frontend rendered that type. On an engine-detected steady session the summary read **"0 Work Intervals"**, the chart shaded nothing, and the badge fell through to grey.

## What changed

**STEADY gets its own identity — cyan.** Badge, row tint, chart annotation and the interval type label in `IntervalsAnalysis.vue`, `IntervalTable.vue` and the map page. Cyan is distinct from WORK (green/primary) and RECOVERY (blue), and is never the grey fallback. `getIntervalColor` gains an explicit `STEADY` case. Text is `cyan-700` in light and `cyan-400` in dark so it holds contrast on both backgrounds.

**Summary semantics — relabel the card, count STEADY separately.** When a session has no WORK reps but does have a STEADY block, the first card relabels itself to "Steady Block", leads with the block **duration** (`1h 15m`) instead of a rep count, and captions it "Continuous Effort — No Reps". STEADY is **never** added to the WORK count, so CW-383's correction stands. A count of "1" was rejected as the headline: a steady session always has exactly one block, so the number carries no information — the duration is what the athlete actually wants. The count is still reachable in the caption if there is ever more than one block. Sessions that do have WORK reps are untouched.

**Chart annotations now actually paint.** The AC asks the chart to shade the STEADY block, and while verifying it I found the annotation boxes had *never* rendered — WORK blocks included. Two causes, both fixed in `IntervalsAnalysis.vue`:
- `ensureChartJsAnnotationDefaults()` replaces `ChartJS.defaults.plugins.annotation` wholesale, which drops the plugin's own defaults including `drawTime`. Every annotation then resolves to no draw phase and silently never paints. Confirmed live by injecting a 60%-opaque red box into the running chart's options — nothing appeared until `drawTime` was set. Now set explicitly on each box.
- `xMin`/`xMax` were formatted time labels, but the series is downsampled and `formatTime` collapses everything past the first hour to whole minutes, so the labels are ambiguous and duplicated. Now resolved to category indices by binary search.

The shared helper is the real root cause but lives outside this ticket's Owned Paths, so it is worked around here and flagged for a follow-up.

**Tooltip** recognises STEADY ("Steady block: …" rather than "Interval: …") and omits the power/HR lines when those values are absent, instead of printing `Avg Power: 0W` on a steady run.

## i18n

None of these three components use Tolgee — every label in them is hardcoded English ("Work Intervals", "Telemetry Event Log", "Peak 5min Effort"). Per the AC, the new strings follow that local convention rather than introducing a namespace. **No new keys, no `tolgee.ts` change.**

## Verification

`pnpm typecheck && pnpm lint` — clean. Typecheck passes, lint reports 0 errors (116 pre-existing warnings repo-wide, **0 in the touched files**). Rebased onto latest `develop` (on top of CW-417) and re-run after.

Verified in the browser against two purpose-built fixtures with no provider laps, so the intervals API falls through to engine detection:
- steady 75-min endurance ride → engine returns `[STEADY 4499s @163W]`
- control 5x3min session → `[WARMUP, WORK, RECOVERY x4, WORK, COOLDOWN]`

Both in light and dark theme: STEADY shades cyan across the whole trace with the power line still legible; the card reads "STEADY BLOCK / 1h 15m / CONTINUOUS EFFORT — NO REPS", matching the workout header's 1:15:00. The control session's WARMUP/WORK/RECOVERY/COOLDOWN badges are unchanged, and its five green WORK boxes now shade the reps for the first time.

## UX critique: required

**Round 1 — FIX-FIRST.** Found that the fixtures used an unsupported `source`, which gated the whole Intervals section and hid the main panel; also flagged the chart shading as unverifiable, the "1" headline as meaningless, light-mode cyan contrast, and inconsistent cyan shades. All addressed: fixture fixed, the annotation bug found and fixed, headline switched to duration, `cyan-700` in light, shades unified.

**Round 2 — INCOMPLETE (environmental).** The dev server was stopped mid-review, so the agent could not finish the matrix. It verified the steady summary card and the STEADY table badge in dark theme before the outage and found no defects. Rather than spend the last round, the outstanding items were confirmed by hand: light-theme chart shading and card, the expanded Telemetry Event Log STEADY badge, and the full control-session regression pass. Its one in-scope nit — the table shows `74:59` while the card shows `1h 15m` — is left alone deliberately, since that formatter is shared with WORK rows and changing it would alter untouched rendering. Its other finding (a contradictory "POOR EXECUTION" badge in the AI Analysis card) is a different component and out of scope.

Screenshots were reviewed in-session but not saved to disk, so none are attached.
