### PR TITLE
fix(charts): merge annotation plugin defaults instead of replacing them (CW-422)

### DIFF
--- a/app/components/IntervalsAnalysis.vue
+++ b/app/components/IntervalsAnalysis.vue
@@ -424,10 +424,9 @@
             xMin: indexForTime(interval.start_time),
             xMax: indexForTime(interval.end_time),
             backgroundColor: shading,
-            // `ensureChartJsAnnotationDefaults` replaces the plugin's own defaults, which
-            // drops its default `drawTime`. Without this every annotation resolves to no
-            // draw phase and silently never paints - the state the WORK boxes shipped in.
-            drawTime: 'afterDatasetsDraw',
+            // No `drawTime` here on purpose: `ensureChartJsAnnotationDefaults` now merges
+            // into the plugin's defaults instead of replacing them, so the plugin's own
+            // `afterDatasetsDraw` default applies (CW-422). One source of truth.
             borderWidth: 0
           }
         }

--- a/app/utils/chartjs-annotation.ts
+++ b/app/utils/chartjs-annotation.ts
@@ -7,15 +7,37 @@ let registered = false
  * Register chartjs-plugin-annotation once and ensure every chart instance
  * has a safe default annotation config. Without this, charts that do not
  * explicitly set plugins.annotation crash when the plugin initializes.
