### PR TITLE
fix(ai): render the interval breakdown from the arbitrated segmentation (CW-391)

### DIFF
--- a/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
+++ b/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
@@ -128,16 +128,16 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 - Avg Temperature: 21.0°C
 
 ## Interval Breakdown
+Segmentation source: provider laps (labels re-derived). These are the same segments the Calculated Workout Facts v2 block above is computed over -- quote reps from this table only.
 
-### Interval 1: Block 1
+### Interval 1: WORK
 - Duration: 12m 0s
 - Avg Power: 255W
 - Intensity: 0.93 IF (93% of threshold)
 - Avg HR: 155 bpm
 - Avg Cadence: 90 rpm
-- Power Variability: 1.04
 
-### Interval 2: Rest 1
+### Interval 2: RECOVERY
 - Duration: 5m 0s
 - Avg Power: 120W
 - Intensity: 0.44 IF (44% of threshold)

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -15,7 +15,11 @@ import {
   resolveSplitPacingVerdictApplicability
 } from './workout-analysis-prompt'
 import * as analyzeWorkoutTrigger from '../../../trigger/analyze-workout'
-import { buildWorkoutAnalysisFactsV2 } from '../workout-analysis-facts'
+import {
+  buildWorkoutAnalysisFactsV2,
+  getActualIntervalsForAnalysis,
+  getActualIntervalsSourceForAnalysis
+} from '../workout-analysis-facts'
 
 /**
  * CW-392 regression coverage.
@@ -817,5 +821,223 @@ describe('clampAnalysisScore', () => {
     expect(clampAnalysisScore(null)).toBeNull()
     expect(clampAnalysisScore(undefined)).toBeNull()
     expect(clampAnalysisScore(Number.NaN)).toBeNull()
+  })
+})
+
+/**
+ * CW-391 regression coverage: ONE segmentation per prompt.
+ *
+ * `buildWorkoutAnalysisData` used to read `rawJson.icu_intervals` directly, so
+ * the "## Interval Breakdown" table could enumerate a different set of reps
+ * than the "## Calculated Workout Facts v2" block printed above it. The v2
+ * hit rates, `firstVsLastIntervalDeltaPct` and the rep-scoped CW-393 signals
+ * are all computed over the arbitrated set returned by
+ * `getActualIntervalsForAnalysis`; the table the model quotes has to be the
+ * same set or every cross-reference the model makes is arithmetic over
+ * mismatched rows.
+ */
+describe('interval segmentation provenance (CW-391)', () => {
+  const SEGMENTATION_SPORT_SETTINGS = { ftp: 250, loadPreference: 'POWER' }
+
+  /**
+   * A session where the provider laps and the engine disagree as loudly as
+   * possible: the file arrived with ONE lap covering the whole ride, while the
+   * power stream and the linked plan both describe 4 x 5 min at ~115% of FTP.
+   */
+  const DISAGREEING_WORKOUT = {
+    id: 'workout-fixture-segmentation',
+    date: new Date('2026-03-19T06:00:00Z'),
+    title: '4x5 VO2',
+    type: 'Ride',
+    durationSec: 3600,
+    ftp: 250,
+    averageWatts: 190,
+    streams: {
+      time: Array.from({ length: 3600 }, (_, index) => index),
+      watts: [
+        ...Array.from({ length: 600 }, () => 150),
+        ...Array.from({ length: 4 }, () => [
+          ...Array.from({ length: 300 }, () => 285),
+          ...Array.from({ length: 300 }, () => 120)
+        ]).flat(),
+        ...Array.from({ length: 600 }, () => 130)
+      ]
+    },
+    rawJson: {
+      icu_intervals: [
+        { type: 'WORK', label: 'Whole ride', moving_time: 3600, average_watts: 190, intensity: 76 }
+      ]
+    }
+  }
+
+  const DISAGREEING_PLAN = {
+    title: '4x5 VO2',
+    durationSec: 3600,
+    structuredWorkout: {
+      steps: [
+        { type: 'Warmup', durationSeconds: 600, power: { range: { start: 0.55, end: 0.62 } } },
+        ...Array.from({ length: 4 }, () => [
+          { type: 'Active', durationSeconds: 300, power: { range: { start: 1.1, end: 1.18 } } },
+          { type: 'Rest', durationSeconds: 300, power: { range: { start: 0.45, end: 0.52 } } }
+        ]).flat(),
+        { type: 'Cooldown', durationSeconds: 600, power: { range: { start: 0.55, end: 0.45 } } }
+      ]
+    }
+  }
+
+  const buildDisagreeingPrompt = () => {
+    const workoutData = buildWorkoutAnalysisData(DISAGREEING_WORKOUT, {
+      plannedWorkout: DISAGREEING_PLAN,
+      sportSettings: SEGMENTATION_SPORT_SETTINGS
+    })
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: DISAGREEING_WORKOUT,
+      sportSettings: SEGMENTATION_SPORT_SETTINGS,
+      plannedWorkout: DISAGREEING_PLAN
+    })
+    const prompt = buildWorkoutAnalysisPrompt(
+      workoutData,
+      'Europe/Budapest',
+      'Supportive',
+      SEGMENTATION_SPORT_SETTINGS,
+      USER_PROFILE,
+      undefined,
+      DISAGREEING_PLAN,
+      facts
+    )
+    return { workoutData, facts, prompt }
+  }
+
+  it('is the fixture the whole ticket is about: laps and detection disagree', () => {
+    // Guard the guard. If a future arbitration change makes the provider lap
+    // win here, this suite stops testing anything and has to be re-fixtured.
+    expect(
+      getActualIntervalsSourceForAnalysis(
+        DISAGREEING_WORKOUT,
+        DISAGREEING_PLAN,
+        SEGMENTATION_SPORT_SETTINGS as any
+      )
+    ).toBe('detected')
+    expect(DISAGREEING_WORKOUT.rawJson.icu_intervals).toHaveLength(1)
+  })
+
+  it('renders the interval table from the arbitrated set, not the provider laps', () => {
+    const { workoutData, prompt } = buildDisagreeingPrompt()
+    const arbitrated = getActualIntervalsForAnalysis(
+      DISAGREEING_WORKOUT,
+      DISAGREEING_PLAN,
+      SEGMENTATION_SPORT_SETTINGS as any
+    )
+
+    // Same rep COUNT as the facts are computed over -- and not the single lap.
+    expect(arbitrated.length).toBeGreaterThan(1)
+    expect(workoutData.intervals).toHaveLength(arbitrated.length)
+    expect(prompt.match(/^### Interval \d+: /gm) || []).toHaveLength(arbitrated.length)
+
+    // Same rep BOUNDARIES: durations and stream offsets, in order.
+    expect(workoutData.intervals.map((i: any) => i.duration_s)).toEqual(
+      arbitrated.map((i) => i.durationSeconds)
+    )
+    expect(workoutData.intervals.map((i: any) => i.start_index)).toEqual(
+      arbitrated.map((i) => i.startIndex)
+    )
+    expect(workoutData.intervals.map((i: any) => i.end_index)).toEqual(
+      arbitrated.map((i) => i.endIndex)
+    )
+    for (const interval of arbitrated) {
+      const minutes = Math.floor(interval.durationSeconds / 60)
+      const seconds = interval.durationSeconds % 60
+      expect(prompt).toContain(`- Duration: ${minutes}m ${seconds}s`)
+    }
+
+    // The provider's lap label and its whole-ride row must not reach the model.
+    expect(prompt).not.toContain('Whole ride')
+    expect(prompt).not.toContain('- Duration: 60m 0s')
+  })
+
+  it('names the segmentation source in the facts block and above the table', () => {
+    const { prompt } = buildDisagreeingPrompt()
+
+    expect(prompt).toContain(
+      '- Interval Segmentation Source: engine detection over the recorded streams'
+    )
+    expect(prompt).toContain(
+      'Segmentation source: engine detection over the recorded streams. These are the same segments the Calculated Workout Facts v2 block above is computed over'
+    )
+  })
+
+  it('reports provider laps as the source when they win the arbitration', () => {
+    const data = buildWorkoutAnalysisData(RIDE_WORKOUT)
+    expect(data.interval_segmentation_source).toBe('raw')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      data,
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+    expect(prompt).toContain('Segmentation source: provider laps (labels re-derived)')
+  })
+
+  it('omits the section entirely when there are no laps and nothing detected', () => {
+    const data = buildWorkoutAnalysisData({
+      id: 'workout-fixture-no-intervals',
+      date: new Date('2026-03-20T06:00:00Z'),
+      title: 'Easy spin',
+      type: 'Ride',
+      durationSec: 1800,
+      averageWatts: 140
+    })
+
+    expect(data.intervals).toBeUndefined()
+    expect(data.interval_segmentation_source).toBeUndefined()
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      data,
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+    expect(prompt).not.toContain('## Interval Breakdown')
+    expect(prompt).not.toContain('Segmentation source:')
+  })
+
+  it('prints a per-rep pace for a run and never for a ride', () => {
+    const runPrompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-run-interval-pace',
+        date: new Date('2026-03-21T06:00:00Z'),
+        title: '3 x 1km',
+        type: 'Run',
+        durationSec: 3000,
+        distanceMeters: 9000,
+        averageSpeed: 3.0,
+        rawJson: {
+          icu_intervals: [
+            { type: 'WORK', moving_time: 240, distance: 1000, average_speed: 4.1667 },
+            { type: 'RECOVERY', moving_time: 120, distance: 400, average_speed: 3.3333 }
+          ]
+        }
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE
+    )
+
+    // 4.1667 m/s = 240 s/km = 4:00/km; 3.3333 m/s = 300 s/km = 5:00/km.
+    expect(runPrompt).toContain('- Avg Pace: 4:00/km')
+    expect(runPrompt).toContain('- Avg Pace: 5:00/km')
+
+    const ridePrompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(RIDE_WORKOUT),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+    expect(ridePrompt).not.toContain('- Avg Pace:')
   })
 })

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -16,7 +16,6 @@ import {
   formatPromptTemperature,
   formatPromptPace
 } from '../ai-prompt-format'
