### PR TITLE
fix(workouts): gate the pacing verdict by session shape in the UI (CW-436)

### DIFF
--- a/app/components/PacingAnalysis.vue
+++ b/app/components/PacingAnalysis.vue
@@ -86,7 +86,7 @@
         </div>
 
         <div
-          v-if="streams.pacingStrategy"
+          v-if="streams.pacingStrategy && splitVerdictApplicable"
           class="p-5 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl border border-emerald-100 dark:border-emerald-800/50 md:col-span-2 lg:col-span-1 group transition-all cursor-pointer hover:border-emerald-500/50 active:scale-[0.98]"
           @click="
             () => {
@@ -116,6 +116,34 @@
             >{{ streams.pacingStrategy.description }}</span
           >
         </div>
+
+        <!--
+          Session shapes whose distance splits are not comparable get an
+          explanation in place of the verdict, never a missing tile (CW-436).
+        -->
+        <div
+          v-else-if="streams.pacingStrategy"
+          class="p-5 bg-gray-50 dark:bg-gray-900/40 rounded-xl border border-gray-200 dark:border-gray-800 md:col-span-2 lg:col-span-1"
+        >
+          <!--
+            No magnifying-glass affordance here: every other tile opens a metric
+            modal on click, so borrowing the icon on a tile that cannot would read
+            as broken rather than as deliberately withheld.
+          -->
+          <div class="flex items-center justify-between mb-4">
+            <span
+              class="block text-[10px] font-black uppercase text-gray-500 dark:text-gray-400 tracking-[0.2em]"
+              >Execution Strategy</span
+            >
+          </div>
+          <span
+            class="block text-2xl font-black text-gray-700 dark:text-gray-300 uppercase tracking-tight"
+            >Not Graded</span
+          >
+          <span class="block text-[10px] text-gray-500 dark:text-gray-400 font-medium italic mt-2"
+            >Distance splits are not comparable for a session shaped like this one.</span
+          >
+        </div>
       </div>
 
       <!-- Lap Splits Table -->
@@ -130,7 +158,7 @@
         >
           <div class="flex items-center gap-2">
             <h3 class="text-[10px] font-black text-gray-400 uppercase tracking-[0.2em]">
-              Segment Splits
+              Distance Splits
             </h3>
             <UIcon
               :name="showSplits ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'"
@@ -139,6 +167,14 @@
           </div>
         </div>
 
+        <p
+          v-if="showSplits"
+          class="-mt-2 mb-4 text-xs font-medium text-gray-500 dark:text-gray-400"
+        >
+          Automatic markers cut at a fixed distance each. These are not laps and not this workout's
+          work intervals.
+        </p>
+
         <div v-if="showSplits" class="overflow-hidden">
           <table class="min-w-full divide-y divide-gray-100 dark:divide-gray-800">
             <thead class="bg-gray-50/50 dark:bg-gray-950/50">
@@ -146,7 +182,7 @@
                 <th
                   class="px-5 py-3 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest"
                 >
-                  Lap
+                  Split
                 </th>
                 <th
                   class="px-5 py-3 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest"
@@ -192,9 +228,12 @@
       </div>
 
       <!-- Pacing Strategy Details -->
-      <div v-if="streams.pacingStrategy" class="pt-6 border-t border-gray-100 dark:border-gray-800">
+      <div
+        v-if="streams.pacingStrategy && splitVerdictApplicable"
+        class="pt-6 border-t border-gray-100 dark:border-gray-800"
+      >
         <h3 class="text-[10px] font-black text-gray-400 uppercase tracking-[0.2em] mb-4">
-          Split Analysis
+          Split Strategy
         </h3>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div class="p-4 bg-gray-50 dark:bg-gray-950 rounded-xl">
@@ -231,15 +270,54 @@
               >Steady State Integrity</span
             >
             <span class="text-[10px] font-black text-gray-900 dark:text-white tracking-widest"
-              >{{ streams.pacingStrategy.evenness }}/100</span
+              >{{ streams.pacingStrategy.evenness ?? 0 }}/100</span
             >
           </div>
           <div class="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden shadow-inner">
             <div
               class="h-full transition-all duration-1000 ease-out"
-              :style="{ width: streams.pacingStrategy.evenness + '%' }"
-              :class="getEvennessClass(streams.pacingStrategy.evenness)"
+              :style="{ width: (streams.pacingStrategy.evenness ?? 0) + '%' }"
+              :class="getEvennessClass(streams.pacingStrategy.evenness ?? 0)"
             />
+          </div>
+        </div>
+      </div>
+
+      <!--
+        The halves, the delta and the evenness grade are all verdicts drawn from a
+        first-half vs second-half comparison, so they are withheld together for a
+        session whose distance splits are not comparable. The split rows above and
+        the consistency variance measurement are untouched (CW-436).
+      -->
+      <div
+        v-else-if="streams.pacingStrategy"
+        class="pt-6 border-t border-gray-100 dark:border-gray-800"
+      >
+        <h3 class="text-[10px] font-black text-gray-400 uppercase tracking-[0.2em] mb-4">
+          Split Strategy
+        </h3>
+        <div
+          class="p-5 bg-gray-50 dark:bg-gray-950 rounded-xl border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-start gap-3">
+            <UIcon
+              name="i-heroicons-information-circle"
+              class="w-5 h-5 text-gray-400 shrink-0 mt-0.5"
+            />
+            <div>
+              <p
+                class="text-[10px] font-black text-gray-700 dark:text-gray-300 uppercase tracking-widest mb-2"
+              >
+                Not graded for this session
+              </p>
+              <p class="text-sm font-medium text-gray-600 dark:text-gray-400 leading-relaxed">
+                These splits are cut at a fixed distance each, not at your efforts, so a single
+                split can hold part of a hard effort and part of a recovery. Comparing the first
+                half against the second half here would tell you where the splits landed, not how
+                you paced the session. Your split times and the consistency variance above are
+                measured as usual.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -369,10 +447,14 @@
     pacingStrategy: {
       strategy: string
       description: string
-      firstHalfPace: number
-      secondHalfPace: number
-      paceDifference: number
-      evenness: number
+      // Withheld together when the split-strategy verdict does not apply to this
+      // session shape (CW-436); the split rows and the variance stay regardless.
+      firstHalfPace?: number
+      secondHalfPace?: number
+      paceDifference?: number
+      evenness?: number
+      verdictApplicable?: boolean
+      verdictWithheldReason?: string | null
     }
     lapSplits: Array<{
       lap: number
@@ -421,6 +503,17 @@
   const validSurges = computed(() => {
     return (streams.value?.surges || []).filter((s) => s && s.time !== undefined)
   })
+
+  /**
+   * Whether the split-strategy verdict applies to this session. Decided server-side
+   * by `resolveSplitPacingVerdictApplicability` -- the same gate CW-389 applied to
+   * the AI prompt -- so this card and the AI analysis never contradict each other
+   * about whether pacing was gradeable (CW-436). Responses predating the gate carry
+   * no flag and stay graded.
+   */
+  const splitVerdictApplicable = computed(
+    () => streams.value?.pacingStrategy?.verdictApplicable !== false
+  )
 
   // Calculate surge position as percentage of total workout time
   function getSurgePosition(surgeTime: number): number {
@@ -550,7 +643,8 @@
       positive_split: 'Positive Split',
       negative_split: 'Negative Split',
       slightly_uneven: 'Slightly Uneven',
-      insufficient_data: 'Insufficient Data'
+      insufficient_data: 'Insufficient Data',
+      not_graded: 'Not Graded'
     }
     return strategies[strategy] || strategy
   }
@@ -567,10 +661,10 @@
     return 'bg-green-50/50 dark:bg-green-900/10'
   }
 
