### PR TITLE
fix(workouts): stop framing a first threshold detection as an improvement (CW-421)

### DIFF
--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -495,29 +495,55 @@ export const thresholdDetectionService = {
     let description = ''
     const unit = metric === 'FTP' ? 'W' : metric === 'THRESHOLD_PACE' ? 's/km' : ' bpm'
 
+    // A first-ever detection arrives with no previous value (absent, 0, or
+    // non-finite). Framing that as an improvement — "increased from 0" — reads
+    // as a bug to the athlete, so the copy branches on whether there is a real
+    // previous value to compare against.
+    const hasPreviousValue = Number.isFinite(oldValue) && oldValue > 0
+
     if (metric === 'LTHR') {
       title = sportName ? `New ${sportName} LTHR Detected` : 'New LTHR Detected'
-      description = sportName
-        ? `Your ${sportName} LTHR has increased from ${oldValue} to ${newValue} bpm.`
-        : `Your LTHR has increased from ${oldValue} to ${newValue} bpm.`
+      if (hasPreviousValue) {
+        description = sportName
+          ? `Your ${sportName} LTHR has increased from ${oldValue} to ${newValue} bpm.`
+          : `Your LTHR has increased from ${oldValue} to ${newValue} bpm.`
+      } else {
+        description = sportName
+          ? `We detected your ${sportName} LTHR: ${newValue} bpm.`
+          : `We detected your LTHR: ${newValue} bpm.`
+      }
     } else if (metric === 'FTP') {
       title = sportName ? `New ${sportName} FTP Detected` : 'New FTP Detected'
-      description = sportName
-        ? `Your ${sportName} FTP has increased from ${oldValue}W to ${newValue}W.`
-        : `Your FTP has increased from ${oldValue}W to ${newValue}W.`
+      if (hasPreviousValue) {
+        description = sportName
+          ? `Your ${sportName} FTP has increased from ${oldValue}W to ${newValue}W.`
+          : `Your FTP has increased from ${oldValue}W to ${newValue}W.`
+      } else {
+        description = sportName
+          ? `We detected your ${sportName} FTP: ${newValue}W.`
+          : `We detected your FTP: ${newValue}W.`
+      }
     } else if (metric === 'MAX_HR') {
       title = sportName
         ? `New Max Heart Rate Detected (${sportName})`
         : 'New Max Heart Rate Detected'
-      description = `We detected a new max heart rate of ${newValue} bpm (previous: ${oldValue} bpm).`
+      description = hasPreviousValue
+        ? `We detected a new max heart rate of ${newValue} bpm (previous: ${oldValue} bpm).`
+        : `We detected your max heart rate: ${newValue} bpm.`
     } else if (metric === 'THRESHOLD_PACE') {
       title = sportName
         ? `New Threshold Pace Detected (${sportName})`
         : 'New Threshold Pace Detected'
       const formattedPace = formatPromptPace(newValue, distanceUnits)
-      description = sportName
-        ? `Your ${sportName} threshold pace has improved to ${formattedPace}.`
-        : `Your threshold pace has improved to ${formattedPace}.`
+      if (hasPreviousValue) {
+        description = sportName
+          ? `Your ${sportName} threshold pace has improved to ${formattedPace}.`
+          : `Your threshold pace has improved to ${formattedPace}.`
+      } else {
+        description = sportName
+          ? `We detected your ${sportName} threshold pace: ${formattedPace}.`
+          : `We detected your threshold pace: ${formattedPace}.`
+      }
     }
 
     // Check if an active recommendation for this metric already exists to avoid spamming

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -548,4 +548,154 @@ describe('thresholdDetectionService', () => {
       })
     })
   })