-import { resolveProviderIntervalTypes } from '../interval-detection'
 import {
   buildAnalysisRequestMetricRules,
   buildMetricPriorityPromptBlock,
@@ -26,9 +25,10 @@ import {
 import { formatStructuredPlanForPrompt } from '../../../trigger/utils/planned-workout-targets'
 import {
   formatCadenceWithUnit,
+  getActualIntervalsForAnalysis,
+  getActualIntervalsSourceForAnalysis,
   isRunningCadenceFamily,
   toCanonicalCadence,
-  toIntervalIntensityFactor,
   type WorkoutAnalysisFactsV2
 } from '../workout-analysis-facts'
 import { summarizePowerFromWatts } from '../power-metrics'
@@ -353,7 +353,47 @@ export function normalizeRunningCadence(
   return toCanonicalCadence(cadence, isRunningWorkout)
 }
 
-export function buildWorkoutAnalysisData(workout: any) {
+/**
+ * Everything `buildWorkoutAnalysisData` needs beyond the workout row itself to
+ * segment the session the same way the v2 facts do.
+ *
+ * Both are optional so the payload builder still works from a bare workout row
+ * (scripts, older tests), but the two production entry points
+ * (`trigger/analyze-workout.ts`, `services/workoutAnalysisService.ts`) must pass
+ * them: without the athlete's real references the arbitration between provider
+ * laps and engine detection can resolve differently here than it does inside
+ * `buildWorkoutAnalysisFactsV2`, which is exactly the split this payload exists
+ * to close (CW-391, and CW-384 on why zeroed refs are a bug in their own right).
+ */
+export interface WorkoutAnalysisDataOptions {
+  plannedWorkout?: any
+  sportSettings?: any
+}
+
+/**
+ * Resolve the athlete's reference values for interval arbitration.
+ *
+ * Deliberately identical to the `refs` literal in `buildWorkoutAnalysisFactsV2`
+ * (`server/utils/workout-analysis-facts.ts`): profile-level sport settings
+ * first, `workout.ftp` only as the documented FTP fallback, and the session's
+ * own max HR never used as a stand-in for the athlete's ceiling. The facts
+ * module does not export its resolver, so this mirror carries the invariant --
+ * if that literal changes, this one has to change with it or the prompt and the
+ * facts can once again disagree about which segmentation won.
+ */
+function resolveIntervalArbitrationRefs(workout: any, sportSettings: any) {
+  return {
+    ftp: Number(sportSettings?.ftp || workout?.ftp || 0),
+    lthr: Number(sportSettings?.lthr || 0),
+    maxHr: Number(sportSettings?.maxHr || 0),
+    thresholdPace: Number(sportSettings?.thresholdPace || 0),
+    hrZones: sportSettings?.hrZones || [],
+    powerZones: sportSettings?.powerZones || [],
+    paceZones: sportSettings?.paceZones || []
+  }
+}
+
+export function buildWorkoutAnalysisData(workout: any, options: WorkoutAnalysisDataOptions = {}) {
   const workoutType = String(workout.type || '')
   const isRunningWorkout = isRunningCadenceFamily(workoutType)
   // The ONLY place session and interval cadence gets converted to the canonical
@@ -472,54 +512,54 @@ export function buildWorkoutAnalysisData(workout: any) {
     }))
   }
 
-  // Extract intervals and pacing splits from rawJson if available
+  // Interval segmentation.
+  //
+  // ONE segmentation per prompt. This used to read `rawJson.icu_intervals`
+  // directly, so the "## Interval Breakdown" table could enumerate a different
+  // set of reps than the "## Calculated Workout Facts v2" block printed above
+  // it -- the hit rates, `firstVsLastIntervalDeltaPct` and every rep-scoped
+  // CW-393 signal are computed over the arbitrated set, while the table the
+  // model actually quotes was the provider laps. When the two disagreed the
+  // model did silent arithmetic across mismatched rows and no claim could be
+  // traced back to a segmentation (CW-391).
+  //
+  // `getActualIntervalsForAnalysis` is the single arbitration point
+  // (`extractActualIntervals`): provider laps with re-derived labels (CW-376)
+  // when they describe the session better, engine detection when they do not.
+  const plannedWorkout = options.plannedWorkout ?? workout?.plannedWorkout
+  const arbitrationRefs = resolveIntervalArbitrationRefs(workout, options.sportSettings)
+  const actualIntervals = getActualIntervalsForAnalysis(workout, plannedWorkout, arbitrationRefs)
+  if (actualIntervals.length > 0) {
+    data.interval_segmentation_source = getActualIntervalsSourceForAnalysis(
+      workout,
+      plannedWorkout,
+      arbitrationRefs
+    )
+    data.intervals = actualIntervals.map((interval) => ({
+      type: interval.type,
+      classification: interval.classification,
+      duration_s: interval.durationSeconds,
+      avg_power: interval.avgPower,
+      // Already an intensity FACTOR: `mapIntervalsToActual` runs the shared
+      // CW-385 heuristic (`toIntervalIntensityFactor`) over the provider's
+      // percentage, and engine-detected segments carry no intensity at all. The
+      // renderer may only label it (CW-388).
+      intensity: interval.intensity,
+      avg_hr: interval.avgHr,
+      avg_cadence: normalizeCadence(interval.avgCadence),
+      avg_speed_ms: interval.avgSpeed,
+      confidence: interval.confidence,
+      ambiguity_note: interval.ambiguityNote,
+      // Stream offsets, so a claim about "your fourth rep" can be reconciled
+      // against the chart afterwards. Null for sources that carry none.
+      start_index: interval.startIndex,
+      end_index: interval.endIndex
+    }))
+  }
+
+  // Extract pacing splits from rawJson if available
   if (workout.rawJson && typeof workout.rawJson === 'object') {
     const raw = workout.rawJson as any
-
-    // Intervals.icu intervals
-    const rawIntervals = Array.isArray(raw.icu_intervals)
-      ? raw.icu_intervals
-      : Array.isArray(raw.intervals)
-        ? raw.intervals
-        : null
-    if (rawIntervals) {
-      // Provider lap labels are unreliable (Intervals.icu marks nearly every
-      // lap WORK); re-derive them so the model does not read recovery jogs as
-      // work reps.
-      const resolvedTypes = resolveProviderIntervalTypes(
-        rawIntervals.map((interval: any) => ({
-          type: interval.type,
-          intensity: Number(interval.intensity),
-          avgPower: Number(interval.average_watts),
-          avgSpeed: Number(interval.average_speed)
-        }))
-      )
-      data.intervals = rawIntervals.map((interval: any, index: number) => ({
-        type: resolvedTypes[index],
-        label: interval.label,
-        // Prefer moving time for pace analysis (elapsed_time can include pauses/stops and distort run interval pace).
-        duration_s: interval.moving_time ?? interval.elapsed_time,
-        distance_m: interval.distance,
-        avg_power: interval.average_watts,
-        max_power: interval.max_watts,
-        weighted_avg_power: interval.weighted_average_watts,
-        // The ONLY place interval intensity gets put on a scale. Provider laps
-        // carry Intervals.icu's PERCENTAGE of threshold (e.g. 101), while the
-        // session-level `intensity` line is an intensity factor (0.83), so the
-        // two collided in one prompt. Reuse the shared CW-385 heuristic rather
-        // than a second copy of it; the renderer may only label (CW-388).
-        intensity: toIntervalIntensityFactor(interval.intensity),
-        avg_hr: interval.average_heartrate,
-        max_hr: interval.max_heartrate,
-        avg_cadence: normalizeCadence(interval.average_cadence),
-        max_cadence: normalizeCadence(interval.max_cadence),
-        avg_speed_ms: interval.average_speed,
-        decoupling: interval.decoupling,
-        variability: interval.w5s_variability,
-        elevation_gain: interval.total_elevation_gain,
-        avg_gradient: interval.average_gradient
-      }))
-    }
 
     // Strava splits (lap pacing data)
     const splits = raw.splits_metric || raw.splits_standard
@@ -690,11 +730,50 @@ function formatPromptFactValue(value: unknown): string | null {
   return String(value)
 }
 
-export function buildAnalysisFactsPromptBlock(analysisFacts?: WorkoutAnalysisFactsV2): string {
+/**
+ * Say which segmentation the whole prompt is built on, in human terms.
+ *
+ * `getActualIntervalsSourceForAnalysis` returns the arbitration verdict as
+ * `'raw' | 'detected' | 'none'`, which means nothing to the model. Naming it in
+ * the prompt is what lets an AI claim about "your fourth rep" be reconciled
+ * against the chart afterwards (CW-391). `'none'` renders as `null` -- with no
+ * segments there is no source to report and the interval section is omitted
+ * entirely.
+ */
+export function describeIntervalSegmentationSource(
+  source: 'raw' | 'detected' | 'none' | null | undefined
+): string | null {
+  if (source === 'raw') return 'provider laps (labels re-derived)'
+  if (source === 'detected') return 'engine detection over the recorded streams'
+  return null
+}
+
+export interface AnalysisFactsPromptBlockOptions {
+  /** Arbitration verdict from `getActualIntervalsSourceForAnalysis`. */
+  intervalSegmentationSource?: 'raw' | 'detected' | 'none' | null
+}
+
+/**
+ * A row of the facts block.
+ *
+ * `path` reads a value out of the facts object and is gated on that path's
+ * `promptDecisions` entry. `value` carries an already-resolved string for facts
+ * that are not part of `WorkoutAnalysisFactsV2` itself -- currently only the
+ * interval-segmentation provenance, which is computed in the payload builder
+ * because that is where the workout row (and therefore the streams) is in
+ * scope. Such rows render whenever the value is non-null; there is no
+ * `promptDecisions` entry to gate them on.
+ */
+type AnalysisFactItem = { label: string; path?: string; value?: string | null }
+
+export function buildAnalysisFactsPromptBlock(
+  analysisFacts?: WorkoutAnalysisFactsV2,
+  options: AnalysisFactsPromptBlockOptions = {}
+): string {
   if (!analysisFacts) return ''
 
   const promptDecisions = analysisFacts.confidence.debugMeta.promptDecisions || {}
-  const groups: Array<{ title: string; items: Array<{ path: string; label: string }> }> = [
+  const groups: Array<{ title: string; items: AnalysisFactItem[] }> = [
     {
       title: 'Guardrails',
       items: [
@@ -714,7 +793,11 @@ export function buildAnalysisFactsPromptBlock(analysisFacts?: WorkoutAnalysisFac
         { path: 'guardrails.telemetry.lrInterpretationMode', label: 'L/R Interpretation Mode' },
         { path: 'guardrails.erg.detected', label: 'ERG Detected' },
         { path: 'guardrails.erg.powerControlMode', label: 'Power Control Mode' },
-        { path: 'guardrails.suppressions', label: 'Suppressions' }
+        { path: 'guardrails.suppressions', label: 'Suppressions' },
+        {
+          label: 'Interval Segmentation Source',
+          value: describeIntervalSegmentationSource(options.intervalSegmentationSource)
+        }
       ]
     },
     {
@@ -830,8 +913,11 @@ export function buildAnalysisFactsPromptBlock(analysisFacts?: WorkoutAnalysisFac
   const sections = groups
     .map((group) => {
       const lines = group.items
-        .filter((item) => promptDecisions[item.path]?.include)
         .map((item) => {
+          if (item.path === undefined) {
+            return item.value ? `- ${item.label}: ${item.value}` : null
+          }
+          if (!promptDecisions[item.path]?.include) return null
           const rawValue = getFactValueByPath(analysisFacts, item.path)
           const formatted = formatPromptFactValue(rawValue)
           return formatted ? `- ${item.label}: ${formatted}` : null
@@ -1124,7 +1210,9 @@ ${
     : ''
 }
 
-${buildAnalysisFactsPromptBlock(analysisFactsV2)}
+${buildAnalysisFactsPromptBlock(analysisFactsV2, {
+  intervalSegmentationSource: workoutData.interval_segmentation_source
+})}
 
 
 
@@ -1494,24 +1582,51 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     prompt += '\n'
   }
 
-  // Add interval analysis if available
+  // Add interval analysis if available.
+  //
+  // These rows ARE the arbitrated segmentation -- the same `ActualInterval[]`
+  // the v2 facts block above is computed over, resolved once in
+  // `buildWorkoutAnalysisData` (CW-391). The renderer only labels; it never
+  // re-derives boundaries and never re-scales a value.
   if (workoutData.intervals && workoutData.intervals.length > 0) {
+    const segmentationSource = describeIntervalSegmentationSource(
+      workoutData.interval_segmentation_source
+    )
+    // Pace is the leading metric for runs and noise for power-primary rides and
+    // indoor/strength work. Gated on the exported running-family predicate
+    // rather than on a second copy of the facts module's family table: narrower
+    // than `formatActualIntervalsForPrompt`'s rule, but exact, and runs are the
+    // family where a per-rep pace is what the athlete is actually judged on.
+    const paceCapable = isRunningCadenceFamily(workoutType)
+
     prompt += '\n## Interval Breakdown\n'
+    if (segmentationSource) {
+      prompt += `Segmentation source: ${segmentationSource}. These are the same segments the Calculated Workout Facts v2 block above is computed over -- quote reps from this table only.\n`
+    }
     workoutData.intervals.forEach((interval: any, index: number) => {
-      prompt += `\n### Interval ${index + 1}: ${interval.label || interval.type || 'Unnamed'}\n`
+      // Headed by the RESOLVED type, not the provider's lap label: the label
+      // only exists for provider laps, it is the untrusted field CW-376 stopped
+      // believing, and it would have read "Rest 1" over a segment the engine
+      // classified as work.
+      prompt += `\n### Interval ${index + 1}: ${interval.type || 'Unnamed'}\n`
       if (interval.duration_s)
         prompt += `- Duration: ${formatIntervalDuration(interval.duration_s)}\n`
-      if (interval.avg_power) prompt += `- Avg Power: ${interval.avg_power}W\n`
+      if (interval.avg_power) prompt += `- Avg Power: ${Math.round(interval.avg_power)}W\n`
       if (interval.intensity)
         prompt += `- Intensity: ${formatIntervalIntensity(Number(interval.intensity))}\n`
-      if (interval.avg_hr) prompt += `- Avg HR: ${interval.avg_hr} bpm\n`
+      if (interval.avg_hr) prompt += `- Avg HR: ${Math.round(interval.avg_hr)} bpm\n`
       // Values are already canonical (buildWorkoutAnalysisData normalised them);
       // this only attaches the unit the workout family uses, so a run no longer
       // reads "177 rpm" (CW-387).
       if (interval.avg_cadence)
         prompt += `- Avg Cadence: ${formatCadenceWithUnit(interval.avg_cadence, workoutType)}\n`
-      if (interval.variability)
-        prompt += `- Power Variability: ${formatMetric(interval.variability, 2)}\n`
+      // `avg_speed_ms` is m/s; 1000 / (m/s) is seconds per km, which
+      // `formatPromptPace` then puts in the athlete's distance units.
+      if (paceCapable && interval.avg_speed_ms > 0)
+        prompt += `- Avg Pace: ${formatPromptPace(1000 / interval.avg_speed_ms, userProfile?.distanceUnits)}\n`
+      if (interval.confidence != null)
+        prompt += `- Detection Confidence: ${Math.round(interval.confidence * 100)}%\n`
+      if (interval.ambiguity_note) prompt += `- Note: ${interval.ambiguity_note}\n`
     })
   }
 

--- a/server/utils/services/workoutAnalysisService.ts
+++ b/server/utils/services/workoutAnalysisService.ts
@@ -192,7 +192,12 @@ export async function runWorkoutAnalysis(payload: {
       workout.type || ''
     )
 
-    const workoutData = buildWorkoutAnalysisData(workout)
+    // Plan + sport settings so the payload's interval segmentation is arbitrated
+    // against the same athlete references as the v2 facts below (CW-391).
+    const workoutData = buildWorkoutAnalysisData(workout, {
+      plannedWorkout: workout.plannedWorkout,
+      sportSettings
+    })
     const analysisFactsV2 = buildWorkoutAnalysisFactsV2({
       workout,
       sportSettings,

--- a/trigger/analyze-workout.ts
+++ b/trigger/analyze-workout.ts
@@ -214,8 +214,17 @@ export const analyzeWorkoutTask = task({
         persona: aiSettings.aiPersona
       })
 
-      // Build comprehensive workout data for analysis
-      const workoutData = buildWorkoutAnalysisData(workout)
+      // Build comprehensive workout data for analysis.
+      //
+      // The plan and the athlete's sport settings are passed in so the payload
+      // segments the session with the SAME references the v2 facts below use --
+      // the arbitration between provider laps and engine detection depends on
+      // them, and a zeroed-refs payload can pick a different set of reps than
+      // the facts block (CW-391, CW-384).
+      const workoutData = buildWorkoutAnalysisData(workout, {
+        plannedWorkout: workout.plannedWorkout,
+        sportSettings
+      })
       const analysisFactsV2 = buildWorkoutAnalysisFactsV2({
         workout,
         sportSettings,


### PR DESCRIPTION
Fixes CW-391

## The defect

`buildWorkoutAnalysisData` read `rawJson.icu_intervals` directly and never called `extractActualIntervals`. So inside **one prompt** the `## Interval Breakdown` table could enumerate a different set of reps than the `## Calculated Workout Facts v2` block printed above it — the hit rates, `firstVsLastIntervalDeltaPct` and every rep-scoped CW-393 signal are computed over the arbitrated set, while the table the model actually quotes was the provider laps. When the two disagreed the model did silent arithmetic across mismatched rows and no claim could be traced back to a segmentation.

## What changed

- `buildWorkoutAnalysisData(workout, { plannedWorkout, sportSettings })` now builds `data.intervals` from `getActualIntervalsForAnalysis` — the single arbitration point — and records `data.interval_segmentation_source` from `getActualIntervalsSourceForAnalysis`. The section moved out of the `if (workout.rawJson)` guard, so a stream-only workout with no provider laps now gets an interval table from engine detection instead of nothing.
- Real athlete refs are passed in. `resolveIntervalArbitrationRefs` mirrors the `refs` literal in `buildWorkoutAnalysisFactsV2` exactly (sport settings first, `workout.ftp` only as the documented FTP fallback, session max HR never a stand-in), and the two production entry points now pass `plannedWorkout` + `sportSettings`. With zeroed refs the arbitration can resolve differently in the payload than in the facts — which is the very split this closes (CW-384).
- Provenance is wired through the `groups` table in `buildAnalysisFactsPromptBlock` as `- Interval Segmentation Source: provider laps (labels re-derived)` / `engine detection over the recorded streams`, via a new value-carrying item kind (path-based items stay gated on `promptDecisions`; there is no decision entry to gate a fact that is not part of `WorkoutAnalysisFactsV2`). The same sentence is printed above the table so the model reading the rows knows what it is reading.
- The renderer keeps CW-388's `formatIntervalDuration` / `formatIntervalIntensity` and CW-387's `formatCadenceWithUnit`; it only labels, never re-derives boundaries and never re-scales.

## Per-interval fields: kept, dropped, added

Only 7 fields of the payload were ever rendered into the prompt — `label`, `type`, `duration_s`, `avg_power`, `intensity`, `avg_hr`, `avg_cadence`, `variability`. The rest (`max_power`, `weighted_avg_power`, `decoupling`, `elevation_gain`, `avg_gradient`, `distance_m`, `max_hr`, `max_cadence`) were built into `data.intervals` and never printed, so the model never saw them and nothing was lost by dropping them from the payload.

**Kept:** duration, avg power, intensity (already an IF — `mapIntervalsToActual` runs the shared CW-385 heuristic), avg HR, avg cadence, and the resolved interval type.

**Dropped, deliberately:**
- `label` — the provider's free-text lap name. It only exists for provider laps, it is precisely the field CW-376 stopped trusting, and it would have headed a segment the engine classified as work with "Rest 1". The heading is now the resolved type.
- `variability` (`w5s_variability`) — a provider-only per-lap field with no counterpart on engine-detected segments, so keeping it would have made the table's shape depend on which source won. The intra-rep equivalent is already in the facts block as `executionStabilityScore` / `cadenceStabilityScore`, computed over the same arbitrated set (CW-393).

**Added** from `ActualInterval`: `Detection Confidence` and `Note` (the engine's ambiguity note) when present, and `Avg Pace` for running-family workouts — gated on the exported `isRunningCadenceFamily` rather than a second copy of the facts module's family table, so it is narrower than `formatActualIntervalsForPrompt`'s rule but exact. Stream offsets (`start_index` / `end_index`) are carried in the payload so a claim about "your fourth rep" can be reconciled against the chart.

## Snapshot diff

Four lines, all intended, no collateral:

```diff
 ## Interval Breakdown
+Segmentation source: provider laps (labels re-derived). These are the same segments ...
-### Interval 1: Block 1
+### Interval 1: WORK
 - Avg Cadence: 90 rpm
-- Power Variability: 1.04
-### Interval 2: Rest 1
+### Interval 2: RECOVERY
```

## Tests

Six new cases in `workout-analysis-prompt.test.ts`, built on a fixture where the file arrived with ONE lap covering the whole ride while the power stream and the linked plan both describe 4x5min at ~115% FTP — i.e. laps and detection disagree as loudly as possible:

- a guard asserting the fixture still resolves to `detected` (if arbitration ever changes and the lap wins, the suite must be re-fixtured rather than silently stop testing anything);
- the table's rep **count** and **boundaries** (durations, `start_index`, `end_index`) equal the arbitrated set, and the whole-ride lap never reaches the model;
- provenance appears in both the facts block and above the table;
- provider laps report as `raw` when they win;
- no laps and nothing detected still omits the section entirely — no empty header;
- per-rep pace for a run, never for a ride.

## Files touched vs Owned Paths

Owned: `workout-analysis-prompt.ts`, `workout-analysis-prompt.test.ts`, the snapshot. Two lines outside them — `trigger/analyze-workout.ts` and `server/utils/services/workoutAnalysisService.ts` each pass the new `{ plannedWorkout, sportSettings }` at their existing `buildWorkoutAnalysisData` call. Unavoidable: the payload cannot arbitrate against the athlete's real references without them, and both files already hold both values on the adjacent line. No export was added to the hot `workout-analysis-facts.ts`; it is only read.

## CW-434

Not addressed here and not made harder. This change consumes the facts layer's segmentation and does not touch `server/api/workouts/[id]/intervals.get.ts`, so the watts-first / pace-first candidate divergence between the endpoint and the facts layer is untouched. If anything it is now easier to close: the AI prompt is one more surface already reading the facts-layer arbitration, so the remaining work is confined to the endpoint. The prompt's new provenance line also makes a divergence observable — a prompt that says `engine detection` while the athlete's chart shows provider laps is now visible in the artifact rather than silent.

## Verification

```
pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts   38 passed
pnpm test:unit server/utils/workout-analysis-facts.test.ts             74 passed
pnpm lint                                                              0 errors (116 pre-existing warnings)
pnpm typecheck                                                         clean
pnpm test:unit (full suite)                                            371 files / 2265 tests passed
```