-  function getDifferenceBgClass(difference: number): string {
-    if (Math.abs(difference) < 5)
+  function getDifferenceBgClass(difference: number | null | undefined): string {
+    if (Math.abs(difference ?? 0) < 5)
       return 'bg-green-50 dark:bg-green-900/20 border-green-100 dark:border-green-800/50 text-green-700 dark:text-green-300'
-    if (difference > 0)
+    if ((difference ?? 0) > 0)
       return 'bg-orange-50 dark:bg-orange-900/20 border-orange-100 dark:border-orange-800/50 text-orange-700 dark:text-orange-300'
     return 'bg-blue-50 dark:bg-blue-900/20 border-blue-100 dark:border-blue-800/50 text-blue-700 dark:text-blue-300'
   }

--- a/server/api/workouts/[id]/streams.get.ts
+++ b/server/api/workouts/[id]/streams.get.ts
@@ -10,6 +10,10 @@ import { sportSettingsRepository } from '../../../utils/repositories/sportSettin
 import { detectIntervals, resolveHrWorkThreshold } from '../../../utils/interval-detection'
 import { detectClimbs } from '../../../utils/climb-detection'
 import { formatPromptPace } from '../../../utils/ai-prompt-format'
+import {
+  buildWorkoutAnalysisFactsV2,
+  type WorkoutAnalysisFactsV2
+} from '../../../utils/workout-analysis-facts'
 
 defineRouteMeta({
   openAPI: {
@@ -72,12 +76,19 @@ export default defineEventHandler(async (event) => {
         userId: authUser.id
       },
       include: {
+        // The pacing verdict is gated on the same v2 analysis facts the AI prompt
+        // uses (CW-436), so the facts builder needs the plan and athlete profile
+        // fields alongside the stream.
+        plannedWorkout: true,
         user: {
           select: {
             ftp: true,
             maxHr: true,
             lthr: true,
-            distanceUnits: true
+            distanceUnits: true,
+            weight: true,
+            weightUnits: true,
+            language: true
           }
         }
       }
@@ -93,6 +104,35 @@ export default defineEventHandler(async (event) => {
     const user = workout.user
 
     const workoutStream = await workoutStreamRepository.findByWorkoutId(workoutId)
+
+    // CW-436: the pacing card and the AI analysis must agree about whether this
+    // session's pacing was gradeable at all, so both are gated on the same v2
+    // analysis facts, built with the same builder the workout detail endpoint uses.
+    //
+    // Built lazily and memoised: the builder runs its own interval detection over
+    // the full streams, so a request that has no splits to grade must not pay for
+    // it. A failure here must never take the pacing card down -- returning
+    // undefined leaves the verdict applicable, i.e. the pre-CW-436 behaviour.
+    let analysisFactsV2Resolved = false
+    let analysisFactsV2: WorkoutAnalysisFactsV2 | undefined
+    const resolveAnalysisFactsV2 = async (): Promise<WorkoutAnalysisFactsV2 | undefined> => {
+      if (analysisFactsV2Resolved) return analysisFactsV2
+      analysisFactsV2Resolved = true
+      try {
+        analysisFactsV2 = buildWorkoutAnalysisFactsV2({
+          workout: { ...workout, streams: workoutStream } as any,
+          sportSettings: await sportSettingsRepository.getForActivityType(
+            workout.userId,
+            workout.type || ''
+          ),
+          plannedWorkout: (workout as any).plannedWorkout,
+          userProfile: user || undefined
+        })
+      } catch (factsError) {
+        console.error('[API] streams.get: failed to build analysis facts v2:', factsError)
+      }
+      return analysisFactsV2
+    }
 
     if (workoutStream) {
       // ON-THE-FLY ZONE CALCULATION (Backfill)
@@ -261,7 +301,10 @@ export default defineEventHandler(async (event) => {
       // if the necessary data (lapSplits) is present in the stream.
 
       if (workoutStream.lapSplits && Array.isArray(workoutStream.lapSplits)) {
-        const strategy = analyzePacingStrategy(workoutStream.lapSplits)
+        const strategy = analyzePacingStrategy(
+          workoutStream.lapSplits,
+          await resolveAnalysisFactsV2()
+        )
 
         // Downsample high-frequency streams to reduce payload size (Fixes COACH-WATTS-B)
         const TARGET_POINTS = 2000
@@ -502,7 +545,7 @@ export default defineEventHandler(async (event) => {
             : 0
 
         // Use shared utility for consistent pacing analysis
-        const pacingStrategy = analyzePacingStrategy(lapSplits)
+        const pacingStrategy = analyzePacingStrategy(lapSplits, await resolveAnalysisFactsV2())
 
         return {
           workoutId: workout.id,

--- a/server/utils/pacing.test.ts
+++ b/server/utils/pacing.test.ts
@@ -148,6 +148,75 @@ describe('Pacing Utils', () => {
     })
   })
 
+  // CW-436: the pacing card reads this function, so the session-shape gate CW-389
+  // applied to the AI prompt has to bite here too, or the two surfaces contradict
+  // each other on the same page.
+  describe('analyzePacingStrategy split-verdict gate', () => {
+    const withSteadiness = (sessionSteadiness: string) =>
+      ({ guardrails: { archetype: { sessionSteadiness, primaryArchetype: 'endurance' } } }) as any
+
+    // A textbook positive split, so any surviving verdict would be unmistakable.
+    const SLOWING_SPLITS = [
+      { paceSeconds: 240 },
+      { paceSeconds: 250 },
+      { paceSeconds: 260 },
+      { paceSeconds: 270 }
+    ]
+
+    it.each(['intervalled', 'stochastic'])(
+      'withholds the verdict for a %s session and explains why',
+      (steadiness) => {
+        const result = analyzePacingStrategy(SLOWING_SPLITS, withSteadiness(steadiness))
+
+        expect(result.verdictApplicable).toBe(false)
+        expect(result.strategy).toBe('not_graded')
+        // No "you slowed down" narrative anywhere in the payload.
+        expect(result.strategy).not.toBe('positive_split')
+        expect(result.description).not.toMatch(/slowed down/i)
+        // Nor the numbers the narrative is drawn from, nor the evenness grade.
+        expect(result.firstHalfPace).toBeUndefined()
+        expect(result.secondHalfPace).toBeUndefined()
+        expect(result.paceDifference).toBeUndefined()
+        expect(result.evenness).toBeUndefined()
+        // The athlete gets a plain-language explanation, not a silent gap.
+        expect(result.description.length).toBeGreaterThan(0)
+        expect(result.verdictWithheldReason).toContain(`session steadiness is ${steadiness}`)
+      }
+    )
+
+    it.each(['steady', 'rolling'])(
+      'leaves a %s session byte-identical to the ungated result',
+      (steadiness) => {
+        const gated = analyzePacingStrategy(SLOWING_SPLITS, withSteadiness(steadiness))
+        const ungated = analyzePacingStrategy(SLOWING_SPLITS)
+
+        expect(gated).toEqual(ungated)
+        expect(gated.verdictApplicable).toBe(true)
+        expect(gated.verdictWithheldReason).toBeNull()
+        expect(gated.strategy).toBe('positive_split')
+        expect(gated.description).toBe('Started fast and slowed down (positive split)')
+        expect(gated.firstHalfPace).toBe(245)
+        expect(gated.secondHalfPace).toBe(265)
+        expect(gated.paceDifference).toBe(20)
+      }
+    )
+
+    it('keeps ingestion-time callers (no facts available) on the graded path', () => {
+      const result = analyzePacingStrategy(SLOWING_SPLITS, undefined)
+
+      expect(result.verdictApplicable).toBe(true)
+      expect(result.strategy).toBe('positive_split')
+      expect(result.evenness).toBeGreaterThan(0)
+    })
+
+    it('reports insufficient data before it reports a withheld verdict', () => {
+      const result = analyzePacingStrategy([{ paceSeconds: 240 }], withSteadiness('intervalled'))
+
+      expect(result.strategy).toBe('insufficient_data')
+      expect(result.verdictApplicable).toBe(false)
+    })
+  })
+
   describe('formatPace', () => {
     it('formats 4:30/km correctly', () => {
       // 4.5 minutes = 4:30

--- a/server/utils/pacing.ts
+++ b/server/utils/pacing.ts
@@ -1,3 +1,31 @@
+import { resolveSplitPacingVerdictApplicability } from './services/workout-analysis-prompt'
+import type { WorkoutAnalysisFactsV2 } from './workout-analysis-facts'
+
+/**
+ * Plain-language stand-in shown to the athlete when the split-strategy verdict
+ * does not apply to this session shape (CW-436). The machine-readable reason from
+ * the shared gate travels alongside it as `verdictWithheldReason`.
+ */
+export const SPLIT_STRATEGY_NOT_GRADED_DESCRIPTION =
+  'Splits are cut at fixed distances, not at your efforts, so a first-half vs second-half comparison would not describe how you paced this session.'
+
+export interface PacingStrategyAnalysis {
+  strategy: string
+  description: string
+  /**
+   * Evenness grade (0-100). Withheld together with the rest of the verdict when
+   * the session shape makes distance-split halves incomparable.
+   */
+  evenness?: number
+  firstHalfPace?: number
+  secondHalfPace?: number
+  paceDifference?: number
+  /** False when the split-strategy verdict is withheld for this session shape. */
+  verdictApplicable: boolean
+  /** Why the verdict was withheld, or null when it applies. */
+  verdictWithheldReason: string | null
+}
+
 /**
  * Calculate lap splits from time and distance streams
  * @param timeData - Array of elapsed time in seconds
@@ -175,16 +203,45 @@ export function formatPace(paceMinPerKm: number | null): string {
 }
 
 /**
- * Detect if pacing was even or if there was positive/negative split
- * @param lapSplits - Array of lap split objects
+ * Detect if pacing was even or if there was positive/negative split.
+ *
+ * These are automatic per-distance splits, not laps and not the workout's work
+ * intervals. For an intervalled or stochastic session they cut across warmup,
+ * work reps, recoveries and cooldown, so their halves are not comparable and the
+ * strategy verdict is withheld (CW-436). The gate is the same one CW-389 applied
+ * to the AI prompt -- `resolveSplitPacingVerdictApplicability` -- so the pacing
+ * card and the AI analysis agree about whether pacing was gradeable.
+ *
+ * The per-split rows and the raw dispersion measurement are unaffected; only the
+ * grading is withheld.
+ *
+ * @param lapSplits - Array of distance-split objects
+ * @param analysisFacts - v2 analysis facts; when omitted the verdict applies, which
+ *   keeps ingestion-time callers (which have no facts) on today's behaviour
  * @returns Analysis of pacing strategy
  */
-export function analyzePacingStrategy(lapSplits: any[]) {
+export function analyzePacingStrategy(
+  lapSplits: any[],
+  analysisFacts?: WorkoutAnalysisFactsV2
+): PacingStrategyAnalysis {
+  const splitVerdict = resolveSplitPacingVerdictApplicability(analysisFacts)
+
   if (lapSplits.length < 2) {
     return {
       strategy: 'insufficient_data',
       description: 'Not enough laps to analyze pacing strategy',
-      evenness: 0
+      evenness: 0,
+      verdictApplicable: splitVerdict.applicable,
+      verdictWithheldReason: splitVerdict.reason
+    }
+  }
+
+  if (!splitVerdict.applicable) {
+    return {
+      strategy: 'not_graded',
+      description: SPLIT_STRATEGY_NOT_GRADED_DESCRIPTION,
+      verdictApplicable: false,
+      verdictWithheldReason: splitVerdict.reason
     }
   }
 
@@ -233,7 +290,9 @@ export function analyzePacingStrategy(lapSplits: any[]) {
     evenness: Math.round(evennessScore),
     firstHalfPace: Math.round(firstHalfAvgPace),
     secondHalfPace: Math.round(secondHalfAvgPace),
-    paceDifference: Math.round(paceDifference)
+    paceDifference: Math.round(paceDifference),
+    verdictApplicable: true,
+    verdictWithheldReason: null
   }
 }
 

--- a/tests/unit/server/api/workouts/streams-hr-work-bar.test.ts
+++ b/tests/unit/server/api/workouts/streams-hr-work-bar.test.ts
@@ -73,8 +73,12 @@ function makeStream() {
   }
 }
 
+// The LAST heart-rate detection is the endpoint's own. Since CW-436 the endpoint also
+// builds the v2 analysis facts (to gate the pacing verdict on session shape), and that
+// builder runs its own interval detection over the same streams -- so the first
+// heart-rate call is the builder's, not the one under test here.
 function hrCall() {
-  return detectIntervals.mock.calls.find((call: any[]) => call[2] === 'heartrate')
+  return detectIntervals.mock.calls.filter((call: any[]) => call[2] === 'heartrate').at(-1)
 }
 
 describe('GET /api/workouts/[id]/streams heart-rate work bar (CW-418)', () => {


### PR DESCRIPTION
Fixes CW-436

## Problem

CW-389 gated the split-strategy verdict in the **AI prompt** for intervalled and stochastic sessions: automatic per-distance splits cut across warmup, work reps, recoveries and cooldown, so their halves are not comparable.

`server/utils/pacing.ts` carried a **second, independent** first-half vs second-half calculation feeding `app/components/PacingAnalysis.vue`, and it was ungated. So the athlete still read "you slowed down" on the pacing card — and the two surfaces contradicted each other on the same page: the AI analysis declined to grade an interval session's pacing while the pacing card graded it anyway. This is the half the athlete actually sees.

## How the shared gate was reached

`resolveSplitPacingVerdictApplicability(analysisFactsV2)` is reused directly — not re-derived, and not reimplemented from `guardrails.archetype.sessionSteadiness`.

The UI's data path does reach it. `PacingAnalysis.vue` does not read the workout record; it fetches `/api/workouts/[id]/streams`, and that endpoint already recomputes `analyzePacingStrategy()` server-side on every request (it deliberately overrides the DB-persisted `pacingStrategy`). Because that path is server-side, `server/utils/pacing.ts` can import the CW-389 export directly and call it with the exact argument CW-389 passes. The streams endpoint now builds `analysisFactsV2` with the same `buildWorkoutAnalysisFactsV2` builder the workout detail endpoint uses, so **both surfaces are gated by one function over one facts object**. No client-side heuristic, no second copy of the rule.

## Changes

- **`server/utils/pacing.ts`** — `analyzePacingStrategy(lapSplits, analysisFacts?)` consults the shared gate. When the verdict is withheld it returns `strategy: 'not_graded'` with a plain-language description, and omits `firstHalfPace` / `secondHalfPace` / `paceDifference` / `evenness` entirely: the server does not ship a verdict it will not stand behind. The facts argument is optional, so the ingestion-time callers (which have no facts) keep today's behaviour.
- **`server/api/workouts/[id]/streams.get.ts`** — builds `analysisFactsV2` and threads it into both `analyzePacingStrategy` call sites. The build is lazy and memoised: the facts builder walks the full streams, so a request with no splits to grade does not pay for it. Wrapped in try/catch: a facts failure leaves the verdict applicable (pre-CW-436 behaviour) and can never take the pacing card down.
- **`app/components/PacingAnalysis.vue`** — the card is not hidden. The Execution Strategy tile shows "Not Graded" with a one-line reason, and the Split Strategy section is replaced by a short plain-language explanation. Split rows and the Consistency Variance measurement are untouched in every case.
- **Labels corrected to match CW-389** — "Segment Splits" → "Distance Splits", table column "Lap" → "Split", "Split Analysis" → "Split Strategy", plus a one-line note that these are automatic distance markers, not laps and not the workout's work intervals.
- **`server/utils/pacing.test.ts`** — 6 new cases: withheld for intervalled/stochastic (asserting the halves, the evenness grade and any "slowed down" wording are all gone), an explicit equality assertion that steady/rolling are **identical** to the ungated result, the no-facts ingestion path, and insufficient-data precedence.

## Acceptance criteria

- Intervalled/stochastic sessions show no split-strategy verdict, and get an explanation instead of a vanished section — yes.
- CW-389's gate reused rather than reimplemented — yes, the export itself, reachable from the UI's data path.
- Steady/rolling unchanged — verified by an equality assertion against the ungated result, and in the browser (`EVEN PACING`, First Half 27.7 / Second Half 27.7 / Speed Delta 0.0, Steady State Integrity 97/100).
- Per-split rows and the raw dispersion survive in all cases — yes; the interval fixture still renders all 25 split rows and its Consistency Variance.
- Labels corrected — yes.
- **UI and AI analysis agree** — verified by running both surfaces off the same facts object for the same workout. For the intervalled fixture the generated prompt contains no `**Split Strategy**` section and no `Positive Split (slowed down)` text, and the card withholds its verdict; for the steady fixture both grade it.

## Verification

```
pnpm typecheck                              -> exit 0
pnpm test:unit server/utils/pacing.test.ts  -> 20 passed
pnpm lint                                   -> 0 errors (116 pre-existing warnings)
pnpm test:unit (full suite)                 -> exit 0
```

Rebased onto `origin/develop` at CW-418 (which also touched `streams.get.ts`); one conflict in the workout `user` select — CW-418 added `lthr`, this branch added `weight`/`weightUnits`/`language` — resolved by keeping both.

### One file outside this ticket's Owned Paths, and why

`tests/unit/server/api/workouts/streams-hr-work-bar.test.ts` (CW-418's test) went red after the rebase. The endpoint's behaviour is unchanged — instrumented and confirmed it still computes the right HR work bar (`135.3 = 165 * 0.82`) and the right `hrRefs`. What broke was the test's *selector*: `buildWorkoutAnalysisFactsV2` runs its own interval detection internally, so a single request now makes five heart-rate `detectIntervals` calls — four from the facts builder (no `hrRefs`) and one from the endpoint — and the helper's `.find(...)` picked the builder's first call instead of the endpoint's.

The helper now takes the **last** heart-rate call, with a comment explaining why. Every assertion in that test is preserved; only the selector changed. Calling it out explicitly since it belongs to another ticket — the assumption it encoded ("only one heart-rate detection happens per request") is genuinely no longer true.

## UX critique: required

Ran against the running app on both a 5x3min interval session and a steady endurance ride.

**Round 1 — FIX-FIRST.** Two in-scope findings, both fixed here:
1. The "Not Graded" tile carried the same info icon that neighbouring tiles use to open a metric modal, but did nothing on click — it read as *broken* rather than as *deliberately withheld*. Icon removed; the tile now has no icon and `cursor: auto` while its siblings keep `pointer`.
2. The explanation was a run-on. Rewritten as three short sentences: why the splits are not comparable, what the naive comparison would actually tell you, and reassurance that the data is intact.

The round-1 critic also raised the AI Analysis block as a blocker, on the grounds that it still showed a graded pacing verdict. That is a false positive: the block is **stored output from an AI run predating CW-389**, which the UI itself badges "Legacy Analysis" — no code change can rewrite an already-stored LLM response — and the text in question grades interval *repeatability* rep-to-rep, a signal CW-389 deliberately kept for interval sessions, not the distance-split verdict this ticket removes. The agreement check above confirms the two surfaces agree for analyses generated today.

**Round 2 — SHIP**, no remaining findings.
