### PR TITLE
fix(ai): correct power provenance and heart-rate plausibility in workout analysis facts (CW-394, CW-395)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2241,3 +2241,74 @@ describe('archetype classification robustness (CW-396)', () => {
     expect(facts.guardrails.archetype.primaryArchetype).toBe('threshold')
   })
 })
+
+describe('Strava estimated ride power provenance (CW-394)', () => {
+  // Strava synthesises watts from speed/gradient/weight when there is no power meter and
+  // marks that with `device_watts: false`. Those numbers must not earn absolute-power
+  // benchmarking rights, so they route into the same 'estimated' path as run/ski power.
+  function estimatedPowerRide(rawJson: Record<string, unknown>) {
+    return buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        type: 'Ride',
+        title: 'Outdoor Ride',
+        durationSec: 3600,
+        averageWatts: 198,
+        normalizedPower: 214,
+        rawJson
+      })
+    })
+  }
+
+  it('treats a ride with device_watts:false as estimated and suppresses absolute power', () => {
+    const facts = estimatedPowerRide({ device_watts: false })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('estimated')
+    expect(facts.guardrails.telemetry.powerAbsoluteUsable).toBe(false)
+    expect(facts.guardrails.telemetry.powerRelativeUsable).toBe(true)
+    expect(facts.guardrails.suppressions.join(' ')).toContain(
+      'Absolute power benchmarking suppressed'
+    )
+  })
+
+  it('honours the lap-level device_watts fallback', () => {
+    const facts = estimatedPowerRide({ laps: [{ device_watts: false }, { device_watts: false }] })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('estimated')
+    expect(facts.guardrails.telemetry.powerAbsoluteUsable).toBe(false)
+  })
+
+  it('keeps device_watts:true rides on measured absolute power', () => {
+    const facts = estimatedPowerRide({ device_watts: true })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('measured')
+    expect(facts.guardrails.telemetry.powerAbsoluteUsable).toBe(true)
+    expect(facts.guardrails.suppressions.join(' ')).not.toContain(
+      'Absolute power benchmarking suppressed'
+    )
+  })
+
+  it('leaves rides with no device_watts flag on measured (Intervals.icu, FIT, legacy rows)', () => {
+    const withoutFlag = estimatedPowerRide({ icu_intervals: [] })
+    const withoutRawJson = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({ type: 'Ride', averageWatts: 198 })
+    })
+
+    expect(withoutFlag.guardrails.telemetry.powerSourceType).toBe('measured')
+    expect(withoutFlag.guardrails.telemetry.powerAbsoluteUsable).toBe(true)
+    expect(withoutRawJson.guardrails.telemetry.powerSourceType).toBe('measured')
+    expect(withoutRawJson.guardrails.telemetry.powerAbsoluteUsable).toBe(true)
+  })
+
+  it('does not claim power provenance for a ride carrying no power at all', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        type: 'Ride',
+        averageWatts: null,
+        normalizedPower: null,
+        rawJson: { device_watts: false }
+      })
+    })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('unknown')
+  })
+})

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2312,3 +2312,111 @@ describe('Strava estimated ride power provenance (CW-394)', () => {
     expect(facts.guardrails.telemetry.powerSourceType).toBe('unknown')
   })
 })
