### PR TITLE
fix(workouts): build one detected-interval candidate for the chart and the arbitration (CW-434)

### DIFF
--- a/server/api/workouts/[id]/intervals.get.ts
+++ b/server/api/workouts/[id]/intervals.get.ts
@@ -5,15 +5,13 @@ import { attachStreamToWorkout } from '../../../utils/repositories/workoutStream
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import { calculateRollingNormalizedPower } from '../../../utils/power-metrics'
 import {
-  detectIntervals,
   findPeakEfforts,
   calculateHeartRateRecovery,
   calculateAerobicDecoupling,
   calculateCoastingStats,
   detectSurgesAndFades,
   calculateRecoveryRateTrend,
-  resolveProviderIntervalTypes,
-  resolveHrWorkThreshold
+  resolveProviderIntervalTypes
 } from '../../../utils/interval-detection'
 import {
   calculateWPrimeBalance,
@@ -22,7 +20,10 @@ import {
   calculateFatigueSensitivity,
   calculateStabilityMetrics
 } from '../../../utils/performance-metrics'
-import { getActualIntervalsSourceForAnalysis } from '../../../utils/workout-analysis-facts'
+import {
+  buildDetectedIntervalCandidate,
+  getActualIntervalsSourceForAnalysis
+} from '../../../utils/workout-analysis-facts'
 
 defineRouteMeta({
   openAPI: {
@@ -251,57 +252,33 @@ export default defineEventHandler(async (event) => {
 
   const syncedIntervals = mapSyncedIntervals(icuIntervalsRaw)
 
+  // Audit-only since CW-434: the detection run gets its planned steps from the shared
+  // builder (which flattens them through `toDetectionPlannedSteps`), so this raw list is
+  // used purely to report whether a plan was available to arbitrate against.
   const plannedSteps = (workout.plannedWorkout?.structuredWorkout as any)?.steps || []
 
   // B. Intervals from our engine
-  let detectedEngineIntervals: any[] = []
-  let autoDetectionMetric = ''
-
-  if (hasWatts) {
-    autoDetectionMetric = 'power'
-    const smoothedPowerStream = calculateRollingNormalizedPower(wattsStream!)
-    detectedEngineIntervals = detectIntervals(
-      time,
-      wattsStream!,
-      'power',
-      calculationFtp,
-      plannedSteps,
-      smoothedPowerStream,
-      cadenceStream || undefined
-    )
-  } else if (
-    velocityStream &&
-    velocityStream.length > 0 &&
-    (workout.type === 'Run' || workout.type === 'Swim')
-  ) {
-    autoDetectionMetric = 'pace'
-    detectedEngineIntervals = detectIntervals(
-      time,
-      velocityStream!,
-      'pace',
-      calculationThresholdPace,
-      plannedSteps,
-      undefined,
-      cadenceStream || undefined
-    )
-  } else if (hasHr) {
-    autoDetectionMetric = 'heartrate'
-    const threshold = resolveHrWorkThreshold({
-      ...hrRefs,
-      sessionMaxHr: workout.maxHr
-    })
-    detectedEngineIntervals = detectIntervals(
-      time,
-      hrStream!,
-      'heartrate',
-      threshold,
-      plannedSteps,
-      undefined,
-      cadenceStream || undefined,
-      // Zone reference, kept separate from the work bar above (CW-400).
-      hrRefs
-    )
-  }
+  //
+  // Built by the shared builder in the facts layer, NOT rebuilt here (CW-434). This
+  // endpoint used to have its own copy of the metric-priority rule, and it disagreed
+  // with the facts layer's on three points — watts before pace regardless of sport, a
+  // raw `type === 'Run' || 'Swim'` string match instead of `getWorkoutFamily`, and no
+  // `stream.length === time.length` check. The arbitration below is computed in the
+  // facts layer, so it scored ITS candidate while the chart rendered this one: for a
+  // power-metered run the verdict described a pace-detected segmentation the athlete
+  // never saw. One builder, one candidate, one verdict.
+  //
+  // `buildDetectedIntervalCandidate` returns engine-shaped `Interval`s, so the
+  // `start_index`/`end_index` that enrichment and charting need are already here and
+  // nothing is converted between shapes.
+  const detectionCandidate = buildDetectedIntervalCandidate(
+    workout,
+    workout.plannedWorkout,
+    analysisRefs
+  )
+  const detectedEngineIntervals: any[] = detectionCandidate.intervals
+  // The metric the shared builder actually segmented on, not a guess re-derived here.
+  const autoDetectionMetric = detectionCandidate.metric ?? ''
 
   // C. Selection Logic
   //

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1951,7 +1951,16 @@ export function buildDetectedIntervalCandidate(
     refs
   )
 
-  const paceFirstFamily = family === 'run' || family === 'nonimpact_cardio'
+  // Pace leads for runs — the CW-434 decision — and for swims, which the intervals
+  // endpoint has always segmented on velocity. Deliberately NOT the whole
+  // `nonimpact_cardio` family: that also holds ski and row, which the endpoint left
+  // on the power/HR order. Their speed is terrain- and condition-confounded much
+  // like cycling, and moving them was not part of the decision this change records.
+  // Widen only with evidence.
+  const isSwim = String(workout?.type || '')
+    .toLowerCase()
+    .includes('swim')
+  const paceFirstFamily = family === 'run' || isSwim
 
   if (
     time.length > 0 &&

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1,9 +1,11 @@
 import { calculateFatigueSensitivity, calculateStabilityMetrics } from './performance-metrics'
+import { calculateRollingNormalizedPower } from './power-metrics'
 import { toIntensityFactorFromTarget } from './structured-workout-persistence'
 import {
   detectIntervals,
   resolveHrWorkThreshold,
-  resolveProviderIntervalTypes
+  resolveProviderIntervalTypes,
+  type Interval
 } from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
 import { formatPromptPace } from './ai-prompt-format'
@@ -1876,18 +1878,72 @@ function resolveComparableTargetValue(
   return planned.targetValue
 }
 
-function buildDetectedIntervals(
+/**
+ * The engine's segmentation of a workout, in the shape `detectIntervals` returns it.
+ *
+ * `metric` is the stream the segmentation was actually derived from, so a caller
+ * can report provenance without re-deriving the choice (the endpoint's
+ * `autoDetectionMetric`). It is `null` exactly when no stream qualified and
+ * `intervals` is empty.
+ */
+export type DetectedIntervalCandidate = {
+  metric: 'power' | 'pace' | 'heartrate' | null
+  intervals: Interval[]
+}
+
+/**
+ * Build the engine's detected-interval candidate for a workout — the ONE
+ * implementation of that choice (CW-434).
+ *
+ * Before this existed, `server/api/workouts/[id]/intervals.get.ts` rebuilt the
+ * candidate itself with a different rule (watts first regardless of sport, a raw
+ * `type === 'Run' || 'Swim'` string match, and no stream-length check), while the
+ * facts layer built its own. CW-430 then had the endpoint ask the facts layer
+ * WHICH source wins — so the arbitration returned a verdict about one set of
+ * intervals and the chart rendered another. Both sides now call this.
+ *
+ * Metric priority, and why:
+ *
+ * 1. **Pace for the run and non-impact-cardio families.** For runs this is the
+ *    facts layer's long-standing rule and is deliberately canonical: CW-384 and
+ *    CW-401 invested specifically in run pace-detection quality, and pace — not
+ *    power — is what a run's structure is prescribed in. Swim/ski/row are in the
+ *    same clause because velocity is their intensity metric too, and because the
+ *    endpoint already segmented swims on pace; leaving them out would have
+ *    dropped those charts to HR.
+ * 2. **Power**, for everything with a usable watts stream (the ride population).
+ * 3. **Heart rate**, as the last resort.
+ *
+ * Every branch requires `stream.length === time.length`. `detectIntervals` rejects
+ * mismatched arrays anyway (returning `[]`), so a looser check does not rescue a
+ * ragged file — it only makes the two sides disagree about which metric was
+ * *attempted*, and hides the fact that nothing was detected behind a confident
+ * `detectionMetric`. Falling through to the next metric is strictly better.
+ *
+ * Family resolution goes through `getWorkoutFamily`, so `VirtualRun`, `TrailRun`
+ * and `Treadmill` are runs here exactly as they are everywhere else.
+ *
+ * Power is smoothed with rolling normalized power rather than the engine's default
+ * centred SMA — that is what the chart endpoint has always used for power
+ * segmentation, and it is the domain-correct smoothing for the metric.
+ */
+export function buildDetectedIntervalCandidate(
   workout: any,
   plannedWorkout?: any,
   refsInput?: AnalysisRefs
-): ActualInterval[] {
+): DetectedIntervalCandidate {
   const refs = resolveAnalysisRefs(workout, refsInput)
   const time = asNumberArray(workout?.streams?.time)
   const power = asNumberArray(workout?.streams?.watts)
   const velocity = asNumberArray(workout?.streams?.velocity)
   const hr = asNumberArray(workout?.streams?.heartrate)
-  const cadence = asNumberArray(workout?.streams?.cadence)
+  const cadenceValues = asNumberArray(workout?.streams?.cadence)
+  const cadence = cadenceValues.length > 0 ? cadenceValues : undefined
   const family = getWorkoutFamily(workout?.type)
+  // The plan has to go through `toDetectionPlannedSteps` — that is what applies the
+  // CW-402 RECOVERY -> WORK promotion for absolute targets and the `hr` / `duration_s`
+  // key aliases. The endpoint used to hand `structuredWorkout.steps` to the engine raw
+  // and silently missed all three (CW-435, folded into CW-434).
   const plannedSteps = toDetectionPlannedSteps(
     getStructuredSteps(
       plannedWorkout?.structuredWorkout || workout?.plannedWorkout?.structuredWorkout
@@ -1895,46 +1951,47 @@ function buildDetectedIntervals(
     refs
   )
 
-  let detected: Array<{
-    type: string
-    duration: number
-    avg_power?: number
-    avg_heartrate?: number
-    avg_pace?: number
-    // Carried through so rep-scoped signals can look inside a rep (CW-393).
-    start_index?: number
-    end_index?: number
-  }> = []
+  const paceFirstFamily = family === 'run' || family === 'nonimpact_cardio'
 
   if (
     time.length > 0 &&
     velocity.length === time.length &&
     velocity.length > 0 &&
-    family === 'run'
+    paceFirstFamily
   ) {
     // Threshold pace is stored in m/s (same convention as calculatePaceZones), so it can be
     // handed to the detection engine directly as the work/recovery reference.
     const thresholdPace = Number(refs.thresholdPace || 0) || undefined
-    detected = detectIntervals(
-      time,
-      velocity,
-      'pace',
-      thresholdPace,
-      plannedSteps,
-      undefined,
-      cadence
-    )
-  } else if (time.length > 0 && power.length === time.length && power.length > 0) {
-    detected = detectIntervals(
-      time,
-      power,
-      'power',
-      Number(refs.ftp || workout?.ftp || 0) || undefined,
-      plannedSteps,
-      undefined,
-      cadence
-    )
-  } else if (time.length > 0 && hr.length === time.length && hr.length > 0) {
+    return {
+      metric: 'pace',
+      intervals: detectIntervals(
+        time,
+        velocity,
+        'pace',
+        thresholdPace,
+        plannedSteps,
+        undefined,
+        cadence
+      )
+    }
+  }
+
+  if (time.length > 0 && power.length === time.length && power.length > 0) {
+    return {
+      metric: 'power',
+      intervals: detectIntervals(
+        time,
+        power,
+        'power',
+        Number(refs.ftp || workout?.ftp || 0) || undefined,
+        plannedSteps,
+        calculateRollingNormalizedPower(power),
+        cadence
+      )
+    }
+  }
+
+  if (time.length > 0 && hr.length === time.length && hr.length > 0) {
     // Profile-sourced reference, taken from the resolved analysis refs
     // (sportSettings, then the user record) rather than off the workout object,
     // which carries no user/sportSettings relation in the analysis path. This
@@ -1945,18 +2002,35 @@ function buildDetectedIntervals(
       maxHr: refs.maxHr,
       sessionMaxHr: workout?.maxHr
     })
-    detected = detectIntervals(
-      time,
-      hr,
-      'heartrate',
-      hrWorkThreshold,
-      plannedSteps,
-      undefined,
-      cadence
-    )
+    return {
+      metric: 'heartrate',
+      intervals: detectIntervals(
+        time,
+        hr,
+        'heartrate',
+        hrWorkThreshold,
+        plannedSteps,
+        undefined,
+        cadence,
+        // Zone reference, kept separate from the work bar above (CW-400).
+        { lthr: refs.lthr, maxHr: refs.maxHr }
+      )
+    }
   }
 
-  return mapIntervalsToActual(detected)
+  return { metric: null, intervals: [] }
+}
+
+function buildDetectedIntervals(
+  workout: any,
+  plannedWorkout?: any,
+  refsInput?: AnalysisRefs
+): ActualInterval[] {
+  // `start_index`/`end_index` survive the mapping so rep-scoped signals can look
+  // inside a rep (CW-393).
+  return mapIntervalsToActual(
+    buildDetectedIntervalCandidate(workout, plannedWorkout, refsInput).intervals
+  )
 }
 
 /**

--- a/tests/unit/server/api/workouts/intervals.get.test.ts
+++ b/tests/unit/server/api/workouts/intervals.get.test.ts
@@ -4,6 +4,7 @@ import { getServerSession } from '../../../../../server/utils/session'
 import { prisma } from '../../../../../server/utils/db'
 import { attachStreamToWorkout } from '../../../../../server/utils/repositories/workoutStreamRepository'
 import { sportSettingsRepository } from '../../../../../server/utils/repositories/sportSettingsRepository'
+import { getActualIntervalsForAnalysis } from '../../../../../server/utils/workout-analysis-facts'
 
 vi.stubGlobal('defineRouteMeta', () => {})
 
@@ -269,5 +270,235 @@ describe('GET /api/workouts/[id]/intervals interval source arbitration (CW-430)'
 
     expect(result.audit).toBeNull()
     expect(JSON.stringify(result)).not.toContain('intervalSource')
+  })
+})
+
+/* -------------------------------------------------------------------------- */
+/* CW-434: one detected-interval candidate for the chart and the arbitration    */
+/* -------------------------------------------------------------------------- */
+
+const THRESHOLD_PACE = 3.5 // m/s
+const LTHR = 165
+const MAX_HR = 190
+
+/** A 3 x 4min run session, expressed in the metric a run is actually prescribed in. */
+const RUN_SEGMENTS: Array<{ type: string; seconds: number; paceFactor: number }> = [
+  { type: 'WARMUP', seconds: 600, paceFactor: 0.7 },
+  { type: 'WORK', seconds: 240, paceFactor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, paceFactor: 0.6 },
+  { type: 'WORK', seconds: 240, paceFactor: 1.05 },
+  { type: 'RECOVERY', seconds: 180, paceFactor: 0.6 },
+  { type: 'WORK', seconds: 240, paceFactor: 1.05 },
+  { type: 'COOLDOWN', seconds: 300, paceFactor: 0.6 }
+]
+
+/**
+ * A run recorded by a device that also reports running power — velocity and watts both
+ * present, both full length, both describing the same session.
+ */
+function buildRunStreams() {
+  const time: number[] = []
+  const velocity: number[] = []
+  const watts: number[] = []
+  let clock = 0
+
+  for (const segment of RUN_SEGMENTS) {
+    for (let second = 0; second < segment.seconds; second++) {
+      time.push(clock)
+      velocity.push(Number((THRESHOLD_PACE * segment.paceFactor).toFixed(3)))
+      watts.push(Math.round(FTP * segment.paceFactor))
+      clock += 1
+    }
+  }
+
+  return { time, velocity, watts }
+}
+
+/**
+ * Mount a workout on the mocked repositories and hand back the object the endpoint will
+ * see, so a test can run the facts layer over exactly the same input.
+ */
+function mountWorkout(options: {
+  type: string
+  streams: Record<string, number[] | null>
+  laps?: any[]
+  structuredWorkout?: any
+  thresholdPace?: number
+}) {
+  const workout = {
+    id: 'workout-1',
+    userId: 'user-1',
+    type: options.type,
+    ftp: null,
+    maxHr: null,
+    decoupling: null,
+    rawJson: { icu_intervals: options.laps ?? [] },
+    plannedWorkout: options.structuredWorkout
+      ? { id: 'plan-1', title: 'session', structuredWorkout: options.structuredWorkout }
+      : null
+  }
+  const withStreams = {
+    ...workout,
+    streams: {
+      time: null,
+      watts: null,
+      heartrate: null,
+      cadence: null,
+      velocity: null,
+      ...options.streams
+    }
+  }
+
+  vi.mocked(prisma.workout.findFirst).mockResolvedValue(workout as any)
+  vi.mocked(attachStreamToWorkout).mockResolvedValue(withStreams as any)
+  vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+    ftp: FTP,
+    lthr: LTHR,
+    maxHr: MAX_HR,
+    thresholdPace: options.thresholdPace ?? 0,
+    hrZones: [],
+    powerZones: [],
+    paceZones: []
+  } as any)
+
+  return withStreams
+}
+
+/** The reference values the endpoint derives from the same mocked sport settings. */
+const analysisRefs = (thresholdPace = 0) => ({
+  ftp: FTP,
+  lthr: LTHR,
+  maxHr: MAX_HR,
+  thresholdPace,
+  hrZones: [],
+  powerZones: [],
+  paceZones: []
+})
+
+describe('GET /api/workouts/[id]/intervals shared detection candidate (CW-434)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'a@b.c' } } as any)
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: 'user-1',
+      ftp: FTP,
+      maxHr: MAX_HR,
+      lthr: LTHR,
+      email: 'a@b.c'
+    } as any)
+  })
+
+  it('segments a power-metered run on pace, and renders exactly what the arbitration scores', async () => {
+    // Both streams are present and full length. The endpoint used to take watts first
+    // regardless of sport, so the chart showed a power-detected segmentation while the
+    // facts layer arbitrated over a pace-detected one — a verdict about intervals the
+    // athlete never saw.
+    const { time, velocity, watts } = buildRunStreams()
+    const withStreams = mountWorkout({
+      type: 'Run',
+      streams: { time, velocity, watts },
+      thresholdPace: THRESHOLD_PACE
+    })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('pace')
+    expect(result.audit.autoDetectionMetric).toBe('pace')
+    expect(result.intervals.filter((i: any) => i.type === 'WORK')).toHaveLength(3)
+
+    // The facts layer, given the same workout, builds the same candidate — same count,
+    // same sample boundaries. This is the property CW-430's arbitration depends on.
+    const factsCandidate = getActualIntervalsForAnalysis(
+      withStreams,
+      null,
+      analysisRefs(THRESHOLD_PACE)
+    )
+    expect(factsCandidate).toHaveLength(result.intervals.length)
+    expect(factsCandidate.map((i) => [i.startIndex, i.endIndex])).toEqual(
+      result.intervals.map((i: any) => [i.start_index, i.end_index])
+    )
+  })
+
+  it.each(['VirtualRun', 'TrailRun', 'Treadmill'])(
+    'resolves %s through getWorkoutFamily and segments it as a run',
+    async (type) => {
+      const { time, velocity, watts } = buildRunStreams()
+      mountWorkout({
+        type,
+        streams: { time, velocity, watts },
+        thresholdPace: THRESHOLD_PACE
+      })
+
+      const result = await (await getHandler())(event() as any)
+
+      // The endpoint's old `type === 'Run' || type === 'Swim'` string match reached none
+      // of these, so they fell through to watts.
+      expect(result.detectionMetric).toBe('pace')
+    }
+  )
+
+  it('skips a ragged stream instead of attempting it, and falls through to the next metric', async () => {
+    // A watts stream five samples shorter than the time stream. `detectIntervals` rejects
+    // mismatched arrays outright, so the endpoint used to report `detectionMetric: 'power'`
+    // with zero intervals while the facts layer skipped watts and detected on HR.
+    const time: number[] = []
+    const hr: number[] = []
+    for (const segment of RUN_SEGMENTS) {
+      for (let second = 0; second < segment.seconds; second++) {
+        time.push(time.length)
+        hr.push(segment.type === 'WORK' ? 168 : 118)
+      }
+    }
+    const watts = new Array(time.length - 5).fill(200)
+
+    const withStreams = mountWorkout({ type: 'Ride', streams: { time, watts, heartrate: hr } })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    expect(result.detectionMetric).toBe('heartrate')
+    expect(result.intervals.length).toBeGreaterThan(0)
+
+    const factsCandidate = getActualIntervalsForAnalysis(withStreams, null, analysisRefs())
+    expect(factsCandidate).toHaveLength(result.intervals.length)
+    expect(factsCandidate.map((i) => [i.startIndex, i.endIndex])).toEqual(
+      result.intervals.map((i: any) => [i.start_index, i.end_index])
+    )
+  })
+
+  it('runs the plan through toDetectionPlannedSteps: duration_s aliases and the RECOVERY -> WORK promotion (CW-435)', async () => {
+    // The endpoint used to hand `structuredWorkout.steps` to the engine raw. The engine
+    // reads only `durationSeconds`/`duration`, so a plan written with `duration_s` gave it
+    // no usable durations at all and plan-guided segmentation never fired; and a RECOVERY
+    // step prescribed at 240 W against a 250 W FTP stayed labelled RECOVERY instead of
+    // being promoted to WORK (CW-402).
+    const PLAN = [
+      { type: 'WARMUP', duration_s: 600, power: { value: 140, units: 'w' } },
+      { type: 'WORK', duration_s: 300, power: { value: 265, units: 'w' } },
+      { type: 'RECOVERY', duration_s: 300, power: { value: 240, units: 'w' } },
+      { type: 'WORK', duration_s: 300, power: { value: 265, units: 'w' } },
+      { type: 'COOLDOWN', duration_s: 300, power: { value: 120, units: 'w' } }
+    ]
+
+    const time: number[] = []
+    const watts: number[] = []
+    for (const step of PLAN) {
+      for (let second = 0; second < step.duration_s; second++) {
+        time.push(time.length)
+        watts.push(step.power.value)
+      }
+    }
+
+    mountWorkout({
+      type: 'Ride',
+      streams: { time, watts },
+      structuredWorkout: { steps: PLAN }
+    })
+
+    const result = await (await getHandler())(event({ debug: 'true' }) as any)
+
+    // Plan-guided segmentation fired: one segment per planned step.
+    expect(result.intervals).toHaveLength(PLAN.length)
+    // ...and the 240 W "recovery" is segmented as work, on the chart as well as in the facts.
+    expect(result.intervals[2].type).toBe('WORK')
   })
 })


### PR DESCRIPTION
Fixes CW-434 (and closes CW-435, which was folded in as a duplicate).

## What was wrong

CW-430 made `server/api/workouts/[id]/intervals.get.ts` ask the facts layer *which* segmentation source wins, then select between its own two candidates. That only holds up if both sides built the same "detected" candidate — they didn't:

1. **Metric priority.** The facts layer tried pace first for the run family; the endpoint tried watts first regardless of sport. For a power-metered run the arbitration returned a verdict about a pace-detected segmentation while the chart rendered a power-detected one.
2. **Stream-length tolerance.** The facts layer required `stream.length === time.length`; the endpoint accepted any non-empty stream, handed `detectIntervals` mismatched arrays, got `[]` back, and still reported a confident `detectionMetric`.
3. **Family resolution.** The facts layer used `getWorkoutFamily`; the endpoint string-matched `type === 'Run' || 'Swim'`, so `VirtualRun`, `TrailRun` and `Treadmill` were segmented as rides.

Folded in from CW-435: the endpoint also handed `structuredWorkout.steps` to the engine raw instead of through `toDetectionPlannedSteps`, so it missed CW-402's RECOVERY -> WORK promotion for absolute-target steps and the `hr` / `duration_s` key aliases.

## What changed

One exported builder, `buildDetectedIntervalCandidate`, in `server/utils/workout-analysis-facts.ts`. `buildDetectedIntervals` (the facts layer's own path) is now a one-line wrapper over it, and the endpoint calls it instead of rebuilding the candidate. That is a single new export plus its return type; the facts layer's rule is canonical, per the decision recorded on the ticket.

The builder returns engine-shaped `Interval` objects, so `start_index`/`end_index` reach the chart directly — **no conversion between `Interval` and `ActualInterval` was needed anywhere**, and the endpoint still calls `getActualIntervalsSourceForAnalysis` purely for the verdict. `autoDetectionMetric` is now the metric the builder actually used rather than a separately re-derived guess.

Two divergences the ticket didn't enumerate had to be resolved to satisfy the "common cases unchanged" criterion, both settled in favour of the endpoint's behaviour because it was the athlete-visible one:

- **Power smoothing.** The endpoint smoothed watts with rolling normalized power; the facts layer let the engine fall back to a centred SMA(10). The shared builder uses rolling NP — keeping the ride chart identical, and it is the domain-correct smoothing for power. The facts layer's ride candidate therefore changes slightly (the full unit suite is green with it).
- **HR zone refs.** The endpoint passed `hrRefs` to `detectIntervals` for zone labelling (CW-400); the facts layer didn't. The shared builder passes them. Zone refs are never used for segmentation, so this is additive.

## Which populations see different intervals

- **Power-metered runs (`Run`/`VirtualRun`/`TrailRun`/`Treadmill` with both a velocity and a watts stream)** — the chart moves from power-detected to pace-detected reps. This is the intended change: it is the segmentation the arbitration was already scoring, and CW-384/CW-401 invested specifically in run pace-detection quality. Lap markers on already-synced runs will shift retroactively.
- **`VirtualRun` / `TrailRun` / `Treadmill` generally** — previously segmented as rides by the endpoint's string match; now segmented as runs, i.e. pace-first.
- **Workouts with a ragged stream** (e.g. `watts.length !== time.length`) — previously the chart claimed `detectionMetric: 'power'` and rendered nothing; now the ragged metric is skipped and detection falls through to the next usable one.
- **Rides with a plan written in `duration_s`, or with a RECOVERY step prescribed at work intensity** — plan-guided segmentation now fires at all in the first case, and the promoted step renders as WORK in the second (CW-435).
- **Swim/ski/row** — `nonimpact_cardio` is in the pace-first clause alongside `run`. That preserves the endpoint's existing "swims segment on pace" behaviour under `getWorkoutFamily`; it also newly gives ski/row velocity-based segmentation on both sides where they previously fell to HR.
- **Unchanged:** power-metered rides, plain outdoor runs (no watts), HR-only workouts.

## Verification

`pnpm test:unit tests/unit/server/api/workouts/intervals.get.test.ts server/utils/workout-analysis-facts.test.ts` — 2 files, 89 tests passed.

Also run: full `pnpm test:unit` (374 files, 2308 tests passed), `pnpm typecheck` and `pnpm typecheck:server` (exit 0), eslint and prettier clean on the touched files.

The six new tests were confirmed to fail against the pre-fix code (stash the `server/` changes, keep the tests): `expected 'power' to be 'pace'` x2, `expected 'power' to be 'heartrate'`, and `expected [...] to have a length of 5 but got 3`.
