### PR TITLE
fix(workouts): use the shared HR work-bar helper on the streams and share endpoints (CW-418)

### DIFF
--- a/server/api/share/workouts/[token]/intervals.get.ts
+++ b/server/api/share/workouts/[token]/intervals.get.ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, createError, getRouterParam } from 'h3'
 import { prisma } from '../../../../utils/db'
 import { attachStreamToWorkout } from '../../../../utils/repositories/workoutStreamRepository'
+import { sportSettingsRepository } from '../../../../utils/repositories/sportSettingsRepository'
 import {
   detectIntervals,
   findPeakEfforts,
@@ -8,7 +9,8 @@ import {
   calculateAerobicDecoupling,
   calculateCoastingStats,
   detectSurgesAndFades,
-  calculateRecoveryRateTrend
+  calculateRecoveryRateTrend,
+  resolveHrWorkThreshold
 } from '../../../../utils/interval-detection'
 import {
   calculateWPrimeBalance,
@@ -93,7 +95,8 @@ export default defineEventHandler(async (event) => {
         select: {
           id: true,
           ftp: true,
-          maxHr: true
+          maxHr: true,
+          lthr: true
         }
       }
     }
@@ -192,8 +195,29 @@ export default defineEventHandler(async (event) => {
   } else if (hasHr) {
     // Detect based on HR (least reliable for short intervals due to lag, but good for steady state)
     detectionMetric = 'heartrate'
-    const maxHr = workout.maxHr || (workout as any).user?.maxHr
-    const threshold = maxHr ? maxHr * 0.7 : undefined // approx Z2 border
+
+    // This endpoint is authenticated by share token, not by session user, so the HR
+    // references must come from the workout OWNER's profile - never from whoever is viewing
+    // the link. `workout.userId` is the owner, and the sport settings are read server-side
+    // only: they feed the detection engine and are NOT added to the response, so the shared
+    // payload gains no athlete profile fields (see share-response-sanitize.test.ts).
+    const ownerId = (workout as any).userId || (workout as any).user?.id
+    const ownerSportSettings = ownerId
+      ? await sportSettingsRepository.getForActivityType(ownerId, workout.type || '')
+      : null
+
+    // Profile first (sport settings, then the user record); `resolveHrWorkThreshold` prefers
+    // 0.82 * LTHR and falls back to 0.7 * max HR, with this workout's own max HR only as an
+    // explicit last resort. Scaling belongs to that helper alone (CW-383/CW-418).
+    const hrRefs = {
+      lthr: ownerSportSettings?.lthr ?? (workout as any).user?.lthr,
+      maxHr: ownerSportSettings?.maxHr ?? (workout as any).user?.maxHr
+    }
+    const threshold = resolveHrWorkThreshold({
+      ...hrRefs,
+      sessionMaxHr: workout.maxHr
+    })
+
     detectedIntervals = detectIntervals(
       time,
       hrStream!,
@@ -201,7 +225,9 @@ export default defineEventHandler(async (event) => {
       threshold,
       undefined,
       undefined,
-      cadenceStream || undefined
+      cadenceStream || undefined,
+      // Zone reference, kept separate from the work bar above (CW-400).
+      hrRefs
     )
   }
 

--- a/server/api/workouts/[id]/streams.get.ts
+++ b/server/api/workouts/[id]/streams.get.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_POWER_ZONES
 } from '../../../utils/training-metrics'
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
-import { detectIntervals } from '../../../utils/interval-detection'
+import { detectIntervals, resolveHrWorkThreshold } from '../../../utils/interval-detection'
 import { detectClimbs } from '../../../utils/climb-detection'
 import { formatPromptPace } from '../../../utils/ai-prompt-format'
 
@@ -76,6 +76,7 @@ export default defineEventHandler(async (event) => {
           select: {
             ftp: true,
             maxHr: true,
+            lthr: true,
             distanceUnits: true
           }
         }
@@ -199,6 +200,22 @@ export default defineEventHandler(async (event) => {
 
       processedStream.hrZones = (settings?.hrZones as any[]) || DEFAULT_HR_ZONES
       processedStream.powerZones = (settings?.powerZones as any[]) || DEFAULT_POWER_ZONES
+
+      // Athlete-level HR references for interval detection, sourced from the PROFILE (the
+      // sport settings loaded above, then the user record) exactly as
+      // `/api/workouts/[id]/intervals` does. They feed two distinct things: the work BAR
+      // (via `resolveHrWorkThreshold`, which prefers 0.82 * LTHR over 0.7 * max HR) and the
+      // zone reference handed to `detectIntervals` as `hrRefs` so HR intervals carry an
+      // `intensity_zone` (CW-400). Never scale these here - `resolveHrWorkThreshold` is the
+      // single place that scaling happens (CW-383/CW-418).
+      const hrRefs = {
+        lthr: settings?.lthr ?? user.lthr,
+        maxHr: settings?.maxHr ?? user.maxHr
+      }
+      const hrWorkThreshold = resolveHrWorkThreshold({
+        ...hrRefs,
+        sessionMaxHr: workout.maxHr
+      })
 
       if (Array.isArray(workoutStream.heartrate) && processedStream.hrZones.length > 0) {
         const recalculatedHrZoneTimes = new Array(processedStream.hrZones.length).fill(0)
@@ -328,15 +345,16 @@ export default defineEventHandler(async (event) => {
               cadence
             )
           } else if (heartrate.length === time.length) {
-            const threshold = user.maxHr ? user.maxHr * 0.7 : undefined
             ;(processedStream as any).detectedIntervals = detectIntervals(
               time,
               heartrate,
               'heartrate',
-              threshold,
+              hrWorkThreshold,
               undefined,
               undefined,
-              cadence
+              cadence,
+              // Zone reference, kept separate from the work bar above (CW-400).
+              hrRefs
             )
           }
 
@@ -413,15 +431,16 @@ export default defineEventHandler(async (event) => {
               cadence
             )
           } else if (heartrate.length === time.length) {
-            const threshold = user.maxHr ? user.maxHr * 0.7 : undefined
             ;(processedStream as any).detectedIntervals = detectIntervals(
               time,
               heartrate,
               'heartrate',
-              threshold,
+              hrWorkThreshold,
               undefined,
               undefined,
-              cadence
+              cadence,
+              // Zone reference, kept separate from the work bar above (CW-400).
+              hrRefs
             )
           }
 

--- a/tests/unit/server/api/share/intervals-hr-work-bar.test.ts
+++ b/tests/unit/server/api/share/intervals-hr-work-bar.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  HR_WORK_BAR_FRACTION_OF_LTHR,
+  HR_WORK_BAR_FRACTION_OF_MAX_HR
+} from '../../../../../server/utils/interval-detection'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const mocks = vi.hoisted(() => ({
+  shareTokenFindUnique: vi.fn(),
+  workoutFindUnique: vi.fn(),
+  getForActivityType: vi.fn(),
+  // Spied so the exact work bar and zone refs handed to the engine can be asserted;
+  // `resolveHrWorkThreshold` stays real so the shared helper is what is under test.
+  detectIntervals: vi.fn(() => [] as any[])
+}))
+
+const { shareTokenFindUnique, workoutFindUnique, getForActivityType, detectIntervals } = mocks
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    shareToken: { findUnique: mocks.shareTokenFindUnique },
+    workout: { findUnique: mocks.workoutFindUnique }
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  attachStreamToWorkout: vi.fn(async (workout: any) => ({
+    ...workout,
+    streams: workout.__streams
+  }))
+}))
+
+vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: { getForActivityType: mocks.getForActivityType }
+}))
+
+vi.mock('../../../../../server/utils/interval-detection', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../server/utils/interval-detection')>()
+  return { ...actual, detectIntervals: mocks.detectIntervals }
+})
+
+const TIME = Array.from({ length: 60 }, (_, i) => i)
+const HEARTRATE = TIME.map((_, i) => (i < 30 ? 120 : 165))
+
+function makeWorkout(user: Record<string, unknown>) {
+  return {
+    id: 'workout-1',
+    userId: 'owner-1',
+    type: 'Run',
+    maxHr: 178,
+    ftp: null,
+    user: { id: 'owner-1', ftp: null, ...user },
+    __streams: { time: TIME, heartrate: HEARTRATE }
+  }
+}
+
+function hrCall() {
+  return detectIntervals.mock.calls.find((call: any[]) => call[2] === 'heartrate')
+}
+
+describe('GET /api/share/workouts/[token]/intervals heart-rate work bar (CW-418)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getForActivityType.mockResolvedValue(null)
+    shareTokenFindUnique.mockResolvedValue({
+      resourceType: 'WORKOUT',
+      resourceId: 'workout-1',
+      expiresAt: null
+    })
+  })
+
+  it("derives the work bar from the OWNER's LTHR when one is on file", async () => {
+    workoutFindUnique.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/intervals.get')
+    await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(hrCall()![3]).toBe(165 * HR_WORK_BAR_FRACTION_OF_LTHR)
+  })
+
+  it("resolves the sport settings of the workout's OWNER, not of the link viewer", async () => {
+    workoutFindUnique.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+    getForActivityType.mockResolvedValue({ lthr: 150, maxHr: 185 })
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/intervals.get')
+    await mod.default({ context: { params: { token: 'share-token' } } })
+
+    // The endpoint has no session user at all, so the only correct source is the owner id
+    // carried by the workout record.
+    expect(getForActivityType).toHaveBeenCalledWith('owner-1', 'Run')
+    expect(hrCall()![3]).toBe(150 * HR_WORK_BAR_FRACTION_OF_LTHR)
+  })
+
+  it('falls back to 0.7 * max HR when the owner has no LTHR on file', async () => {
+    workoutFindUnique.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: null }))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/intervals.get')
+    await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(hrCall()![3]).toBe(190 * HR_WORK_BAR_FRACTION_OF_MAX_HR)
+  })
+
+  it('passes the owner refs as hrRefs so HR intervals can carry an intensity_zone', async () => {
+    workoutFindUnique.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/intervals.get')
+    await mod.default({ context: { params: { token: 'share-token' } } })
+
+    expect(hrCall()![7]).toEqual({ lthr: 165, maxHr: 190 })
+  })
+
+  it('keeps the owner HR profile out of the public response', async () => {
+    workoutFindUnique.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+    getForActivityType.mockResolvedValue({ lthr: 150, maxHr: 185, hrZones: [{ min: 100 }] })
+
+    const mod = await import('../../../../../server/api/share/workouts/[token]/intervals.get')
+    const result: any = await mod.default({ context: { params: { token: 'share-token' } } })
+
+    for (const denied of ['user', 'userId', 'lthr', 'maxHr', 'hrZones', 'sportSettings']) {
+      expect(result).not.toHaveProperty(denied)
+    }
+    // The whole serialized payload must not carry the athlete's HR references either.
+    const serialized = JSON.stringify(result)
+    expect(serialized).not.toContain('lthr')
+    expect(serialized).not.toContain('owner-1')
+  })
+})

