### PR TITLE
fix(workouts): return null instead of inventing an FTP when no reference exists (CW-415)

### DIFF
--- a/server/utils/structured-workout-persistence.test.ts
+++ b/server/utils/structured-workout-persistence.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeStructuredWorkoutForPersistence,
   computeStructuredWorkoutDurationSec,
   computeStructuredWorkoutMetrics,
+  selectStepIntensity,
   toIntensityFactorFromTarget
 } from './structured-workout-persistence'
 
@@ -502,5 +503,110 @@ describe('structured workout persistence', () => {
     )
 
     expect(normalized.steps[0].power.ramp).toBe(false)
+  })
+})
+
+describe('toIntensityFactorFromTarget without references', () => {
+  const noRefs = {
+    ftp: 0,
+    lthr: 0,
+    maxHr: 0,
+    thresholdPace: 0,
+    hrZones: [],
+    powerZones: [],
+    paceZones: []
+  }
+
+  // The three absolute-unit paths must agree: with no reference value there is
+  // nothing to divide by, so the only honest answer is `null`. Returning a
+  // plausible number here (e.g. by assuming an FTP of 250) hides the missing
+  // reference from every caller — that fabrication masked CW-402.
+  it('returns null for absolute watts, bpm and pace alike when no reference exists', () => {
+    expect(toIntensityFactorFromTarget({ value: 250, units: 'w' }, 'power', noRefs)).toBeNull()
+    expect(toIntensityFactorFromTarget({ value: 300, units: 'watts' }, 'power', noRefs)).toBeNull()
+    expect(
+      toIntensityFactorFromTarget({ value: 150, units: 'bpm' }, 'heartRate', noRefs)
+    ).toBeNull()
+    expect(toIntensityFactorFromTarget({ value: 4.5, units: 'min/km' }, 'pace', noRefs)).toBeNull()
+  })
+
+  it('does not invent an FTP for a watts range either', () => {
+    expect(
+      toIntensityFactorFromTarget({ range: { start: 240, end: 260 }, units: 'w' }, 'power', noRefs)
+    ).toBeNull()
+  })
+
+  it('still converts absolute watts when an FTP is available', () => {
+    // Deliberately away from 250 so a reintroduced magic constant cannot pass.
+    const intensity = toIntensityFactorFromTarget({ value: 250, units: 'w' }, 'power', {
+      ...noRefs,
+      ftp: 265
+    })
+
+    expect(intensity).toBeCloseTo(250 / 265)
+  })
+
+  it('leaves relative and percentage power targets unaffected without an FTP', () => {
+    expect(toIntensityFactorFromTarget({ value: 85, units: '%' }, 'power', noRefs)).toBeCloseTo(
+      0.85
+    )
+    expect(
+      toIntensityFactorFromTarget({ value: 0.85, units: 'relative' }, 'power', noRefs)
+    ).toBeCloseTo(0.85)
+    expect(
+      toIntensityFactorFromTarget({ value: 95, units: 'pct_ftp' }, 'power', noRefs)
+    ).toBeCloseTo(0.95)
+  })
+
+  it('leaves power-zone targets unaffected without an FTP', () => {
+    expect(
+      toIntensityFactorFromTarget({ value: 4, units: 'power_zone' }, 'power', noRefs)
+    ).toBeCloseTo(0.85)
+    expect(toIntensityFactorFromTarget({ value: 2, units: 'zone' }, 'power', noRefs)).toBeCloseTo(
+      0.65
+    )
+  })
+
+  it('advances selectStepIntensity to the next metric when watts yield nothing', () => {
+    const intensity = selectStepIntensity(
+      {
+        type: 'Active',
+        power: { value: 250, units: 'w' },
+        heartRate: { value: 0.9, units: 'lthr' }
+      },
+      noRefs,
+      ['power', 'heartRate', 'pace', 'rpe']
+    )
+
+    expect(intensity).toBeCloseTo(0.9)
+  })
+
+  it('falls back to RPE, then to the step-type default, rather than a fabricated watts intensity', () => {
+    expect(
+      selectStepIntensity({ type: 'Active', power: { value: 250, units: 'w' }, rpe: 5 }, noRefs, [
+        'power',
+        'heartRate',
+        'pace',
+        'rpe'
+      ])
+    ).toBeCloseTo(0.5)
+
+    expect(
+      selectStepIntensity({ type: 'Warmup', power: { value: 150, units: 'w' } }, noRefs, [
+        'power',
+        'heartRate',
+        'pace',
+        'rpe'
+      ])
+    ).toBeCloseTo(0.5)
+
+    expect(
+      selectStepIntensity({ type: 'Active', power: { value: 250, units: 'w' } }, noRefs, [
+        'power',
+        'heartRate',
+        'pace',
+        'rpe'
+      ])
+    ).toBeCloseTo(0.75)
   })
 })