+ *
+ * MERGE into `ChartJS.defaults.plugins.annotation` - never reassign it.
+ *
+ * `ChartJS.register()` above is what populates that object with the plugin's own
+ * defaults: `common.drawTime: 'afterDatasetsDraw'`, `common.init`, `common.label`,
+ * `clip: true`, the `animations` number/colour descriptors and the `interaction`
+ * fallbacks. Replacing the object wholesale (as this helper used to) throws all of
+ * that away. The fatal one is `drawTime`: an annotation whose draw time resolves to
+ * `undefined` is never collected into any draw phase, so it paints nothing - no
+ * error, no warning, no annotation. That is CW-422: the WORK/STEADY interval shading
+ * on the workout intervals chart was invisible for every session since this helper
+ * landed, and every other component adding annotations hit the same silent no-op.
+ *
+ * `annotations` is the only key we own here; the plugin does not define it, and
+ * charts that never set `plugins.annotation` need it present to initialise.
  */
 export function ensureChartJsAnnotationDefaults() {
   if (registered) return
 
   ChartJS.register(annotationPlugin)
   ChartJS.defaults.plugins = ChartJS.defaults.plugins || {}
-  ChartJS.defaults.plugins.annotation = {
-    annotations: {}
+
+  const annotationDefaults = (ChartJS.defaults.plugins.annotation ||
+    ({} as typeof ChartJS.defaults.plugins.annotation)) as { annotations?: unknown }
+
+  if (!annotationDefaults.annotations) {
+    annotationDefaults.annotations = {}
   }
+
+  ChartJS.defaults.plugins.annotation =
+    annotationDefaults as typeof ChartJS.defaults.plugins.annotation
 
   registered = true
 }

--- a/tests/unit/app/chartjs-annotation.test.ts
+++ b/tests/unit/app/chartjs-annotation.test.ts
@@ -9,7 +9,42 @@ import {
 describe('chartjs-annotation', () => {
   it('sets default annotation config on Chart.js', () => {
     ensureChartJsAnnotationDefaults()
-    expect(ChartJS.defaults.plugins?.annotation).toEqual({ annotations: {} })
+    expect(ChartJS.defaults.plugins?.annotation?.annotations).toEqual({})
+  })
+
+  // CW-422 regression guard. The helper used to assign a fresh
+  // `{ annotations: {} }` over `ChartJS.defaults.plugins.annotation`, which wiped the
+  // defaults `ChartJS.register(annotationPlugin)` had just installed. Losing
+  // `common.drawTime` meant every annotation resolved to no draw phase and painted
+  // nothing, silently. If this test ever fails, someone has gone back to replacing
+  // the defaults object instead of merging into it.
+  it('preserves the annotation plugin defaults instead of replacing them', () => {
+    ensureChartJsAnnotationDefaults()
+
+    const annotationDefaults = ChartJS.defaults.plugins?.annotation as
+      Record<string, any> | undefined
+
+    expect(annotationDefaults).toBeTruthy()
+    // The one that actually broke rendering.
+    expect(annotationDefaults?.common?.drawTime).toBe('afterDatasetsDraw')
+    // The rest of what a wholesale replacement was also discarding.
+    expect(annotationDefaults?.common?.init).toBe(false)
+    expect(annotationDefaults?.common?.label).toBeTruthy()
+    expect(annotationDefaults?.clip).toBe(true)
+    expect(annotationDefaults?.animations?.numbers?.type).toBe('number')
+    expect(annotationDefaults?.animations?.colors?.type).toBe('color')
+    expect(annotationDefaults?.interaction).toBeTruthy()
+  })
+
+  it('is idempotent and keeps the plugin defaults on repeat calls', () => {
+    ensureChartJsAnnotationDefaults()
+    ensureChartJsAnnotationDefaults()
+
+    const annotationDefaults = ChartJS.defaults.plugins?.annotation as
+      Record<string, any> | undefined
+
+    expect(annotationDefaults?.common?.drawTime).toBe('afterDatasetsDraw')
+    expect(annotationDefaults?.annotations).toEqual({})
   })
 
   it('safeChartUpdate no-ops for destroyed charts', () => {


### PR DESCRIPTION
Fixes CW-422

## Root cause

`ensureChartJsAnnotationDefaults()` did:

```ts
ChartJS.register(annotationPlugin)
ChartJS.defaults.plugins.annotation = { annotations: {} }   // <- replace, not merge
```

`ChartJS.register()` is exactly what populates `defaults.plugins.annotation` with the
plugin's own defaults. Assigning a fresh object on the next line threw all of them away.
The fatal loss was `common.drawTime: 'afterDatasetsDraw'` — an annotation whose draw time
resolves to `undefined` is never collected into any draw phase, so it paints nothing, with
no error and no warning.

The helper now merges: it keeps whatever `register()` installed and only fills in
`annotations: {}` (the one key the plugin does not define, needed so charts that never set
`plugins.annotation` still initialise).

## What else the wholesale replacement was discarding

Verified empirically — the new unit test asserts each of these against the real registered
plugin, and the *old* test asserted `toEqual({ annotations: {} })` (deep strict equality),
which is proof that nothing else survived:

| Default | Effect of losing it |
| --- | --- |
| `common.drawTime: 'afterDatasetsDraw'` | **The bug.** No draw phase, annotation never paints. |
| `common.init: false` | Annotation init/animation-from state fell back to undefined. |
| `common.label: {}` | Annotation label sub-scope base object gone. |
| `clip: true` | Annotations would no longer be clipped to the chart area. |
| `animations.numbers` (x, y, x2, y2, width, height, centerX, centerY, pointX, pointY, radius as `number`) | Annotation geometry transitions not animated. |
| `animations.colors` (`backgroundColor`, `borderColor` as `color`) | Annotation colour transitions not animated. |
| `interaction: { mode, axis, intersect }` | Annotation-specific interaction fallbacks gone (all three values are `undefined` in the plugin defaults, so this one was benign in practice). |

Not affected: the plugin's `descriptors` and `additionalOptionScopes` — Chart.js stores
descriptors via `defaults.describe()` in a separate registry, so overwriting
`defaults.plugins.annotation` never touched them.

## Workaround removed

CW-399's per-annotation `drawTime: 'afterDatasetsDraw'` in `app/components/IntervalsAnalysis.vue`
is gone. One source of truth: the plugin default. A comment marks why no `drawTime` is set there.

## Other consumers that have been silently rendering nothing

Grepped every caller of `ensureChartJsAnnotationDefaults`. **Not fixed in this PR** — they need
no change, they simply start working now that the default is restored:

* `app/components/nutrition/LiveEnergyChart.vue` — `nowLine` (the NOW marker + label),
  `optimalZone` and `dangerZone` boxes. None set `drawTime`; all three have been invisible.
* `app/components/nutrition/MultiDayEnergyChart.vue` — `nowLine` and the `dayLine{i}` day-boundary
  lines have been invisible. (`workoutBar{i}` and `highlightBox` set `drawTime: 'beforeDatasetsDraw'`
  explicitly, so those were rendering.)
* `app/components/analytics/ChartRenderer.vue` — passes `props.data?.annotations` straight through.
  The server-built annotations that feed it (`server/api/analytics/workout-explorer/streams.post.ts`
  lap-band boxes and FTP/LTHR/W'-zero reference lines, and `summary.post.ts` annotations) set no
  `drawTime` either, so the workout-explorer reference lines and lap bands were also invisible.
* `app/components/plans/PlanArchitectTimelineChart.vue` — every annotation sets
  `drawTime: 'beforeDatasetsDraw'` explicitly; unaffected.
* `app/components/WorkoutTimeline.vue` — passes an empty `annotations: {}`; unaffected.
* `AdvancedWorkoutMetrics.vue`, `PowerCurveChart.vue` — call the helper but define no annotations.

Net effect for the ones above: annotations that were always meant to be there start painting.
The newly-visible boxes are low-alpha (0.03–0.05) zone tints and 1–1.5px marker lines, so they land
as the intended subtle overlay rather than a visual change of character.

## Verification

```
pnpm typecheck   -> EXIT 0
pnpm lint        -> EXIT 0 (116 pre-existing warnings, 0 errors; all vue/require-default-prop in email components)
pnpm test:unit tests/unit/app -> 35 files, 138 tests passed
```

**Visual (the part that must not regress):** ran the app locally against the seeded
`watts-postgres:5439` fixtures with the workaround removed, and loaded
`/workouts/<CW-399 Interval Session (control)>`. The Intervals chart renders all five green
WORK boxes, correctly aligned to the five power surges, with `drawTime` coming only from the
merged plugin default. This is a real render, not a static reading.

The STEADY (cyan) variant was **not** re-rendered visually — the dev server's client hydration
stalled repeatedly on that second workout page (Vite dep re-optimization churn), so that
specific claim is a static one: STEADY and WORK build the identical `annotations[boxN]` box
object in the same code path and differ only in `backgroundColor`, so restoring the default
draw time covers both. Likewise, the newly-visible nutrition and workout-explorer annotations
listed above are a static reading of the code, not something I rendered.

UX critique: skipped — restores intended annotation rendering, no new UI surface.

## Files touched vs Owned Paths

* `app/utils/chartjs-annotation.ts` (owned)
* `app/components/IntervalsAnalysis.vue` (owned)
* `tests/unit/app/chartjs-annotation.test.ts` — extended the existing test file. Owned Paths
  listed `tests/unit/app/utils/chartjs-annotation.test.ts`; the test for this helper already
  existed one directory up, so it was extended in place rather than duplicated.
