### PR TITLE
fix(ui): unify analysis status colour mapping across surfaces (CW-424)

### DIFF
--- a/app/components/ScoreDetailModal.vue
+++ b/app/components/ScoreDetailModal.vue
@@ -182,6 +182,8 @@
 </template>
 
 <script setup lang="ts">
+  import { getAnalysisStatusColor } from '~/utils/analysis-status'
+
   interface AnalysisData {
     executive_summary?: string
     sections?: Array<{
@@ -247,21 +249,8 @@
   })
 
   // Status helpers
-  const getStatusColor = (
-    status: string
-  ): 'neutral' | 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' => {
-    if (!status) return 'neutral'
-    const map: Record<
-      string,
-      'neutral' | 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error'
-    > = {
-      excellent: 'success',
-      good: 'primary',
-      moderate: 'warning',
-      needs_improvement: 'error'
-    }
-    return map[status] || 'neutral'
-  }
+  /** Shared with the workout, report and share surfaces (CW-424). */
+  const getStatusColor = (status?: string | null) => getAnalysisStatusColor(status)
 
   const getStatusLabel = (status: string) => {
     if (!status) return 'Unknown'

--- a/app/pages/report/[id].vue
+++ b/app/pages/report/[id].vue
@@ -118,6 +118,8 @@
                       :color="
                         getStatusBadgeColor(report.analysisJson.current_fitness.status) as any
                       "
+                      :class="getStatusBadgeClass(report.analysisJson.current_fitness.status)"
+                      variant="subtle"
                       size="lg"
                     >
                       {{ report.analysisJson.current_fitness.status_label }}
@@ -494,7 +496,12 @@
                 <template #header>
                   <div class="flex items-center justify-between">
                     <h3 class="text-xl font-semibold">{{ section.title }}</h3>
-                    <UBadge :color="getStatusBadgeColor(section.status) as any" size="lg">
+                    <UBadge
+                      :color="getStatusBadgeColor(section.status) as any"
+                      :class="getStatusBadgeClass(section.status)"
+                      variant="subtle"
+                      size="lg"
+                    >
                       {{ section.status_label }}
                     </UBadge>
                   </div>
@@ -823,6 +830,7 @@
 <script setup lang="ts">
   import { formatDistance as formatDist } from '~/utils/metrics'
   import { mobileListCardUi } from '~/utils/mobile-surface-ui'
+  import { getAnalysisStatusColor } from '~/utils/analysis-status'
 
   const route = useRoute()
   const { formatDate: baseFormatDate, formatDateTime, formatShortDate } = useFormat()
@@ -920,15 +928,32 @@
     return colors[report.value.status] || 'neutral'
   })
 
