### PR TITLE
fix(workouts): gate the pacing verdict on the public share endpoint (CW-441)

### DIFF
--- a/server/api/share/workouts/[token]/streams.get.ts
+++ b/server/api/share/workouts/[token]/streams.get.ts
@@ -1,7 +1,13 @@
 import { defineEventHandler, createError, getRouterParam } from 'h3'
 import { prisma } from '../../../../utils/db'
 import { workoutStreamRepository } from '../../../../utils/repositories/workoutStreamRepository'
+import { sportSettingsRepository } from '../../../../utils/repositories/sportSettingsRepository'
 import { formatPromptPace } from '../../../../utils/ai-prompt-format'
+import { analyzePacingStrategy } from '../../../../utils/pacing'
+import {
+  buildWorkoutAnalysisFactsV2,
+  type WorkoutAnalysisFactsV2
+} from '../../../../utils/workout-analysis-facts'
 
 defineRouteMeta({
   openAPI: {
@@ -68,15 +74,24 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  // Get workout with streams by ID
+  // Get workout with streams by ID.
+  //
+  // `plannedWorkout` and the owner profile fields are DETECTION INPUTS ONLY: they feed the
+  // v2 analysis facts builder below and are never returned. The response body is built from
+  // the stream record (or, in the fallback, from hand-picked split fields), so nothing on
+  // `workout` -- including `user` and `userId` -- reaches the shared payload (CW-418/CW-441).
   const workout = await (prisma as any).workout.findUnique({
     where: {
       id: shareToken.resourceId
     },
     include: {
+      plannedWorkout: true,
       user: {
         select: {
-          distanceUnits: true
+          distanceUnits: true,
+          weight: true,
+          weightUnits: true,
+          language: true
         }
       }
     }
@@ -91,8 +106,57 @@ export default defineEventHandler(async (event) => {
 
   const workoutStream = await workoutStreamRepository.findByWorkoutId(workout.id)
 
+  // CW-441: the shared view must agree with the owner's pacing card (CW-436) and with the AI
+  // analysis (CW-389) about whether this session's pacing was gradeable at all. The persisted
+  // `pacingStrategy` was computed at ingestion with no facts available, so it carries an
+  // ungraded verdict; the verdict is therefore recomputed here, on the same shared gate.
+  //
+  // This endpoint is authenticated by share token and has no session user, so the sport
+  // settings the builder needs are resolved from the workout OWNER via `workout.userId` --
+  // never from whoever is viewing the link (the CW-418 precedent in the sibling
+  // intervals.get.ts). Those settings stay server-side; see the note on the query above.
+  //
+  // Built lazily and memoised, mirroring the owner endpoint: the builder runs its own
+  // interval detection over the full streams, so a request with no splits to grade must not
+  // pay for it, and it runs at most once per request. A failure here must never take the
+  // pacing card down -- returning undefined leaves the verdict applicable, i.e. the
+  // pre-CW-441 behaviour.
+  let analysisFactsV2Resolved = false
+  let analysisFactsV2: WorkoutAnalysisFactsV2 | undefined
+  const resolveAnalysisFactsV2 = async (): Promise<WorkoutAnalysisFactsV2 | undefined> => {
+    if (analysisFactsV2Resolved) return analysisFactsV2
+    analysisFactsV2Resolved = true
+    try {
+      const ownerId = workout.userId || workout.user?.id
+      analysisFactsV2 = buildWorkoutAnalysisFactsV2({
+        workout: { ...workout, streams: workoutStream } as any,
+        sportSettings: ownerId
+          ? await sportSettingsRepository.getForActivityType(ownerId, workout.type || '')
+          : null,
+        plannedWorkout: workout.plannedWorkout,
+        userProfile: workout.user || undefined
+      })
+    } catch (factsError) {
+      console.error('[API] share streams.get: failed to build analysis facts v2:', factsError)
+    }
+    return analysisFactsV2
+  }
+
   if (workoutStream) {
-    // Return actual time-series stream data
+    // Return actual time-series stream data, with the split-strategy verdict re-graded on the
+    // shared gate. Only `pacingStrategy` is replaced: the split rows and the raw dispersion
+    // measurement (`lapSplits`, `paceVariability`, `avgPacePerKm`) are untouched, because it
+    // is the grading that is withheld, not the data.
+    if (workoutStream.lapSplits && Array.isArray(workoutStream.lapSplits)) {
+      return {
+        ...workoutStream,
+        pacingStrategy: analyzePacingStrategy(
+          workoutStream.lapSplits,
+          await resolveAnalysisFactsV2()
+        ) as any
+      }
+    }
+
     return workoutStream
   }
 
@@ -142,31 +206,11 @@ export default defineEventHandler(async (event) => {
             )
           : 0
 
-      // Calculate first/second half for pacing strategy
-      const halfwayIndex = Math.floor(lapSplits.length / 2)
-      const firstHalf = lapSplits.slice(0, halfwayIndex)
-      const secondHalf = lapSplits.slice(halfwayIndex)
-
-      const firstHalfPace =
-        firstHalf.reduce((sum: number, s: any) => sum + s.paceSeconds, 0) / firstHalf.length
-      const secondHalfPace =
-        secondHalf.reduce((sum: number, s: any) => sum + s.paceSeconds, 0) / secondHalf.length
-      const paceDifference = secondHalfPace - firstHalfPace
-
-      let strategy = 'even'
-      let description = 'Consistent pacing throughout'
-      if (paceDifference > 10) {
-        strategy = 'positive_split'
-        description = 'Slowed down in second half'
-      } else if (paceDifference < -10) {
-        strategy = 'negative_split'
-        description = 'Sped up in second half'
-      }
-
-      const evenness = Math.max(
-        0,
-        Math.min(100, 100 - (Math.abs(paceDifference) / avgPaceSecondsValue) * 100)
-      )
+      // Use the shared utility, exactly as the owner's endpoint does for this same fallback.
+      // It applies `resolveSplitPacingVerdictApplicability` internally, so the owner view and
+      // the shared view reach the same verdict decision for the same workout instead of
+      // drifting apart through a second, hand-rolled copy of the thresholds (CW-441).
+      const pacingStrategy = analyzePacingStrategy(lapSplits, await resolveAnalysisFactsV2())
 
       return {
         workoutId: workout.id,
@@ -174,14 +218,7 @@ export default defineEventHandler(async (event) => {
         lapSplits,
         avgPacePerKm: avgPaceMinPerKm,
         paceVariability: paceVariability,
-        pacingStrategy: {
-          strategy,
-          description,
-          firstHalfPace: firstHalfPace,
-          secondHalfPace: secondHalfPace,
-          paceDifference: paceDifference,
-          evenness: Math.round(evenness)
-        },
+        pacingStrategy,
         createdAt: new Date(),
         updatedAt: new Date()
       }

--- a/tests/unit/server/api/share/share-streams-pacing.test.ts
+++ b/tests/unit/server/api/share/share-streams-pacing.test.ts
@@ -1,0 +1,369 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * CW-441: the public share endpoint must gate the split-strategy verdict the same way the
+ * owner's pacing card does (CW-436) and the AI prompt does (CW-389).
+ *
+ * Two things are being pinned here:
+ *  1. the verdict itself -- withheld for an intervalled/stochastic session, graded otherwise,
+ *     decided by the SHARED `resolveSplitPacingVerdictApplicability` (left unmocked on
+ *     purpose; only the facts BUILDER is stubbed, so the gate under test is the real one);
+ *  2. that nothing about the workout owner leaks into a public payload as a side effect of
+ *     needing the owner's sport settings to build those facts (CW-418).
+ */
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => undefined)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('getRouterParam', (event: any, key: string) => event.context?.params?.[key])
+
+const shareTokenFindUnique = vi.fn()
+const workoutFindUnique = vi.fn()
+const workoutFindFirst = vi.fn()
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    shareToken: { findUnique: shareTokenFindUnique },
+    workout: { findUnique: workoutFindUnique }
+  }
+}))
+
+// The owner endpoint reaches `prisma` through Nuxt's auto-import rather than a module import.
+vi.stubGlobal('prisma', {
+  shareToken: { findUnique: shareTokenFindUnique },
+  workout: { findUnique: workoutFindUnique, findFirst: workoutFindFirst }
+})
+
+const findByWorkoutId = vi.fn()
+const updateMetadata = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../../../../../server/utils/repositories/workoutStreamRepository', () => ({
+  workoutStreamRepository: { findByWorkoutId, updateMetadata }
+}))
+
+const getForActivityType = vi.fn()
+
+vi.mock('../../../../../server/utils/repositories/sportSettingsRepository', () => ({
+  sportSettingsRepository: { getForActivityType }
+}))
+
+const buildWorkoutAnalysisFactsV2 = vi.fn()
+
+// Only the builder is stubbed: the module's other exports are real, and the gate itself
+// (`resolveSplitPacingVerdictApplicability`, reached through `analyzePacingStrategy`) is the
+// production one, so these tests exercise the shared implementation rather than a stand-in.
+vi.mock('../../../../../server/utils/workout-analysis-facts', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  buildWorkoutAnalysisFactsV2
+}))
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({
+  requireAuth: vi.fn().mockResolvedValue({ id: 'owner-user-1' })
+}))
+
+const OWNER_ID = 'owner-user-1'
+const SHARE_TOKEN = 'share-token'
+
+// Two splits: the second half is 30s/km slower than the first, i.e. the raw numbers say
+// "positive split". For an intervalled session that verdict is meaningless and must be withheld.
+const LAP_SPLITS = [
+  { lap: 1, distance: 1000, time: 300, paceSeconds: 300 },
+  { lap: 2, distance: 1000, time: 330, paceSeconds: 330 }
+]
+
+// Owner-only detection inputs. None of these may appear in the share response.
+const OWNER_SPORT_SETTINGS = {
+  lthr: 168,
+  maxHr: 190,
+  ftp: 260,
+  hrZones: [{ min: 0, max: 120 }],
+  powerZones: [{ min: 0, max: 150 }]
+}
+
+function factsWithSteadiness(sessionSteadiness: string) {
+  return {
+    guardrails: {
+      archetype: { sessionSteadiness }
+    }
+  } as any
+}
+
+function makeStream(overrides: Record<string, any> = {}) {
+  return {
+    id: 'stream-1',
+    workoutId: 'workout-1',
+    lapSplits: LAP_SPLITS,
+    avgPacePerKm: 5.25,
+    paceVariability: 15,
+    // The persisted verdict, computed at ingestion with no facts available.
+    pacingStrategy: {
+      strategy: 'positive_split',
+      description: 'Started fast and slowed down (positive split)',
+      evenness: 85,
+      verdictApplicable: true,
+      verdictWithheldReason: null
+    },
+    ...overrides
+  }
+}
+
+function makeSharedWorkout() {
+  return {
+    id: 'workout-1',
+    userId: OWNER_ID,
+    type: 'Run',
+    maxHr: 182,
+    plannedWorkout: null,
+    user: {
+      distanceUnits: 'Kilometers',
+      weight: 70,
+      weightUnits: 'kg',
+      language: 'en'
+    }
+  }
+}
+
+function makeRawSplitsWorkout() {
+  return {
+    ...makeSharedWorkout(),
+    rawJson: {
+      splits_metric: [
+        { distance: 1000, moving_time: 300, average_heartrate: 150, average_speed: 3.33 },
+        { distance: 1000, moving_time: 330, average_heartrate: 155, average_speed: 3.03 }
+      ]
+    }
+  }
+}
+
+async function callShareStreams() {
+  const mod = await import('../../../../../server/api/share/workouts/[token]/streams.get')
+  return mod.default({ context: { params: { token: SHARE_TOKEN } } })
+}
+
+async function callOwnerStreams() {
+  const mod = await import('../../../../../server/api/workouts/[id]/streams.get')
+  return mod.default({ context: { params: { id: 'workout-1' } } })
+}
+
+describe('GET /api/share/workouts/[token]/streams pacing verdict gate (CW-441)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getForActivityType.mockResolvedValue(OWNER_SPORT_SETTINGS)
+    buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('steady'))
+    shareTokenFindUnique.mockResolvedValue({
+      resourceType: 'WORKOUT',
+      resourceId: 'workout-1',
+      expiresAt: null
+    })
+    workoutFindUnique.mockResolvedValue(makeSharedWorkout())
+    findByWorkoutId.mockResolvedValue(makeStream())
+  })
+
+  describe('the verdict', () => {
+    it('withholds the split-strategy verdict for a shared intervalled session', async () => {
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('intervalled'))
+
+      const result: any = await callShareStreams()
+
+      expect(result.pacingStrategy.strategy).toBe('not_graded')
+      expect(result.pacingStrategy.verdictApplicable).toBe(false)
+      expect(result.pacingStrategy.verdictWithheldReason).toContain('intervalled')
+      // The misleading persisted verdict must not survive into the shared payload.
+      expect(result.pacingStrategy.strategy).not.toBe('positive_split')
+    })
+
+    it('withholds the verdict for a shared stochastic session', async () => {
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('stochastic'))
+
+      const result: any = await callShareStreams()
+
+      expect(result.pacingStrategy.verdictApplicable).toBe(false)
+      expect(result.pacingStrategy.strategy).toBe('not_graded')
+    })
+
+    it('leaves a shared steady session graded, exactly as before', async () => {
+      const result: any = await callShareStreams()
+
+      expect(result.pacingStrategy.strategy).toBe('positive_split')
+      expect(result.pacingStrategy.verdictApplicable).toBe(true)
+      expect(result.pacingStrategy.verdictWithheldReason).toBeNull()
+    })
+
+    it('keeps the split rows and the raw dispersion measurement when the verdict is withheld', async () => {
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('intervalled'))
+
+      const result: any = await callShareStreams()
+
+      // It is the grading that is withheld, not the data.
+      expect(result.lapSplits).toEqual(LAP_SPLITS)
+      expect(result.paceVariability).toBe(15)
+      expect(result.avgPacePerKm).toBe(5.25)
+    })
+
+    it('applies the same gate on the rawJson splits fallback path', async () => {
+      findByWorkoutId.mockResolvedValue(null)
+      workoutFindUnique.mockResolvedValue(makeRawSplitsWorkout())
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('intervalled'))
+
+      const result: any = await callShareStreams()
+
+      expect(result.dataSource).toBe('splits_fallback')
+      expect(result.pacingStrategy.strategy).toBe('not_graded')
+      expect(result.pacingStrategy.verdictApplicable).toBe(false)
+      expect(result.lapSplits).toHaveLength(2)
+      expect(result.paceVariability).toBeGreaterThan(0)
+    })
+  })
+
+  describe('facts build: lazy, memoised, fail-open', () => {
+    it('does not build the facts when there are no splits to grade', async () => {
+      findByWorkoutId.mockResolvedValue(makeStream({ lapSplits: null, pacingStrategy: null }))
+
+      await callShareStreams()
+
+      expect(buildWorkoutAnalysisFactsV2).not.toHaveBeenCalled()
+      expect(getForActivityType).not.toHaveBeenCalled()
+    })
+
+    it('builds the facts at most once per request', async () => {
+      await callShareStreams()
+
+      expect(buildWorkoutAnalysisFactsV2).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails open when the facts builder throws: the verdict stays applicable', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      buildWorkoutAnalysisFactsV2.mockImplementation(() => {
+        throw new Error('facts builder exploded')
+      })
+
+      const result: any = await callShareStreams()
+
+      // A facts problem must never take the pacing card down.
+      expect(result.pacingStrategy.strategy).toBe('positive_split')
+      expect(result.pacingStrategy.verdictApplicable).toBe(true)
+      consoleError.mockRestore()
+    })
+
+    it('fails open when the owner sport settings lookup rejects', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+      getForActivityType.mockRejectedValue(new Error('db down'))
+
+      const result: any = await callShareStreams()
+
+      expect(result.pacingStrategy.verdictApplicable).toBe(true)
+      consoleError.mockRestore()
+    })
+  })
+
+  describe('owner settings resolution (CW-418 precedent)', () => {
+    it("resolves sport settings from the workout OWNER's id, not from any viewer", async () => {
+      await callShareStreams()
+
+      expect(getForActivityType).toHaveBeenCalledWith(OWNER_ID, 'Run')
+    })
+
+    it('feeds the owner settings to the facts builder and to nothing else', async () => {
+      await callShareStreams()
+
+      const args = buildWorkoutAnalysisFactsV2.mock.calls[0]![0]
+      expect(args.sportSettings).toBe(OWNER_SPORT_SETTINGS)
+      expect(args.workout.userId).toBe(OWNER_ID)
+    })
+  })
+
+  describe('the public payload leaks nothing about the owner', () => {
+    const forbiddenKeys = [
+      'user',
+      'userId',
+      'lthr',
+      'maxHr',
+      'ftp',
+      'hrZones',
+      'powerZones',
+      'sportSettings',
+      'weight',
+      'weightUnits',
+      'language',
+      'plannedWorkout'
+    ]
+
+    it('returns no owner fields and no owner id on the stream path', async () => {
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('intervalled'))
+
+      const result: any = await callShareStreams()
+
+      for (const key of forbiddenKeys) {
+        expect(result).not.toHaveProperty(key)
+      }
+      // Nothing nested carries it either.
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain(OWNER_ID)
+      expect(serialized).not.toContain(String(OWNER_SPORT_SETTINGS.lthr))
+      expect(serialized).not.toContain(String(OWNER_SPORT_SETTINGS.ftp))
+    })
+
+    it('returns no owner fields and no owner id on the splits fallback path', async () => {
+      findByWorkoutId.mockResolvedValue(null)
+      workoutFindUnique.mockResolvedValue(makeRawSplitsWorkout())
+
+      const result: any = await callShareStreams()
+
+      for (const key of forbiddenKeys) {
+        expect(result).not.toHaveProperty(key)
+      }
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain(OWNER_ID)
+      expect(serialized).not.toContain(String(OWNER_SPORT_SETTINGS.lthr))
+      expect(serialized).not.toContain(String(OWNER_SPORT_SETTINGS.ftp))
+    })
+
+    it('exposes the same keys it exposed before the gate was added', async () => {
+      // The response is still the stream record, verdict aside: no key was gained.
+      const result: any = await callShareStreams()
+
+      expect(Object.keys(result).sort()).toEqual(Object.keys(makeStream()).sort())
+    })
+  })
+
+  describe('owner view and share view agree (CW-436 / CW-441)', () => {
+    beforeEach(() => {
+      workoutFindFirst.mockResolvedValue({
+        ...makeSharedWorkout(),
+        user: {
+          ftp: 260,
+          maxHr: 190,
+          lthr: 168,
+          distanceUnits: 'Kilometers',
+          weight: 70,
+          weightUnits: 'kg',
+          language: 'en'
+        }
+      })
+    })
+
+    it('withholds the verdict on both endpoints for the same intervalled workout', async () => {
+      buildWorkoutAnalysisFactsV2.mockReturnValue(factsWithSteadiness('intervalled'))
+
+      const shared: any = await callShareStreams()
+      findByWorkoutId.mockResolvedValue(makeStream())
+      const owner: any = await callOwnerStreams()
+
+      expect(shared.pacingStrategy).toEqual(owner.pacingStrategy)
+      expect(shared.pacingStrategy.verdictApplicable).toBe(false)
+    })
+
+    it('grades the verdict on both endpoints for the same steady workout', async () => {
+      const shared: any = await callShareStreams()
+      findByWorkoutId.mockResolvedValue(makeStream())
+      const owner: any = await callOwnerStreams()
+
+      expect(shared.pacingStrategy).toEqual(owner.pacingStrategy)
+      expect(shared.pacingStrategy.verdictApplicable).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Fixes CW-441

Third and final surface of one defect. CW-389 gated the misleading split-strategy verdict in the AI prompt; CW-436 gated it in the owner's pacing card; the public share page still served the persisted, ungraded value, so a shared interval workout told the viewer the athlete slowed down while the owner saw the corrected view.

## What changed

`server/api/share/workouts/[token]/streams.get.ts` now recomputes the split-strategy verdict on the share request, mirroring CW-436, rather than returning the value persisted at ingestion (which was computed with no facts available). Recomputing on the request — instead of gating at ingestion — is what makes the fix apply to every already-stored workout.

- The gate is the shared `resolveSplitPacingVerdictApplicability`, reached through `analyzePacingStrategy(lapSplits, facts)`. No third copy of the logic.
- The v2 facts are built **lazily and memoised**, exactly as in the reference implementation `server/api/workouts/[id]/streams.get.ts`: the builder runs its own interval detection over the full streams, so a request with no splits to grade never pays for it, and it runs at most once per request.
- A builder failure **fails open** — the verdict stays applicable, i.e. pre-CW-441 behaviour — so a facts problem can never take the pacing card down.
- The `rawJson` splits fallback path had its own inline, hand-rolled copy of the pacing thresholds (10s vs the shared 5s, its own evenness formula). It now calls the same shared `analyzePacingStrategy`, which is what the owner endpoint does for this same fallback. Without this the two views could not agree.
- Split rows and the raw dispersion measurement (`lapSplits`, `paceVariability`, `avgPacePerKm`) are untouched in every case — it is the grading that is withheld, not the data.

## Owner settings resolution (public endpoint)

This route is token-authenticated and has no session user, so per CW-418's precedent in the sibling `intervals.get.ts`, the sport settings the facts builder needs are resolved from the workout **owner** via `workout.userId` — never from the viewer.

Those settings are detection inputs only. The response body is built from the stream record (or, in the fallback, from hand-picked split fields); the `workout` record — including `user`, `userId` and `plannedWorkout` — is never returned. The user select was widened only to `weight`/`weightUnits`/`language` (all the facts builder's `userProfile` reads); no `lthr`, `maxHr`, `ftp` or zone data is loaded onto the user at all.

Proven by `tests/unit/server/api/share/share-streams-pacing.test.ts`:

- both response paths assert the payload has no `user`, `userId`, `lthr`, `maxHr`, `ftp`, `hrZones`, `powerZones`, `sportSettings`, `weight`, `weightUnits`, `language`, `plannedWorkout`;
- `JSON.stringify(result)` contains neither the owner id nor the owner's LTHR/FTP values anywhere in its serialization;
- a key-set assertion pins that the response exposes exactly the keys it exposed before the gate was added.

These assertions were mutation-tested: adding `userId: workout.userId` to the returned object turns two of them red.

## Tests

16 new cases in `tests/unit/server/api/share/share-streams-pacing.test.ts` (new file, per Owned Paths — deliberately not folded into an existing share test file). Only the facts *builder* is stubbed; the gate itself is the production one. Coverage: verdict withheld for intervalled and stochastic, graded and unchanged for steady, gate applied on the fallback path, split rows/dispersion preserved, facts built lazily and at most once, fail-open on builder throw and on a sport-settings rejection, owner-id resolution, the leak assertions above, and two cases pinning that the owner endpoint and the share endpoint produce an identical `pacingStrategy` for the same workout.

## Verification

```
pnpm typecheck && pnpm test:unit tests/unit/server/api/share && pnpm lint
```

- `pnpm typecheck` — clean
- `pnpm test:unit tests/unit/server/api/share` — Test Files 6 passed (6), Tests 36 passed (36)
- `pnpm lint` — 116 problems (0 errors, 116 warnings); all warnings pre-existing, none in the touched files
- Broader regression run `tests/unit/server/api` + `server/utils/pacing.test.ts` + `server/utils/services/workout-analysis-prompt.test.ts` — 83 files, 346 tests passed

Re-run clean after rebasing onto `origin/develop` (c85a258b).

UX critique: skipped — same gate and same card state as CW-436, no new UI surface.
