### PR TITLE
fix(workouts): allow corroborated first-time FTP and LTHR nomination (CW-420)

### DIFF
--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -6,7 +6,7 @@ import { queueThresholdUpdateEmail } from '../workout-insight-email'
 import { logger } from '@trigger.dev/sdk/v3'
 import { workoutStreamRepository } from '../repositories/workoutStreamRepository'
 import { formatPromptPace } from '../ai-prompt-format'
-import { calculateHrZones } from '../zones'
+import { calculateHrZones, calculatePaceZones, calculatePowerZones } from '../zones'
 
 /**
  * Threshold pace is taken directly off the best sustained 40 minute effort (no
@@ -23,11 +23,52 @@ import { calculateHrZones } from '../zones'
 export const THRESHOLD_PACE_PEAK_DURATION_SEC = 2400
 
 /**
- * Share of the peak window's samples that must carry a usable heart rate before
- * the average is treated as evidence. A strap that dropped out for most of the
- * effort corroborates nothing.
+ * Share of the peak window's samples that must carry a usable reading before the
+ * average is treated as evidence. A strap (or a power meter) that dropped out
+ * for most of the effort corroborates nothing.
  */
-const THRESHOLD_PACE_HR_COVERAGE_MIN = 0.8
+const THRESHOLD_EFFORT_COVERAGE_MIN = 0.8
+
+/**
+ * A first-ever detection arrives with no previous value: the field is absent,
+ * zero, or non-finite. Framing that as an improvement — "increased from 0" —
+ * reads as a bug to the athlete, so every piece of threshold copy branches on
+ * this one predicate rather than re-deriving the test (CW-421, CW-420).
+ */
+function hasPreviousValue(oldValue: number | null | undefined): boolean {
+  return typeof oldValue === 'number' && Number.isFinite(oldValue) && oldValue > 0
+}
+
+/**
+ * Mean of `values` over the closed `[startSec, endSec]` window, or `null` when
+ * too few of the window's samples carry a usable reading.
+ */
+function averageOverWindow(
+  times: number[],
+  values: readonly number[],
+  startSec: number,
+  endSec: number,
+  isUsable: (value: number) => boolean
+): number | null {
+  let inWindow = 0
+  let usable = 0
+  let sum = 0
+
+  for (let i = 0; i < times.length; i++) {
+    const t = times[i]
+    if (t === undefined || t < startSec || t > endSec) continue
+    inWindow++
+    const value = values[i]
+    if (typeof value === 'number' && Number.isFinite(value) && isUsable(value)) {
+      usable++
+      sum += value
+    }
+  }
+
+  if (inWindow === 0 || usable / inWindow < THRESHOLD_EFFORT_COVERAGE_MIN) return null
+
+  return sum / usable
+}
 
 export interface ThresholdEffortHrEvidence {
   corroborated: boolean
@@ -81,26 +122,12 @@ export function corroborateThresholdEffortWithHr(args: {
     return { corroborated: false, reason: 'no_hr_reference' }
   }
 
-  let inWindow = 0
-  let usable = 0
-  let sum = 0
+  // A zero is a dropped sample, not a resting heart rate, so it is not averaged.
+  const avgHr = averageOverWindow(times, heartrate, startSec, endSec, (hr) => hr > 0)
 
-  for (let i = 0; i < times.length; i++) {
-    const t = times[i]
-    if (t === undefined || t < startSec || t > endSec) continue
-    inWindow++
-    const hr = heartrate[i]
-    if (typeof hr === 'number' && Number.isFinite(hr) && hr > 0) {
-      usable++
-      sum += hr
-    }
-  }
-
-  if (inWindow === 0 || usable / inWindow < THRESHOLD_PACE_HR_COVERAGE_MIN) {
+  if (avgHr === null) {
     return { corroborated: false, reason: 'insufficient_hr_coverage', floorHr }
   }
-
-  const avgHr = sum / usable
 
   return {
     corroborated: avgHr >= floorHr,
@@ -108,6 +135,111 @@ export function corroborateThresholdEffortWithHr(args: {
     avgHr,
     floorHr
   }
+}
+
+export interface ThresholdEffortWorkEvidence {
+  corroborated: boolean
+  /** Machine-readable reason, for logs. */
+  reason:
+    'no_corroborating_axis' | 'insufficient_coverage' | 'below_threshold_band' | 'in_threshold_band'
+  /** Which axis produced the verdict. */
+  axis?: 'power' | 'pace'
+  avgValue?: number
+  floorValue?: number
+}
+
+/**
+ * Was a peak effort's own window worked at threshold *on a non-heart-rate axis*?
+ *
+ * This is the LTHR counterpart of `corroborateThresholdEffortWithHr`, and it
+ * exists because that function cannot serve here: corroborating a heart-rate
+ * derived threshold with heart rate is circular — the same 20 minute window
+ * would be both the claim and its own evidence. Power and pace are independent
+ * measurements of how hard the athlete was actually working, so they can vouch
+ * for the effort without begging the question (CW-420).
+ *
+ * The bar on each axis is that axis's own Z4 floor as the shared zone models
+ * already define it — `calculatePowerZones` (0.9 x FTP) and `calculatePaceZones`
+ * (0.95 x threshold speed). No new coefficient is invented here, exactly as in
+ * the CW-413 heart-rate precedent.
+ *
+ * Both references are the athlete's *stored* FTP and threshold pace, never a
+ * value detected in this same pass, so there is no cross-metric feedback loop.
+ *
+ * The axes are an OR: a ride corroborated by power and a run corroborated by
+ * pace both count, and the first axis that clears its floor wins. When neither
+ * axis is available — no stored FTP and no stored threshold pace, or no matching
+ * stream — the answer is `no_corroborating_axis` and the caller must not
+ * nominate. Preferring no recommendation over a weak one is the whole reason
+ * CW-413 works, and a machine-generated LTHR moves every heart rate zone in the
+ * app.
+ */
+export function corroborateThresholdEffortWithWorkRate(args: {
+  times: number[]
+  watts?: number[] | null
+  velocity?: number[] | null
+  startSec: number
+  endSec: number
+  ftp?: number | null
+  /** The athlete's stored threshold pace, in seconds per kilometre. */
+  thresholdPaceSecPerKm?: number | null
+}): ThresholdEffortWorkEvidence {
+  const { times, watts, velocity, startSec, endSec, ftp, thresholdPaceSecPerKm } = args
+
+  const axes: Array<{ axis: 'power' | 'pace'; values: number[]; floor: number }> = []
+
+  if (Array.isArray(watts) && watts.length > 0 && ftp && ftp > 0) {
+    const floor = calculatePowerZones(ftp).find((zone) => zone.name.startsWith('Z4'))?.min
+    if (floor && floor > 0) axes.push({ axis: 'power', values: watts, floor })
+  }
+
+  if (
+    Array.isArray(velocity) &&
+    velocity.length > 0 &&
+    thresholdPaceSecPerKm &&
+    thresholdPaceSecPerKm > 0
+  ) {
+    // Zones are built from threshold *speed* in m/s; the profile stores pace in
+    // seconds per kilometre.
+    const thresholdSpeed = 1000 / thresholdPaceSecPerKm
+    const floor = calculatePaceZones(thresholdSpeed).find((zone) => zone.name.startsWith('Z4'))?.min
+    if (floor && floor > 0) axes.push({ axis: 'pace', values: velocity, floor })
+  }
+
+  if (axes.length === 0) return { corroborated: false, reason: 'no_corroborating_axis' }
+
+  let rejection: ThresholdEffortWorkEvidence | null = null
+
+  for (const { axis, values, floor } of axes) {
+    // Unlike heart rate, a zero here is real: coasting and standing still are
+    // part of the effort and drag the average down, which fails safe.
+    const avgValue = averageOverWindow(times, values, startSec, endSec, (value) => value >= 0)
+
+    if (avgValue === null) {
+      rejection ??= {
+        corroborated: false,
+        reason: 'insufficient_coverage',
+        axis,
+        floorValue: floor
+      }
+      continue
+    }
+
+    if (avgValue >= floor) {
+      return { corroborated: true, reason: 'in_threshold_band', axis, avgValue, floorValue: floor }
+    }
+
+    // A measured rejection is more informative than an unmeasurable one.
+    rejection = {
+      corroborated: false,
+      reason: 'below_threshold_band',
+      axis,
+      avgValue,
+      floorValue: floor
+    }
+  }
+
+  return rejection ?? { corroborated: false, reason: 'no_corroborating_axis' }
 }
 
 export const thresholdDetectionService = {
@@ -228,9 +360,10 @@ export const thresholdDetectionService = {
         'heartrate'
       )
 
-      const peak20mHR = hrPeaks.find((p) => p.duration === 1200)?.value
+      const peak20m = hrPeaks.find((p) => p.duration === 1200)
+      const peak20mHR = peak20m?.value
 
-      if (peak20mHR && currentLthr) {
+      if (peak20m && peak20mHR) {
         // Industry standard (TrainingPeaks): LTHR is estimated as 95% of peak 20m HR
         // unless it's a specific 30m test protocol. For auto-detection, 95% is more accurate.
         const estimatedLthr = Math.round(peak20mHR * 0.95)
@@ -247,15 +380,66 @@ export const thresholdDetectionService = {
 
         results.minDurationMet = minMet
 
-        if (estimatedLthr > currentLthr && minMet) {
-          results.lthr = { old: currentLthr, new: estimatedLthr, detected: true }
+        // Two different questions, so two different tests (CW-420).
+        //
+        // The athlete who already has an LTHR is vouched for by the improvement
+        // test: a 20 minute peak that beats their known threshold is itself the
+        // evidence, and the value only ever ratchets upward. That path is
+        // deliberately untouched.
+        //
+        // The athlete who has none had, until CW-420, no path at all — the
+        // branch required `currentLthr` to be truthy, so a first-time athlete
+        // never received an LTHR and their heart rate zones stayed unset,
+        // silently degrading every zone-based analysis and (since CW-383/CW-384)
+        // interval detection too. Enabling it naively would be the CW-413 bug
+        // inverted: the 0.95 coefficient cannot tell a maximal 20 minutes from
+        // the steady middle of an easy ride, and there is nothing to beat.
+        //
+        // Decision (product, 2026-08-10): nominate, but only on corroborated
+        // effort — and on an axis other than heart rate, because corroborating
+        // an HR-derived threshold with HR is circular. Power or pace must show
+        // the same window was worked at threshold. If neither is available we do
+        // not nominate at all; a missing recommendation is invisible, a wrong one
+        // moves every training zone the athlete has. The result is a
+        // recommendation the athlete confirms, never a write to their profile.
+        let accepted: boolean
+
+        if (currentLthr) {
+          accepted = estimatedLthr > currentLthr && minMet
+        } else {
+          const evidence = corroborateThresholdEffortWithWorkRate({
+            times: workout.streams.time as number[],
+            watts: workout.streams.watts as number[] | null,
+            velocity: workout.streams.velocity as number[] | null,
+            startSec: peak20m.start_time,
+            endSec: peak20m.end_time,
+            ftp: currentFtp,
+            thresholdPaceSecPerKm: currentThresholdPace
+          })
+          accepted = minMet && evidence.corroborated
+
+          if (!accepted) {
+            logger.log('LTHR nomination rejected: no threshold-intensity evidence', {
+              workoutId: workout.id,
+              reason: evidence.reason,
+              axis: evidence.axis,
+              avgValue: evidence.avgValue,
+              floorValue: evidence.floorValue,
+              minMet,
+              estimatedLthr
+            })
+          }
+        }
+
+        if (accepted) {
+          results.lthr = { old: currentLthr || 0, new: estimatedLthr, detected: true }
 
           if (!dryRun) {
             await this.createThresholdRecommendation(
               workout.userId,
               workout.id,
               'LTHR',
-              currentLthr,
+              currentLthr || 0,
               estimatedLthr,
               peak20mHR,
               sportName,
@@ -269,16 +453,20 @@ export const thresholdDetectionService = {
                 title: sportName
                   ? `New Heart Rate Threshold Detected (${sportName})`
                   : 'New Heart Rate Threshold Detected',
-                message: sportName
-                  ? `Congratulations! Your ${sportName} profile threshold heart rate increased to ${estimatedLthr} bpm (previous: ${currentLthr} bpm) based on "${workout.title}".`
-                  : `Congratulations! Your threshold heart rate increased to ${estimatedLthr} bpm (previous: ${currentLthr} bpm) based on "${workout.title}".`,
+                message: hasPreviousValue(currentLthr)
+                  ? sportName
+                    ? `Congratulations! Your ${sportName} profile threshold heart rate increased to ${estimatedLthr} bpm (previous: ${currentLthr} bpm) based on "${workout.title}".`
+                    : `Congratulations! Your threshold heart rate increased to ${estimatedLthr} bpm (previous: ${currentLthr} bpm) based on "${workout.title}".`
+                  : sportName
+                    ? `We detected your ${sportName} profile threshold heart rate: ${estimatedLthr} bpm, based on "${workout.title}".`
+                    : `We detected your threshold heart rate: ${estimatedLthr} bpm, based on "${workout.title}".`,
                 icon: 'i-heroicons-bolt',
                 link: `/activities/${workout.id}`
               })
             }
           }
         } else {
-          results.lthr = { old: currentLthr, new: estimatedLthr, detected: false }
+          results.lthr = { old: currentLthr || 0, new: estimatedLthr, detected: false }
         }
       }
     }
@@ -295,20 +483,59 @@ export const thresholdDetectionService = {
         'power'
       )
 
-      const peak20mPower = powerPeaks.find((p) => p.duration === 1200)?.value
+      const peak20m = powerPeaks.find((p) => p.duration === 1200)
+      const peak20mPower = peak20m?.value
 
-      if (peak20mPower && currentFtp) {
+      if (peak20m && peak20mPower) {
         const estimatedFtp = Math.round(peak20mPower * 0.95)
 
-        if (estimatedFtp > currentFtp) {
-          results.ftp = { old: currentFtp, new: estimatedFtp, detected: true }
+        // Same two questions as the LTHR branch above, and the same decision
+        // (CW-420). The improvement path is untouched: beating a known FTP over
+        // 20 minutes is its own evidence.
+        //
+        // The first nomination has nothing to beat, so the 0.95 coefficient
+        // alone would happily mint an FTP off the strongest 20 minutes of an
+        // easy ride. FTP is the tractable half of this ticket: heart rate is an
+        // independent axis here, so the CW-413 corroboration applies directly —
+        // the same window must also sit in the athlete's Z4 heart rate band.
+        // `corroborateThresholdEffortWithHr` fails safe on every "we cannot
+        // tell" path (no strap, no HR reference, dropouts), so an athlete with
+        // no HR data gets no nomination rather than a guessed one.
+        let accepted: boolean
+
+        if (currentFtp) {
+          accepted = estimatedFtp > currentFtp
+        } else {
+          const evidence = corroborateThresholdEffortWithHr({
+            times: workout.streams.time as number[],
+            heartrate: workout.streams.heartrate as number[] | null,
+            startSec: peak20m.start_time,
+            endSec: peak20m.end_time,
+            lthr: currentLthr,
+            maxHr: currentMaxHr
+          })
+          accepted = evidence.corroborated
+
+          if (!accepted) {
+            logger.log('FTP nomination rejected: no threshold-intensity evidence', {
+              workoutId: workout.id,
+              reason: evidence.reason,
+              avgHr: evidence.avgHr,
+              floorHr: evidence.floorHr,
+              estimatedFtp
+            })
+          }
+        }
+
+        if (accepted) {
+          results.ftp = { old: currentFtp || 0, new: estimatedFtp, detected: true }
 
           if (!dryRun) {
             await this.createThresholdRecommendation(
               workout.userId,
               workout.id,
               'FTP',
-              currentFtp,
+              currentFtp || 0,
               estimatedFtp,
               peak20mPower,
               sportName,
@@ -320,16 +547,20 @@ export const thresholdDetectionService = {
             if (!noNotify) {
               await createUserNotification(workout.userId, {
                 title: sportName ? `New ${sportName} FTP Detected` : 'New FTP Detected',
-                message: sportName
-                  ? `Great job! Your ${sportName} profile FTP increased to ${estimatedFtp}W (previous: ${currentFtp}W) based on "${workout.title || 'your workout'}".`
-                  : `Great job! Your FTP increased to ${estimatedFtp}W (previous: ${currentFtp}W) based on "${workout.title || 'your workout'}".`,
+                message: hasPreviousValue(currentFtp)
+                  ? sportName
+                    ? `Great job! Your ${sportName} profile FTP increased to ${estimatedFtp}W (previous: ${currentFtp}W) based on "${workout.title || 'your workout'}".`
+                    : `Great job! Your FTP increased to ${estimatedFtp}W (previous: ${currentFtp}W) based on "${workout.title || 'your workout'}".`
+                  : sportName
+                    ? `We detected your ${sportName} profile FTP: ${estimatedFtp}W, based on "${workout.title || 'your workout'}".`
+                    : `We detected your FTP: ${estimatedFtp}W, based on "${workout.title || 'your workout'}".`,
                 icon: 'i-heroicons-fire',
                 link: `/activities/${workout.id}`
               })
             }
           }
         } else {
-          results.ftp = { old: currentFtp, new: estimatedFtp, detected: false }
+          results.ftp = { old: currentFtp || 0, new: estimatedFtp, detected: false }
         }
       }
 
@@ -495,15 +726,13 @@ export const thresholdDetectionService = {
     let description = ''
     const unit = metric === 'FTP' ? 'W' : metric === 'THRESHOLD_PACE' ? 's/km' : ' bpm'
 
-    // A first-ever detection arrives with no previous value (absent, 0, or
-    // non-finite). Framing that as an improvement — "increased from 0" — reads
-    // as a bug to the athlete, so the copy branches on whether there is a real
-    // previous value to compare against.
-    const hasPreviousValue = Number.isFinite(oldValue) && oldValue > 0
+    // See `hasPreviousValue`: the copy branches on whether there is a real
+    // previous value to compare against, never on the raw number.
+    const hasPrevious = hasPreviousValue(oldValue)
 
     if (metric === 'LTHR') {
       title = sportName ? `New ${sportName} LTHR Detected` : 'New LTHR Detected'
-      if (hasPreviousValue) {
+      if (hasPrevious) {
         description = sportName
           ? `Your ${sportName} LTHR has increased from ${oldValue} to ${newValue} bpm.`
           : `Your LTHR has increased from ${oldValue} to ${newValue} bpm.`
@@ -514,7 +743,7 @@ export const thresholdDetectionService = {
       }
     } else if (metric === 'FTP') {
       title = sportName ? `New ${sportName} FTP Detected` : 'New FTP Detected'
-      if (hasPreviousValue) {
+      if (hasPrevious) {
         description = sportName
           ? `Your ${sportName} FTP has increased from ${oldValue}W to ${newValue}W.`
           : `Your FTP has increased from ${oldValue}W to ${newValue}W.`
@@ -527,7 +756,7 @@ export const thresholdDetectionService = {
       title = sportName
         ? `New Max Heart Rate Detected (${sportName})`
         : 'New Max Heart Rate Detected'
-      description = hasPreviousValue
+      description = hasPrevious
         ? `We detected a new max heart rate of ${newValue} bpm (previous: ${oldValue} bpm).`
         : `We detected your max heart rate: ${newValue} bpm.`
     } else if (metric === 'THRESHOLD_PACE') {
@@ -535,7 +764,7 @@ export const thresholdDetectionService = {
         ? `New Threshold Pace Detected (${sportName})`
         : 'New Threshold Pace Detected'
       const formattedPace = formatPromptPace(newValue, distanceUnits)
-      if (hasPreviousValue) {
+      if (hasPrevious) {
         description = sportName
           ? `Your ${sportName} threshold pace has improved to ${formattedPace}.`
           : `Your threshold pace has improved to ${formattedPace}.`

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -10,6 +10,7 @@ import { createUserNotification } from '../../../../../server/utils/notification
 import { queueThresholdUpdateEmail } from '../../../../../server/utils/workout-insight-email'
 import {
   corroborateThresholdEffortWithHr,
+  corroborateThresholdEffortWithWorkRate,
   THRESHOLD_PACE_PEAK_DURATION_SEC,
   thresholdDetectionService
 } from '../../../../../server/utils/services/thresholdDetectionService'
@@ -95,6 +96,42 @@ function runWithSustained40mEffortAndHr(options: {
   const { time, velocity } = runWithSustained40mEffort(options.velocity)
   const heartrate = time.map((t) => (t <= 300 ? options.warmupHr : options.effortHr))
   return { time, velocity, heartrate }
+}
+
+/**
+ * A 1Hz session: 5 minutes easy, then exactly 20 minutes steady — so the real
+ * `findPeakEfforts` reads its 20 minute bucket off the effort, not the warmup.
+ * Only the channels whose values are supplied are attached, which is how the
+ * "no corroborating signal at all" cases are built.
+ */
+function sessionWith20mEffort(options: {
+  warmupHr?: number
+  effortHr?: number
+  warmupWatts?: number
+  effortWatts?: number
+  warmupVelocity?: number
+  effortVelocity?: number
+}) {
+  const WARMUP_SEC = 300
+  const EFFORT_SEC = 1200
+
+  const time: number[] = []
+  for (let t = 0; t <= WARMUP_SEC + EFFORT_SEC; t++) time.push(t)
+
+  const channel = (warmup?: number, effort?: number) =>
+    warmup === undefined || effort === undefined
+      ? undefined
+      : time.map((t) => (t <= WARMUP_SEC ? warmup : effort))
+
+  const streams: Record<string, number[]> = { time }
+  const heartrate = channel(options.warmupHr, options.effortHr)
+  if (heartrate) streams.heartrate = heartrate
+  const watts = channel(options.warmupWatts, options.effortWatts)
+  if (watts) streams.watts = watts
+  const velocity = channel(options.warmupVelocity, options.effortVelocity)
+  if (velocity) streams.velocity = velocity
+
+  return streams
 }
 
 describe('thresholdDetectionService', () => {
@@ -393,6 +430,454 @@ describe('thresholdDetectionService', () => {
       expect(prisma.recommendation.create).toHaveBeenCalledWith({
         data: expect.objectContaining({ metric: 'THRESHOLD_PACE' })
       })
+    })
+  })
+
+  // Before CW-420 both branches required the athlete's CURRENT value to be
+  // truthy, so an athlete who had never configured an FTP or an LTHR got no
+  // first detection, ever — silently. Enabling it naively would have been the
+  // CW-413 bug inverted: the 0.95 coefficient cannot tell a maximal 20 minutes
+  // from the strongest 20 minutes of an easy session, and a first nomination has
+  // nothing to beat. Each metric now needs corroboration on an axis it is not
+  // itself derived from.
+  describe('first FTP nomination (athlete has none)', () => {
+    it('nominates one from a 20 minute effort held in the threshold heart rate band', async () => {
+      const workoutDate = new Date('2025-04-01T06:00:00Z')
+
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        lthr: 170
+      } as any)
+
+      // 280W held for 20 minutes at 168 bpm — 99% of LTHR, well inside the Z4
+      // band (floor 159 bpm).
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-ftp-first',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'FTP Test',
+        durationSec: 3600,
+        date: workoutDate,
+        streams: sessionWith20mEffort({
+          warmupHr: 115,
+          effortHr: 168,
+          warmupWatts: 150,
+          effortWatts: 280
+        }),
+        user: {}
+      })
+
+      expect(results?.ftp).toMatchObject({ old: 0, new: 266, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'FTP',
+          description: 'We detected your Cycling FTP: 266W.'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          message: 'We detected your Cycling profile FTP: 266W, based on "FTP Test".'
+        })
+      )
+    })
+
+    it('does not nominate one from an easy 20 minute segment', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        lthr: 170
+      } as any)
+
+      // The same 280W block, but at 130 bpm — 76% of LTHR, an easy aerobic heart
+      // rate nowhere near the Z4 floor. Nothing about this was maximal.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-ftp-easy',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Endurance Ride',
+        durationSec: 3600,
+        date: new Date('2025-04-02T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 105,
+          effortHr: 130,
+          warmupWatts: 150,
+          effortWatts: 280
+        }),
+        user: {}
+      })
+
+      expect(results?.ftp).toMatchObject({ old: 0, new: 266, detected: false })
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when the ride carries no heart rate stream', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        lthr: 170
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-ftp-nostrap',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Unstrapped Ride',
+        durationSec: 3600,
+        date: new Date('2025-04-03T06:00:00Z'),
+        streams: sessionWith20mEffort({ warmupWatts: 150, effortWatts: 280 }),
+        user: {}
+      })
+
+      expect(results?.ftp?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when the athlete has no LTHR or max HR reference', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-ftp-noref',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Hard Ride, No Profile',
+        durationSec: 3600,
+        date: new Date('2025-04-04T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 115,
+          effortHr: 168,
+          warmupWatts: 150,
+          effortWatts: 280
+        }),
+        user: {}
+      })
+
+      expect(results?.ftp?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('leaves the improvement path ungated for an athlete who already has an FTP', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        ftp: 250,
+        lthr: 170
+      } as any)
+
+      // Easy heart rate, but 266W beats the stored 250W. Twenty minutes above a
+      // known FTP is its own evidence, so the HR gate deliberately does not apply.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-ftp-improve',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Steady Ride',
+        durationSec: 3600,
+        date: new Date('2025-04-05T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 105,
+          effortHr: 130,
+          warmupWatts: 150,
+          effortWatts: 280
+        }),
+        user: {}
+      })
+
+      expect(results?.ftp).toMatchObject({ old: 250, new: 266, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'FTP',
+          description: 'Your Cycling FTP has increased from 250W to 266W.'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          message: expect.stringContaining('Cycling profile FTP increased to 266W (previous: 250W)')
+        })
+      )
+    })
+  })
+
+  // LTHR cannot be corroborated by heart rate — the window would be both the
+  // claim and its own evidence — so it is corroborated on a work-rate axis
+  // instead: power against the stored FTP, or pace against the stored threshold
+  // pace. With neither, there is no nomination.
+  describe('first LTHR nomination (athlete has none)', () => {
+    it('nominates one when the 20 minute peak coincides with threshold power', async () => {
+      const workoutDate = new Date('2025-05-01T06:00:00Z')
+
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        ftp: 250
+      } as any)
+
+      // 260W over the same 20 minutes is above the Z4 power floor (226W), so the
+      // 180 bpm was earned. 260W is below the stored FTP, so this test isolates
+      // the LTHR branch.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-first',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Threshold Intervals',
+        durationSec: 3600,
+        date: workoutDate,
+        streams: sessionWith20mEffort({
+          warmupHr: 115,
+          effortHr: 180,
+          warmupWatts: 150,
+          effortWatts: 260
+        }),
+        user: {}
+      })
+
+      expect(results?.lthr).toMatchObject({ old: 0, new: 171, detected: true })
+      expect(results?.ftp?.detected).toBe(false)
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'LTHR',
+          description: 'We detected your Cycling LTHR: 171 bpm.'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          message:
+            'We detected your Cycling profile threshold heart rate: 171 bpm, based on "Threshold Intervals".'
+        })
+      )
+    })
+
+    it('nominates one when the 20 minute peak coincides with threshold pace', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Running',
+        thresholdPace: 300
+      } as any)
+
+      // 4 m/s clears the Z4 pace floor (0.95 x 3.33 m/s threshold speed). The
+      // effort is only 20 minutes, so no 40 minute pace bucket exists and the
+      // threshold-pace branch stays out of this.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-pace',
+        userId: 'user-1',
+        type: 'Run',
+        title: 'Tempo Run',
+        durationSec: 3000,
+        date: new Date('2025-05-02T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 115,
+          effortHr: 172,
+          warmupVelocity: 2.5,
+          effortVelocity: 4
+        }),
+        user: {}
+      })
+
+      expect(results?.lthr).toMatchObject({ old: 0, new: 163, detected: true })
+      expect(results?.thresholdPace).toBeNull()
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ metric: 'LTHR' })
+      })
+    })
+
+    it('does not nominate one from an easy 20 minute segment', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        ftp: 250
+      } as any)
+
+      // 150W is Z2 endurance for a 250W athlete — the highest 20 minutes of an
+      // easy ride, and nothing the 142 bpm can be read as a threshold from.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-easy',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Recovery Spin',
+        durationSec: 3600,
+        date: new Date('2025-05-03T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 105,
+          effortHr: 142,
+          warmupWatts: 120,
+          effortWatts: 150
+        }),
+        user: {}
+      })
+
+      expect(results?.lthr).toMatchObject({ old: 0, detected: false })
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when there is no power or pace axis to corroborate with', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // Heart rate only, and no stored FTP or threshold pace to measure any work
+      // rate against. Prefer no recommendation over a weak one.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-noaxis',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Strap Only',
+        durationSec: 3600,
+        date: new Date('2025-05-04T06:00:00Z'),
+        streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 180 }),
+        user: {}
+      })
+
+      expect(results?.lthr).toMatchObject({ old: 0, new: 171, detected: false })
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when the athlete has a stored FTP but the ride has no power', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        ftp: 250
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-nopower',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'No Power Meter',
+        durationSec: 3600,
+        date: new Date('2025-05-05T06:00:00Z'),
+        streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 180 }),
+        user: {}
+      })
+
+      expect(results?.lthr?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+
+    it('leaves the improvement path ungated for an athlete who already has an LTHR', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        lthr: 160
+      } as any)
+
+      // No power and no pace at all, so the work-rate gate could not pass if it
+      // applied. Beating a known LTHR over 20 minutes is its own evidence.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-improve',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Hard Group Ride',
+        durationSec: 3600,
+        date: new Date('2025-05-06T06:00:00Z'),
+        streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 180 }),
+        user: {}
+      })
+
+      expect(results?.lthr).toMatchObject({ old: 160, new: 171, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'LTHR',
+          description: 'Your Cycling LTHR has increased from 160 to 171 bpm.'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'threshold heart rate increased to 171 bpm (previous: 160 bpm)'
+          )
+        })
+      )
+    })
+
+    it('still respects the minimum workout duration on a first nomination', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        ftp: 250
+      } as any)
+
+      // Corroborated by power, but a 40 minute ride is under the 50 minute bar
+      // the LTHR branch has always applied.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-lthr-short',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Short Session',
+        durationSec: 2400,
+        date: new Date('2025-05-07T06:00:00Z'),
+        streams: sessionWith20mEffort({
+          warmupHr: 115,
+          effortHr: 180,
+          warmupWatts: 150,
+          effortWatts: 260
+        }),
+        user: {}
+      })
+
+      expect(results?.minDurationMet).toBe(false)
+      expect(results?.lthr?.detected).toBe(false)
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('corroborateThresholdEffortWithWorkRate', () => {
+    const times = Array.from({ length: 601 }, (_, i) => i)
+
+    it('accepts a window ridden above the Z4 power floor', () => {
+      expect(
+        corroborateThresholdEffortWithWorkRate({
+          times,
+          watts: times.map(() => 240),
+          startSec: 0,
+          endSec: 600,
+          ftp: 250
+        })
+      ).toMatchObject({ corroborated: true, reason: 'in_threshold_band', axis: 'power' })
+    })
+
+    it('rejects a window ridden below the Z4 power floor', () => {
+      expect(
+        corroborateThresholdEffortWithWorkRate({
+          times,
+          watts: times.map(() => 180),
+          startSec: 0,
+          endSec: 600,
+          ftp: 250
+        })
+      ).toMatchObject({ corroborated: false, reason: 'below_threshold_band', axis: 'power' })
+    })
+
+    it('falls back to the pace axis when there is no power to read', () => {
+      expect(
+        corroborateThresholdEffortWithWorkRate({
+          times,
+          velocity: times.map(() => 4),
+          startSec: 0,
+          endSec: 600,
+          thresholdPaceSecPerKm: 300
+        })
+      ).toMatchObject({ corroborated: true, reason: 'in_threshold_band', axis: 'pace' })
+    })
+
+    it('reports no axis when neither a stored FTP nor a stored threshold pace exists', () => {
+      expect(
+        corroborateThresholdEffortWithWorkRate({
+          times,
+          watts: times.map(() => 300),
+          velocity: times.map(() => 5),
+          startSec: 0,
+          endSec: 600
+        })
+      ).toMatchObject({ corroborated: false, reason: 'no_corroborating_axis' })
+    })
+
+    it('rejects a window whose power mostly dropped out', () => {
+      expect(
+        corroborateThresholdEffortWithWorkRate({
+          times,
+          watts: times.map((t) => (t > 480 ? 300 : Number.NaN)),
+          startSec: 0,
+          endSec: 600,
+          ftp: 250
+        })
+      ).toMatchObject({ corroborated: false, reason: 'insufficient_coverage', axis: 'power' })
     })
   })
 


