### PR TITLE
fix(ai): gate the split-strategy verdict by session shape (CW-389)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -11,7 +11,8 @@ import {
   clampAnalysisScore,
   getAnalysisSectionsGuidance,
   getWorkoutTypeGuidance,
-  normalizeRunningCadence
+  normalizeRunningCadence,
+  resolveSplitPacingVerdictApplicability
 } from './workout-analysis-prompt'
 import * as analyzeWorkoutTrigger from '../../../trigger/analyze-workout'
 import { buildWorkoutAnalysisFactsV2 } from '../workout-analysis-facts'
@@ -226,6 +227,40 @@ describe('buildAnalysisFactsPromptBlock / buildAnalysisGuardrailInstructions', (
     expect(buildAnalysisGuardrailInstructions('Ride', undefined)).toContain(
       'Do not use ATL, CTL, or TSB alone as proof of technique breakdown'
     )
+
+    // The soft guardrail above asks the model to disregard non-constant pace;
+    // the same session must also stop being handed the hard split verdict that
+    // contradicts it (CW-389).
+    expect(resolveSplitPacingVerdictApplicability(facts).applicable).toBe(false)
+  })
+})
+
+describe('resolveSplitPacingVerdictApplicability', () => {
+  const withSteadiness = (sessionSteadiness: string, primaryArchetype = 'endurance') =>
+    ({ guardrails: { archetype: { sessionSteadiness, primaryArchetype } } }) as any
+
+  it('withholds the verdict for intervalled and stochastic sessions, with a reason', () => {
+    for (const steadiness of ['intervalled', 'stochastic']) {
+      const verdict = resolveSplitPacingVerdictApplicability(withSteadiness(steadiness))
+      expect(verdict.applicable).toBe(false)
+      expect(verdict.reason).toContain(`session steadiness is ${steadiness}`)
+    }
+  })
+
+  it('allows the verdict for steady and rolling sessions', () => {
+    for (const steadiness of ['steady', 'rolling']) {
+      expect(resolveSplitPacingVerdictApplicability(withSteadiness(steadiness))).toEqual({
+        applicable: true,
+        reason: null
+      })
+    }
+  })
+
+  it('leaves the legacy no-facts path applicable so the prompt is unchanged', () => {
+    expect(resolveSplitPacingVerdictApplicability(undefined)).toEqual({
+      applicable: true,
+      reason: null
+    })
   })
 })
 
