### PR TITLE
fix(ui): stop rendering a stray dash after interval power and HR values (CW-423)

### DIFF
--- a/app/components/IntervalsAnalysis.vue
+++ b/app/components/IntervalsAnalysis.vue
@@ -237,7 +237,7 @@
                       >W</span
                     ></span
                   >
-                  <span class="text-zinc-600">-</span>
+                  <span v-else class="text-zinc-600">-</span>
                 </td>
                 <td
                   class="px-6 py-4 whitespace-nowrap text-sm font-black text-gray-900 dark:text-white tabular-nums"
@@ -248,7 +248,7 @@
                       >bpm</span
                     ></span
                   >
-                  <span class="text-zinc-600">-</span>
+                  <span v-else class="text-zinc-600">-</span>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Fixes CW-423

## Problem

In `app/components/IntervalsAnalysis.vue`, the Avg Power and Avg HR table cells had a `v-if` span followed by an **unconditional** fallback `<span class="text-zinc-600">-</span>`. The dash therefore rendered *in addition to* the value rather than instead of it, so every interval row read `162 W-` and `148 bpm-`.

Pre-existing and not specific to any recent change: it affected every interval row on every interval table in the app, for every athlete with intervals. That is why triage raised it from P4 to P3.

## Change

Added `v-else` to the fallback span in both cells. Two lines, no other changes.

## Neighbouring cells: checked, and they are fine

The ticket asked for a sweep of the surrounding cells, so nobody needs to re-check this:

- **There are no cadence or pace cells in this table.** The intervals table has five columns only: Type, Start, Duration, Avg Power, Avg HR.
- The Type, Start and Duration cells use plain interpolation with no fallback span.
- `formatPace()` uses a correct single-expression guard (`if (!mps) return '-'`) — not the broken pattern.
- A file-wide sweep for the unconditional-dash pattern found exactly the two occurrences fixed here.
- The CSV/clipboard/tooltip export path is untouched and already guards correctly with `if (...) lines.push(...)`, so it gains no dash.

## Verification

Run in a clean worktree rebased onto `develop` @ `c85a258b`:

```
pnpm lint          -> exit 0 — 116 problems (0 errors, 116 warnings)
pnpm typecheck:fast -> exit 0 — clean
```

All 116 lint warnings are pre-existing `vue/require-default-prop` warnings in email-template components. **Zero** originate from `IntervalsAnalysis.vue`, so no new warnings. `prettier --check` on the file is clean.

**Behavioural check.** I wrote a throwaway vitest spec that extracts the two `<td>` blocks verbatim from the real file at runtime and mounts them, so the assertions run against the component source rather than against a copy of it. Results:

- value present -> `162W` and `148 bpm`, no dash
- value `null`/`undefined` -> exactly one `-` per cell
- mixed row (power present, HR missing) -> `210W` and `-`

Run against the **pre-fix** file via `git stash`, the same spec fails with `expected '162W-' to be '162W'`, reproducing the reported symptom exactly. Red before, green after. The temp spec was deleted and is not part of this commit.

**Not verified in a browser.** The worktree has no `.env`, so standing up a dev server would have meant building an environment from scratch for a missing `v-else`. The component-level render above is the substantive check; the diff is otherwise a one-token change per cell.

UX critique: skipped — corrects a rendering artifact, no design change.