--- a/tests/unit/server/api/workouts/streams-hr-work-bar.test.ts
+++ b/tests/unit/server/api/workouts/streams-hr-work-bar.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  HR_WORK_BAR_FRACTION_OF_LTHR,
+  HR_WORK_BAR_FRACTION_OF_MAX_HR
+} from '../../../../../server/utils/interval-detection'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const mocks = vi.hoisted(() => ({
+  workoutFindFirst: vi.fn(),
+  findByWorkoutId: vi.fn(),
+  updateMetadata: vi.fn(async () => ({})),
+  getForActivityType: vi.fn(),
+  // `detectIntervals` is spied so the exact work bar and zone refs the endpoint hands it can
+  // be asserted; `resolveHrWorkThreshold` stays real so the assertion exercises the shared
+  // helper rather than a re-implementation of it.
+  detectIntervals: vi.fn(() => [] as any[])
+}))
+
+const { workoutFindFirst, findByWorkoutId, getForActivityType, detectIntervals } = mocks
+
+vi.stubGlobal('prisma', {
+  workout: { findFirst: mocks.workoutFindFirst }
+})
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  workoutStreamRepository: {
+    findByWorkoutId: mocks.findByWorkoutId,
+    updateMetadata: mocks.updateMetadata
+  }
+}))
+
+vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: { getForActivityType: mocks.getForActivityType }
+}))
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn(async () => ({ id: 'user-1' }))
+}))
+
+vi.mock('../../../../../server/utils/interval-detection', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../../../server/utils/interval-detection')>()
+  return { ...actual, detectIntervals: mocks.detectIntervals }
+})
+
+const TIME = Array.from({ length: 60 }, (_, i) => i)
+const HEARTRATE = TIME.map((_, i) => (i < 30 ? 120 : 165))
+
+function makeWorkout(user: Record<string, unknown>) {
+  return {
+    id: 'workout-1',
+    userId: 'user-1',
+    type: 'Run',
+    maxHr: 178,
+    user: { ftp: null, distanceUnits: 'Kilometers', ...user }
+  }
+}
+
+function makeStream() {
+  return {
+    workoutId: 'workout-1',
+    time: TIME,
+    heartrate: HEARTRATE,
+    lapSplits: [{ lap: 1, distance: 1000, time: 300, paceSeconds: 300 }]
+  }
+}
+
+function hrCall() {
+  return detectIntervals.mock.calls.find((call: any[]) => call[2] === 'heartrate')
+}
+
+describe('GET /api/workouts/[id]/streams heart-rate work bar (CW-418)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findByWorkoutId.mockResolvedValue(makeStream())
+    getForActivityType.mockResolvedValue(null)
+  })
+
+  it('derives the work bar from the profile LTHR when the athlete has one on file', async () => {
+    workoutFindFirst.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    const call = hrCall()
+    expect(call).toBeDefined()
+    expect(call![3]).toBe(165 * HR_WORK_BAR_FRACTION_OF_LTHR)
+  })
+
+  it('prefers the sport settings LTHR over the user record', async () => {
+    workoutFindFirst.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+    getForActivityType.mockResolvedValue({ lthr: 150, maxHr: 185 })
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    expect(hrCall()![3]).toBe(150 * HR_WORK_BAR_FRACTION_OF_LTHR)
+  })
+
+  it('falls back to 0.7 * max HR unchanged when no LTHR is on file', async () => {
+    workoutFindFirst.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: null }))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    expect(hrCall()![3]).toBe(190 * HR_WORK_BAR_FRACTION_OF_MAX_HR)
+  })
+
+  it('passes the profile refs as hrRefs so HR intervals can carry an intensity_zone', async () => {
+    workoutFindFirst.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    expect(hrCall()![7]).toEqual({ lthr: 165, maxHr: 190 })
+  })
+
+  it('uses the same bar on the no-lapSplits downsampling branch', async () => {
+    // Second detection call site in this endpoint: reached when the stream carries no
+    // lapSplits and is long enough to be downsampled. It used to duplicate the inline
+    // `maxHr * 0.7` too.
+    const longTime = Array.from({ length: 2001 }, (_, i) => i)
+    findByWorkoutId.mockResolvedValue({
+      workoutId: 'workout-1',
+      time: longTime,
+      heartrate: longTime.map((_, i) => (i % 200 < 100 ? 120 : 165))
+    })
+    workoutFindFirst.mockResolvedValue(makeWorkout({ maxHr: 190, lthr: 165 }))
+
+    const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+    await mod.default({ context: { params: { id: 'workout-1' } } })
+
+    const call = hrCall()
+    expect(call).toBeDefined()
+    expect(call![3]).toBe(165 * HR_WORK_BAR_FRACTION_OF_LTHR)
+    expect(call![7]).toEqual({ lthr: 165, maxHr: 190 })
+  })
+})