@@ -457,6 +492,134 @@ describe('buildWorkoutAnalysisPrompt', () => {
 
     expect(data.intervals[0].intensity).toBeCloseTo(1.01, 5)
     expect(data.intervals[1].intensity).toBeCloseTo(0.93, 5)
+  })
+
+  /**
+   * CW-389 fixtures.
+   *
+   * Six automatic per-kilometre splits from one interval session: a warmup km,
+   * three rep-ish kms, then a jog and a cooldown km. First half averages 278s/km
+   * and second half 307s/km, so the unconditional verdict called it a
+   * "Positive Split (slowed down)"; the SD across them is ~41s, which the grade
+   * band called "Variable pacing". Both numbers describe the warmup and the
+   * cooldown, not the athlete's execution.
+   */
+  const KM_SPLITS = [
+    { distance: 1000, moving_time: 330, average_speed: 3.03, average_heartrate: 132 },
+    { distance: 1000, moving_time: 250, average_speed: 4.0, average_heartrate: 165 },
+    { distance: 1000, moving_time: 255, average_speed: 3.92, average_heartrate: 168 },
+    { distance: 1000, moving_time: 262, average_speed: 3.82, average_heartrate: 170 },
+    { distance: 1000, moving_time: 300, average_speed: 3.33, average_heartrate: 158 },
+    { distance: 1000, moving_time: 360, average_speed: 2.78, average_heartrate: 138 }
+  ]
+
+  const INTERVAL_RUN = {
+    id: 'workout-fixture-interval-splits',
+    date: new Date('2026-03-19T06:00:00Z'),
+    title: '4 x 1km Threshold',
+    type: 'Run',
+    durationSec: 1757,
+    distanceMeters: 6000,
+    averageSpeed: 3.42,
+    averageHr: 155,
+    maxHr: 182,
+    variabilityIndex: 1.14,
+    rawJson: {
+      splits_metric: KM_SPLITS,
+      icu_intervals: [
+        { type: 'WORK', label: 'Rep 1', moving_time: 240, distance: 1000, average_speed: 4.17 },
+        { type: 'RECOVERY', label: 'Jog 1', moving_time: 120, distance: 400, average_speed: 3.0 },
+        { type: 'WORK', label: 'Rep 2', moving_time: 242, distance: 1000, average_speed: 4.13 },
+        { type: 'RECOVERY', label: 'Jog 2', moving_time: 120, distance: 400, average_speed: 3.0 },
+        { type: 'WORK', label: 'Rep 3', moving_time: 245, distance: 1000, average_speed: 4.08 },
+        { type: 'RECOVERY', label: 'Jog 3', moving_time: 120, distance: 400, average_speed: 3.0 },
+        { type: 'WORK', label: 'Rep 4', moving_time: 247, distance: 1000, average_speed: 4.05 }
+      ]
+    }
+  }
+
+  const STEADY_RUN = {
+    id: 'workout-fixture-steady-splits',
+    date: new Date('2026-03-19T06:00:00Z'),
+    title: 'Steady Long Run',
+    type: 'Run',
+    durationSec: 3600,
+    distanceMeters: 6000,
+    averageSpeed: 3.42,
+    averageHr: 148,
+    maxHr: 162,
+    variabilityIndex: 1.02,
+    rawJson: { splits_metric: KM_SPLITS }
+  }
+
+  it('withholds the split-strategy verdict on an intervalled session (CW-389)', () => {
+    const facts = buildWorkoutAnalysisFactsV2({ workout: INTERVAL_RUN } as any)
+    expect(facts.guardrails.archetype.sessionSteadiness).toBe('intervalled')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(INTERVAL_RUN),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    // The measurements survive: every split row, plus the raw dispersion.
+    expect(prompt).toContain('## Distance Split Pacing')
+    expect(prompt).toContain('**Split 1**')
+    expect(prompt).toContain('**Split 6**')
+    expect(prompt).toContain('**Split Pace Consistency**')
+
+    // The derived verdicts do not.
+    expect(prompt).not.toContain('**Split Strategy**')
+    expect(prompt).not.toContain('Positive Split (slowed down)')
+    expect(prompt).not.toContain('>20s = Variable pacing')
+    expect(prompt).not.toContain('Lower is better (more consistent pacing)')
+
+    // ...and the gap says why, because "do not infer meaning from omitted
+    // facts" is a stated rule of the facts contract.
+    expect(prompt).toContain('Split-strategy verdict omitted: session steadiness is intervalled')
+    expect(prompt).toContain('Consistency grading omitted: session steadiness is intervalled')
+
+    // These were never laps -- they are the provider's automatic distance splits.
+    expect(prompt).not.toContain('## Lap Pacing Analysis')
+    expect(prompt).not.toContain('**Lap 1**')
+  })
+
+  it('still emits both verdicts for a steady session (CW-389)', () => {
+    const facts = buildWorkoutAnalysisFactsV2({ workout: STEADY_RUN } as any)
+    expect(facts.guardrails.archetype.sessionSteadiness).toBe('steady')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(STEADY_RUN),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    expect(prompt).toContain('**Split Strategy**: Positive Split (slowed down)')
+    expect(prompt).toContain('>20s = Variable pacing')
+    expect(prompt).not.toContain('Split-strategy verdict omitted')
+  })
+
+  it('leaves the no-facts legacy path exactly as it was (CW-389)', () => {
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(INTERVAL_RUN),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('**Split Strategy**: Positive Split (slowed down)')
+    expect(prompt).toContain('>20s = Variable pacing')
   })
 
   it('respects the athlete distanceUnits preference for strength set distances', () => {

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -945,6 +945,54 @@ export function formatIntervalIntensity(intensityFactor: number): string {
   return `${intensityFactor.toFixed(2)} IF (${Math.round(intensityFactor * 100)}% of threshold)`
 }
 
+/**
+ * Decide whether the derived pacing verdicts over `lap_splits` -- the
+ * first-half/second-half "split strategy" call and the pace-variability grade
+ * band -- mean anything for this session (CW-389).
+ *
+ * `lap_splits` are NOT laps. `buildWorkoutAnalysisData` fills them from
+ * `raw.splits_metric || raw.splits_standard` (and the FIT/Rouvy path from
+ * `calculateLapSplits(..., 1000)`), i.e. automatic per-kilometre or per-mile
+ * splits. On an intervalled or stochastic session those splits straddle warmup,
+ * work reps, recovery jogs and cooldown arbitrarily, so comparing the first half
+ * against the second half compares "mostly warmup" against "mostly cooldown" and
+ * reliably reports `Positive Split (slowed down)` for a workout that was simply
+ * intervals. The prompt used to assert that verdict as fact several hundred
+ * lines after `buildAnalysisGuardrailInstructions` had politely asked the model
+ * to disregard non-constant pace on such sessions (CW-393) -- a soft request
+ * losing to a hard assertion. The fix is to stop emitting the verdict.
+ *
+ * Gated on `guardrails.archetype.sessionSteadiness` rather than on an entry of
+ * `performanceSignals.applicability`: the closest neighbour there,
+ * `lateSessionFade`, also reports `applicable: false` whenever its own value
+ * could not be computed, which says nothing about whether half-splits are
+ * comparable. Session steadiness is the shape question this verdict actually
+ * poses -- `primaryArchetype` is an intent label (an interval run still reads
+ * `endurance` when no plan is linked) and does not answer it. The return shape
+ * follows `SignalApplicability` so a withheld verdict carries the reason it was
+ * withheld.
+ *
+ * Without v2 facts there is no session-shape evidence to gate on, so the legacy
+ * path is left exactly as it was.
+ */
+export function resolveSplitPacingVerdictApplicability(analysisFacts?: WorkoutAnalysisFactsV2): {
+  applicable: boolean
+  reason: string | null
+} {
+  if (!analysisFacts) return { applicable: true, reason: null }
+
+  const { sessionSteadiness } = analysisFacts.guardrails.archetype
+
+  if (sessionSteadiness === 'intervalled' || sessionSteadiness === 'stochastic') {
+    return {
+      applicable: false,
+      reason: `session steadiness is ${sessionSteadiness}, so automatic distance splits cut across warmup, work reps, recoveries and cooldown; their halves are not comparable`
+    }
+  }
+
+  return { applicable: true, reason: null }
+}
+
 export function buildWorkoutAnalysisPrompt(
   workoutData: any,
 
@@ -1375,13 +1423,20 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     })
   }
 
