### PR TITLE
fix(ai): unify workout analysis schema scores and status vocabulary (CW-403)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ANALYSIS_SCORE_MAX,
+  ANALYSIS_SCORE_MIN,
+  ANALYSIS_SECTION_STATUSES,
+  analysisSchema,
   buildAnalysisFactsPromptBlock,
   buildAnalysisGuardrailInstructions,
   buildWorkoutAnalysisData,
   buildWorkoutAnalysisPrompt,
+  clampAnalysisScore,
   getAnalysisSectionsGuidance,
   getWorkoutTypeGuidance,
   normalizeRunningCadence
@@ -432,5 +437,135 @@ describe('shared-module wiring', () => {
     expect(serviceSource).toContain("} from './workout-analysis-prompt'")
     expect(serviceSource).not.toContain('function buildWorkoutAnalysisPrompt')
     expect(serviceSource).not.toContain('function buildWorkoutAnalysisData')
+  })
+})
+
+/**
+ * CW-403 regression coverage.
+ *
+ * The response schema used to exist twice -- once in `trigger/analyze-workout.ts`
+ * (1-10 scores, `excellent/good/moderate/needs_improvement/poor`) and once in
+ * `server/utils/services/workoutAnalysisService.ts` (0-100 scores,
+ * `excellent/good/fair/needs_attention/info`). Gemini enforces whichever schema it is
+ * handed, so the service path -- the one that actually runs in production -- forced the
+ * model off the vocabulary the prompt asks for, and every UI status->colour mapper fell
+ * through to `neutral`: problem sections rendered grey instead of red.
+ *
+ * These tests read the vocabulary and the score scale back out of the *prompt string*
+ * and compare them to the schema, so the two cannot drift apart again silently.
+ */
+describe('analysisSchema matches the prompt it is handed with', () => {
+  const sectionStatusEnum = (analysisSchema.properties.sections as any).items.properties.status.enum
+  const scoreProps = (analysisSchema.properties.scores as any).properties
+  const scoreKeys = ['overall', 'technical', 'effort', 'pacing', 'execution'] as const
+
+  /** Every distinct "Assign status: a/b/c" vocabulary the prompt instructs, across sports. */
+  function statusVocabulariesInstructedByPrompt(): string[][] {
+    const guidance = [
+      getAnalysisSectionsGuidance('Strength', false, true),
+      getAnalysisSectionsGuidance('Run', true, false),
+      getAnalysisSectionsGuidance('Ride', true, false)
+    ].join('\n')
+
+    const matches = [...guidance.matchAll(/Assign status: ([a-z_/]+)/g)]
+    expect(matches.length).toBeGreaterThan(0)
+    return matches.map((m) => m[1]!.split('/'))
+  }
+
+  it('instructs exactly one status vocabulary across every sport variant', () => {
+    const vocabularies = statusVocabulariesInstructedByPrompt()
+    for (const vocabulary of vocabularies) {
+      expect(vocabulary).toEqual(vocabularies[0])
+    }
+  })
+
+  it('declares the section status enum the prompt asks for, and nothing else', () => {
+    const [instructed] = statusVocabulariesInstructedByPrompt()
+
+    expect(sectionStatusEnum).toEqual(instructed)
+    expect(sectionStatusEnum).toEqual([...ANALYSIS_SECTION_STATUSES])
+    // The retired vocabulary must never come back: the UI mappers do not understand it.
+    expect(sectionStatusEnum).not.toContain('fair')
+    expect(sectionStatusEnum).not.toContain('needs_attention')
+    expect(sectionStatusEnum).not.toContain('info')
+  })
+
+  it('declares 1-10 score bounds, matching the scale the prompt states', () => {
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(RIDE_WORKOUT),
+      'Europe/Budapest',
+      'Supportive',
+      undefined,
+      USER_PROFILE
+    )
+    expect(prompt).toContain('**Performance Scores** (1-10 scale for tracking progress over time)')
+
+    expect(ANALYSIS_SCORE_MIN).toBe(1)
+    expect(ANALYSIS_SCORE_MAX).toBe(10)
+    for (const key of scoreKeys) {
+      expect(scoreProps[key].minimum).toBe(1)
+      expect(scoreProps[key].maximum).toBe(10)
+      expect(scoreProps[key].description).toContain('(1-10)')
+    }
+  })
+
+  it('is the exact same object on both analysis entry points', () => {
+    expect(analyzeWorkoutTrigger.analysisSchema).toBe(analysisSchema)
+  })
+
+  it('is not redefined by either entry point', async () => {
+    const fs = await import('node:fs')
+    const serviceSource = fs.readFileSync(
+      new URL('./workoutAnalysisService.ts', import.meta.url),
+      'utf-8'
+    )
+    const triggerSource = fs.readFileSync(
+      new URL('../../../trigger/analyze-workout.ts', import.meta.url),
+      'utf-8'
+    )
+
+    expect(serviceSource).not.toContain('const analysisSchema')
+    expect(triggerSource).not.toContain('const analysisSchema')
+    expect(serviceSource).not.toContain('interface StructuredAnalysis')
+    expect(triggerSource).not.toContain('interface StructuredAnalysis')
+    // The service must import, never re-export: server/utils is Nitro auto-imported and
+    // re-exporting produces "Duplicated imports" warnings (CW-392 NOTE, CW-404).
+    expect(serviceSource).not.toMatch(/^export \{/m)
+  })
+})
+
+describe('clampAnalysisScore', () => {
+  it('is the single implementation both entry points call', async () => {
+    expect(analyzeWorkoutTrigger.clampAnalysisScore).toBe(clampAnalysisScore)
+
+    const fs = await import('node:fs')
+    const serviceSource = fs.readFileSync(
+      new URL('./workoutAnalysisService.ts', import.meta.url),
+      'utf-8'
+    )
+    const triggerSource = fs.readFileSync(
+      new URL('../../../trigger/analyze-workout.ts', import.meta.url),
+      'utf-8'
+    )
+    expect(serviceSource).not.toContain('const clampScore')
+    expect(triggerSource).not.toContain('const clampScore')
+  })
+
+  it('keeps 1-10 scores on the stored scale', () => {
+    expect(clampAnalysisScore(1)).toBe(1)
+    expect(clampAnalysisScore(7.4)).toBe(7)
+    expect(clampAnalysisScore(10)).toBe(10)
+  })
+
+  it('folds a stray 0-100 score back onto the stored 1-10 scale', () => {
+    // Safety net for responses produced while one entry point still declared 0-100.
+    expect(clampAnalysisScore(88)).toBe(9)
+    expect(clampAnalysisScore(100)).toBe(10)
+  })
+
+  it('returns null for non-numeric input', () => {
+    expect(clampAnalysisScore(null)).toBeNull()
+    expect(clampAnalysisScore(undefined)).toBeNull()
+    expect(clampAnalysisScore(Number.NaN)).toBeNull()
   })
 })

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -55,6 +55,289 @@ export interface WorkoutAnalysisPromptRecentContext {
 }
 
 /**
+ * The section-status vocabulary the prompt instructs the model to emit -- see the
+ * repeated "Assign status: excellent/good/moderate/needs_improvement/poor" lines in
+ * {@link getAnalysisSectionsGuidance}.
+ *
+ * This is also the vocabulary every UI status->colour mapper understands
+ * (`app/pages/workouts/[id]/index.vue`, `app/components/ScoreDetailModal.vue`,
+ * `app/pages/report/[id].vue`, `app/pages/share/workouts/[token].vue`). Until CW-403
+ * the Redis-worker service handed Gemini a *different* enum
+ * (`fair`/`needs_attention`/`info`), which those mappers fall through to `neutral`,
+ * so problem sections rendered grey instead of red. Keep this list, the schema enum
+ * below, and the prompt text in lockstep; `workout-analysis-prompt.test.ts` fails if
+ * they drift.
+ */
+export const ANALYSIS_SECTION_STATUSES = [
+  'excellent',
+  'good',
+  'moderate',
+  'needs_improvement',
+  'poor'
+] as const
+
+export type AnalysisSectionStatus = (typeof ANALYSIS_SECTION_STATUSES)[number]
+
+/**
+ * Inclusive bounds of the performance-score scale. The prompt asks for
+ * "**Performance Scores** (1-10 scale for tracking progress over time)" and the DB
+ * columns (`overallScore`, `technicalScore`, ...) already hold 1-10 values, so this
+ * is the scale the schema must declare too. Do not change without a data migration.
+ */
+export const ANALYSIS_SCORE_MIN = 1
+export const ANALYSIS_SCORE_MAX = 10
+
+/**
+ * Shape of the structured analysis Gemini returns for {@link analysisSchema}.
+ *
+ * `status` is typed as a plain `string` on purpose: analyses stored before CW-403 can
+ * contain the retired `fair`/`needs_attention`/`info` values, and the renderers must
+ * keep accepting them.
+ */
+export interface StructuredAnalysis {
+  type: string
+  title: string
+  date?: string
+  executive_summary: string
+  sections?: Array<{
+    title: string
+    status: string
+    status_label?: string
+    analysis_points: string[]
+  }>
+  recommendations?: Array<{
+    title: string
+    description: string
+    priority?: string
+  }>
+  strengths?: string[]
+  weaknesses?: string[]
+  scores?: {
+    overall: number
+    overall_explanation: string
+    technical: number
+    technical_explanation: string
+    effort: number
+    effort_explanation: string
+    pacing: number
+    pacing_explanation: string
+    execution: number
+    execution_explanation: string
+  }
+  metrics_summary?: {
+    avg_power?: number
+    ftp?: number
+    intensity?: number
+    duration_minutes?: number
+    tss?: number
+  }
+}
+
+/**
+ * The single response schema handed to `generateStructuredAnalysis` by BOTH workout
+ * analysis entry points -- the Redis-worker service
+ * (`server/utils/services/workoutAnalysisService.ts`, the one that runs in production)
+ * and the Trigger.dev task (`trigger/analyze-workout.ts`).
+ *
+ * It lives next to the prompt that describes it so the two cannot drift (CW-403).
+ * Gemini enforces the schema, so anything declared here overrides what the prompt
+ * text asks for.
+ */
+export const analysisSchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      description: 'Type of analysis: workout, weekly_report, planning, etc.',
+      enum: ['workout', 'weekly_report', 'planning', 'comparison']
+    },
+    title: {
+      type: 'string',
+      description: 'Title of the analysis'
+    },
+    date: {
+      type: 'string',
+      description: 'Date or date range of the analysis'
+    },
+    executive_summary: {
+      type: 'string',
+      description: '2-3 sentence high-level summary of key findings'
+    },
+    sections: {
+      type: 'array',
+      description: 'Analysis sections with status and points',
+      items: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Section title (e.g., Pacing Strategy, Power Application)'
+          },
+          status: {
+            type: 'string',
+            description: 'Overall assessment',
+            enum: [...ANALYSIS_SECTION_STATUSES]
+          },
+          status_label: {
+            type: 'string',
+            description: 'Display label for status'
+          },
+          analysis_points: {
+            type: 'array',
+            description: 'Detailed analysis points for this section',
+            items: {
+              type: 'string'
+            }
+          }
+        },
+        required: ['title', 'status', 'analysis_points']
+      }
+    },
+    recommendations: {
+      type: 'array',
+      description: 'Actionable recommendations',
+      items: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Recommendation title'
+          },
+          description: {
+            type: 'string',
+            description: 'Detailed recommendation'
+          },
+          priority: {
+            type: 'string',
+            description: 'Priority level',
+            enum: ['high', 'medium', 'low']
+          }
+        },
+        required: ['title', 'description']
+      }
+    },
+    strengths: {
+      type: 'array',
+      description: 'Key strengths identified',
+      items: {
+        type: 'string'
+      }
+    },
+    weaknesses: {
+      type: 'array',
+      description: 'Areas needing improvement',
+      items: {
+        type: 'string'
+      }
+    },
+    scores: {
+      type: 'object',
+      description:
+        'Performance scores on 1-10 scale for tracking over time, with detailed explanations',
+      properties: {
+        overall: {
+          type: 'number',
+          description: 'Overall workout quality (1-10)',
+          minimum: ANALYSIS_SCORE_MIN,
+          maximum: ANALYSIS_SCORE_MAX
+        },
+        overall_explanation: {
+          type: 'string',
+          description:
+            'Detailed explanation of overall quality: key factors contributing to score, what went well, what could improve, and 2-3 specific actionable improvements'
+        },
+        technical: {
+          type: 'number',
+          description: 'Technical execution score - form, technique, efficiency (1-10)',
+          minimum: ANALYSIS_SCORE_MIN,
+          maximum: ANALYSIS_SCORE_MAX
+        },
+        technical_explanation: {
+          type: 'string',
+          description:
+            'Technical analysis: power application smoothness, cadence consistency, form observations, and specific technique improvements needed'
+        },
+        effort: {
+          type: 'number',
+          description: 'Effort appropriateness relative to plan and goals (1-10)',
+          minimum: ANALYSIS_SCORE_MIN,
+          maximum: ANALYSIS_SCORE_MAX
+        },
+        effort_explanation: {
+          type: 'string',
+          description:
+            'Effort management analysis: whether intensity matched goals, HR/power relationship, and recommendations for effort control'
+        },
+        pacing: {
+          type: 'number',
+          description: 'Pacing strategy and execution quality (1-10)',
+          minimum: ANALYSIS_SCORE_MIN,
+          maximum: ANALYSIS_SCORE_MAX
+        },
+        pacing_explanation: {
+          type: 'string',
+          description:
+            'Pacing strategy analysis: consistency throughout workout, whether pacing was appropriate, and specific pacing improvements'
+        },
+        execution: {
+          type: 'number',
+          description: 'How well the workout plan was executed (1-10)',
+          minimum: ANALYSIS_SCORE_MIN,
+          maximum: ANALYSIS_SCORE_MAX
+        },
+        execution_explanation: {
+          type: 'string',
+          description:
+            'Execution quality analysis: adherence to workout structure, target achievement, and recommendations for better execution'
+        }
+      },
+      required: [
+        'overall',
+        'overall_explanation',
+        'technical',
+        'technical_explanation',
+        'effort',
+        'effort_explanation',
+        'pacing',
+        'pacing_explanation',
+        'execution',
+        'execution_explanation'
+      ]
+    },
+    metrics_summary: {
+      type: 'object',
+      description: 'Key metrics at a glance',
+      properties: {
+        avg_power: { type: 'number' },
+        ftp: { type: 'number' },
+        intensity: { type: 'number' },
+        duration_minutes: { type: 'number' },
+        tss: { type: 'number' }
+      }
+    }
+  },
+  required: ['type', 'title', 'executive_summary', 'sections', 'scores']
+}
+
+/**
+ * Normalise a model-supplied performance score to the 1-10 integer scale the
+ * `*Score` workout columns hold.
+ *
+ * The `> 10` branch is a safety net for historic responses produced while one entry
+ * point still declared a 0-100 schema; it is kept so a stray 0-100 score is folded
+ * back onto the stored scale instead of being clamped flat to 10.
+ *
+ * Named `clampAnalysisScore` rather than `clampScore` because everything under
+ * `server/utils` is Nitro auto-imported and `clampScore` is already used as a local
+ * (0-100) helper elsewhere in the server tree.
+ */
+export function clampAnalysisScore(val?: number | null): number | null {
+  if (typeof val !== 'number' || Number.isNaN(val)) return null
+  const num = val > ANALYSIS_SCORE_MAX ? val / 10 : val
+  return Math.min(ANALYSIS_SCORE_MAX, Math.max(ANALYSIS_SCORE_MIN, Math.round(num)))
+}
+
+/**
  * Running exports sometimes report "per-foot" cadence (< 120). Convert those into
  * total steps per minute so the model never reads a 85 spm run as a form problem.
  *

--- a/server/utils/services/workoutAnalysisService.ts
+++ b/server/utils/services/workoutAnalysisService.ts
@@ -13,206 +13,28 @@ import { thresholdDetectionService } from './thresholdDetectionService'
 import { pbDetectionService } from './pbDetectionService'
 import { isWorkoutEligibleForAutomaticInsights } from '../automatic-workout-insights'
 import { buildWorkoutAnalysisFactsV2 } from '../workout-analysis-facts'
-import { buildWorkoutAnalysisData, buildWorkoutAnalysisPrompt } from './workout-analysis-prompt'
+import {
+  analysisSchema,
+  buildWorkoutAnalysisData,
+  buildWorkoutAnalysisPrompt,
+  clampAnalysisScore,
+  type StructuredAnalysis
+} from './workout-analysis-prompt'
 import { registerTaskHandler } from '../task-registry'
 
 // NOTE: the payload/prompt builders now live in ./workout-analysis-prompt so this
 // service and the Trigger.dev task (trigger/analyze-workout.ts) cannot drift apart
-// again (CW-392). They are deliberately NOT re-exported from here: everything under
-// server/utils is Nitro auto-imported, and re-exporting would register the same
-// symbol twice and trigger "Duplicated imports" warnings. Import them from
+// again (CW-392). The response schema, the StructuredAnalysis type and the score
+// clamp moved there too (CW-403) -- the two schema copies had drifted onto different
+// score scales and different section-status enums, and this file was handing Gemini
+// an enum the UI colour mappers do not understand.
+//
+// None of them are re-exported from here: everything under server/utils is Nitro
+// auto-imported, and re-exporting would register the same symbol twice and trigger
+// "Duplicated imports" warnings. Import them from
 // server/utils/services/workout-analysis-prompt instead.
 
 const logger = console
-
-export interface StructuredAnalysis {
-  type: string
-  title: string
-  date?: string
-  executive_summary: string
-  sections?: Array<{
-    title: string
-    status: string
-    status_label?: string
-    analysis_points: string[]
-  }>
-  recommendations?: Array<{
-    title: string
-    description: string
-    priority?: string
-  }>
-  strengths?: string[]
-  weaknesses?: string[]
-  scores?: {
-    overall: number
-    overall_explanation: string
-    technical: number
-    technical_explanation: string
-    effort: number
-    effort_explanation: string
-    pacing: number
-    pacing_explanation: string
-    execution: number
-    execution_explanation: string
-  }
-  metrics_summary?: {
-    avg_power?: number
-    ftp?: number
-    intensity?: number
-    duration_minutes?: number
-    tss?: number
-  }
-}
-
-export const analysisSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      description: 'Type of analysis: workout, weekly_report, planning, etc.',
-      enum: ['workout', 'weekly_report', 'planning', 'comparison']
-    },
-    title: {
-      type: 'string',
-      description: 'Title of the analysis'
-    },
-    date: {
-      type: 'string',
-      description: 'Date of the analysis in ISO format'
-    },
-    executive_summary: {
-      type: 'string',
-      description: 'High-level summary of the workout or report'
-    },
-    sections: {
-      type: 'array',
-      description: 'Detailed analysis sections (e.g., Pacing, Heart Rate, Execution)',
-      items: {
-        type: 'object',
-        properties: {
-          title: { type: 'string' },
-          status: {
-            type: 'string',
-            enum: ['excellent', 'good', 'fair', 'needs_attention', 'info']
-          },
-          status_label: { type: 'string' },
-          analysis_points: {
-            type: 'array',
-            items: { type: 'string' }
-          }
-        },
-        required: ['title', 'status', 'analysis_points']
-      }
-    },
-    recommendations: {
-      type: 'array',
-      description: 'Actionable recommendations for future training',
-      items: {
-        type: 'object',
-        properties: {
-          title: { type: 'string' },
-          description: { type: 'string' },
-          priority: {
-            type: 'string',
-            enum: ['high', 'medium', 'low']
-          }
-        },
-        required: ['title', 'description']
-      }
-    },
-    strengths: {
-      type: 'array',
-      items: { type: 'string' },
-      description: 'Key positive aspects of the workout'
-    },
-    weaknesses: {
-      type: 'array',
-      items: { type: 'string' },
-      description: 'Areas for improvement'
-    },
-    scores: {
-      type: 'object',
-      description:
-        'Quantitative scoring (0-100) for different aspects of the workout, each accompanied by a 1-sentence explanation.',
-      properties: {
-        overall: {
-          type: 'integer',
-          minimum: 0,
-          maximum: 100,
-          description: 'Overall workout quality score (0-100)'
-        },
-        overall_explanation: {
-          type: 'string',
-          description: '1-sentence explanation justifying the overall quality score.'
-        },
-        technical: {
-          type: 'integer',
-          minimum: 0,
-          maximum: 100,
-          description: 'Technical execution score (form, CADENCE, power accuracy) (0-100)'
-        },
-        technical_explanation: {
-          type: 'string',
-          description: '1-sentence explanation justifying the technical execution score.'
-        },
-        effort: {
-          type: 'integer',
-          minimum: 0,
-          maximum: 100,
-          description: 'Effort management score (intensity vs target, HR control) (0-100)'
-        },
-        effort_explanation: {
-          type: 'string',
-          description: '1-sentence explanation justifying the effort management score.'
-        },
-        pacing: {
-          type: 'integer',
-          minimum: 0,
-          maximum: 100,
-          description: 'Pacing strategy score (consistency, negative splits, drift) (0-100)'
-        },
-        pacing_explanation: {
-          type: 'string',
-          description: '1-sentence explanation justifying the pacing strategy score.'
-        },
-        execution: {
-          type: 'integer',
-          minimum: 0,
-          maximum: 100,
-          description: 'Interval & plan adherence score (followed target steps) (0-100)'
-        },
-        execution_explanation: {
-          type: 'string',
-          description: '1-sentence explanation justifying the execution adherence score.'
-        }
-      },
-      required: [
-        'overall',
-        'overall_explanation',
-        'technical',
-        'technical_explanation',
-        'effort',
-        'effort_explanation',
-        'pacing',
-        'pacing_explanation',
-        'execution',
-        'execution_explanation'
-      ]
-    },
-    metrics_summary: {
-      type: 'object',
-      description: 'Key metrics for quick reference',
-      properties: {
-        avg_power: { type: 'number' },
-        ftp: { type: 'number' },
-        intensity: { type: 'number' },
-        duration_minutes: { type: 'number' },
-        tss: { type: 'number' }
-      }
-    }
-  },
-  required: ['type', 'title', 'executive_summary', 'sections', 'scores']
-}
 
 export function convertWorkoutAnalysisToMarkdown(analysis: any): string {
   let markdown = `# ${analysis.title}\n\n`
@@ -425,22 +247,16 @@ export async function runWorkoutAnalysis(payload: {
 
     const markdownAnalysis = convertWorkoutAnalysisToMarkdown(structuredAnalysis)
 
-    const clampScore = (val?: number | null) => {
-      if (typeof val !== 'number' || isNaN(val)) return null
-      const num = val > 10 ? val / 10 : val
-      return Math.min(10, Math.max(1, Math.round(num)))
-    }
-
     await workoutRepository.update(workoutId, {
       aiAnalysis: markdownAnalysis,
       aiAnalysisJson: structuredAnalysis as any,
       aiAnalysisStatus: 'COMPLETED',
       aiAnalyzedAt: new Date(),
-      overallScore: clampScore(structuredAnalysis.scores?.overall),
-      technicalScore: clampScore(structuredAnalysis.scores?.technical),
-      effortScore: clampScore(structuredAnalysis.scores?.effort),
-      pacingScore: clampScore(structuredAnalysis.scores?.pacing),
-      executionScore: clampScore(structuredAnalysis.scores?.execution),
+      overallScore: clampAnalysisScore(structuredAnalysis.scores?.overall),
+      technicalScore: clampAnalysisScore(structuredAnalysis.scores?.technical),
+      effortScore: clampAnalysisScore(structuredAnalysis.scores?.effort),
+      pacingScore: clampAnalysisScore(structuredAnalysis.scores?.pacing),
+      executionScore: clampAnalysisScore(structuredAnalysis.scores?.execution),
       overallQualityExplanation: structuredAnalysis.scores?.overall_explanation,
       technicalExecutionExplanation: structuredAnalysis.scores?.technical_explanation,
       effortManagementExplanation: structuredAnalysis.scores?.effort_explanation,

--- a/tests/unit/server/utils/services/workoutAnalysisService.test.ts
+++ b/tests/unit/server/utils/services/workoutAnalysisService.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   convertWorkoutAnalysisToMarkdown,
-  runWorkoutAnalysis,
-  type StructuredAnalysis
+  runWorkoutAnalysis
 } from '../../../../../server/utils/services/workoutAnalysisService'
 // CW-392: the payload builder now lives in the shared prompt module, which both the
-// service and the Trigger.dev task consume.
-import { buildWorkoutAnalysisData } from '../../../../../server/utils/services/workout-analysis-prompt'
+// service and the Trigger.dev task consume. CW-403 moved the response schema, the
+// StructuredAnalysis type and the score clamp there too; the service imports them
+// without re-exporting (server/utils is Nitro auto-imported).
+import {
+  buildWorkoutAnalysisData,
+  type StructuredAnalysis
+} from '../../../../../server/utils/services/workout-analysis-prompt'
 import { prisma } from '../../../../../server/utils/db'
 import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
 import { hasTaskHandler, getTaskHandler } from '../../../../../server/utils/task-registry'
@@ -86,16 +90,17 @@ describe('Workout Analysis Service', () => {
       type: 'workout',
       title: 'Endurance Run Analysis',
       executive_summary: 'Solid steady-state run with excellent pacing.',
+      // CW-403: the unified schema is the 1-10 scale, matching the stored *Score columns.
       scores: {
-        overall: 88,
+        overall: 9,
         overall_explanation: 'Strong execution throughout.',
-        technical: 90,
+        technical: 9,
         technical_explanation: 'Cadence remained stable at 172 rpm.',
-        effort: 85,
+        effort: 8,
         effort_explanation: 'Heart rate stayed within Zone 2 targets.',
-        pacing: 87,
+        pacing: 9,
         pacing_explanation: 'Negative split in final 5km.',
-        execution: 90,
+        execution: 9,
         execution_explanation: 'Followed prescribed workout steps.'
       },
       sections: [

--- a/trigger/analyze-workout.ts
+++ b/trigger/analyze-workout.ts
@@ -22,240 +22,32 @@ import { pbDetectionService } from '../server/utils/services/pbDetectionService'
 import { isWorkoutEligibleForAutomaticInsights } from '../server/utils/automatic-workout-insights'
 import { buildWorkoutAnalysisFactsV2 } from '../server/utils/workout-analysis-facts'
 import {
+  analysisSchema,
   buildWorkoutAnalysisData,
-  buildWorkoutAnalysisPrompt
+  buildWorkoutAnalysisPrompt,
+  clampAnalysisScore,
+  type StructuredAnalysis
 } from '../server/utils/services/workout-analysis-prompt'
 
 // The payload/prompt builders live in the shared module so this task and the
 // Redis-worker service (server/utils/services/workoutAnalysisService.ts) cannot
-// drift apart again (CW-392). Re-exported here for backwards compatibility with
-// existing importers of this module.
+// drift apart again (CW-392); the response schema, the StructuredAnalysis type and
+// the score clamp joined them there in CW-403. Re-exported here for backwards
+// compatibility with existing importers of this module -- safe because trigger/ is
+// not Nitro auto-import scanned (server/utils is, which is why the service side
+// imports without re-exporting).
 export {
+  analysisSchema,
   buildAnalysisFactsPromptBlock,
   buildAnalysisGuardrailInstructions,
   buildWorkoutAnalysisData,
   buildWorkoutAnalysisPrompt,
+  clampAnalysisScore,
   getAnalysisSectionsGuidance,
   getWorkoutTypeGuidance,
   normalizeRunningCadence
 } from '../server/utils/services/workout-analysis-prompt'
-
-// TypeScript interface for the structured analysis
-interface StructuredAnalysis {
-  type: string
-  title: string
-  date?: string
-  executive_summary: string
-  sections?: Array<{
-    title: string
-    status: string
-    status_label?: string
-    analysis_points: string[]
-  }>
-  recommendations?: Array<{
-    title: string
-    description: string
-    priority?: string
-  }>
-  strengths?: string[]
-  weaknesses?: string[]
-  scores?: {
-    overall: number
-    overall_explanation: string
-    technical: number
-    technical_explanation: string
-    effort: number
-    effort_explanation: string
-    pacing: number
-    pacing_explanation: string
-    execution: number
-    execution_explanation: string
-  }
-  metrics_summary?: {
-    avg_power?: number
-    ftp?: number
-    intensity?: number
-    duration_minutes?: number
-    tss?: number
-  }
-}
-
-// Flexible analysis schema that works for workouts, reports, planning, etc.
-export const analysisSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      description: 'Type of analysis: workout, weekly_report, planning, etc.',
-      enum: ['workout', 'weekly_report', 'planning', 'comparison']
-    },
-    title: {
-      type: 'string',
-      description: 'Title of the analysis'
-    },
-    date: {
-      type: 'string',
-      description: 'Date or date range of the analysis'
-    },
-    executive_summary: {
-      type: 'string',
-      description: '2-3 sentence high-level summary of key findings'
-    },
-    sections: {
-      type: 'array',
-      description: 'Analysis sections with status and points',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Section title (e.g., Pacing Strategy, Power Application)'
-          },
-          status: {
-            type: 'string',
-            description: 'Overall assessment',
-            enum: ['excellent', 'good', 'moderate', 'needs_improvement', 'poor']
-          },
-          status_label: {
-            type: 'string',
-            description: 'Display label for status'
-          },
-          analysis_points: {
-            type: 'array',
-            description: 'Detailed analysis points for this section',
-            items: {
-              type: 'string'
-            }
-          }
-        },
-        required: ['title', 'status', 'analysis_points']
-      }
-    },
-    recommendations: {
-      type: 'array',
-      description: 'Actionable recommendations',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Recommendation title'
-          },
-          description: {
-            type: 'string',
-            description: 'Detailed recommendation'
-          },
-          priority: {
-            type: 'string',
-            description: 'Priority level',
-            enum: ['high', 'medium', 'low']
-          }
-        },
-        required: ['title', 'description']
-      }
-    },
-    strengths: {
-      type: 'array',
-      description: 'Key strengths identified',
-      items: {
-        type: 'string'
-      }
-    },
-    weaknesses: {
-      type: 'array',
-      description: 'Areas needing improvement',
-      items: {
-        type: 'string'
-      }
-    },
-    scores: {
-      type: 'object',
-      description:
-        'Performance scores on 1-10 scale for tracking over time, with detailed explanations',
-      properties: {
-        overall: {
-          type: 'number',
-          description: 'Overall workout quality (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        overall_explanation: {
-          type: 'string',
-          description:
-            'Detailed explanation of overall quality: key factors contributing to score, what went well, what could improve, and 2-3 specific actionable improvements'
-        },
-        technical: {
-          type: 'number',
-          description: 'Technical execution score - form, technique, efficiency (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        technical_explanation: {
-          type: 'string',
-          description:
-            'Technical analysis: power application smoothness, cadence consistency, form observations, and specific technique improvements needed'
-        },
-        effort: {
-          type: 'number',
-          description: 'Effort appropriateness relative to plan and goals (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        effort_explanation: {
-          type: 'string',
-          description:
-            'Effort management analysis: whether intensity matched goals, HR/power relationship, and recommendations for effort control'
-        },
-        pacing: {
-          type: 'number',
-          description: 'Pacing strategy and execution quality (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        pacing_explanation: {
-          type: 'string',
-          description:
-            'Pacing strategy analysis: consistency throughout workout, whether pacing was appropriate, and specific pacing improvements'
-        },
-        execution: {
-          type: 'number',
-          description: 'How well the workout plan was executed (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        execution_explanation: {
-          type: 'string',
-          description:
-            'Execution quality analysis: adherence to workout structure, target achievement, and recommendations for better execution'
-        }
-      },
-      required: [
-        'overall',
-        'overall_explanation',
-        'technical',
-        'technical_explanation',
-        'effort',
-        'effort_explanation',
-        'pacing',
-        'pacing_explanation',
-        'execution',
-        'execution_explanation'
-      ]
-    },
-    metrics_summary: {
-      type: 'object',
-      description: 'Key metrics at a glance',
-      properties: {
-        avg_power: { type: 'number' },
-        ftp: { type: 'number' },
-        intensity: { type: 'number' },
-        duration_minutes: { type: 'number' },
-        tss: { type: 'number' }
-      }
-    }
-  },
-  required: ['type', 'title', 'executive_summary', 'sections', 'scores']
-}
+export type { StructuredAnalysis } from '../server/utils/services/workout-analysis-prompt'
 
 export const analyzeWorkoutTask = task({
   id: 'analyze-workout',
@@ -490,12 +282,6 @@ export const analyzeWorkoutTask = task({
       })
 
       // Clamp 1-10 (and normalize 0-100 style values) so DB check constraints hold.
-      const clampScore = (val?: number | null) => {
-        if (typeof val !== 'number' || Number.isNaN(val)) return null
-        const num = val > 10 ? val / 10 : val
-        return Math.min(10, Math.max(1, Math.round(num)))
-      }
-
       // Save both formats to the database, including scores and explanations
       await workoutRepository.update(workoutId, {
         aiAnalysis: markdownAnalysis,
@@ -503,11 +289,11 @@ export const analyzeWorkoutTask = task({
         aiAnalysisStatus: 'COMPLETED',
         aiAnalyzedAt: new Date(),
         // Store scores for easy querying and tracking
-        overallScore: clampScore(structuredAnalysis.scores?.overall),
-        technicalScore: clampScore(structuredAnalysis.scores?.technical),
-        effortScore: clampScore(structuredAnalysis.scores?.effort),
-        pacingScore: clampScore(structuredAnalysis.scores?.pacing),
-        executionScore: clampScore(structuredAnalysis.scores?.execution),
+        overallScore: clampAnalysisScore(structuredAnalysis.scores?.overall),
+        technicalScore: clampAnalysisScore(structuredAnalysis.scores?.technical),
+        effortScore: clampAnalysisScore(structuredAnalysis.scores?.effort),
+        pacingScore: clampAnalysisScore(structuredAnalysis.scores?.pacing),
+        executionScore: clampAnalysisScore(structuredAnalysis.scores?.execution),
         // Store explanations for user guidance
         overallQualityExplanation: structuredAnalysis.scores?.overall_explanation,
         technicalExecutionExplanation: structuredAnalysis.scores?.technical_explanation,


### PR DESCRIPTION
Fixes CW-403

## What was wrong

The two `analysisSchema` constants handed to `generateStructuredAnalysis` disagreed with each other, and one disagreed with the shared prompt that CW-392 had just deduplicated:

| | `workoutAnalysisService.ts` (production path) | `trigger/analyze-workout.ts` |
| --- | --- | --- |
| score scale | `integer`, 0-100 | `number`, 1-10 |
| section status enum | `excellent/good/fair/needs_attention/info` | `excellent/good/moderate/needs_improvement/poor` |
| matches the shared prompt? | **no** | yes |

Gemini enforces whichever schema it is handed, so the service path forced the model off the vocabulary the prompt asks for. Every UI status-to-colour mapper only understands the *other* vocabulary and falls through to `neutral` for anything else — so a section the model wanted to flag as a problem came back as `needs_attention` and rendered **neutral grey instead of red**. Since Trigger.dev deploy was removed from the production pipeline (`c4fca04e`), the Redis-worker handler in `workoutAnalysisService.ts` is the live path, and it was the one carrying the wrong enum.

## What changed

`server/utils/services/workout-analysis-prompt.ts` — the module that already owns the prompt text — is now also the single home for the things that describe the model's response:

- `analysisSchema` — one definition, on the **1-10** score scale with the `excellent/good/moderate/needs_improvement/poor` status enum, matching what the prompt already instructs. The enum is built from a new exported `ANALYSIS_SECTION_STATUSES` const and the bounds from `ANALYSIS_SCORE_MIN`/`ANALYSIS_SCORE_MAX`.
- `StructuredAnalysis` — the two interfaces were byte-identical; now one. `status` stays typed `string` on purpose so historic rows carrying the retired values still type-check.
- `clampAnalysisScore` — the two identical `clampScore` closures, deduplicated. Renamed from `clampScore` because `server/utils` is Nitro auto-imported and `clampScore` is already used as an unrelated local (0-100) helper in `server/api/analytics/workout-explorer/summary.post.ts`.

**The prompt text is unchanged** — the snapshot file was not touched, which is the proof.

Both entry points now import from the shared module. `workoutAnalysisService.ts` imports **without re-exporting**, per the existing NOTE (CW-392 / CW-404): re-exporting from `server/utils` registers the symbol twice and produces "Duplicated imports" warnings on `nuxt prepare`. `trigger/analyze-workout.ts` re-exports as it already did — `trigger/` is not Nitro-scanned.

## Already-stored analyses: nothing changes, no migration

- **Scores.** Both paths already ran an identical `val > 10 ? val / 10 : val` clamp to 1-10 before `workoutRepository.update`, so `overallScore`/`technicalScore`/`effortScore`/`pacingScore`/`executionScore` have always been 1-10 in the DB regardless of which schema produced them. Unifying the *schema* on 1-10 changes what the model is asked for, not what is stored. The `> 10` branch is deliberately kept as a safety net so a stray 0-100 value still folds onto the stored scale instead of clamping flat to 10. No migration, no backfill, no change to `workoutRepository.update` field semantics.
- **Section statuses.** Rows written under the old service-path enum keep their `fair`/`needs_attention`/`info` values inside `aiAnalysisJson`. Nothing rewrites them. They render exactly as they do today — all four mappers are `map[status] || 'neutral'` / if-chains with a `neutral` fallback, so those values fall through to neutral. No crash, no blank badge, no reinterpretation of historic data. `fair` continues to map to `warning` in `app/pages/workouts/[id]/index.vue`, which still handles it. New analyses get the correct severity colour; old ones are left alone rather than silently reinterpreted.

Verified by reading all four mappers, unchanged by this PR: `app/pages/workouts/[id]/index.vue:5827`, `app/components/ScoreDetailModal.vue:261`, `app/pages/report/[id].vue:928`, `app/pages/share/workouts/[token].vue:663`. All four fully cover the chosen enum.

## Drift regression test

`server/utils/services/workout-analysis-prompt.test.ts` gains a suite that reads the vocabulary and the score scale back out of the **prompt string** and compares them to the schema, so the two cannot silently diverge again:

- every sport variant of `getAnalysisSectionsGuidance` instructs the same status vocabulary, parsed out of the `Assign status: ...` lines;
- the schema's `sections.items.properties.status.enum` equals that parsed vocabulary exactly, and explicitly does not contain `fair`/`needs_attention`/`info`;
- the built prompt states the 1-10 scale and every score property declares `minimum: 1` / `maximum: 10`;
- both entry points resolve to the same `analysisSchema` object and the same `clampAnalysisScore` function, and neither file redefines them;
- `workoutAnalysisService.ts` contains no `export {` block, pinning the no-re-export constraint.

## Verification

```
$ pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts tests/unit/server/utils/services/workoutAnalysisService.test.ts
 Test Files  2 passed (2)
      Tests  27 passed (27)

$ pnpm typecheck
(clean — no errors, no "Duplicated imports" warning from nuxt prepare)

$ pnpm lint
✖ 116 problems (0 errors, 116 warnings)   # all pre-existing vue/require-default-prop in email templates

$ pnpm test:unit tests/unit/trigger/analyze-workout-prompt.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Rebased onto `origin/develop` @ `33a50413` and re-verified after the rebase.

## UX critique

**Attempted, interrupted — not completed.** The critique round was started (dev server on :3099, athlete persona, flow = open a workout with a completed AI analysis and inspect section status badges) but the agent call was interrupted before it produced a verdict.

Being precise about what that leaves unverified: this diff changes **no UI files** — only `server/utils/services/*`, `trigger/analyze-workout.ts`, and tests. The user-visible improvement comes from the model now emitting values the existing, unchanged mappers already handle correctly, and it only materialises on a *newly generated* analysis (a live Gemini call), which is not reproducible on demand in the dev environment. The mapper coverage was verified by reading all four files, which is what the ticket's acceptance criteria ask for. A reviewer who wants a visual confirmation should regenerate one workout analysis and check that a problem section renders red rather than grey.