+
+describe('heart-rate physiological plausibility (CW-395)', () => {
+  // A clean stream reading `usable: true` is the primary acceptance criterion here:
+  // falsely suppressing HR removes decoupling, zone times, EF and durability from the
+  // analysis, which is a worse outcome than the over-trusting behaviour being fixed.
+  function cleanHrStream(length = 3600) {
+    return Array.from({ length }, (_, index) => {
+      const ramp = 120 + (45 * index) / (length - 1)
+      // Deterministic beat-to-beat variation of a few bpm, as a real 1 Hz stream shows.
+      const variation = 2 * Math.sin(index / 7) + 1.5 * Math.sin(index / 3)
+      return Math.round(ramp + variation)
+    })
+  }
+
+  function hrFacts(heartrate: number[]) {
+    return buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        type: 'Ride',
+        title: 'HR Telemetry Session',
+        durationSec: heartrate.length,
+        averageWatts: 200,
+        streams: {
+          time: heartrate.map((_, index) => index),
+          watts: heartrate.map(() => 200),
+          heartrate
+        }
+      })
+    })
+  }
+
+  it('REGRESSION: a clean ramping stream stays fully usable with no artifact', () => {
+    const facts = hrFacts(cleanHrStream())
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.guardrails.telemetry.hrArtifactSeverity).toBe('none')
+    expect(facts.guardrails.suppressions.join(' ')).not.toContain('Heart-rate-derived')
+  })
+
+  it('REGRESSION: a clean stream sampled at 5 s is not mistaken for impossible jumps', () => {
+    // 30 bpm across a 5 s gap is 6 bpm/s - a real interval onset, not an artifact. The
+    // rate-of-change check reads the time stream precisely so this cannot false-positive.
+    const heartrate = Array.from({ length: 720 }, (_, index) => (index % 120 < 60 ? 165 : 135))
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        type: 'Ride',
+        durationSec: 3600,
+        averageWatts: 230,
+        streams: {
+          time: Array.from({ length: 720 }, (_, index) => index * 5),
+          watts: Array.from({ length: 720 }, (_, index) => (index % 120 < 60 ? 320 : 150)),
+          heartrate
+        }
+      })
+    })
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.guardrails.telemetry.hrArtifactSeverity).toBe('none')
+  })
+
+  it('treats a 240 bpm strap-static burst as unusable with high severity', () => {
+    const clean = cleanHrStream(600)
+    const heartrate = clean.map((value, index) => (index < 60 ? 240 : value))
+    const facts = hrFacts(heartrate)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(false)
+    expect(facts.guardrails.telemetry.hrArtifactSeverity).toBe('high')
+    expect(facts.guardrails.suppressions.join(' ')).toContain('Heart-rate-derived')
+  })
+
+  it('treats sample-to-sample jumps of 40 bpm as unusable', () => {
+    const heartrate = Array.from({ length: 600 }, (_, index) => (index % 2 === 0 ? 130 : 170))
+    const facts = hrFacts(heartrate)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(false)
+    expect(facts.guardrails.telemetry.hrArtifactSeverity).toBe('high')
+  })
+
+  it('flags a handful of isolated out-of-range samples without discarding the stream', () => {
+    const clean = cleanHrStream(1200)
+    // 37 samples ~= 3.1% of the stream: past the 2% flag line, short of the 5% degrade
+    // line, so the artifact is reported but the stream survives.
+    const heartrate = clean.map((value, index) => (index % 33 === 0 ? 245 : value))
+    const facts = hrFacts(heartrate)
+    const v1 = buildWorkoutAnalysisFacts({
+      workout: makeWorkout({
+        type: 'Ride',
+        durationSec: heartrate.length,
+        streams: { time: heartrate.map((_, index) => index), heartrate }
+      })
+    })
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.guardrails.telemetry.hrArtifactSeverity).toBe('low')
+    expect(v1.telemetry.hrArtifactFlag).toBe(true)
+    expect(v1.telemetry.hrUsable).toBe(true)
+  })
+
+  it('does not double-penalise dropout samples as implausible or as jumps', () => {
+    // A stream whose only defect is a 4% dropout must behave exactly as it did before
+    // the plausibility checks existed: flagged nowhere, still usable.
+    const clean = cleanHrStream(1000)
+    const heartrate = clean.map((value, index) => (index % 25 === 0 ? 0 : value))
+    const facts = hrFacts(heartrate)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.guardrails.telemetry.hrZeroRatio).toBe(0.04)
+  })
+})

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -377,6 +377,27 @@ function inferImpactProfile(
   return 'medium'
 }
 
