### PR TITLE
fix(workouts): correct detected interval segment boundaries (CW-426)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -249,6 +249,30 @@ export interface HrZoneRefs {
  * `hrRefs` is the separate, optional channel for the athlete's profile LTHR/max
  * HR. It exists only so HR intervals can be assigned an `intensity_zone`, and is
  * never used for segmentation — see `HrZoneRefs`.
+ *
+ * SEGMENT BOUNDARY CONVENTION (`start_index` / `end_index`):
+ * - **Fully inclusive.** A block occupying samples N..M is returned as
+ *   `start_index: N, end_index: M`. Both endpoints belong to the segment, which
+ *   is why every consumer slices it as `stream.slice(start_index, end_index + 1)`
+ *   (`createIntervalObj`, `computeSegmentAverage`, `calculateStabilityMetrics`,
+ *   the intervals endpoints).
+ * - **Disjoint and contiguous.** Consecutive segments never share a sample:
+ *   `next.start_index === prev.end_index + 1`. No sample is counted twice and
+ *   none is dropped.
+ * - This is the same convention providers use for synced laps
+ *   (Intervals.icu `icu_intervals[].start_index`/`end_index`), and both sources
+ *   are normalised through one code path downstream, so they must agree.
+ * - `start_time`/`end_time` are the timestamps of those two samples and
+ *   `duration` is the elapsed span between them. At 1 Hz a K-sample block is
+ *   therefore `K - 1` seconds long — the same arithmetic the whole-session
+ *   STEADY block has always reported.
+ *
+ * Neither path honoured this before CW-426, and they were broken differently:
+ * the candidate/merge pass below ended each segment on the FIRST sample of the
+ * next block (so adjacent segments overlapped by one sample), while
+ * `detectIntervalsFromPlannedSteps` shifted every segment one sample later at
+ * both ends. Either way a work rep carried one out-of-band sample, which is the
+ * single worst input to a coefficient of variation computed inside that rep.
  */
 export function detectIntervals(
   times: number[],
@@ -326,16 +350,23 @@ export function detectIntervals(
       inInterval = true
       startIndex = i
     } else if (!isWork && inInterval) {
-      // End of potential interval
+      // End of potential interval. `i` is the first sample that is NOT work, so
+      // the last sample the interval owns is `i - 1` — ends are inclusive (see
+      // the boundary convention above). Using `i` handed every work rep the
+      // first sample of the recovery that follows it and left adjacent segments
+      // overlapping on that sample (CW-426).
       inInterval = false
-      const currentTime = times[i]
+      const endIndex = i - 1
+      const currentTime = times[endIndex]
       const startTime = times[startIndex]
 
       if (currentTime !== undefined && startTime !== undefined) {
+        // Gate on the duration of the segment actually emitted, not on the span
+        // out to the first recovery sample.
         const duration = currentTime - startTime
 
         if (duration >= minDuration) {
-          candidates.push({ start: startIndex, end: i })
+          candidates.push({ start: startIndex, end: endIndex })
         }
       }
     }
@@ -385,7 +416,10 @@ export function detectIntervals(
   // Identify warmup (first segment before first work interval)
   // Identify cooldown (segment after last work interval)
 
-  let lastEndIndex = 0
+  // Index of the first sample not yet claimed by an emitted segment. Segments
+  // are inclusive and disjoint, so a filler block runs from here up to the
+  // sample before the next work interval starts (CW-426).
+  let nextSegmentStart = 0
 
   // SPECIAL CASE: If no intervals detected but the duration is long (> 15 min),
   // and average is reasonable (> 40% FTP), classify the whole thing as STEADY.
@@ -421,16 +455,19 @@ export function detectIntervals(
     }
   } else {
     merged.forEach((candidate, index) => {
-      // Add recovery/warmup segment before this work interval
-      if (candidate.start > lastEndIndex) {
+      // Add recovery/warmup segment before this work interval. It ends on the
+      // sample BEFORE the work interval starts: `candidate.start` is the rep's
+      // own first sample and belongs to the rep, not to the block feeding it.
+      const fillerEnd = candidate.start - 1
+      if (fillerEnd >= nextSegmentStart) {
         const type = index === 0 ? 'WARMUP' : 'RECOVERY'
-        if (times[lastEndIndex] !== undefined && times[candidate.start] !== undefined) {
+        if (times[nextSegmentStart] !== undefined && times[fillerEnd] !== undefined) {
           intervals.push(
             createIntervalObj(
               times,
               values,
-              lastEndIndex,
-              candidate.start,
+              nextSegmentStart,
+              fillerEnd,
               type,
               threshold,
               metricType,
@@ -458,20 +495,20 @@ export function detectIntervals(
         )
       }
 
-      lastEndIndex = candidate.end
+      nextSegmentStart = candidate.end + 1
     })
 
     // Add cooldown if there's data after the last interval
     if (
-      lastEndIndex < times.length - 1 &&
-      times[lastEndIndex] !== undefined &&
+      nextSegmentStart <= times.length - 1 &&
+      times[nextSegmentStart] !== undefined &&
       times[times.length - 1] !== undefined
     ) {
       intervals.push(
         createIntervalObj(
           times,
           values,
-          lastEndIndex,
+          nextSegmentStart,
           times.length - 1,
           'COOLDOWN',
           threshold,
@@ -609,11 +646,25 @@ function flattenPlannedStepsForDetection(
   return flattened
 }
 
-function findIndexAtOrAfterTime(times: number[], targetTime: number, fallbackIndex: number) {
+/**
+ * Index of the LAST sample belonging to a step that ends at `targetTime`.
+ *
+ * Segment ends are inclusive (see the boundary convention on `detectIntervals`),
+ * so a step owns every sample recorded strictly before its end time and the
+ * first sample at or after that time is the next step's opening sample. This
+ * used to return that next-step sample instead, which pushed the step's own end
+ * one sample too far and — because the following step then started at
+ * `endIdx + 1` — pushed its start one sample too far as well. Every planned
+ * segment came back as [N+1, M+1] (CW-426).
+ *
+ * Never returns less than `fallbackIndex`, so a step always keeps one sample.
+ */
+function findLastIndexBeforeTime(times: number[], targetTime: number, fallbackIndex: number) {
   for (let index = fallbackIndex; index < times.length; index++) {
     const time = times[index]
-    if (time !== undefined && time >= targetTime) return index
+    if (time !== undefined && time >= targetTime) return Math.max(fallbackIndex, index - 1)
   }
+  // Every remaining sample precedes the target: the step runs to the end.
   return times.length - 1
 }
 
@@ -652,6 +703,12 @@ function normalizeMetricDelta(
   return Math.abs(actualValue - targetValue) / targetValue
 }
 
+/**
+ * Score `candidateIndex` as the INCLUSIVE last sample of `currentStep` — the
+ * "before" window ends on it and the "after" window opens at `candidateIndex + 1`.
+ * This scorer always used the inclusive reading; it was the seed boundary handed
+ * to it that did not (CW-426).
+ */
 function scoreBoundaryCandidate(params: {
   candidateIndex: number
   currentStartIdx: number
@@ -777,7 +834,7 @@ function detectIntervalsFromPlannedSteps(
     const isLast = index === flattened.length - 1
     let endIdx = isLast
       ? times.length - 1
-      : findIndexAtOrAfterTime(times, plannedEndTime, currentStartIdx)
+      : findLastIndexBeforeTime(times, plannedEndTime, currentStartIdx)
     let confidence = 0.7
     let ambiguityNote: string | undefined
 
@@ -1114,6 +1171,16 @@ function resolveZoneNumber(value: number, zones: Zone[]): number | undefined {
   return parseInt(match[1])
 }
 
+/**
+ * Build one segment over the INCLUSIVE sample range [`startIdx`, `endIdx`] —
+ * see the boundary convention on `detectIntervals`. Every average here is taken
+ * over `slice(startIdx, endIdx + 1)`, so both callers must hand in the segment's
+ * own last sample and never the first sample of the block that follows it.
+ *
+ * `duration` is the elapsed span between those two samples. It deliberately does
+ * not reach out to the next block's timestamp: adjacent segments are disjoint,
+ * so the second between them is claimed by exactly one of them.
+ */
 function createIntervalObj(
   times: number[],
   values: number[],

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -335,6 +335,158 @@ describe('detectIntervals', () => {
         expect(interval.label).toBeUndefined()
       })
   })
+
+  /**
+   * CW-426: segment boundaries are inclusive and disjoint — a block occupying
+   * samples N..M comes back as exactly `start_index: N, end_index: M`, and the
+   * next segment opens at M + 1.
+   *
+   * Both segmentation paths broke this, and they broke it DIFFERENTLY:
+   *   - the candidate/merge pass ended each segment on the first sample of the
+   *     next block, so adjacent segments overlapped on that sample (a 4min rep
+   *     came back as [600..840] and the recovery after it as [840..1020]);
+   *   - `detectIntervalsFromPlannedSteps` used the first sample at or after the
+   *     planned end time as the step's own inclusive end and then started the
+   *     next step at `end + 1`, shifting every segment to [N+1, M+1] — the
+   *     `start_index: 601, end_index: 840` measured on CW-393's fixture.
+   *
+   * Either way every work rep lost its own first sample and/or carried one
+   * sample of the block next door, which is the worst possible contamination
+   * for CW-393's rep-scoped coefficient-of-variation signals.
+   *
+   * `smoothedValues` is passed through verbatim so these assertions measure the
+   * boundary arithmetic and not the lag of the default moving average (a
+   * centred SMA necessarily rounds a sharp edge; that is a separate concern).
+   */
+  describe('segment boundaries (CW-426)', () => {
+    const BLOCKS = [
+      { type: 'WARMUP', watts: 120, seconds: 600 },
+      { type: 'WORK', watts: 280, seconds: 240 },
+      { type: 'RECOVERY', watts: 110, seconds: 180 },
+      { type: 'WORK', watts: 280, seconds: 240 },
+      { type: 'RECOVERY', watts: 110, seconds: 180 },
+      { type: 'WORK', watts: 280, seconds: 240 },
+      { type: 'RECOVERY', watts: 110, seconds: 180 },
+      { type: 'WORK', watts: 280, seconds: 240 },
+      { type: 'COOLDOWN', watts: 100, seconds: 300 }
+    ] as const
+
+    /** The fixture plus the sample range each block genuinely occupies. */
+    const buildSharpBlocks = () => {
+      const watts: number[] = []
+      const expected: { type: string; start: number; end: number }[] = []
+      for (const block of BLOCKS) {
+        const start = watts.length
+        for (let index = 0; index < block.seconds; index++) watts.push(block.watts)
+        expected.push({ type: block.type, start, end: watts.length - 1 })
+      }
+      return { watts, time: watts.map((_, index) => index), expected }
+    }
+
+    const asRanges = (intervals: { type: string; start_index: number; end_index: number }[]) =>
+      intervals.map((interval) => ({
+        type: interval.type,
+        start: interval.start_index,
+        end: interval.end_index
+      }))
+
+    it('returns a block occupying samples N..M as exactly N..M (candidate/merge pass)', () => {
+      const { watts, time, expected } = buildSharpBlocks()
+
+      const intervals = detectIntervals(time, watts, 'power', 250, undefined, watts)
+
+      // Before the fix: WARMUP [0..600], WORK [600..840], RECOVERY [840..1020]...
+      expect(asRanges(intervals)).toEqual(expected)
+    })
+
+    it('returns a block occupying samples N..M as exactly N..M (plan-guided pass)', () => {
+      const { watts, time, expected } = buildSharpBlocks()
+      const plannedSteps = BLOCKS.map((block) => ({
+        type: block.type,
+        durationSeconds: block.seconds,
+        power: { value: block.watts }
+      }))
+
+      const intervals = detectIntervals(time, watts, 'power', 250, plannedSteps, watts)
+
+      // Before the fix: WARMUP [0..600], WORK [601..840], RECOVERY [841..1020]...
+      expect(asRanges(intervals)).toEqual(expected)
+    })
+
+    it('makes the two segmentation paths agree with each other', () => {
+      // They used to disagree, which was a second latent bug: for the identical
+      // 240-sample rep the candidate pass reported [600..840] (duration 240,
+      // overlapping its neighbours) and the plan-guided pass [601..840]
+      // (duration 239, disjoint but shifted). Neither was right.
+      const { watts, time } = buildSharpBlocks()
+      const plannedSteps = BLOCKS.map((block) => ({
+        type: block.type,
+        durationSeconds: block.seconds,
+        power: { value: block.watts }
+      }))
+
+      const fromCandidates = detectIntervals(time, watts, 'power', 250, undefined, watts)
+      const fromPlan = detectIntervals(time, watts, 'power', 250, plannedSteps, watts)
+
+      expect(asRanges(fromCandidates)).toEqual(asRanges(fromPlan))
+      expect(fromCandidates.map((interval) => interval.duration)).toEqual(
+        fromPlan.map((interval) => interval.duration)
+      )
+    })
+
+    it('emits disjoint, contiguous, gap-free segments that cover the stream once', () => {
+      const { watts, time } = buildSharpBlocks()
+
+      const intervals = detectIntervals(time, watts, 'power', 250, undefined, watts)
+
+      expect(intervals[0]?.start_index).toBe(0)
+      expect(intervals.at(-1)?.end_index).toBe(time.length - 1)
+      intervals.slice(1).forEach((interval, index) => {
+        // No shared sample, no skipped sample.
+        expect(interval.start_index).toBe(intervals[index]!.end_index + 1)
+      })
+    })
+
+    it('keeps every per-segment average free of the neighbouring block', () => {
+      // The point of the whole ticket: one foreign sample in a 240-sample rep
+      // dragged the average off its true value and inflated the rep's CoV.
+      const { watts, time } = buildSharpBlocks()
+
+      const intervals = detectIntervals(time, watts, 'power', 250, undefined, watts)
+
+      intervals
+        .filter((interval) => interval.type === 'WORK')
+        .forEach((interval) => {
+          // Exactly 280 W, not the 279.29 W a stray 110 W recovery sample gave.
+          expect(interval.avg_power).toBe(280)
+          expect(interval.max_power).toBe(280)
+        })
+      intervals
+        .filter((interval) => interval.type === 'RECOVERY')
+        .forEach((interval) => expect(interval.avg_power).toBe(110))
+    })
+
+    it('reports each segment duration as its own elapsed span, counting no second twice', () => {
+      const { watts, time } = buildSharpBlocks()
+
+      const intervals = detectIntervals(time, watts, 'power', 250, undefined, watts)
+
+      intervals.forEach((interval) => {
+        expect(interval.end_time - interval.start_time).toBe(interval.duration)
+        // A K-sample block at 1 Hz spans K - 1 seconds, the same arithmetic the
+        // whole-session STEADY block has always reported (2400 samples ->
+        // 2399s). The candidate pass used to report a flat 240 for a 240-sample
+        // rep only because it was measuring out to the FIRST RECOVERY SAMPLE:
+        // that 240 was the off-by-one, not a correct duration.
+        expect(interval.duration).toBe(interval.end_index - interval.start_index)
+      })
+
+      const workDurations = intervals
+        .filter((interval) => interval.type === 'WORK')
+        .map((interval) => interval.duration)
+      expect(workDurations).toEqual([239, 239, 239, 239])
+    })
+  })
 })
 
 describe('resolveHrWorkThreshold', () => {


### PR DESCRIPTION
Fixes CW-426

Detected interval segments were off by one sample, contaminating every per-rep statistic. This corrects **both** segmentation paths and writes the boundary convention down, because the bug existed partly because it never was.

## Convention chosen

`start_index` / `end_index` are **fully inclusive**, and adjacent segments are **disjoint and contiguous** (`next.start_index === prev.end_index + 1`). A block occupying samples N..M is returned as exactly `[N, M]`.

Not an arbitrary pick — it is the convention already in force everywhere else:

- every consumer slices `stream.slice(start_index, end_index + 1)` (`createIntervalObj`, `computeSegmentAverage`, `calculateStabilityMetrics`, both intervals endpoints);
- provider laps (Intervals.icu `icu_intervals[].start_index`/`end_index`) are inclusive and disjoint, and `workout-analysis-facts.ts` normalises provider laps and engine segments through the *same* code path, so they have to agree;
- `scoreBoundaryCandidate` already read its candidate as the inclusive last sample of the current step (`before` window ends on it, `after` window opens at `+1`). It was the seed boundary handed to it that disagreed.

It is documented in a new `SEGMENT BOUNDARY CONVENTION` block alongside the existing threshold contract on `detectIntervals`, plus notes on `createIntervalObj`, `findLastIndexBeforeTime` and `scoreBoundaryCandidate`.

## The two paths disagreed — a second latent bug

They were both wrong, but in different ways, so they did not even produce the same segments for the same session:

| | 240-sample rep at samples 600..839 | shape |
|---|---|---|
| candidate/merge pass | `[600..840]`, duration 240 | **overlapping** — the recovery after it started at 840 too, so sample 840 was in two segments |
| `detectIntervalsFromPlannedSteps` | `[601..840]`, duration 239 | disjoint but **shifted** by one at both ends |
| provider laps / truth | `[600..839]`, duration 239 | inclusive, disjoint |

- **Candidate/merge pass**: the loop pushed `{ start: startIndex, end: i }` where `i` is the *first sample that is not work*. Ends are inclusive, so it must be `i - 1`. The warmup/recovery/cooldown filler blocks inherited the same error from `lastEndIndex`, which is now a `nextSegmentStart` cursor (`prev.end + 1` … `next.start - 1`).
- **`detectIntervalsFromPlannedSteps`**: `findIndexAtOrAfterTime` returned the first sample *at or after* the planned end time and that was used as the step's own inclusive end; the next step then started at `endIdx + 1`, skipping its genuine first sample. Replaced by `findLastIndexBeforeTime`. This is the exact `start_index: 601, end_index: 840` the ticket measured.

## Measured effect

Reproduced on CW-393's own threshold fixture (`workout-analysis-facts.test.ts`, `THRESHOLD_BLOCKS` + `thresholdPlan`, FTP 280), reading `performanceSignals.durability.executionStabilityScore`:

| boundary source | before | after |
|---|---|---|
| provider laps | 96.9 | 96.9 |
| **engine, plan-guided** | **80.6** | **96.9** |
| engine, candidate/merge (no plan) | 71.3 | 78.5 |

The plan-guided engine source now lands *exactly* on the provider-lap number instead of 16.3 points below it, which is the acceptance criterion. Per-rep averages on that fixture go from 270.45 / 273.44 / 275.43 W to the blocks' true 271 / 274 / 276 W.

The residual gap on the no-plan candidate/merge row is **not** boundary arithmetic — it is lag in the default `smoothData` moving average, which necessarily rounds a sharp block edge (it puts a rep at `[599..841]` even with perfect boundary handling). Separate concern, noted but not touched here.

## On `duration`

`duration` stays `end_time - start_time` and is verified per segment by a new test. Two things worth stating explicitly:

- The plan-guided path's durations are **unchanged** (239 before and after) — both endpoints were shifted together.
- The candidate/merge path's work reps go **240 → 239** for a 240-sample rep. The old 240 was the off-by-one, not a correct duration: it was measuring from the rep's first sample out to *the first sample of the recovery*. 239 is the elapsed span between the rep's own first and last sample, which is exactly the arithmetic the whole-session STEADY block has always reported (`expect(intervals[0]?.duration).toBe(2399)` for a 2400-sample session — an existing, unchanged assertion). It also makes the two paths agree on duration, which they previously did not.

## No existing expectation changed

Every existing assertion in both suites passes untouched. Nothing had to be adjusted, so there is no old number to explain away. New coverage in `describe('segment boundaries (CW-426)')`: exact `N..M` on a sharp-block fixture for each path independently, the two paths agreeing with each other, disjoint/contiguous/gap-free coverage of the stream, uncontaminated per-segment averages, and the duration invariant.

## Verification

```
pnpm typecheck                                                  exit 0
pnpm test:unit tests/unit/server/utils/interval-detection.test.ts   37 passed (37)
pnpm test:unit server/utils/workout-analysis-facts.test.ts          56 passed (56)
pnpm test:unit  (full)                        370 files, 2214 passed (2214)
pnpm lint                                     exit 0, 0 errors
```

Files touched: `server/utils/interval-detection.ts`, `tests/unit/server/utils/interval-detection.test.ts` — exactly the ticket's Owned Paths.
