### PR TITLE
fix(ai): make workout archetype classification intensity-aware (CW-396)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2039,3 +2039,205 @@ describe('rep-scoped durability and stability signals', () => {
     expect(facts.performanceSignals.applicability.repeatability.applicable).toBe(false)
   })
 })
+
+describe('archetype classification robustness (CW-396)', () => {
+  const FTP = 250
+  const THRESHOLD_PACE = 4.0 // m/s, roughly 4:10/km
+
+  /** Work laps at `intensity`, separated by recovery laps, plus a warmup/cooldown. */
+  function lapSet(reps: number, workSeconds: number, intensity: number) {
+    const laps: Array<Record<string, unknown>> = [
+      { type: 'WORK', moving_time: 600, average_watts: FTP * 0.55, intensity: 0.55 }
+    ]
+    for (let rep = 0; rep < reps; rep++) {
+      laps.push({
+        type: 'WORK',
+        moving_time: workSeconds,
+        average_watts: Math.round(FTP * intensity),
+        intensity
+      })
+      if (rep < reps - 1)
+        laps.push({
+          type: 'WORK',
+          moving_time: 180,
+          average_watts: Math.round(FTP * 0.5),
+          intensity: 0.5
+        })
+    }
+    laps.push({ type: 'WORK', moving_time: 600, average_watts: FTP * 0.5, intensity: 0.5 })
+    return laps
+  }
+
+  /** A structured plan of `reps` work steps at `watts`, bracketed by warmup/cooldown. */
+  function repPlan(reps: number, workSeconds: number, watts: number) {
+    return {
+      structuredWorkout: {
+        steps: [
+          {
+            name: 'Warmup',
+            type: 'Warmup',
+            durationSeconds: 600,
+            power: { value: Math.round(FTP * 0.55), units: 'w' }
+          },
+          {
+            reps,
+            steps: [
+              {
+                name: 'Effort',
+                type: 'Interval',
+                durationSeconds: workSeconds,
+                power: { value: watts, units: 'w' }
+              },
+              {
+                name: 'Float',
+                type: 'Recovery',
+                durationSeconds: 180,
+                power: { value: Math.round(FTP * 0.5), units: 'w' }
+              }
+            ]
+          },
+          {
+            name: 'Cooldown',
+            type: 'Cooldown',
+            durationSeconds: 600,
+            power: { value: Math.round(FTP * 0.5), units: 'w' }
+          }
+        ]
+      }
+    }
+  }
+
+  it('classifies six long sub-threshold reps as tempo rather than vo2', () => {
+    // Six work reps used to be enough on their own: the arm read
+    // `intervalCount >= 6` with no reference to intensity, so this session came
+    // back as `vo2` and was judged against VO2max expectations. At IF 0.9 and
+    // six minutes a rep, the only honest reading is tempo.
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: '6 x 6min tempo blocks',
+        durationSec: 4500,
+        intensity: 0.88,
+        variabilityIndex: 1.08,
+        rawJson: { icu_intervals: lapSet(6, 360, 0.9) }
+      }),
+      plannedWorkout: repPlan(6, 360, Math.round(FTP * 0.9)),
+      sportSettings: { ftp: FTP }
+    })
+
+    expect(facts.guardrails.archetype.primaryArchetype).toBe('tempo')
+  })
+
+  it('still classifies six short hard reps as vo2 and says which evidence fired', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: '6 x 3min hard',
+        durationSec: 3600,
+        intensity: 0.95,
+        variabilityIndex: 1.18,
+        rawJson: { icu_intervals: lapSet(6, 180, 1.12) }
+      }),
+      plannedWorkout: repPlan(6, 180, Math.round(FTP * 1.12)),
+      sportSettings: { ftp: FTP }
+    })
+
+    expect(facts.guardrails.archetype.primaryArchetype).toBe('vo2')
+    // The rationale must name the evidence instead of asserting an unchecked
+    // "Repeated hard work intervals detected."
+    expect(facts.guardrails.archetype.rationale.join(' ')).toContain('median intensity factor')
+  })
+
+  it('treats repeated short reps with no recorded intensity as vo2-shaped', () => {
+    // Engine-detected intervals carry no intensity at all, so rep length is the
+    // only shape evidence available; 45s reps repeated eight times are not tempo.
+    const laps = Array.from({ length: 8 }, () => ({ type: 'WORK', moving_time: 45 }))
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Sprint set',
+        durationSec: 3600,
+        intensity: 0.95,
+        variabilityIndex: 1.3,
+        rawJson: { icu_intervals: laps }
+      }),
+      sportSettings: { ftp: FTP }
+    })
+
+    expect(facts.guardrails.archetype.primaryArchetype).toBe('vo2')
+    expect(facts.guardrails.archetype.rationale.join(' ')).toContain('no recorded intensity')
+  })
+
+  it('does not read a trailing "event" in a title as a race', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Recovery spin after event',
+        durationSec: 3600,
+        intensity: 0.55,
+        variabilityIndex: 1.02
+      })
+    })
+
+    expect(facts.guardrails.archetype.primaryArchetype).not.toBe('race')
+    expect(facts.guardrails.archetype.primaryArchetype).toBe('recovery')
+  })
+
+  it('does not match race tokens inside longer words', () => {
+    for (const title of ['Prevention ride', 'Eventually easy', 'Laps of the terrace']) {
+      const facts = buildWorkoutAnalysisFactsV2({
+        workout: makeWorkout({ title, durationSec: 3600, intensity: 0.55, variabilityIndex: 1.02 })
+      })
+      expect(facts.guardrails.archetype.primaryArchetype).not.toBe('race')
+    }
+  })
+
+  it('still classifies genuine race titles as race', () => {
+    for (const title of ['Race day', 'Local criterium', 'Marathon', 'Event day']) {
+      const facts = buildWorkoutAnalysisFactsV2({
+        workout: makeWorkout({ title, durationSec: 3600, intensity: 0.55, variabilityIndex: 1.02 })
+      })
+      expect(facts.guardrails.archetype.primaryArchetype).toBe('race')
+    }
+  })
+
+  it('classifies a pace-targeted threshold run plan as threshold (refs plumbing regression)', () => {
+    // Guards the CW-384 / CW-402 refs plumbing: with a real threshold pace the
+    // planned steps carry an intensity factor, so the threshold arm can fire.
+    // With zeroed refs the IFs come back null and this lands on endurance.
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Threshold repeats',
+        type: 'Run',
+        durationSec: 3600,
+        averageWatts: null,
+        averageSpeed: 3.9,
+        intensity: 0.92,
+        variabilityIndex: 1.04
+      }),
+      plannedWorkout: {
+        structuredWorkout: {
+          steps: [
+            {
+              name: 'Warmup',
+              type: 'Warmup',
+              durationSeconds: 600,
+              pace: { value: 3.0, units: 'm/s' }
+            },
+            {
+              name: 'Threshold rep',
+              type: 'Interval',
+              durationSeconds: 900,
+              pace: { value: 4.2, units: 'm/s' }
+            },
+            {
+              name: 'Cooldown',
+              type: 'Cooldown',
+              durationSeconds: 600,
+              pace: { value: 3.0, units: 'm/s' }
+            }
+          ]
+        }
+      },
+      sportSettings: { thresholdPace: THRESHOLD_PACE }
+    })
+
+    expect(facts.guardrails.archetype.primaryArchetype).toBe('threshold')
+  })
+})

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -2362,6 +2362,41 @@ function rateConfidence(score: number): FactConfidence {
   return 'low'
 }
 
