### PR TITLE
fix(workouts): use the arbitrated interval segmentation for the workout chart (CW-430)

### DIFF
--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -22,6 +22,7 @@ import {
   calculateFatigueSensitivity,
   calculateStabilityMetrics
 } from '../../../utils/performance-metrics'
+import { getActualIntervalsSourceForAnalysis } from '../../../utils/workout-analysis-facts'
 
 defineRouteMeta({
   openAPI: {
@@ -185,6 +186,32 @@ export default defineEventHandler(async (event) => {
   // Threshold pace is stored in m/s (same convention as calculatePaceZones), so it can be
   // handed to the detection engine directly as the pace work/recovery reference.
   const calculationThresholdPace = Number(sportSettings?.thresholdPace || 0) || undefined
+  // Source the HR references from the athlete's PROFILE (the `sportSettings` loaded above,
+  // then the user record). Using this workout's own max HR would make the bar
+  // self-referential and drift session to session, so it is only reached as an explicit last
+  // resort inside `resolveHrWorkThreshold` when the profile carries neither LTHR nor max HR.
+  const hrRefs = {
+    lthr: sportSettings?.lthr ?? user.lthr,
+    maxHr: sportSettings?.maxHr ?? user.maxHr
+  }
+
+  /**
+   * The athlete's real reference values, in the shape the analysis/facts layer expects.
+   *
+   * These are deliberately the SAME numbers this endpoint hands to its own detection run
+   * below, so when the facts layer re-derives its candidates to arbitrate between them it
+   * scores the same two segmentations the chart is choosing from. Passing zeroed
+   * placeholders here would make the arbitration score blind — that exact bug was CW-384.
+   */
+  const analysisRefs = {
+    ftp: Number(calculationFtp || 0),
+    lthr: Number(hrRefs.lthr || 0),
+    maxHr: Number(hrRefs.maxHr || 0),
+    thresholdPace: Number(calculationThresholdPace || 0),
+    hrZones: sportSettings?.hrZones || [],
+    powerZones: sportSettings?.powerZones || [],
+    paceZones: sportSettings?.paceZones || []
+  }
 
   // 1. INTERVAL DETECTION LOGIC
 
@@ -259,15 +286,6 @@ export default defineEventHandler(async (event) => {
     )
   } else if (hasHr) {
     autoDetectionMetric = 'heartrate'
-    // Source the reference from the athlete's PROFILE (the `sportSettings`
-    // already loaded above, then the user record). Using this workout's own max
-    // HR would make the bar self-referential and drift session to session, so it
-    // is only reached as an explicit last resort inside `resolveHrWorkThreshold`
-    // when the profile carries neither LTHR nor max HR.
-    const hrRefs = {
-      lthr: sportSettings?.lthr ?? user.lthr,
-      maxHr: sportSettings?.maxHr ?? user.maxHr
-    }
     const threshold = resolveHrWorkThreshold({
       ...hrRefs,
       sessionMaxHr: workout.maxHr
@@ -286,16 +304,46 @@ export default defineEventHandler(async (event) => {
   }
 
   // C. Selection Logic
-  let finalIntervals: typeof syncedIntervals
-  let detectionMetric: string
-
-  if (syncedIntervals.length > 0) {
-    finalIntervals = syncedIntervals
-    detectionMetric = 'intervals.icu'
-  } else {
-    finalIntervals = detectedEngineIntervals
-    detectionMetric = autoDetectionMetric
+  //
+  // Provider laps used to win unconditionally here, while the analysis side arbitrates
+  // between the same two candidates (`chooseActualIntervalsSource`) and can pick either.
+  // The chart and every AI claim could therefore describe the same session with different
+  // reps. The chart now follows the arbitration too (CW-430).
+  //
+  // The facts layer works in `ActualInterval` shape, which carries no stream indices, so we
+  // ask it ONLY which source won and then select between the `Interval`-shaped objects this
+  // endpoint has already built. Nothing is converted between the two shapes.
+  //
+  // Nothing is persisted: the verdict is recomputed on every request, so a chart picks up
+  // detection and threshold fixes as soon as they ship (accepted tradeoff: the segmentation
+  // of a historical workout can change between two views of it).
+  //
+  // `arbitratedSource` stays `null` when there is nothing to arbitrate (one side has no
+  // candidates at all); the fallback below is then the endpoint's long-standing behaviour.
+  let arbitratedSource: 'raw' | 'detected' | 'none' | null = null
+  if (syncedIntervals.length > 0 && detectedEngineIntervals.length > 0) {
+    arbitratedSource = getActualIntervalsSourceForAnalysis(
+      workout,
+      workout.plannedWorkout,
+      analysisRefs
+    )
   }
+
+  // With no linked plan there is nothing to score the two candidates against, and
+  // `getActualIntervalsSourceForAnalysis` returns `'raw'` — provider laps win, which is the
+  // same answer this endpoint gave before CW-430 and a defensible default: without a plan we
+  // have no evidence the engine's segmentation describes the session any better. `'none'`
+  // (the facts layer found neither candidate, e.g. streams it cannot read) also falls back to
+  // provider laps rather than rendering an empty chart.
+  const useDetectedIntervals =
+    arbitratedSource === null ? syncedIntervals.length === 0 : arbitratedSource === 'detected'
+
+  const finalIntervals: typeof syncedIntervals = useDetectedIntervals
+    ? detectedEngineIntervals
+    : syncedIntervals
+  // Keep the reported metric meaningful for existing consumers: the provider name when its
+  // laps won, the detection metric when our engine did.
+  const detectionMetric: string = useDetectedIntervals ? autoDetectionMetric : 'intervals.icu'
 
   // 2. PEAKS & RECOVERY
   const peakPower = hasWatts ? findPeakEfforts(time, wattsStream!, 'power') : []
@@ -439,7 +487,24 @@ export default defineEventHandler(async (event) => {
       plannedTitle: workout.plannedWorkout?.title || null,
       calculationFtp,
       calculationThresholdPace: calculationThresholdPace ?? null,
-      autoDetectionMetric
+      autoDetectionMetric,
+      // Provenance of the segmentation the athlete is actually looking at (CW-430).
+      // Debug-only on purpose: divergence between the two candidates is never surfaced to
+      // athletes, it is only inspectable here when troubleshooting.
+      intervalSource: {
+        // What the chart rendered: provider laps ('raw') or our engine ('detected').
+        chosen: useDetectedIntervals ? 'detected' : 'raw',
+        // What the arbitration returned, or null when there was nothing to arbitrate
+        // because one of the two candidate sets was empty.
+        arbitrated: arbitratedSource,
+        syncedCount: syncedIntervals.length,
+        detectedCount: detectedEngineIntervals.length,
+        // Arbitration can only score the candidates when a plan is linked; without one it
+        // returns 'raw' by definition.
+        planAvailable: plannedSteps.length > 0,
+        plannedStepCount: plannedSteps.length,
+        detectionMetric
+      }
     }
 
     // Generate a planned power stream that matches the recorded time samples

--- a/tests/unit/server/api/workouts/intervals.get.test.ts
+++ b/tests/unit/server/api/workouts/intervals.get.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { prisma } from '../../../../../server/utils/db'
+import { attachStreamToWorkout } from '../../../../../server/utils/repositories/workoutStreamRepository'
+import { sportSettingsRepository } from '../../../../../server/utils/repositories/sportSettingsRepository'
+
+vi.stubGlobal('defineRouteMeta', () => {})
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: any) => fn,
+  createError: (err: any) => Object.assign(new Error(err.message), { statusCode: err.statusCode }),
+  getRouterParam: (event: any, key: string) => event?.context?.params?.[key],
+  getQuery: (event: any) => event?.query ?? {}
+}))
+
+vi.mock('../../../../../server/utils/session', () => ({
+  getServerSession: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    workout: { findFirst: vi.fn() }
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  attachStreamToWorkout: vi.fn()
+}))
+
+vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: { getForActivityType: vi.fn() }
+}))
+
+const getHandler = async () =>
+  (await import('../../../../../server/api/workouts/[id]/intervals.get')).default
+
+const FTP = 250
+
+/**
+ * A 4 x 3min @ 105% FTP session with 3min recoveries, book-ended by a warmup and a
+ * cooldown. Flat (no repeat blocks) because the endpoint hands `structuredWorkout.steps`
+ * to the detection engine verbatim.
+ */
+const PLAN_SEGMENTS: Array<{ type: string; seconds: number; factor: number }> = [
+  { type: 'WARMUP', seconds: 600, factor: 0.55 },
+  { type: 'WORK', seconds: 180, factor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, factor: 0.5 },
+  { type: 'WORK', seconds: 180, factor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, factor: 0.5 },
+  { type: 'WORK', seconds: 180, factor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, factor: 0.5 },
+  { type: 'WORK', seconds: 180, factor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, factor: 0.5 },
+  { type: 'COOLDOWN', seconds: 300, factor: 0.5 }
+]
+
+const structuredWorkout = {
+  steps: PLAN_SEGMENTS.map((segment) => ({
+    type: segment.type,
+    durationSeconds: segment.seconds,
+    power: { value: segment.factor }
+  }))
+}
+
+/**
+ * Build the recorded power stream.
+ *
+ * `fragmentReps` puts a short coast in the middle of every work rep — the kind of
+ * junction/soft-pedal an athlete really does. The engine then segments each rep in two,
+ * while the provider's laps (recorded from the athlete's lap button) still describe the
+ * four reps the plan asked for.
+ */
+function buildStream(options: { fragmentReps: boolean }) {
+  const time: number[] = []
+  const watts: number[] = []
+  let clock = 0
+
+  for (const segment of PLAN_SEGMENTS) {
+    const target = Math.round(FTP * segment.factor)
+    for (let second = 0; second < segment.seconds; second++) {
+      const inRepCoast =
+        options.fragmentReps &&
+        segment.type === 'WORK' &&
+        second >= Math.floor(segment.seconds / 2) - 12 &&
+        second < Math.floor(segment.seconds / 2) + 12
+      time.push(clock)
+      watts.push(inRepCoast ? Math.round(FTP * 0.4) : target)
+      clock += 1
+    }
+  }
+
+  return { time, watts }
+}
+
+/** Provider laps that describe exactly the planned structure. */
+function trueProviderLaps() {
+  let start = 0
+  return PLAN_SEGMENTS.map((segment) => {
+    const lap = {
+      type: segment.type === 'WORK' ? 'WORK' : 'RECOVERY',
+      start_index: start,
+      end_index: start + segment.seconds - 1,
+      start_time: start,
+      end_time: start + segment.seconds,
+      duration: segment.seconds,
+      average_watts: Math.round(FTP * segment.factor),
+      intensity: Math.round(segment.factor * 100)
+    }
+    start += segment.seconds
+    return lap
+  })
+}
+
+/** Auto-laps every 5 minutes: no relationship at all to the session's structure. */
+function autoLaps(totalSeconds: number) {
+  const laps: any[] = []
+  for (let start = 0; start < totalSeconds; start += 300) {
+    const seconds = Math.min(300, totalSeconds - start)
+    laps.push({
+      type: 'WORK',
+      start_index: start,
+      end_index: start + seconds - 1,
+      start_time: start,
+      end_time: start + seconds,
+      duration: seconds,
+      average_watts: Math.round(FTP * 0.75),
+      intensity: 75
+    })
+  }
+  return laps
+}
+
+type Scenario = {
+  laps: any[]
+  fragmentReps?: boolean
+  plan?: boolean
+}
+
+function mockWorkout(scenario: Scenario) {
+  const streams = buildStream({ fragmentReps: Boolean(scenario.fragmentReps) })
+  const workout = {
+    id: 'workout-1',
+    userId: 'user-1',
+    type: 'Ride',
+    ftp: null,
+    maxHr: null,
+    decoupling: null,
+    rawJson: { icu_intervals: scenario.laps },
+    plannedWorkout:
+      scenario.plan === false ? null : { id: 'plan-1', title: '4x3', structuredWorkout }
+  }
+
+  vi.mocked(prisma.workout.findFirst).mockResolvedValue(workout as any)
+  vi.mocked(attachStreamToWorkout).mockResolvedValue({
+    ...workout,
+    streams: {
+      time: streams.time,
+      watts: streams.watts,
+      heartrate: null,
+      cadence: null,
+      velocity: null
+    }
+  } as any)
+
+  return { workout, streams }
+}
+
+const event = (query: Record<string, unknown> = {}) => ({
+  context: { params: { id: 'workout-1' } },
+  query
+})
+
+const totalPlannedSeconds = PLAN_SEGMENTS.reduce((sum, segment) => sum + segment.seconds, 0)
+
+describe('GET /api/workouts/[id]/intervals interval source arbitration (CW-430)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'a@b.c' } } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      ftp: FTP,
+      maxHr: 190,
+      lthr: 165,
+      email: 'a@b.c'
+    } as any)
+    vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+      ftp: FTP,
+      lthr: 165,
+      maxHr: 190,
+      thresholdPace: 0,
+      hrZones: [],
+      powerZones: [],
+      paceZones: []
+    } as any)
+  })
+
+  it('keeps the provider laps when they describe the plan better than our engine does', async () => {
+    // The recorded reps contain a mid-rep coast, so the engine splits each of the four reps
+    // in two while the provider's laps still match the plan.
+    mockWorkout({ laps: trueProviderLaps(), fragmentReps: true })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('intervals.icu')
+    expect(result.intervals).toHaveLength(PLAN_SEGMENTS.length)
+    expect(result.audit.intervalSource).toMatchObject({
+      chosen: 'raw',
+      arbitrated: 'raw',
+      planAvailable: true,
+      detectionMetric: 'intervals.icu'
+    })
+    expect(result.audit.intervalSource.syncedCount).toBe(PLAN_SEGMENTS.length)
+    expect(result.audit.intervalSource.detectedCount).toBeGreaterThan(0)
+  })
+
+  it('switches the chart to the engine segmentation when the provider laps do not match the plan', async () => {
+    // Auto-laps every 5 minutes: the athlete rode the session cleanly, but the provider's
+    // laps describe none of it. Before CW-430 these won unconditionally.
+    mockWorkout({ laps: autoLaps(totalPlannedSeconds) })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('power')
+    expect(result.audit.intervalSource).toMatchObject({
+      chosen: 'detected',
+      arbitrated: 'detected',
+      planAvailable: true,
+      detectionMetric: 'power'
+    })
+    expect(result.intervals.length).toBe(result.audit.intervalSource.detectedCount)
+    // The chart no longer renders the provider's 5-minute blocks.
+    expect(result.intervals.length).not.toBe(result.audit.intervalSource.syncedCount)
+  })
+
+  it('falls back to the provider laps when no plan is linked (nothing to arbitrate against)', async () => {
+    mockWorkout({ laps: autoLaps(totalPlannedSeconds), plan: false })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('intervals.icu')
+    expect(result.audit.intervalSource).toMatchObject({
+      chosen: 'raw',
+      arbitrated: 'raw',
+      planAvailable: false,
+      plannedStepCount: 0
+    })
+  })
+
+  it('uses the engine segmentation when the provider sent no laps at all', async () => {
+    mockWorkout({ laps: [] })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('power')
+    expect(result.audit.intervalSource).toMatchObject({
+      chosen: 'detected',
+      // Nothing to arbitrate: only one candidate existed.
+      arbitrated: null,
+      syncedCount: 0
+    })
+  })
+
+  it('never exposes the interval provenance outside the debug audit block', async () => {
+    mockWorkout({ laps: autoLaps(totalPlannedSeconds) })
+
+    const result = await (await getHandler())(event() as any)
+
+    expect(result.audit).toBeNull()
+    expect(JSON.stringify(result)).not.toContain('intervalSource')
+  })
+})