-  // Add lap splits pacing analysis if available
+  // Add distance-split pacing analysis if available.
+  //
+  // These rows are the provider's automatic per-distance splits, not laps the
+  // athlete triggered and not the session's work intervals; the section used to
+  // be headed "Lap Pacing Analysis", which invited the model to talk about
+  // "laps" that never existed (CW-389).
   if (workoutData.lap_splits && workoutData.lap_splits.length > 0) {
-    prompt += '\n## Lap Pacing Analysis\n'
-    prompt += `Split-by-split pacing data showing consistency and strategy:\n\n`
+    const splitVerdict = resolveSplitPacingVerdictApplicability(analysisFactsV2)
+
+    prompt += '\n## Distance Split Pacing\n'
+    prompt += `Automatic per-distance splits (1 km / 1 mi) recorded for this session. These are not laps and not the workout's work intervals:\n\n`
 
     workoutData.lap_splits.forEach((split: any) => {
-      prompt += `**Lap ${split.lap}**: `
+      prompt += `**Split ${split.lap}**: `
       prompt += `${formatPromptDistance(split.distance_m, userProfile?.distanceUnits)} in ${Math.floor(split.time_s / 60)}:${(split.time_s % 60).toString().padStart(2, '0')} `
 
       const paceSecondsPerKm =
@@ -1393,13 +1448,19 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     })
 
     if (workoutData.pace_variability_seconds) {
-      prompt += `\n**Pace Consistency**: ${formatMetric(workoutData.pace_variability_seconds, 1)} seconds standard deviation\n`
-      prompt += `- Lower is better (more consistent pacing)\n`
-      prompt += `- <10s = Excellent consistency, 10-20s = Good, >20s = Variable pacing\n`
+      // The raw dispersion is a measurement and may stay; the grade band is a
+      // verdict and only applies to a session that was meant to hold one pace.
+      prompt += `\n**Split Pace Consistency**: ${formatMetric(workoutData.pace_variability_seconds, 1)} seconds standard deviation\n`
+      if (splitVerdict.applicable) {
+        prompt += `- Lower is better (more consistent pacing)\n`
+        prompt += `- <10s = Excellent consistency, 10-20s = Good, >20s = Variable pacing\n`
+      } else {
+        prompt += `- Consistency grading omitted: ${splitVerdict.reason}. Do not read this number as a pacing grade.\n`
+      }
     }
 
     // Add first/second half comparison
-    if (workoutData.lap_splits.length >= 2) {
+    if (workoutData.lap_splits.length >= 2 && splitVerdict.applicable) {
       const halfwayIndex = Math.floor(workoutData.lap_splits.length / 2)
       const firstHalf = workoutData.lap_splits.slice(0, halfwayIndex)
       const secondHalf = workoutData.lap_splits.slice(halfwayIndex)
@@ -1423,6 +1484,11 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
       prompt += `- First half avg: ${formatPromptPace(firstHalfAvgPace, userProfile?.distanceUnits)}\n`
       prompt += `- Second half avg: ${formatPromptPace(secondHalfAvgPace, userProfile?.distanceUnits)}\n`
       prompt += `- Difference: ${Math.abs(splitDiff).toFixed(1)}s ${splitDiff > 0 ? 'slower' : 'faster'} in second half\n`
+    } else if (workoutData.lap_splits.length >= 2) {
+      // Stated rather than left as a silent gap: "do not infer meaning from
+      // omitted facts" is already a rule in the v2 facts contract, so a missing
+      // section has to say why it is missing.
+      prompt += `\nSplit-strategy verdict omitted: ${splitVerdict.reason}.\n`
     }
 
     prompt += '\n'


### PR DESCRIPTION
Fixes CW-389

## Problem

The `## Lap Pacing Analysis` block emitted a first-half/second-half **Split Strategy** verdict and a pace-variability grade band unconditionally, for every workout carrying splits. On an interval session those halves compare "mostly warmup" against "mostly cooldown", so the model was handed `Positive Split (slowed down)` and `>20s = Variable pacing` as facts and criticised the athlete for them.

Two aggravating details:

- These are **not laps**. `buildWorkoutAnalysisData` fills `lap_splits` from `raw.splits_metric || raw.splits_standard` (and the FIT/Rouvy path from `calculateLapSplits(..., 1000)`) - automatic per-kilometre/mile splits, never the athlete's or the provider's interval laps. The `Lap` naming was itself a misnomer that invited the model to discuss "laps" that never existed.
- CW-393 already asks the model, in `buildAnalysisGuardrailInstructions`, not to criticise non-constant pace on intervalled/stochastic sessions. That soft request was competing with a hard assertion several hundred lines later in the same prompt.

## Change

- New exported `resolveSplitPacingVerdictApplicability(analysisFactsV2)`, returning the same `{ applicable, reason }` shape the CW-393 `performanceSignals.applicability.*` gates use. Gate: `guardrails.archetype.sessionSteadiness` - suppressed for `intervalled` and `stochastic`, allowed for `steady` and `rolling`. With no v2 facts it returns applicable, so the legacy path and the committed snapshot are untouched.
- The `**Split Strategy**` verdict and the `Lower is better` / `<10s = Excellent ... >20s = Variable pacing` grade band are emitted only when that gate is applicable.
- When suppressed, the prompt states the omission and its reason rather than leaving a silent gap ("do not infer meaning from omitted facts" is an existing rule of the facts contract).
- Per-split rows and the raw standard-deviation measurement are unchanged - only the derived verdicts are gated.
- Header/labels corrected: `## Lap Pacing Analysis` -> `## Distance Split Pacing`, `**Lap N**` -> `**Split N**`, `**Pace Consistency**` -> `**Split Pace Consistency**`, with a one-line note that these are automatic distance splits, not laps and not work intervals.

Not gated on an existing `applicability` entry: the closest neighbour, `lateSessionFade`, also reports `applicable: false` whenever its own value could not be computed, which says nothing about whether half-splits are comparable. `primaryArchetype` is an intent label (an interval run still classifies as `endurance` with no plan linked) and does not answer the shape question either.

**Out of scope (per the ticket):** replacing the suppressed verdict with work-rep-scoped pacing aggregates - that is CW-381 and needs the work-only aggregate payload it introduces. The section is left withheld with a reason rather than half-built.

## What an interval session's prompt now says

```
## Distance Split Pacing
Automatic per-distance splits (1 km / 1 mi) recorded for this session. These are not laps and not the workout's work intervals:

**Split 1**: 1.00 km in 5:30 (5:30/km pace), HR 132 bpm, 3.03 m/s
... (all rows unchanged) ...

**Split Pace Consistency**: 41.2 seconds standard deviation
- Consistency grading omitted: session steadiness is intervalled, so automatic distance splits cut across warmup, work reps, recoveries and cooldown; their halves are not comparable. Do not read this number as a pacing grade.

Split-strategy verdict omitted: session steadiness is intervalled, so automatic distance splits cut across warmup, work reps, recoveries and cooldown; their halves are not comparable.
```

## Verification

```
pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts && pnpm lint && pnpm typecheck
  Test Files  1 passed (1)
       Tests  32 passed (32)
  116 problems (0 errors, 116 warnings)   <- pre-existing vue/require-default-prop warnings
  typecheck exit 0
```

Full suite after rebasing onto `origin/develop` (`6b75cc96`, CW-396): 370 files / 2243 tests passed. The committed prompt snapshot is byte-identical - its fixture passes no v2 facts and carries no splits.