+/**
+ * Strava sets `device_watts: false` on rides whose watts it *estimated* from speed,
+ * gradient and rider weight rather than read off a power meter. Those numbers can be
+ * 10-30% off, so they must not earn absolute-power benchmarking rights.
+ *
+ * Returns `true` (real power meter), `false` (Strava-estimated) or `null` when the flag
+ * is absent — `null` deliberately preserves today's behaviour for Intervals.icu rows,
+ * FIT uploads and older Strava rows that predate the field.
+ *
+ * The lap-level fallback mirrors what `scripts/debug-workout-load.ts` already reads:
+ * some activity payloads carry the flag only on the laps.
+ */
+function inferStravaDeviceWatts(workout: any): boolean | null {
+  const raw = workout?.rawJson as any
+  if (!raw || typeof raw !== 'object') return null
+  if (typeof raw.device_watts === 'boolean') return raw.device_watts
+  const lapDeviceWatts = Array.isArray(raw.laps) ? raw.laps[0]?.device_watts : undefined
+  if (typeof lapDeviceWatts === 'boolean') return lapDeviceWatts
+  return null
+}
+
 function inferPowerSourceType(
   workout: any,
   family: ReturnType<typeof getWorkoutFamily>
@@ -394,7 +415,10 @@ function inferPowerSourceType(
       .includes('ski')
   )
     return 'estimated'
-  if (family === 'ride') return 'measured'
+  if (family === 'ride') {
+    // Only an explicit `false` downgrades the ride; absent/undefined stays 'measured'.
+    return inferStravaDeviceWatts(workout) === false ? 'estimated' : 'measured'
+  }
   return 'unknown'
 }
 

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -422,12 +422,33 @@ function inferPowerSourceType(
   return 'unknown'
 }
 