-  const getStatusBadgeColor = (status: string) => {
-    const colors: Record<string, string> = {
-      excellent: 'success',
-      good: 'info',
-      moderate: 'warning',
-      needs_improvement: 'warning',
-      poor: 'error'
+  /**
+   * AI analysis *section* status -> colour. Shared with the workout page, the share
+   * page and the score modal (CW-424). Not to be confused with `statusColor` above,
+   * which colours the report's own PENDING/PROCESSING/COMPLETED/FAILED lifecycle.
+   */
+  const getStatusBadgeColor = (status?: string | null) => getAnalysisStatusColor(status)
+
+  /**
+   * Text colour for the status badges. Nuxt UI's `subtle` variant resolves the label to
+   * the base 500-level token in *both* themes and only flips the backdrop, which reads
+   * fine on a dark tint but drops to ~2:1 on the light one. Pinning an explicit
+   * light/dark pair is the same thing the share page and the workout pill do.
+   */
+  const getStatusBadgeClass = (status?: string | null) => {
+    switch (getAnalysisStatusColor(status)) {
+      case 'success':
+        return 'text-emerald-800 dark:text-emerald-300'
+      case 'warning':
+        return 'text-amber-800 dark:text-amber-300'
+      case 'error':
+        return 'text-red-800 dark:text-red-300'
+      case 'info':
+        return 'text-blue-800 dark:text-blue-300'
+      default:
+        return 'text-zinc-800 dark:text-zinc-300'
     }
-    return colors[status] || 'neutral'
   }
 
   const getPriorityBadgeColor = (priority: string) => {

--- a/app/pages/share/workouts/[token].vue
+++ b/app/pages/share/workouts/[token].vue
@@ -538,6 +538,7 @@
 
 <script setup lang="ts">
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
+  import { getAnalysisStatusColor } from '~/utils/analysis-status'
 
   import PlanAdherence from '~/components/workouts/PlanAdherence.vue'
 
@@ -652,19 +653,26 @@
     return `${baseClass} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200`
   }
 
-  function getStatusBadgeClass(status: string) {
+  /**
+   * Soft-pill styling for an AI analysis section status. The severity decision comes
+   * from `~/utils/analysis-status`, shared with the workout page, the report page and
+   * the score modal, so a shared analysis cannot be coloured differently from the same
+   * analysis on the owner's own workout page (CW-424).
+   */
+  function getStatusBadgeClass(status?: string | null) {
     const baseClass = 'px-3 py-1 rounded-full text-xs font-semibold'
-    if (status === 'excellent')
-      return `${baseClass} bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200`
-    if (status === 'good')
-      return `${baseClass} bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200`
-    if (status === 'moderate')
-      return `${baseClass} bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200`
-    if (status === 'needs_improvement')
-      return `${baseClass} bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200`
-    if (status === 'poor')
-      return `${baseClass} bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200`
-    return `${baseClass} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200`
+    switch (getAnalysisStatusColor(status)) {
+      case 'success':
+        return `${baseClass} bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200`
+      case 'warning':
+        return `${baseClass} bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200`
+      case 'error':
+        return `${baseClass} bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200`
+      case 'info':
+        return `${baseClass} bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200`
+      default:
+        return `${baseClass} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200`
+    }
   }
 
   function shouldShowPowerCurve(w: any) {

--- a/app/pages/workouts/[id]/index.vue
+++ b/app/pages/workouts/[id]/index.vue
@@ -2421,15 +2421,7 @@
                       </h3>
                       <div
                         class="px-2 py-0.5 rounded border font-black uppercase tracking-widest text-[8px] transition-colors duration-500"
-                        :class="[
-                          section.status?.toLowerCase().includes('good') ||
-                          section.status?.toLowerCase().includes('excellent')
-                            ? 'border-[#00DC82]/30 text-[#00DC82] bg-[#00DC82]/5'
-                            : section.status?.toLowerCase().includes('poor') ||
-                                section.status?.toLowerCase().includes('bad')
-                              ? 'border-red-500/30 text-red-500 dark:text-red-400 bg-red-500/5'
-                              : 'border-orange-500/30 text-orange-600 dark:text-orange-400 bg-orange-500/5'
-                        ]"
+                        :class="getStatusPillClass(section.status)"
                       >
                         {{ section.status_label || section.status }}
                       </div>
@@ -3740,6 +3732,7 @@
   import StreamChartModal from '~/components/charts/streams/StreamChartModal.vue'
   import { getWorkoutSourceLabel } from '~/utils/workout-source'
   import { metricTooltips } from '~/utils/tooltips'
+  import { getAnalysisStatusColor } from '~/utils/analysis-status'
   import {
     convertElevation,
     formatDistance as formatDist,
@@ -5824,27 +5817,28 @@
     return true
   }
 
-  function getStatusColor(status: string) {
-    if (!status) return 'neutral'
-    const s = status.toLowerCase()
-    if (s === 'excellent' || s === 'good') return 'success'
-    if (s === 'moderate' || s === 'fair') return 'warning'
-    if (s === 'needs_improvement' || s === 'poor' || s === 'failing') return 'error'
-    return 'neutral'
-  }
-
-  function getStatusBadgeClass(status: string) {
-    const color = getStatusColor(status)
-    const baseClass = 'px-3 py-1 rounded-full text-xs font-semibold'
-
-    if (color === 'success')
-      return `${baseClass} bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200`
-    if (color === 'warning')
-      return `${baseClass} bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200`
-    if (color === 'error')
-      return `${baseClass} bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200`
-
-    return `${baseClass} bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200`
+  /**
+   * HUD pill styling for an AI analysis section status. The severity decision itself
+   * lives in `~/utils/analysis-status` so this page, the report page, the share page
+   * and the score modal cannot disagree about it again (CW-424); only the pill's
+   * look is local.
+   */
+  function getStatusPillClass(status?: string | null) {
+    // Each branch carries an explicit light value: the pill text is 8px, and the
+    // bright HUD tones these dark-mode values use (the brand `#00DC82` in
+    // particular) drop under 2:1 against the light card background.
+    switch (getAnalysisStatusColor(status)) {
+      case 'success':
+        return 'border-emerald-600/30 dark:border-[#00DC82]/30 text-emerald-700 dark:text-[#00DC82] bg-emerald-500/10 dark:bg-[#00DC82]/5'
+      case 'warning':
+        return 'border-amber-600/30 dark:border-amber-500/30 text-amber-700 dark:text-amber-400 bg-amber-500/10 dark:bg-amber-500/5'
+      case 'error':
+        return 'border-red-600/30 dark:border-red-500/30 text-red-700 dark:text-red-400 bg-red-500/10 dark:bg-red-500/5'
+      case 'info':
+        return 'border-blue-600/30 dark:border-blue-500/30 text-blue-700 dark:text-blue-400 bg-blue-500/10 dark:bg-blue-500/5'
+      default:
+        return 'border-zinc-500/30 dark:border-zinc-400/30 text-zinc-600 dark:text-zinc-400 bg-zinc-500/10 dark:bg-zinc-500/5'
+    }
   }
 
   function getPriorityBadgeClass(priority: string) {

--- a/app/utils/analysis-status.test.ts
+++ b/app/utils/analysis-status.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { ANALYSIS_SECTION_STATUSES } from '../../server/utils/services/workout-analysis-prompt'
+import {
+  ANALYSIS_STATUS_COLORS,
+  ANALYSIS_STATUS_FALLBACK_COLOR,
+  getAnalysisStatusColor
+} from './analysis-status'
+
+/**
+ * CW-424 regression coverage.
+ *
+ * Four surfaces used to carry their own status->colour table, so the same analysis
+ * rendered amber on the report page and red on the workout page. These tests pin the
+ * one shared table, and -- crucially -- pin the *legacy* vocabulary too: analyses
+ * written before CW-403 still sit in `aiAnalysisJson` and are never rewritten, so
+ * dropping legacy handling would quietly turn correctly-stored old analyses grey.
+ */
+describe('getAnalysisStatusColor', () => {
+  it('colours the current vocabulary along one warm severity ramp', () => {
+    expect(getAnalysisStatusColor('excellent')).toBe('success')
+    expect(getAnalysisStatusColor('good')).toBe('success')
+    expect(getAnalysisStatusColor('moderate')).toBe('warning')
+    expect(getAnalysisStatusColor('needs_improvement')).toBe('warning')
+    expect(getAnalysisStatusColor('poor')).toBe('error')
+  })
+
+  it('keeps red for the worst tier only, so it stays meaningful', () => {
+    const red = Object.entries(ANALYSIS_STATUS_COLORS)
+      .filter(([, color]) => color === 'error')
+      .map(([status]) => status)
+
+    expect(red).toContain('poor')
+    expect(red).not.toContain('needs_improvement')
+    expect(red).not.toContain('needs_attention')
+  })
+
+  it('still colours the retired pre-CW-403 vocabulary', () => {
+    // `fair` and `needs_attention` are the legacy equivalents of `moderate` and
+    // `needs_improvement`; `info` marked a non-severity, informational section.
+    expect(getAnalysisStatusColor('fair')).toBe('warning')
+    expect(getAnalysisStatusColor('needs_attention')).toBe('warning')
+    expect(getAnalysisStatusColor('info')).toBe('info')
+  })
+
+  it('preserves the defensive aliases the per-page mappers carried', () => {
+    expect(getAnalysisStatusColor('failing')).toBe('error')
+    expect(getAnalysisStatusColor('bad')).toBe('error')
+  })
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(getAnalysisStatusColor('NEEDS_IMPROVEMENT')).toBe('warning')
+    expect(getAnalysisStatusColor('  Excellent  ')).toBe('success')
+    expect(getAnalysisStatusColor('Poor')).toBe('error')
+  })
+
+  it('falls back to neutral for missing or unrecognised statuses', () => {
+    expect(getAnalysisStatusColor(undefined)).toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+    expect(getAnalysisStatusColor(null)).toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+    expect(getAnalysisStatusColor('')).toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+    expect(getAnalysisStatusColor('   ')).toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+    expect(getAnalysisStatusColor('sideways')).toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+  })
+})
+
+/**
+ * The mapping must not silently fall behind the schema: if someone adds a status to
+ * `ANALYSIS_SECTION_STATUSES` without colouring it, it would render grey on every
+ * surface and this test fails instead.
+ */
+describe('coverage of the schema vocabulary', () => {
+  it('colours every status the analysis schema can emit', () => {
+    for (const status of ANALYSIS_SECTION_STATUSES) {
+      expect(
+        getAnalysisStatusColor(status),
+        `${status} is in ANALYSIS_SECTION_STATUSES but has no colour`
+      ).not.toBe(ANALYSIS_STATUS_FALLBACK_COLOR)
+    }
+  })
+
+  it('never maps a schema status to the informational blue token', () => {
+    // Blue is reserved for the legacy, non-severity `info` status.
+    for (const status of ANALYSIS_SECTION_STATUSES) {
+      expect(getAnalysisStatusColor(status)).not.toBe('info')
+    }
+  })
+})

--- a/app/utils/analysis-status.ts
+++ b/app/utils/analysis-status.ts
@@ -1,0 +1,78 @@
+/**
+ * Single source of truth for colouring an AI analysis section status.
+ *
+ * CW-403 unified the *schema* so every new analysis emits one status vocabulary
+ * (`ANALYSIS_SECTION_STATUSES` in `server/utils/services/workout-analysis-prompt.ts`).
+ * CW-424 unifies how that vocabulary is *coloured*: before this module the workout
+ * page, the report page, the share page and the score modal each carried their own
+ * mapper with three different colour tables, so the same analysis rendered amber on
+ * one surface and red on another.
+ *
+ * ## The ramp
+ *
+ * Severity is carried by a warm, monotonic ramp -- green -> amber -> red. Blue
+ * (`info`) sits deliberately *outside* that ramp and is reserved for the one legacy
+ * status that is not a severity judgement at all. Grey (`neutral`) means "no status /
+ * unrecognised"; after CW-424 no value of either the current or the legacy vocabulary
+ * lands there.
+ *
+ * Five ordered statuses have to share four usable tokens, so exactly one adjacent pair
+ * must collapse. `excellent` + `good` collapse to green: both mean "nothing to act on",
+ * and the degree of praise is already carried by the badge label. Collapsing
+ * `needs_improvement` into `poor` (red) instead would erase the difference between
+ * "work on this" and "this went badly", and would make red -- which should be rare
+ * enough to mean something -- the colour of the single most common finding in a
+ * workout analysis.
+ *
+ * ## Legacy values
+ *
+ * Analyses written before CW-403 are stored verbatim in `aiAnalysisJson` and are never
+ * rewritten, so the retired vocabulary (`excellent/good/fair/needs_attention/info`)
+ * still reaches these renderers and must keep colouring correctly. `fair` and
+ * `needs_attention` are the legacy equivalents of `moderate` and `needs_improvement`;
+ * `info` marks a purely informational section, which is why it -- and nothing else --
+ * gets the blue token.
+ */
+
+/** Nuxt UI colour tokens this module is allowed to return. */
+export type AnalysisStatusColor = 'success' | 'warning' | 'error' | 'info' | 'neutral'
+
+/**
+ * Status -> colour token. Keys are lowercase; look-ups go through
+ * {@link getAnalysisStatusColor}, which normalises first.
+ */
+export const ANALYSIS_STATUS_COLORS: Readonly<Record<string, AnalysisStatusColor>> = Object.freeze({
+  // Current vocabulary (ANALYSIS_SECTION_STATUSES, CW-403).
+  excellent: 'success',
+  good: 'success',
+  moderate: 'warning',
+  needs_improvement: 'warning',
+  poor: 'error',
+
+  // Retired vocabulary, still present in analyses stored before CW-403.
+  fair: 'warning',
+  needs_attention: 'warning',
+  info: 'info',
+
+  // Defensive aliases carried over from the per-page mappers this module replaced,
+  // so nothing that renders red today silently turns grey.
+  failing: 'error',
+  bad: 'error'
+})
+
+/** Colour token used when a status is missing, empty or unrecognised. */
+export const ANALYSIS_STATUS_FALLBACK_COLOR: AnalysisStatusColor = 'neutral'
+
+/**
+ * Map an analysis section status to a Nuxt UI colour token.
+ *
+ * Case- and whitespace-insensitive: stored analyses have carried `Needs_Improvement`
+ * and padded values. Call sites that need CSS classes derive them from the returned
+ * token rather than re-deriving the mapping.
+ */
+export function getAnalysisStatusColor(status?: string | null): AnalysisStatusColor {
+  if (!status) return ANALYSIS_STATUS_FALLBACK_COLOR
+  const normalised = String(status).trim().toLowerCase()
+  if (!normalised) return ANALYSIS_STATUS_FALLBACK_COLOR
+  return ANALYSIS_STATUS_COLORS[normalised] ?? ANALYSIS_STATUS_FALLBACK_COLOR
+}


### PR DESCRIPTION
Fixes CW-424

Four surfaces each carried their own analysis-section status -> colour table, with three
different colour tables between them. The same analysis rendered amber on the report page
and red on the workout page; `good` rendered green on two surfaces and blue on two others;
and statuses from the pre-CW-403 vocabulary rendered **grey** — indistinguishable from "no
status" — on the report, share and modal surfaces.

CW-403 unified the *schema* so new analyses emit one vocabulary. This unifies how that
vocabulary is **coloured**, and keeps legacy values rendering consistently wherever they
still exist in stored `aiAnalysisJson`.

## The shared helper

New `app/utils/analysis-status.ts` exports one mapping from status to a Nuxt UI colour
token. Per the ticket, it exposes the **token**; each call site derives its own class
string from it, so each surface keeps its own badge language (HUD pill, `UBadge`, soft
pill) while the severity decision is made in exactly one place.

| status | colour | |
| --- | --- | --- |
| `excellent` | `success` (green) | |
| `good` | `success` (green) | |
| `moderate` | `warning` (amber) | |
| `needs_improvement` | `warning` (amber) | |
| `poor` | `error` (red) | |
| `fair` | `warning` (amber) | legacy |
| `needs_attention` | `warning` (amber) | legacy |
| `info` | `info` (blue) | legacy |
| unrecognised / empty | `neutral` (grey) | |

Look-ups are case- and whitespace-insensitive.

## Which mapper I treated as canonical, and why

Not "whichever I read first" — the mappers disagree and some of them are simply wrong.

**A correction to the ticket's divergence table first.** The workout-page mapper the table
cites (`workouts/[id]/index.vue:5827` `getStatusColor` + `5836` `getStatusBadgeClass`) is
**dead code** — nothing calls it. The badge that actually renders on the workout page was
an inline substring ternary in the template: `good`/`excellent` -> brand green,
`poor`/`bad` -> red, **everything else -> orange**. So in reality `needs_improvement`
rendered *orange* there rather than red, and `moderate`, `fair`, `needs_attention` and
`info` were all silently swept into the same orange. That inline ternary is the fifth
mapper, and it is the one that mattered; it is now gone along with the two dead functions.

**`needs_improvement` -> `warning` (amber), not `error` (red).** The report page was right
and `ScoreDetailModal` was wrong. The vocabulary already has `poor` as its worst tier; if
`needs_improvement` is also red, the two collapse and the scale loses its bottom. Reserving
red for `poor` also keeps red *rare*, which is what makes it legible as an alarm — a
"needs improvement" section is the single most common finding in a workout analysis, and a
report that is mostly red tells the athlete nothing. This is also the smallest real change
for existing users: three of the four surfaces that actually render already showed this
status in the amber/orange family.

**`good` -> `success` (green), not `info`/blue.** Severity should read as a monotonic warm
ramp — green -> amber -> red. Blue is a cold, informational hue; putting it *between* green
and amber makes the ordering unscannable. `good` means "nothing to act on", the same
action class as `excellent`, and the badge label already carries the degree of praise.

**Five statuses, four usable tokens** — so exactly one adjacent pair must share a colour.
`excellent`+`good` is the cheapest collapse: both mean "no action". Collapsing
`needs_improvement`+`poor` instead would erase the difference between "work on this" and
"this went badly".

**Blue is reserved for legacy `info`** — the one status in either vocabulary that is not a
severity judgement at all. That is the positive reason blue is not used for `good`.

## How legacy statuses render

Analyses written before CW-403 are stored verbatim and are never rewritten, so the retired
vocabulary (`excellent`/`good`/`fair`/`needs_attention`/`info`) still reaches these
renderers. `fair` and `needs_attention` are the legacy equivalents of `moderate` and
`needs_improvement` and now colour identically to them; `info` gets blue. Previously `fair`
and `needs_attention` fell through to grey on three of four surfaces — correctly-stored old
analyses looked like they had no status at all. Verified against real seeded rows of both
vocabularies on all three renderable surfaces: **zero grey badges**.

The unit test pins the legacy values explicitly, and asserts every member of
`ANALYSIS_SECTION_STATUSES` (imported from the schema) maps to a non-neutral colour, so the
table cannot silently fall behind the schema.

`app/pages/report/[id].vue`'s `statusColor` computed (report `PENDING`/`PROCESSING`/
`COMPLETED`/`FAILED`) is a different vocabulary and is untouched.

## UX critique: required

Ran per the ticket (athlete persona; workout page -> report page -> share page for the same
analysis, both vocabularies, light and dark, desktop and 375px).

**Round 1 verdict: FIX-FIRST**, on two light-theme legibility findings — both in code this
branch writes:

1. The workout-page HUD pill used one colour for both themes, so the brand green measured
   **1.71:1** in light mode (amber 3.00, red 3.48). Each branch now carries explicit light
   and dark values.
2. The report page's section badges were solid-filled with white text — amber **2.15:1**,
   and amber is now the destination for four statuses, i.e. the most common non-green
   badge on the page.

**Round 2 verdict: fix 1 confirmed, fix 2 rejected.** Worth recording why, because the
first attempt at 2 was wrong in an instructive way. I reached for `variant="subtle"` on the
assumption that it was what makes the share page legible. It isn't — the share page doesn't
use `subtle` at all, it hardcodes light/dark pairs at the 800 level. Nuxt UI's `subtle`
resolves the label to the **base 500-level token in both themes** and only flips the
backdrop, so a bright mid-tone that reads 8:1 on a dark tint reads ~2:1 on a pale one. It
measured *worse* than the solid badges it replaced (amber 2.15 -> 1.97).

The fix that shipped applies the mechanism that made fix 1 pass — an explicit light/dark
text pair over the `/10` tint — so all three surfaces now use one coherent mechanism rather
than three:

| light theme | before | `subtle` (rejected) | shipped |
| --- | --- | --- | --- |
| green | 2.38 | 2.17 | **7.54** |
| amber | 2.15 | 1.97 | **7.04** |
| red | 3.82 | 3.31 | **8.24** |

Dark did not move (green 8.87, amber 9.30, red 7.07). Re-measured by me on both the current
and the legacy report — the legacy badges are numerically identical to their current-
vocabulary equivalents in both themes, which is the whole point of the ticket. Workout-page
pill after fix 1: light 4.68 / 4.55 / 5.45 (from 1.71 / 3.00 / 3.48), dark byte-identical.

Two consequences worth stating rather than leaving to be discovered:

- **The brand green `#00DC82` is now dark-mode-only on the workout pill.** Light mode uses
  `emerald-700`, because `#00DC82` cannot clear AA on any light surface. That is the right
  trade for an 8px label, but it does mean the brand colour is no longer literally present
  in light mode there.
- **The 700 vs 800 light-mode levels are per-surface, not an inconsistency.** Each was
  measured against its own composited background (the HUD card is tinted, the report card
  is not) rather than assuming one token travels.
- **The report's lifecycle chip (`COMPLETED`) is untouched and still solid**, so in light
  mode it is now louder than the analysis grades beneath it (2.38:1 white-on-green, itself
  below AA). That is finding 4, pre-existing and out of scope — flagged as a follow-up.

Findings 3-7 (8px pill label carrying the collapsed amber pair, the lifecycle chip
resembling a section badge, three different greens for one token across surfaces, mobile
scanability, and the adjacent per-score colour language) are out of scope and reported
separately for triage.

**Not verified by observation:** the score-detail modal reads an aggregate insights record
that no seed data covers, so it showed no status badges to compare. Its change is a pure
delegation to the shared helper and is covered by typecheck and the unit test, but no one
has looked at it rendering. The `info` -> blue and unrecognised -> grey branches were also
not observed live, only unit-tested.

## Verification

```
pnpm test:unit app/utils/analysis-status.test.ts   # 8 passed
pnpm lint                                          # 0 errors (116 pre-existing warnings, email templates)
pnpm typecheck:fast                                # exit 0
```

Rebased onto `develop` @ 8c84f1b7 and re-verified after the rebase. Files touched are
exactly the ticket's Owned Paths.
