### PR TITLE
fix(ai): give pace-primary runs a session cadence baseline (CW-412)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -379,8 +379,9 @@ describe('buildWorkoutAnalysisPrompt', () => {
       }),
       'Europe/Budapest',
       'Supportive',
-      // HR-primary so the session cadence line is not condensed away; the
-      // Interval Breakdown prints cadence either way.
+      // HR-primary. Since CW-412 the session cadence line no longer depends on
+      // the metric priority at all -- the pace-primary variant is pinned by the
+      // test below.
       { loadPreference: 'HR' },
       USER_PROFILE
     )
@@ -393,6 +394,84 @@ describe('buildWorkoutAnalysisPrompt', () => {
     expect(prompt).toContain('- Avg Cadence: 180 spm')
     expect(prompt).toContain('- Avg Cadence: 152 spm')
     // A run prompt must never mention rpm anywhere.
+    expect(prompt).not.toContain('rpm')
+    expect(prompt).not.toContain('RPM')
+  })
+
+  it('gives a pace-primary run a session cadence baseline for its interval rows (CW-412)', () => {
+    // `shouldCondenseHeartRateSection` fires for a pace-primary run, and the
+    // session-level cadence lines used to sit inside that branch. The Interval
+    // Breakdown prints per-interval cadence unconditionally, so the exact case
+    // where running cadence matters most handed the model per-rep numbers with
+    // nothing session-wide to compare them against. Cadence now follows
+    // `isCadenceRelevant` alone.
+    //
+    // `loadPreference: 'PACE'` rather than an omitted setting: the default
+    // priority is HR > PACE > POWER, so a bare default is HR-primary and would
+    // not condense at all. (That default contradicting the pace guardrail is
+    // CW-397, out of scope here.)
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData({
+        id: 'workout-fixture-run-pace-primary-cadence',
+        date: new Date('2026-03-18T06:00:00Z'),
+        title: '3 x 1km Threshold',
+        type: 'Run',
+        durationSec: 3000,
+        distanceMeters: 9000,
+        averageSpeed: 3.0,
+        averageHr: 158,
+        maxHr: 176,
+        // One-legged, exactly as Strava / Intervals.icu store run cadence.
+        averageCadence: 88,
+        maxCadence: 95,
+        rawJson: {
+          icu_intervals: [
+            {
+              type: 'WORK',
+              label: 'Rep 1',
+              moving_time: 240,
+              distance: 1000,
+              average_heartrate: 168,
+              average_cadence: 90,
+              average_speed: 4.1667,
+              intensity: 101
+            },
+            {
+              type: 'RECOVERY',
+              label: 'Jog 1',
+              moving_time: 120,
+              distance: 400,
+              average_heartrate: 138,
+              average_cadence: 76,
+              average_speed: 3.0,
+              intensity: 68
+            }
+          ]
+        }
+      }),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE
+    )
+
+    // Pace really is primary here, i.e. the condensing branch is live.
+    expect(prompt).toContain('## Pace & Speed (Primary Metric)')
+
+    // Heart-rate condensing itself is untouched: condensed heading, same HR lines.
+    expect(prompt).toContain('## Heart Rate (Secondary Corroboration) & Cadence')
+    expect(prompt).not.toContain('## Heart Rate & Cadence')
+    expect(prompt).toContain('- Average HR: 158 bpm')
+    expect(prompt).toContain('- Max HR: 176 bpm')
+
+    // The baseline the interval rows are read against -- this is what regressed.
+    expect(prompt).toContain('- Average Cadence: 176 spm')
+    expect(prompt).toContain('- Max Cadence: 190 spm')
+
+    // ...and the per-interval rows it explains, in the same CW-387 convention.
+    expect(prompt).toContain('## Interval Breakdown')
+    expect(prompt).toContain('- Avg Cadence: 180 spm')
+    expect(prompt).toContain('- Avg Cadence: 152 spm')
     expect(prompt).not.toContain('rpm')
     expect(prompt).not.toContain('RPM')
   })

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -1373,8 +1373,14 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 
     if (workoutData.max_hr) prompt += `- Max HR: ${workoutData.max_hr} bpm\n`
 