+/**
+ * Median of the finite entries; `null` when there are none.
+ *
+ * `null` and `undefined` are dropped rather than coerced — `Number(null)` is a
+ * perfectly finite `0`, which would drag a median of real intensity factors
+ * toward zero every time a step carried no target.
+ */
+function medianOf(values: Array<number | null | undefined>): number | null {
+  const finite = values
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b)
+  if (finite.length === 0) return null
+  const middle = Math.floor(finite.length / 2)
+  return finite.length % 2 === 1 ? finite[middle]! : (finite[middle - 1]! + finite[middle]!) / 2
+}
+
+/**
+ * Whole-word race markers for the title/description.
+ *
+ * Substring matching used to be the rule here, which made `'event'` fire on
+ * `prevention`, `eventually` and `events`, and `'race'` fire on `racecourse`
+ * and `terrace` (CW-396). Word boundaries fix those, but they do not rescue a
+ * bare `event`: `'Recovery spin after event'` is a whole-word match and still
+ * is not a race. The bare token is therefore gone, and only phrasings that
+ * actually frame the session as the event itself remain.
+ */
+const RACE_TITLE_PATTERN =
+  /\b(?:races?|racing|criteriums?|triathlons?|marathons?|event day|goal event|target event|a[- ]event)\b/
+
+function detectRaceContext(titleContext: string): boolean {
+  return RACE_TITLE_PATTERN.test(titleContext)
+}
+
 function classifyArchetype(params: {
   workout: any
   family: ReturnType<typeof getWorkoutFamily>
@@ -2394,23 +2429,67 @@ function classifyArchetype(params: {
   )
   const workSteps = plannedSteps.filter((step) => step.classification === 'work')
   const actualIntervals = extractActualIntervals(workout, plannedWorkout, refs)
-  const intervalCount = actualIntervals.filter(
+  const actualWorkIntervals = actualIntervals.filter(
     (interval) => interval.classification === 'work'
-  ).length
+  )
+  const intervalCount = actualWorkIntervals.length
   const vi = Number(workout?.variabilityIndex || 0)
   const intensity = Number.isFinite(Number(workout?.intensity)) ? Number(workout.intensity) : null
-  const isRace = ['race', 'criterium', 'triathlon', 'marathon', 'event'].some((token) =>
-    titleContext.includes(token)
+  const isRace = detectRaceContext(titleContext)
+
+  // Evidence for the "repeated reps" vo2 arm (CW-396). The arm used to fire on
+  // `intervalCount >= 6` alone, which is a count with no reference to how hard
+  // the reps were: six 6-minute tempo blocks came back as `vo2` and the session
+  // was then judged against VO2max expectations it was never meant to meet.
+  //
+  // Planned targets are the better evidence when a plan exists (they state the
+  // athlete's intent); measured rep intensity is the fallback. Both are on the
+  // same fraction-of-threshold scale. The median, not the max, so a single
+  // sprint lap inside an otherwise steady set does not carry the whole session.
+  const plannedWorkIntensityFactor = medianOf(workSteps.map((step) => step.intensityFactor))
+  const repIntensityFactor =
+    plannedWorkIntensityFactor ??
+    medianOf(actualWorkIntervals.map((interval) => interval.intensity))
+  // Duration is a shape proxy, only consulted when there is no intensity signal
+  // at all (engine-detected intervals never carry one). Reps this short are not
+  // sustainable at tempo, so repeating six of them is VO2-shaped by itself.
+  const medianWorkRepSeconds = medianOf(
+    actualWorkIntervals.map((interval) => interval.durationSeconds || null)
   )
+  const hasRepeatedReps = intervalCount >= 6
+  const plannedVo2Target = workSteps.some((step) => (step.intensityFactor || 0) >= 1.15)
+  const repeatedHardReps =
+    hasRepeatedReps && repIntensityFactor !== null && repIntensityFactor >= 1.1
+  const repeatedShortReps =
+    hasRepeatedReps &&
+    repIntensityFactor === null &&
+    medianWorkRepSeconds !== null &&
+    medianWorkRepSeconds <= 300
 
   let primaryArchetype: PrimaryArchetype
   if (family === 'strength') primaryArchetype = 'strength'
   else if (isRace) {
     primaryArchetype = 'race'
     rationale.push('Workout title or description indicates an event/race context.')
-  } else if (workSteps.some((step) => (step.intensityFactor || 0) >= 1.15) || intervalCount >= 6) {
+  } else if (plannedVo2Target || repeatedHardReps || repeatedShortReps) {
     primaryArchetype = 'vo2'
-    rationale.push('Repeated hard work intervals detected.')
+    // Say which evidence actually fired; the old unconditional "Repeated hard
+    // work intervals detected." asserted a hardness nothing in the arm checked.
+    if (plannedVo2Target)
+      rationale.push('Planned work steps target supra-threshold intensity (IF >= 1.15).')
+    else if (repeatedHardReps)
+      rationale.push(
+        `${intervalCount} work reps at a median intensity factor of ${repIntensityFactor!.toFixed(2)} indicate repeated hard efforts.`
+      )
+    else {
+      const repLength =
+        medianWorkRepSeconds! >= 60
+          ? `${(medianWorkRepSeconds! / 60).toFixed(1)}min`
+          : `${Math.round(medianWorkRepSeconds!)}s`
+      rationale.push(
+        `${intervalCount} work reps with a median length of ${repLength} and no recorded intensity; short repeated reps are treated as VO2-shaped.`
+      )
+    }
   } else if (workSteps.some((step) => (step.intensityFactor || 0) >= 1.03)) {
     primaryArchetype = 'threshold'
     rationale.push('Planned work steps cluster around threshold intensity.')


### PR DESCRIPTION
Fixes CW-396

`classifyArchetype` produces `guardrails.archetype.primaryArchetype`, which drives durability suppressions and — since CW-393 — the rep-scoped signal gates. Two of its decision arms fired on evidence that did not support the conclusion.

## 1. The vo2 arm was intensity-blind

`workSteps.some(IF >= 1.15) || intervalCount >= 6` — the second disjunct is a bare count of work-classified actual intervals with no reference to how hard or how long they were. Six 6-minute tempo blocks classified as `vo2`, and the session was then judged against VO2max expectations it was never meant to meet. The rationale string even asserted "Repeated hard work intervals detected." — a hardness nothing in that arm checked.

The count now has to be paired with intensity evidence:

- **Planned targets first** (they state the athlete's intent), **measured rep intensity as the fallback** — both are on the same fraction-of-threshold scale.
- **Median, not max**, so a single sprint lap inside an otherwise steady set does not carry the whole session.
- `intervalCount >= 6` + median work-rep IF `>= 1.1` → `vo2`.
- When there is no intensity signal at all (engine-detected intervals never carry one), rep length is the only shape evidence available: `intervalCount >= 6` + median work-rep length `<= 5min` → `vo2`.
- Otherwise the session falls through to the threshold / tempo / endurance arms as before.

The `>= 1.15` planned-target disjunct is unchanged.

The rationale now names the evidence that actually fired, in all three cases.

## 2. Race detection matched a bare `event` substring

`['race', 'criterium', 'triathlon', 'marathon', 'event'].some(token => titleContext.includes(token))` classified `'Recovery spin after event'` as a race — and so did `prevention`, `eventually`, `events`, `racecourse` and `terrace`. A false `race` archetype pushes the session into race-specific durability suppressions and the model stops interpreting signals it should have interpreted.

Matching is now a word-boundary regex. Word boundaries alone do not rescue a bare `event` (`'after event'` is a whole-word match and still is not a race), so the bare token is gone; only phrasings that frame the session as the event itself remain (`event day`, `goal event`, `target event`, `a event`).

## Not in scope

The original finding's third claim (zeroed refs in `classifyArchetype`) was already fixed by CW-384 / CW-402. Verified end to end through `buildWorkoutAnalysisFactsV2` -> `classifyArchetype` -> `flattenPlannedSteps` before starting; untouched here, and a regression test now pins it.

## Sessions that classify differently

| Shape | Before | After |
|---|---|---|
| 6 x 6min tempo (work-rep IF ~0.9) | `vo2` | `tempo` |
| 6+ work reps at any sub-1.1 intensity | `vo2` | falls through to threshold / tempo / endurance |
| 6 x 3min at IF >= 1.1 | `vo2` | `vo2` (unchanged) |
| 6+ short reps, no recorded intensity | `vo2` | `vo2` (unchanged) |
| `'Recovery spin after event'` | `race` | `recovery` |
| `'Prevention ride'`, `'Eventually easy'`, `'Laps of the terrace'` | `race` | not `race` |
| `'Race day'`, `'Local criterium'`, `'Marathon'`, `'Event day'` | `race` | `race` (unchanged) |

## On existing expectations

**No existing test expectation changed.** All 56 pre-existing tests in `workout-analysis-facts.test.ts` pass untouched, including the CW-393 rep-scoped signal gates and the CW-402 refs coverage. Seven tests were added; the five behavioural ones were confirmed to fail against the pre-fix source and pass after.

## Verification

```
pnpm test:unit server/utils/workout-analysis-facts.test.ts   ->  63 passed (63)
pnpm lint                                                    ->  exit 0
pnpm typecheck                                               ->  exit 0
pnpm test:unit (full sweep)                                  ->  370 files, 2234 passed
```

Rebased onto `origin/develop` at 6d7d4b57 (CW-426) and re-verified after.