+/**
+ * Physiological plausibility bounds and thresholds for heart-rate telemetry (CW-395).
+ *
+ * These are deliberately wide. A false "HR unusable" removes decoupling, HR zone times,
+ * EF and durability from the analysis for an athlete whose data was fine, which is worse
+ * than the over-trusting behaviour they replace — so every bound sits outside anything a
+ * human cardiovascular system produces, and only sustained corruption degrades usability.
+ */
+/** Below any adult resting HR; a sub-30 bpm sample mid-activity is a sensor artifact. */
+const HR_MIN_PLAUSIBLE_BPM = 30
+/** Above the ~220-age ceiling for any adult; dry-electrode strap static reads 220-250. */
+const HR_MAX_PLAUSIBLE_BPM = 230
+/** No cardiovascular system ramps this fast; sustained >10 bpm/s is electrical noise. */
+const HR_MAX_DELTA_BPM_PER_SEC = 10
+/** Corruption at 2% of samples is worth flagging but not worth discarding the stream. */
+const HR_CORRUPTION_FLAG_RATIO = 0.02
+/** At 5% the artifacts are systemic, not isolated, and derived HR facts stop being safe. */
+const HR_CORRUPTION_UNUSABLE_RATIO = 0.05
+
 function getHrStats(workout: any) {
   const hrStream = asNumberArray(workout?.streams?.heartrate)
   if (hrStream.length === 0) {
     return {
       zeroRatio: workout?.averageHr ? 0 : null,
       missingRatio: workout?.averageHr ? 0 : null,
+      implausibleRatio: workout?.averageHr ? 0 : null,
+      jumpRatio: workout?.averageHr ? 0 : null,
       artifactFlag: false,
       usable: Boolean(workout?.averageHr)
     }
@@ -438,12 +459,67 @@ function getHrStats(workout: any) {
   const validCount = hrStream.filter((value) => value > 0).length
   const zeroRatio = zeroCount / hrStream.length
   const missingRatio = invalidCount / hrStream.length
-  const artifactFlag = zeroRatio >= 0.05 || missingRatio >= 0.15
-  const usable = validCount >= Math.max(60, hrStream.length * 0.75) && !artifactFlag
+
+  // Dropouts (zero / non-finite) are already counted above; only live readings are judged
+  // for plausibility so a gappy stream is not penalised twice for the same samples.
+  const implausibleCount = hrStream.filter(
+    (value) =>
+      Number.isFinite(value) &&
+      value > 0 &&
+      (value < HR_MIN_PLAUSIBLE_BPM || value > HR_MAX_PLAUSIBLE_BPM)
+  ).length
+  const implausibleRatio = implausibleCount / hrStream.length
+
+  // Rate of change is measured per *second*, not per sample: streams arrive at 1 Hz, 5 s
+  // or 30 s cadence, and treating a legitimate 30 bpm rise across a 5 s gap as a 30 bpm/s
+  // jump is exactly how a healthy interval session would get its HR wrongly suppressed.
+  // Without a usable time stream we assume 1 Hz.
+  //
+  // A pair is only judged when both samples are live and already within the plausible
+  // band. Dropouts are counted by zeroRatio and out-of-range spikes by implausibleRatio;
+  // counting them here too would charge one defect to two ratios and push streams past
+  // the degrade threshold on the strength of a single artifact. The two checks therefore
+  // stay orthogonal: this one catches impossible movement between believable values.
+  const isLivePlausible = (value: number | undefined): value is number =>
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= HR_MIN_PLAUSIBLE_BPM &&
+    value <= HR_MAX_PLAUSIBLE_BPM
+  const timeStream = asNumberArray(workout?.streams?.time)
+  const hasAlignedTime = timeStream.length === hrStream.length
+  let jumpCount = 0
+  for (let index = 1; index < hrStream.length; index += 1) {
+    const previous = hrStream[index - 1]
+    const current = hrStream[index]
+    if (!isLivePlausible(previous) || !isLivePlausible(current)) continue
+    const currentTime = timeStream[index]
+    const previousTime = timeStream[index - 1]
+    const rawDelta =
+      hasAlignedTime && typeof currentTime === 'number' && typeof previousTime === 'number'
+        ? currentTime - previousTime
+        : 1
+    const seconds = Number.isFinite(rawDelta) && rawDelta > 0 ? rawDelta : 1
+    if (Math.abs(current - previous) / seconds > HR_MAX_DELTA_BPM_PER_SEC) jumpCount += 1
+  }
+  const jumpRatio = jumpCount / hrStream.length
+
+  const dropoutFlag = zeroRatio >= 0.05 || missingRatio >= 0.15
+  const corruptionFlag =
+    implausibleRatio >= HR_CORRUPTION_FLAG_RATIO || jumpRatio >= HR_CORRUPTION_FLAG_RATIO
+  const corruptionDisqualifying =
+    implausibleRatio >= HR_CORRUPTION_UNUSABLE_RATIO || jumpRatio >= HR_CORRUPTION_UNUSABLE_RATIO
+  const artifactFlag = dropoutFlag || corruptionFlag
+  // Note the asymmetry: dropouts disqualify at the flag threshold (unchanged behaviour),
+  // but corruption only disqualifies at the higher threshold, so a handful of isolated
+  // spikes surfaces as an artifact without deleting an otherwise good stream.
+  const usable =
+    validCount >= Math.max(60, hrStream.length * 0.75) && !dropoutFlag && !corruptionDisqualifying
 
   return {
     zeroRatio: round(zeroRatio, 3),
     missingRatio: round(missingRatio, 3),
+    implausibleRatio: round(implausibleRatio, 3),
+    jumpRatio: round(jumpRatio, 3),
     artifactFlag,
     usable
   }
@@ -1305,10 +1381,17 @@ function getPromptFactValueByPath(value: unknown, path: string) {
 function inferHrArtifactSeverity(stats: ReturnType<typeof getHrStats>): HrArtifactSeverity {
   const zeroRatio = stats.zeroRatio ?? 0
   const missingRatio = stats.missingRatio ?? 0
-  const combined = Math.max(zeroRatio, missingRatio)
-  if (!stats.usable && combined >= 0.2) return 'high'
-  if (!stats.usable && combined >= 0.1) return 'moderate'
-  if (stats.artifactFlag || combined > 0) return 'low'
+  const implausibleRatio = stats.implausibleRatio ?? 0
+  const jumpRatio = stats.jumpRatio ?? 0
+  // Dropouts and corruption are graded on separate ladders because their thresholds
+  // differ: missing samples are tolerated up to 15%, whereas 5% of physiologically
+  // impossible readings already means the sensor was misbehaving for the whole session.
+  const dropoutRatio = Math.max(zeroRatio, missingRatio)
+  const corruptionRatio = Math.max(implausibleRatio, jumpRatio)
+  if (!stats.usable && corruptionRatio >= HR_CORRUPTION_UNUSABLE_RATIO) return 'high'
+  if (!stats.usable && dropoutRatio >= 0.2) return 'high'
+  if (!stats.usable && dropoutRatio >= 0.1) return 'moderate'
+  if (stats.artifactFlag || dropoutRatio > 0 || corruptionRatio > 0) return 'low'
   return 'none'
 }
 


### PR DESCRIPTION
Authorised bundle of two telemetry-provenance fixes in `server/utils/workout-analysis-facts.ts`. They touch disjoint functions, so they share a branch and a PR but keep one commit each.

Fixes CW-394
Fixes CW-395

## CW-394 - Strava-estimated ride power was granted absolute-power benchmarking rights

`inferPowerSourceType` classified **any** ride carrying watts as `'measured'`. Strava synthesises watts from speed, gradient and rider weight when there is no power meter, and marks that with `device_watts: false` - a flag we already persist verbatim in `rawJson`. Estimated values run 10-30% off, so the model was quoting absolute wattage, comparing it to FTP and drawing threshold conclusions from an inferred number.

Rides with an explicit `device_watts: false` (activity level, or the first-lap fallback `scripts/debug-workout-load.ts` already reads) now return `'estimated'`, routing them into the suppression path that run and ski power have always used. An explicit `true`, or an absent flag (Intervals.icu, FIT uploads, legacy Strava rows), is untouched.

Intervals.icu's own `icu_pm_*` provenance fields are out of scope per the ticket.

## CW-395 - `getHrStats` had no physiological plausibility checks

Every existing check was about *absence* (zero ratio, missing ratio), so impossible values sailed through as usable: dry-electrode strap static at 220-250 bpm actually **raised** `validCount`, and impossible sample-to-sample jumps were invisible. That feeds `hrUsable`, which gates decoupling interpretability, HR zone times, EF, the CW-393 applicability gates and the prompt's `HR Usable` line.

Two deterministic checks, both named constants with a stated rationale - a plausibility band (30-230 bpm) and a rate-of-change bound (10 bpm/s).

### Why it is built this way

Over-tightening is worse than the bug. A false "HR unusable" removes a whole signal family from the analysis for an athlete whose data was fine. Three choices follow from that:

1. **Rate of change is per second, read off the time stream - not per sample.** Streams arrive at 1 Hz, 5 s and 30 s cadence. Treating a real 30 bpm interval onset across a 5 s gap as a 30 bpm/s jump is precisely how a healthy session would lose its HR analysis. There is a dedicated regression test for the 5 s case.
2. **The two checks are orthogonal.** Dropouts are counted only by `zeroRatio`, out-of-range spikes only by `implausibleRatio`, and neither is re-counted as a jump. Without this, a single out-of-range spike charges two ratios at once (a spike inherently creates two large adjacent deltas) and can push a stream past the degrade threshold on the strength of one defect.
3. **Asymmetric thresholds.** Corruption flags at 2% but only degrades to unusable at 5%; dropouts still disqualify at their existing thresholds. Isolated spikes surface as an artifact without deleting an otherwise good stream.

`inferHrArtifactSeverity` grades corruption on its own ladder so a spiky stream reports `high` rather than `none`. The dropout ladder is unchanged.

### Deliberately left out

The optical-wrist-HR **cadence lock-on** check, per the ticket. Detecting HR that tracks step rate needs a correlation heuristic validated against real run data and the cadence stream; specifying it from first principles would ship a guess that silently disables HR for legitimate hard runs. A wrong "HR unusable" is expensive.

## On existing test expectations

**No existing assertion changed.** When both new HR ratios are zero the code path is bit-for-bit what it was before, which is what makes that true - `usable` no longer keys off `!artifactFlag` (that would have made the 2% flag disqualifying), but the dropout terms are reproduced exactly. The pre-existing square-wave HR fixtures survive because of the per-second rate calculation, not because a threshold was tuned around them.

The regression direction the ticket flagged - `hrUsable` feeding CW-393's applicability gates - did not move any gate expectation.

## Verification

Both tickets share a verification command; run once, plus the full suite as a sweep. All post-rebase onto `ffd3916d`.

```
pnpm test:unit server/utils/workout-analysis-facts.test.ts
  Test Files  1 passed (1)
       Tests  74 passed (74)          # 63 baseline + 11 new, 0 changed

pnpm lint       -> exit 0 (0 errors, 116 pre-existing warnings)
pnpm typecheck  -> exit 0

pnpm test:unit  (full sweep)
  Test Files  371 passed (371)
       Tests  2253 passed (2253)
```

Files touched: `server/utils/workout-analysis-facts.ts`, `server/utils/workout-analysis-facts.test.ts` - exactly the union of both tickets' Owned Paths. No change to `server/utils/interval-detection.ts` (CW-426/CW-430) or `server/utils/services/workout-analysis-prompt.ts` (CW-389).