-    // Cadence is only relevant for cycling/running-like workouts
-    if (isCadenceRelevant && !condensedHrSection) {
+    // Cadence is only relevant for cycling/running-like workouts. It is gated on
+    // `isCadenceRelevant` alone and deliberately NOT on `condensedHrSection`
+    // (CW-412): condensing exists to stop heart rate dominating the narrative
+    // when pace leads, and cadence is not heart rate. Coupling the two meant a
+    // pace-primary run -- the case where running cadence matters most -- got the
+    // unconditional per-interval cadence rows in `## Interval Breakdown` with no
+    // session baseline to compare them against.
+    if (isCadenceRelevant) {
       if (workoutData.avg_cadence)
         prompt += `- Average Cadence: ${formatCadenceWithUnit(workoutData.avg_cadence, workoutType)}\n`
       else prompt += `- Average Cadence: N/A\n`


### PR DESCRIPTION
Fixes CW-412

## What was wrong

`shouldCondenseHeartRateSection` returns true when the primary metric is PACE and pace is available — the common outdoor-run case. The session-level `Average Cadence` / `Max Cadence` lines sat inside that branch (`if (isCadenceRelevant && !condensedHrSection)`), while `## Interval Breakdown` printed per-interval cadence unconditionally.

So for a pace-primary run — the exact case where running cadence matters most — the model received per-rep cadence values with no session baseline to compare them against.

## The fix

The session cadence lines now follow `isCadenceRelevant` alone. Condensing exists to stop heart rate dominating the narrative when pace leads; cadence is not heart rate, so the suppression was a side effect of the HR rule rather than a rule of its own. I did not add a separate condensing rule for cadence: two lines are the entire session-level cadence budget, and they are what makes the per-interval rows readable.

Heart-rate condensing itself is untouched — after this change `condensedHrSection` governs only the section heading, which is what it was meant to govern.

Both call sites still print through `formatCadenceWithUnit` (CW-387): a run reads `spm`, a ride reads `rpm`. No hardcoded unit was reintroduced.

## What a pace-primary run's prompt now contains

```
## Heart Rate (Secondary Corroboration) & Cadence
- Average HR: 158 bpm
- Max HR: 176 bpm
- Average Cadence: 176 spm
- Max Cadence: 190 spm
...
### Interval 1: WORK
- Avg Cadence: 180 spm
### Interval 2: RECOVERY
- Avg Cadence: 152 spm
```

## Snapshot

`__snapshots__/workout-analysis-prompt.test.ts.snap` is **unchanged**, and that is the correct outcome: the snapshot fixture is a POWER-primary `Ride`, so `condensedHrSection` was already false for it and its cadence lines were already emitted. Only pace-primary sessions change.

## Tests

New test `gives a pace-primary run a session cadence baseline for its interval rows (CW-412)` pins a `loadPreference: 'PACE'` Run prompt containing both the session line and the interval rows, plus the unchanged condensed HR heading and HR lines. Verified it **fails** against the old `&& !condensedHrSection` condition and passes with the fix, so it pins the coupling against reintroduction.

The test uses an explicit `loadPreference: 'PACE'` rather than an omitted setting, because the default priority is `HR > PACE > POWER` — a bare default is HR-primary and would not exercise condensing at all. That default contradicting the pace guardrail is **CW-397** and is deliberately untouched here.

### Effect on CW-397

Neutral-to-slightly-easier. This change removes one of the two consumers of `condensedHrSection`, so whoever takes CW-397 now has a smaller blast radius: changing the default priority can no longer silently add or remove cadence lines, only the HR heading. `resolveMetricPriorityContext` and `shouldCondenseHeartRateSection` are otherwise unmodified.

## Verification

```
$ pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

Also green: `pnpm test:unit tests/unit/trigger/workout-metric-priority.test.ts` (5 passed), `pnpm typecheck:server`, `eslint` and `prettier --check` on both touched files.