### PR DESCRIPTION
Fixes CW-418

`server/api/workouts/[id]/streams.get.ts` (both detection call sites) and
`server/api/share/workouts/[token]/intervals.get.ts` computed the heart-rate work bar
inline as `maxHr * 0.7` instead of calling `resolveHrWorkThreshold()`, which CW-383
established as the single place that physiological scaling happens. Neither passed
`hrRefs` to `detectIntervals`, so after CW-400 they were the only paths returning HR
intervals with no `intensity_zone`.

Both endpoints now mirror `server/api/workouts/[id]/intervals.get.ts`: resolve LTHR/max HR
from the athlete's sport settings, then the user record; hand those refs to
`resolveHrWorkThreshold` (with the session max HR only as an explicit last resort) for the
work bar; and pass the same refs as `hrRefs` to `detectIntervals` for the zone reference.
No scaling is done in either caller.

## Share endpoint: whose settings?

`/api/share/workouts/[token]/intervals` is authenticated by share token, not by session
user, so it resolves the sport settings of the workout **owner** (`workout.userId`, the
same id already used to select `user.ftp`/`user.maxHr`), never of whoever opened the link.
The lookup happens inside the HR branch only, so the power and pace paths do not gain a
query.

**Nothing new is exposed publicly.** The owner's LTHR/max HR and sport settings are read
server-side and used purely as detection inputs; the response is still the same explicit
object (`intervals`, `peaks`, `recovery`, `advanced`, `chartData`) with no user fields.
A test asserts the payload carries no `user`/`userId`/`lthr`/`maxHr`/`hrZones` and does not
mention the owner id anywhere in its serialization.