### PR DESCRIPTION
Fixes CW-430

The intervals endpoint computed both segmentations and then threw one away: provider laps won unconditionally whenever they existed, while the analysis side arbitrates between the same two candidates. The chart and the AI's interval set could therefore describe the same session with different reps.

## What changed

`server/api/workouts/[id]/intervals.get.ts` now asks the facts layer which source won and follows it:

- `getActualIntervalsSourceForAnalysis(workout, plannedWorkout, refs)` is called only when both candidate sets are non-empty (there is nothing to arbitrate otherwise), and the endpoint then selects between its own already-built `syncedIntervals` and `detectedEngineIntervals`. **No conversion between `Interval` and `ActualInterval` shape** — the facts layer is asked only for the verdict.
- The arbitration gets **real athlete refs**: the same `calculationFtp` / threshold pace / LTHR / max HR (hoisted out of the HR detection branch) this endpoint already hands to its own detection run, plus the sport-settings zones. No zeroed placeholders (CW-384).
- `detectionMetric` still reports the source actually chosen: `'intervals.icu'` when provider laps win, the detection metric (`power` / `pace` / `heartrate`) when the engine wins.
- The **debug-only** audit block gains `audit.intervalSource`: `chosen`, `arbitrated` (null when nothing was arbitrated), `syncedCount`, `detectedCount`, `planAvailable`, `plannedStepCount`, `detectionMetric`. Nothing new is exposed to athletes — no badge, no warning, no copy. A test asserts the provenance never leaves the audit block.
- Recompute, do not persist: no schema change, no stored segmentation.