### PR DESCRIPTION
Fixes CW-420

FTP and LTHR auto-detection guarded on the athlete's *current* value being truthy (`if (peak20mHR && currentLthr)`, `if (peak20mPower && currentFtp)`), so an athlete who had never configured one got no first detection, ever, and silently. Their power and HR zones stayed unset, degrading every zone-based analysis and — since CW-383/CW-384 — interval detection itself.

This is the inverse of the threshold-pace defect CW-413 fixed: pace nominated for anyone (too loose), FTP and LTHR never nominate at all (too tight).

## The rule

First-time nomination is enabled for both metrics, but gated on effort corroboration following CW-413's precedent rather than trusting the 0.95 coefficient alone — a 20-minute *maximal* effort approximates threshold, a 20-minute segment of an easy ride does not, and the coefficient cannot tell them apart.

**FTP** — reuses the existing `corroborateThresholdEffortWithHr` (CW-413) over the 20-minute peak *power* window. The same window's mean heart rate must reach the athlete's Z4 floor as `calculateHrZones` already defines it (0.93 x LTHR, or 0.8 x max HR). No new coefficient. Fails safe on every "we cannot tell" path: no HR stream, no LTHR/max-HR reference, or under 80% strap coverage all mean no nomination.

**LTHR** — corroborating a heart-rate-derived threshold *with heart rate* is circular: the same window would be both the claim and its own evidence. A new `corroborateThresholdEffortWithWorkRate` uses an independent axis instead. The 20-minute peak HR window must also clear a work-rate Z4 floor:

- **power**, against the athlete's stored FTP — `calculatePowerZones` Z4 floor (0.9 x FTP), or
- **pace**, against the athlete's stored threshold pace — `calculatePaceZones` Z4 floor (0.95 x threshold speed).

The axes are an OR; the first to clear its floor wins. **If neither is available** — no stored FTP and no stored threshold pace, or no matching stream — **there is no nomination.** Preferring no recommendation over a weak one is why CW-413 works, and a machine-generated LTHR moves every heart rate zone in the app. The existing minimum-workout-duration bar (50m ride / 40m run / 30m other) still applies to a first nomination.

Both references are the athlete's **stored** FTP and threshold pace, never a value detected in the same pass, so there is no cross-metric feedback loop.

Every detection stays **recommendation-to-confirm**: an ACTIVE `Recommendation` the athlete accepts. Nothing writes to the profile.

## Not weakened

The improvement paths are byte-identical in behaviour — `estimatedFtp > currentFtp` and `estimatedLthr > currentLthr && minMet`, with no corroboration applied. Beating a known threshold over 20 minutes is its own evidence. Two dedicated tests assert this by putting an athlete who already has a value through a session where the corroborating axis is absent or easy, and expecting detection anyway.

## Copy (carried over from CW-421)

CW-421 fixed `createThresholdRecommendation` but deliberately left the two `createUserNotification` bodies in these branches, because they sit exactly here. Now that first-time nomination fires they are reachable and would have read "increased to 265W (previous: 0W)". They now branch on the predicate CW-421 introduced, which has been lifted to a shared module-level `hasPreviousValue()` rather than copied a third time.