+
+  describe('createThresholdRecommendation copy', () => {
+    const workoutDate = new Date('2025-03-01T06:00:00Z')
+
+    /** Runs the recommendation and returns the `{ title, description }` written. */
+    async function recommendationCopy(options: {
+      metric: 'LTHR' | 'FTP' | 'MAX_HR' | 'THRESHOLD_PACE'
+      oldValue: number
+      newValue: number
+      sportName?: string | null
+    }) {
+      await thresholdDetectionService.createThresholdRecommendation(
+        'user-1',
+        'workout-copy',
+        options.metric,
+        options.oldValue,
+        options.newValue,
+        options.newValue,
+        options.sportName ?? null,
+        workoutDate,
+        undefined,
+        true,
+        'Kilometers'
+      )
+
+      const { data } = vi.mocked(prisma.recommendation.create).mock.calls.at(-1)![0] as any
+      return { title: data.title as string, description: data.description as string }
+    }
+
+    // A first detection arrives with oldValue 0 — the copy must not imply there
+    // was a previous value to improve on (CW-421).
+    it('does not frame a first LTHR detection as an increase from zero', async () => {
+      const { title, description } = await recommendationCopy({
+        metric: 'LTHR',
+        oldValue: 0,
+        newValue: 158
+      })
+
+      expect(description).toBe('We detected your LTHR: 158 bpm.')
+      expect(description).not.toContain('increased')
+      expect(description).not.toContain('0')
+      expect(title).toBe('New LTHR Detected')
+    })
+
+    it('still frames an LTHR improvement over an existing value as an increase', async () => {
+      const { description } = await recommendationCopy({
+        metric: 'LTHR',
+        oldValue: 152,
+        newValue: 158
+      })
+
+      expect(description).toBe('Your LTHR has increased from 152 to 158 bpm.')
+    })
+
+    it('does not frame a first FTP detection as an increase from zero', async () => {
+      const { title, description } = await recommendationCopy({
+        metric: 'FTP',
+        oldValue: 0,
+        newValue: 265
+      })
+
+      expect(description).toBe('We detected your FTP: 265W.')
+      expect(description).not.toContain('increased')
+      expect(description).not.toContain('0W')
+      expect(title).toBe('New FTP Detected')
+    })
+
+    it('still frames an FTP improvement over an existing value as an increase', async () => {
+      const { description } = await recommendationCopy({
+        metric: 'FTP',
+        oldValue: 250,
+        newValue: 265
+      })
+
+      expect(description).toBe('Your FTP has increased from 250W to 265W.')
+    })
+
+    it('does not report a previous max heart rate of zero on a first detection', async () => {
+      const { title, description } = await recommendationCopy({
+        metric: 'MAX_HR',
+        oldValue: 0,
+        newValue: 191
+      })
+
+      expect(description).toBe('We detected your max heart rate: 191 bpm.')
+      expect(description).not.toContain('previous')
+      expect(title).toBe('New Max Heart Rate Detected')
+    })
+
+    it('still reports the previous max heart rate when there was one', async () => {
+      const { description } = await recommendationCopy({
+        metric: 'MAX_HR',
+        oldValue: 186,
+        newValue: 191
+      })
+
+      expect(description).toBe('We detected a new max heart rate of 191 bpm (previous: 186 bpm).')
+    })
+
+    it('does not frame a first threshold pace detection as an improvement', async () => {
+      const { title, description } = await recommendationCopy({
+        metric: 'THRESHOLD_PACE',
+        oldValue: 0,
+        newValue: 250
+      })
+
+      expect(description).toBe('We detected your threshold pace: 4:10/km.')
+      expect(description).not.toContain('improved')
+      expect(title).toBe('New Threshold Pace Detected')
+    })
+
+    it('still frames a threshold pace improvement over an existing pace as an improvement', async () => {
+      const { description } = await recommendationCopy({
+        metric: 'THRESHOLD_PACE',
+        oldValue: 260,
+        newValue: 250
+      })
+
+      expect(description).toBe('Your threshold pace has improved to 4:10/km.')
+    })
+
+    it('keeps the sport profile name in both the first-detection and improvement copy', async () => {
+      const first = await recommendationCopy({
+        metric: 'THRESHOLD_PACE',
+        oldValue: 0,
+        newValue: 250,
+        sportName: 'Running'
+      })
+      expect(first.description).toBe('We detected your Running threshold pace: 4:10/km.')
+      expect(first.title).toBe('New Threshold Pace Detected (Running)')
+
+      const improved = await recommendationCopy({
+        metric: 'FTP',
+        oldValue: 250,
+        newValue: 265,
+        sportName: 'Cycling'
+      })
+      expect(improved.description).toBe('Your Cycling FTP has increased from 250W to 265W.')
+    })
+
+    it('treats a non-finite previous value as no previous value', async () => {
+      const { description } = await recommendationCopy({
+        metric: 'FTP',
+        oldValue: Number.NaN,
+        newValue: 265
+      })
+
+      expect(description).toBe('We detected your FTP: 265W.')
+    })
+  })
 })


### PR DESCRIPTION
Fixes CW-421

A first-ever threshold detection arrives with `oldValue = 0`, and
`createThresholdRecommendation` still framed it as an improvement — "increased
from 0" reads as a bug to the athlete. The copy now branches on whether there is
a real previous value:

```ts
const hasPreviousValue = Number.isFinite(oldValue) && oldValue > 0
```

Copy only. No change to the detection maths, the thresholds, or which
recommendations fire.

## Before / after

| Metric | First detection — before | First detection — after |
| --- | --- | --- |
| LTHR | `Your LTHR has increased from 0 to 158 bpm.` | `We detected your LTHR: 158 bpm.` |
| FTP | `Your FTP has increased from 0W to 265W.` | `We detected your FTP: 265W.` |
| MAX_HR | `We detected a new max heart rate of 191 bpm (previous: 0 bpm).` | `We detected your max heart rate: 191 bpm.` |
| THRESHOLD_PACE | `Your threshold pace has improved to 4:10/km.` | `We detected your threshold pace: 4:10/km.` |

Sport-profile variants follow the same shape, e.g. `We detected your Running
threshold pace: 4:10/km.`

The improvement wording is untouched when a previous value exists:

- `Your LTHR has increased from 152 to 158 bpm.`
- `Your FTP has increased from 250W to 265W.`
- `We detected a new max heart rate of 191 bpm (previous: 186 bpm).`
- `Your threshold pace has improved to 4:10/km.`

## Titles

Checked, no change needed. `New LTHR Detected`, `New FTP Detected`, `New Max
Heart Rate Detected` and `New Threshold Pace Detected` (plus their
`(Sport)` / `New <Sport> …` variants) all already read correctly for a first
detection.

## Reachability

The threshold-pace string is reachable today (CW-405 revived the branch, CW-413
gated it). The FTP and LTHR strings cannot yet fire for a first-time athlete
because those branches are guarded on the current value being truthy — that is
CW-420. Fixed here anyway so the copy is correct whichever way CW-420 lands.

## Verification

```
$ pnpm test:unit tests/unit/server/utils/services/thresholdDetectionService.test.ts
 Test Files  1 passed (1)
      Tests  26 passed (26)

$ pnpm typecheck:server   # clean
$ npx eslint <touched files>   # clean
$ npx prettier --check <touched files>   # All matched files use Prettier code style!
```

10 new unit tests cover the first-detection and improvement wording for each of
the four metrics, the sport-profile variants, and a non-finite `oldValue`.