## No linked plan

`getActualIntervalsSourceForAnalysis` returns `'raw'` when the plan flattens to zero steps, so provider laps win — the same answer this endpoint gave before, and defensible: without a plan there is no evidence the engine segments the session any better. `'none'` (the facts layer sees neither candidate, e.g. streams it cannot read) also falls back to provider laps rather than rendering an empty chart. Both paths are commented in the handler and covered by tests.

## Share endpoint

`server/api/share/workouts/[token]/intervals.get.ts` is untouched (CW-418). It **should** follow: it has the identical unconditional `if (syncedIntervals.length > 0)` preference, so a shared workout can now show a different segmentation than the athlete's own view of the same workout — a divergence this PR narrows on one side only. The change there is the same selection swap; the extra work is resolving the owner's sport settings from the share token rather than the session user.

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server
```

```
typecheck exit=0
Test Files  255 passed (255)
     Tests  1455 passed (1455)
```

`pnpm lint`: 0 errors (116 pre-existing warnings, none in the touched files).

New: `tests/unit/server/api/workouts/intervals.get.test.ts` (no test file existed for this endpoint) — provider laps win when they match the plan better than a fragmented engine detection; the engine wins when the provider only sent 5-minute auto-laps; audit provenance in both cases; no-plan fallback; no-laps fallback; provenance absent without `?debug=true`.

UX critique: skipped — no new UI surface; segmentation-source change accepted by the maintainer in the ticket.