Exact strings, for review at a glance:

**FTP notification** — improvement (unchanged):
> `Great job! Your Cycling profile FTP increased to 266W (previous: 250W) based on "Steady Ride".`

**FTP notification** — first detection (new):
> `We detected your Cycling profile FTP: 266W, based on "FTP Test".`

**LTHR notification** — improvement (unchanged):
> `Congratulations! Your Cycling profile threshold heart rate increased to 171 bpm (previous: 160 bpm) based on "Hard Group Ride".`

**LTHR notification** — first detection (new):
> `We detected your Cycling profile threshold heart rate: 171 bpm, based on "Threshold Intervals".`

The `Recommendation` copy itself is CW-421's and unchanged: `We detected your Cycling FTP: 266W.` / `We detected your Cycling LTHR: 171 bpm.`

## Tests

17 new tests, covering for **each** of FTP and LTHR: a genuine corroborated maximal effort nominates; an easy 20-minute segment does not; no corroborating signal at all does not; and the existing improvement path is unchanged. Plus unit coverage of the new corroboration helper (power axis accept/reject, pace fallback, no-axis, dropout coverage).

`interval-detection` remains unmocked (CW-405) — every case drives real synthetic streams through the real `findPeakEfforts`.

## Verification

```
pnpm test:unit tests/unit/server/utils/services/thresholdDetectionService.test.ts
  Test Files  1 passed (1)
       Tests  43 passed (43)      # was 26

pnpm test:unit                    # full suite, post-rebase onto develop @ c2064d9d
  Test Files  374 passed (374)
       Tests  2330 passed (2330)

pnpm typecheck:server             # clean
eslint + prettier on both touched files   # clean
```

Files touched match Owned Paths exactly: `server/utils/services/thresholdDetectionService.ts`, `tests/unit/server/utils/services/thresholdDetectionService.test.ts`.
