### PR TITLE
fix(ai): correct interval duration rendering and intensity scale in the analysis prompt (CW-388)

### DIFF
--- a/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
+++ b/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
@@ -132,7 +132,7 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 ### Interval 1: Block 1
 - Duration: 12m 0s
 - Avg Power: 255W
-- Intensity: 0.93
+- Intensity: 0.93 IF (93% of threshold)
 - Avg HR: 155 bpm
 - Avg Cadence: 90 rpm
 - Power Variability: 1.04
@@ -140,7 +140,7 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 ### Interval 2: Rest 1
 - Duration: 5m 0s
 - Avg Power: 120W
-- Intensity: 0.44
+- Intensity: 0.44 IF (44% of threshold)
 - Avg HR: 128 bpm
 - Avg Cadence: 78 rpm
 

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -372,6 +372,93 @@ describe('buildWorkoutAnalysisPrompt', () => {
     expect(prompt).not.toContain('spm')
   })
 
+  it('floors the minutes term of an interval duration instead of rounding it (CW-388)', () => {
+    // The seconds term is a true remainder, so rounding the minutes counted it
+    // twice: 150s rendered as "3m 30s" and 110s as "2m 50s".
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-duration',
+        date: new Date('2026-03-18T06:00:00Z'),
+        title: 'Short reps',
+        type: 'Ride',
+        durationSec: 1800,
+        ftp: 275,
+        rawJson: {
+          icu_intervals: [
+            { type: 'WORK', label: 'Rep 1', moving_time: 150, average_watts: 300 },
+            { type: 'WORK', label: 'Rep 2', moving_time: 110, average_watts: 295 },
+            { type: 'WORK', label: 'Rep 3', moving_time: 720, average_watts: 260 }
+          ]
+        }
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('- Duration: 2m 30s')
+    expect(prompt).toContain('- Duration: 1m 50s')
+    // A whole number of minutes is unaffected.
+    expect(prompt).toContain('- Duration: 12m 0s')
+    expect(prompt).not.toContain('- Duration: 3m 30s')
+    expect(prompt).not.toContain('- Duration: 2m 50s')
+  })
+
+  it('puts interval intensity on the session Intensity Factor scale and labels it (CW-388)', () => {
+    // Intervals.icu hands us `icu_intervals[].intensity` as a PERCENTAGE of
+    // threshold, while the session line is a factor. Both must read as one scale.
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-intensity',
+        date: new Date('2026-03-18T06:00:00Z'),
+        title: 'Threshold blocks',
+        type: 'Ride',
+        durationSec: 3600,
+        ftp: 275,
+        averageWatts: 230,
+        intensity: 0.83,
+        rawJson: {
+          icu_intervals: [
+            // Percent scale, as the provider sends it.
+            { type: 'WORK', label: 'Block 1', moving_time: 600, intensity: 101 },
+            // Already on the factor scale -- must pass through, not be divided again.
+            { type: 'WORK', label: 'Block 2', moving_time: 600, intensity: 0.93 }
+          ]
+        }
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('- Intensity Factor: 0.830')
+    expect(prompt).toContain('- Intensity: 1.01 IF (101% of threshold)')
+    expect(prompt).toContain('- Intensity: 0.93 IF (93% of threshold)')
+    // The raw provider percentage must never reach the model unlabelled.
+    expect(prompt).not.toContain('- Intensity: 101.00')
+  })
+
+  it('normalises interval intensity in the payload, not in the renderer (CW-388)', () => {
+    const data = buildWorkoutAnalysisData({
+      id: 'workout-fixture-intensity-payload',
+      date: new Date('2026-03-18T06:00:00Z'),
+      title: 'Threshold blocks',
+      type: 'Ride',
+      durationSec: 3600,
+      rawJson: {
+        icu_intervals: [
+          { type: 'WORK', label: 'Block 1', moving_time: 600, intensity: 101 },
+          { type: 'WORK', label: 'Block 2', moving_time: 600, intensity: 0.93 }
+        ]
+      }
+    })
+
+    expect(data.intervals[0].intensity).toBeCloseTo(1.01, 5)
+    expect(data.intervals[1].intensity).toBeCloseTo(0.93, 5)
+  })
+
   it('respects the athlete distanceUnits preference for strength set distances', () => {
     const workoutData = {
       date: new Date('2026-03-15T10:00:00Z'),

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -28,6 +28,7 @@ import {
   formatCadenceWithUnit,
   isRunningCadenceFamily,
   toCanonicalCadence,
+  toIntervalIntensityFactor,
   type WorkoutAnalysisFactsV2
 } from '../workout-analysis-facts'
 import { summarizePowerFromWatts } from '../power-metrics'
@@ -502,7 +503,12 @@ export function buildWorkoutAnalysisData(workout: any) {
         avg_power: interval.average_watts,
         max_power: interval.max_watts,
         weighted_avg_power: interval.weighted_average_watts,
-        intensity: interval.intensity,
+        // The ONLY place interval intensity gets put on a scale. Provider laps
+        // carry Intervals.icu's PERCENTAGE of threshold (e.g. 101), while the
+        // session-level `intensity` line is an intensity factor (0.83), so the
+        // two collided in one prompt. Reuse the shared CW-385 heuristic rather
+        // than a second copy of it; the renderer may only label (CW-388).
+        intensity: toIntervalIntensityFactor(interval.intensity),
         avg_hr: interval.average_heartrate,
         max_hr: interval.max_heartrate,
         avg_cadence: normalizeCadence(interval.average_cadence),
@@ -908,6 +914,35 @@ export function buildAnalysisGuardrailInstructions(
   }
 
   return rules.map((rule) => `- ${rule}`).join('\n')
+}
+
+/**
+ * Render an interval's duration as `<minutes>m <seconds>s`.
+ *
+ * The minutes term must FLOOR: the seconds term is a true remainder, so
+ * rounding the minutes counts the remainder twice and invents up to a full
+ * minute of work (150s used to render as "3m 30s" instead of "2m 30s", and the
+ * model quoted the inflated number back to the athlete). Same convention as
+ * `formatActualIntervalsForPrompt` in `workout-analysis-facts.ts` and as the
+ * lap-split renderer below (CW-388).
+ */
+export function formatIntervalDuration(durationSeconds: number): string {
+  const minutes = Math.floor(durationSeconds / 60)
+  const seconds = durationSeconds % 60
+  return `${minutes}m ${seconds}s`
+}
+
+/**
+ * Label an interval intensity that `buildWorkoutAnalysisData` has ALREADY put
+ * on the intensity-factor scale (`toIntervalIntensityFactor`).
+ *
+ * The prompt used to print a bare `Intensity: 101.00` a few lines from
+ * `Intensity Factor: 0.83` -- two scales for one concept, neither labelled. The
+ * percentage in brackets is a restatement of the same number, not a second
+ * scale, so the model can tie the row to the session line either way (CW-388).
+ */
+export function formatIntervalIntensity(intensityFactor: number): string {
+  return `${intensityFactor.toFixed(2)} IF (${Math.round(intensityFactor * 100)}% of threshold)`
 }
 
 export function buildWorkoutAnalysisPrompt(
@@ -1399,9 +1434,10 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     workoutData.intervals.forEach((interval: any, index: number) => {
       prompt += `\n### Interval ${index + 1}: ${interval.label || interval.type || 'Unnamed'}\n`
       if (interval.duration_s)
-        prompt += `- Duration: ${Math.round(interval.duration_s / 60)}m ${interval.duration_s % 60}s\n`
+        prompt += `- Duration: ${formatIntervalDuration(interval.duration_s)}\n`
       if (interval.avg_power) prompt += `- Avg Power: ${interval.avg_power}W\n`
-      if (interval.intensity) prompt += `- Intensity: ${formatMetric(interval.intensity, 2)}\n`
+      if (interval.intensity)
+        prompt += `- Intensity: ${formatIntervalIntensity(Number(interval.intensity))}\n`
       if (interval.avg_hr) prompt += `- Avg HR: ${interval.avg_hr} bpm\n`
       // Values are already canonical (buildWorkoutAnalysisData normalised them);
       // this only attaches the unit the workout family uses, so a run no longer

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1519,7 +1519,7 @@ function mapProviderIntervalsToActual(intervals: any[]): ActualInterval[] {
  * Engine-detected intervals (`detectIntervals`) carry no intensity field at
  * all, so they stay `null` — there is no second unit to reconcile.
  */
-function toIntervalIntensityFactor(value: unknown): number | null {
+export function toIntervalIntensityFactor(value: unknown): number | null {
   const numeric = Number(value)
   if (!Number.isFinite(numeric)) return null
   return numeric > 5 ? numeric / 100 : numeric


### PR DESCRIPTION
Fixes CW-388

Two defects in the `## Interval Breakdown` rows of the athlete-facing analysis prompt.

## 1. Minute rounding invented up to a full minute

`- Duration: ${Math.round(duration_s / 60)}m ${duration_s % 60}s` rounded the minutes term while the seconds term was a true remainder, so the remainder was counted twice: a 150s rep rendered as `3m 30s`. Any interval with a remainder >= 30s gained a phantom minute, and the model quoted the inflated length back to the athlete.

Now floored, matching `formatActualIntervalsForPrompt` in `workout-analysis-facts.ts` and the lap-split renderer in the same module. 150s -> `2m 30s`, 110s -> `1m 50s`.

## 2. Interval intensity was on a different scale from the session Intensity Factor

`icu_intervals[].intensity` is Intervals.icu's *percentage* of threshold (`101`), and it was passed through verbatim and printed unlabelled a few lines from the session-level `- Intensity Factor: 0.83` on the *factor* scale. Two scales for one concept, no units on either.

`buildWorkoutAnalysisData` now normalises it with `toIntervalIntensityFactor` from `server/utils/workout-analysis-facts.ts` (the CW-385 helper with the documented `> 5 ? v/100 : v` rule) rather than a second copy of the heuristic; that function gains the `export` keyword and nothing else. Per the CW-387 convention, normalisation happens once in the data builder and the renderer only labels:

```
- Intensity: 1.01 IF (101% of threshold)
```

A value already on the factor scale (`0.93`) passes through unchanged.

## Shape of the change

Both fixes live in named module-scope helpers (`formatIntervalDuration`, `formatIntervalIntensity`) rather than inline in the template string, so CW-391's renderer rewrite carries them along instead of having to re-derive them.

## Verification

`pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts` — 26 passed (3 new tests: the 150s/110s duration case, percent-scale `101` vs factor-scale `0.93` rendering, and payload-level normalisation).
`pnpm lint` — 0 errors.
`pnpm typecheck` — clean.

Snapshot: `__snapshots__/workout-analysis-prompt.test.ts.snap` changed on exactly two lines, both the intensity label (`- Intensity: 0.93` -> `- Intensity: 0.93 IF (93% of threshold)`, and the same for `0.44`). The fixture's durations are whole minutes, so no duration line moved.