## Which populations change

- **Athletes with an LTHR on file** (profile or sport settings): the bar moves from
  `0.7 * maxHR` to `0.82 * LTHR` on the streams and share paths, matching what
  `/api/workouts/[id]/intervals` has done since CW-383. This is the improvement.
- **Athletes with only a max HR**: identical bar, `0.7 * maxHR`. No behaviour change.
- **Athletes with no profile HR references at all**: previously `undefined` on the streams
  path; now `0.7 * sessionMaxHr` where the workout recorded one — the same explicit
  last-resort fallback the main endpoint uses.
- **Share path only, narrow case**: the old code preferred the *workout's* max HR over the
  owner's profile max HR. It now prefers the profile, per `resolveHrWorkThreshold`'s
  contract (a bar derived from the session being analysed is self-referential and drifts
  session to session). Only athletes whose recorded session max HR differs from their
  profile max HR see a bar shift, and it moves toward the stable profile value.
- **All athletes with an LTHR or max HR on file**: HR intervals from these two endpoints now
  carry an `intensity_zone`, which they never did before.

## Verification

```
pnpm test:unit tests/unit/server/api/workouts tests/unit/server/api/share
  Test Files  14 passed (14)
       Tests  48 passed (48)

pnpm test:unit           -> 373 files / 2279 tests passed
pnpm typecheck           -> exit 0, 0 errors
pnpm lint                -> 0 errors (116 pre-existing warnings, none in touched files)
```

New tests: `tests/unit/server/api/workouts/streams-hr-work-bar.test.ts` (both call sites)
and `tests/unit/server/api/share/intervals-hr-work-bar.test.ts` (owner resolution + no
public leak). Both spy on `detectIntervals` while keeping `resolveHrWorkThreshold` real, so
they assert the exact bar and refs the shared helper produces.