--- a/server/utils/structured-workout-persistence.ts
+++ b/server/utils/structured-workout-persistence.ts
@@ -347,7 +347,11 @@ export function toIntensityFactorFromTarget(
   if (kind === 'power') {
     if (units === 'w' || units === 'watts') {
       if (refs.ftp > 0) return clamp(value / refs.ftp)
-      return clamp(value > 3 ? value / 250 : value)
+      // No FTP reference: an absolute wattage cannot be converted to an intensity
+      // factor. Never invent an FTP — a plausible-but-fabricated IF is worse than
+      // `null`, because callers cannot tell it was made up. This mirrors the bpm
+      // branch above and lets callers fall back to type/labels instead.
+      return value > 3 ? null : clamp(value)
     }
     if (units === 'power_zone' || units.includes('zone') || units.startsWith('z')) {
       const bounds = getZoneBoundsFromRefs('power', value, refs)


### PR DESCRIPTION
Fixes CW-415

## Problem

The watts branch of `toIntensityFactorFromTarget` (`server/utils/structured-workout-persistence.ts`) fabricated an FTP of 250 W whenever no reference was available:

```ts
if (refs.ftp > 0) return clamp(value / refs.ftp)
return clamp(value > 3 ? value / 250 : value)   // <- invents an FTP of 250
```

The heart-rate branch in the same function does the opposite and correctly returns `null` when it has no reference. A plausible-but-fabricated intensity factor is worse than an explicit `null`, because callers cannot tell it was invented. This actively masked CW-402: a 250 W step against a real FTP of 265 looked fine with fully zeroed refs, because 250/250 = 1.0 by coincidence.

## Change

The watts branch now mirrors the bpm branch — it returns `null` when `refs.ftp <= 0` and the value looks like an absolute wattage (`value > 3`). Sub-3 values, which are already fractions of threshold, still clamp through unchanged.

Relative/percentage watt targets (`%`, `relative`, `pct`) and power-zone targets (`zone`, `z*`) never entered this branch and are unaffected.

`selectStepIntensity` already skips a metric that yields `null` and advances to the next in its fallback order, ending at the step-type default (0.4 / 0.5 / 0.75) — so no `null` propagates out of it.

## Caller audit

Independently re-verified against `origin/develop` after rebase; every caller of the shared function already handles `null`:

- `server/utils/workout-analysis-facts.ts:1531-1548` (`flattenPlannedSteps`) — branches on `intensityFactor === null || !Number.isFinite(...)`; the value is stored as `FlattenedPlannedStep.intensityFactor: number | null` and every downstream reader guards it (`!== null`, `?? 0`, `|| 0`, `medianOf` filters nulls)
- `server/utils/workout-analysis-facts.ts:1757-1772` (`toDetectionPlannedSteps`) — the RECOVERY -> WORK promotion is guarded by `intensity !== null && Number.isFinite(intensity) && intensity >= 0.8`; `null` means "no promotion", which is the pre-fix behaviour
- `server/utils/structured-workout-persistence.ts:396` (`selectStepIntensity`) — skips and advances, as above
- `trigger/generate-structured-workout.ts:1494` and `trigger/adjust-structured-workout.ts:1360` consume `selectStepIntensity`, which always returns a number

## Tests

`server/utils/structured-workout-persistence.test.ts` gains a `toIntensityFactorFromTarget without references` block:

- watts, bpm and pace all return `null` for absolute values with no refs (the consistency test the ticket asks for — this is what stops the next person reintroducing a magic constant)
- watts ranges do not invent an FTP either
- absolute watts still convert when an FTP exists, asserted against 265 W rather than 250 W so a reintroduced constant cannot pass by coincidence
- relative/percentage and power-zone targets stay unaffected
- `selectStepIntensity` advances to heart rate, then RPE, then the step-type default

## Verification

```
pnpm test:unit server/utils/structured-workout-persistence.test.ts server/utils/workout-analysis-facts.test.ts
 Test Files  2 passed (2)
      Tests  98 passed (98)
```

Full suite after rebasing onto `develop` @ 5863f57c: 371 files / 2272 tests passed. `pnpm typecheck:server` clean, eslint clean. No existing expectations changed.

## Out of scope

`trigger/generate-structured-workout.ts:572` and `trigger/adjust-structured-workout.ts:500` each carry a private copy of `toIntensityFactorFromTarget` with the same 250 W fabrication. Both are still affected; a follow-up ticket will cover them.