### PR TITLE
fix(zones): align the migration tool with the canonical zone model (CW-431)

### DIFF
--- a/cli/db/migrate-zones.ts
+++ b/cli/db/migrate-zones.ts
@@ -1,65 +1,147 @@
 import { Command } from 'commander'
 import chalk from 'chalk'
 import { prisma } from '../../server/utils/db'
-import { sportSettingsRepository } from '../../server/utils/repositories/sportSettingsRepository'
+import { calculateHrZones, calculatePowerZones, type Zone } from '../../server/utils/zones'
 
 const migrateZonesCommand = new Command('migrate-zones')
 
-// Methodology Constants (matching Frontend)
-const POWER_PCT = [0.55, 0.75, 0.9, 1.05, 1.2, 1.5, 9.99]
-const POWER_NAMES = [
-  'Z1 Active Recovery',
-  'Z2 Endurance',
-  'Z3 Tempo',
-  'Z4 Threshold',
-  'Z5 VO2 Max',
-  'Z6 Anaerobic',
-  'Z7 Neuromuscular'
-]
+/**
+ * Zone maths lives in exactly one place: `server/utils/zones.ts` (CW-431).
+ *
+ * This file used to carry its own copy of the percentages and band names. It
+ * had drifted: HR bands were named `Z5 SuperThreshold` / `Z6 Aerobic Capacity`
+ * / `Z7 Anaerobic` against the canonical `Z5a` / `Z5b` / `Z5c`, Z1 topped out at
+ * 80% of LTHR instead of 81%, the sixth band at 105% instead of 106%, the top
+ * band at `threshold * 1.1` instead of max HR, and a missing LTHR was papered
+ * over with a `maxHr * 0.85` estimate so the tool always emitted seven Friel
+ * bands where the app emits the five-band max-HR model. Two athletes therefore
+ * saw different zone names for the same physiology depending on whether their
+ * profile was written by this migration or computed by the app.
+ *
+ * Import the canonical helpers; never re-derive bands here.
+ */
 
-const HR_PCT = [0.8, 0.89, 0.93, 0.99, 1.02, 1.05, 1.1]
-const HR_NAMES = [
-  'Z1 Recovery',
-  'Z2 Aerobic',
-  'Z3 Tempo',
-  'Z4 SubThreshold',
-  'Z5 SuperThreshold',
-  'Z6 Aerobic Capacity',
-  'Z7 Anaerobic'
-]
-
-function calculatePowerZones(ftp: number) {
-  return POWER_PCT.map((pct, i) => {
-    const prevPct = i === 0 ? 0 : (POWER_PCT[i - 1] ?? 0)
-    return {
-      name: POWER_NAMES[i],
-      min: Math.round(ftp * prevPct) + (i === 0 ? 0 : 1),
-      max: pct > 5 ? 2000 : Math.round(ftp * pct)
-    }
-  })
+/** The athlete references this migration derives zone definitions from. */
+export interface ZoneReferences {
+  ftp?: number | null
+  lthr?: number | null
+  maxHr?: number | null
 }
 
-function calculateHrZones(lthr: number | null, maxHr: number | null) {
-  const threshold = lthr || (maxHr ? Math.round(maxHr * 0.85) : 160)
-  const calcMaxHr = maxHr || Math.round(threshold * 1.1)
+export interface ResolvedZones {
+  hrZones: Zone[]
+  powerZones: Zone[]
+  /** True when the band definitions were derived rather than carried over. */
+  computedHrZones: boolean
+  computedPowerZones: boolean
+}
 
-  return HR_PCT.map((pct, i) => {
-    const prevPct = i === 0 ? 0 : (HR_PCT[i - 1] ?? 0)
-    return {
-      name: HR_NAMES[i],
-      min: Math.round(threshold * prevPct) + (i === 0 ? 0 : 1),
-      max: i === HR_PCT.length - 1 ? calcMaxHr : Math.round(threshold * pct)
-    }
+/**
+ * Decide which zone definitions to store for one athlete.
+ *
+ * Precedence is legacy-custom > calculated > empty: zones the athlete already
+ * has are carried over untouched, and only a missing set is derived - from the
+ * canonical model, so a migrated profile is indistinguishable from one the app
+ * computes for the same references.
+ */
+export function resolveZonesForMigration(
+  refs: ZoneReferences,
+  existingHrZones?: unknown,
+  existingPowerZones?: unknown
+): ResolvedZones {
+  const carriedHrZones = Array.isArray(existingHrZones) ? (existingHrZones as Zone[]) : []
+  const carriedPowerZones = Array.isArray(existingPowerZones) ? (existingPowerZones as Zone[]) : []
+
+  const computePower = carriedPowerZones.length === 0 && !!refs.ftp
+  const computeHr = carriedHrZones.length === 0 && !!(refs.lthr || refs.maxHr)
+
+  return {
+    powerZones: computePower ? calculatePowerZones(refs.ftp!) : carriedPowerZones,
+    hrZones: computeHr ? calculateHrZones(refs.lthr ?? null, refs.maxHr ?? null) : carriedHrZones,
+    computedPowerZones: computePower,
+    computedHrZones: computeHr
+  }
+}
+
+/** Compact one-line summary of a band set, for the recompute diff log. */
+function describeZones(zones: unknown): string {
+  if (!Array.isArray(zones) || zones.length === 0) return 'none'
+  return (zones as Zone[]).map((zone) => `${zone.name} ${zone.min}-${zone.max}`).join(', ')
+}
+
+/**
+ * Opt-in remediation for profiles this tool already wrote with the pre-CW-431
+ * band names and percentages.
+ *
+ * This is deliberately NOT part of a plain run. It rewrites athlete-visible
+ * zone definitions in place - band names change (`Z5 SuperThreshold` becomes
+ * `Z5a SuperThreshold`), boundaries shift by roughly a percent, and an athlete
+ * with a max HR but no LTHR drops from seven bands to the canonical five - and
+ * it cannot tell a stale migrated band set from one the athlete customised by
+ * hand, so it replaces both. Run `--dry-run` first and read the diff.
+ */
+async function recomputeExistingProfiles(dryRun: boolean) {
+  const profiles = await prisma.sportSettings.findMany({
+    select: { id: true, name: true, userId: true, ftp: true, lthr: true, maxHr: true }
   })
+
+  console.log(chalk.gray(`Found ${profiles.length} sport settings profiles to inspect.`))
+
+  let rewritten = 0
+  let skipped = 0
+
+  for (const profile of profiles) {
+    // Derive from the profile's own references, ignoring whatever is stored, so
+    // the result is exactly what the app would compute for this athlete.
+    const { hrZones, powerZones } = resolveZonesForMigration(profile)
+
+    if (hrZones.length === 0 && powerZones.length === 0) {
+      skipped++
+      continue
+    }
+
+    console.log(chalk.cyan(`Recomputing zones for profile ${profile.name} (${profile.id})`))
+    if (hrZones.length > 0) console.log(chalk.gray(`  HR    -> ${describeZones(hrZones)}`))
+    if (powerZones.length > 0) console.log(chalk.gray(`  Power -> ${describeZones(powerZones)}`))
+
+    if (!dryRun) {
+      await prisma.sportSettings.update({
+        where: { id: profile.id },
+        data: {
+          ...(hrZones.length > 0 ? { hrZones } : {}),
+          ...(powerZones.length > 0 ? { powerZones } : {})
+        }
+      })
+    }
+    rewritten++
+  }
+
+  console.log(chalk.bold('\nRecompute Results:'))
+  console.log(`Total Profiles: ${profiles.length}`)
+  console.log(`${dryRun ? 'Would rewrite' : 'Rewritten'}:  ${rewritten}`)
+  console.log(`Skipped (no references): ${skipped}`)
 }
 
 migrateZonesCommand
   .description('Migrate custom zones (HR/Power) from User model to SportSettings')
   .option('--force', 'Force re-creation of default profiles even if they exist')
+  .option(
+    '--recompute-zones',
+    'Rewrite the stored zone definitions of EXISTING default profiles onto the canonical model ' +
+      '(server/utils/zones.ts). Athlete-visible: it replaces band names and boundaries, including ' +
+      'any the athlete customised. Off by default - a plain run never touches an existing profile.'
+  )
+  .option('--dry-run', 'Report what would change without writing anything')
   .action(async (options) => {
     console.log(chalk.blue('🚀 Starting Custom Zones Migration...'))
+    if (options.dryRun) console.log(chalk.magenta('DRY RUN - no writes will be performed.'))
 
     try {
+      if (options.recomputeZones) {
+        await recomputeExistingProfiles(Boolean(options.dryRun))
+        return
+      }
+
       const users = await prisma.user.findMany({
         select: {
           id: true,
@@ -86,17 +168,16 @@ migrateZonesCommand
           })
 
           // Determine optimal zones (Legacy > Calculated > Empty)
-          let finalHrZones = (user.hrZones as any[]) || []
-          let finalPowerZones = (user.powerZones as any[]) || []
+          const resolved = resolveZonesForMigration(user, user.hrZones, user.powerZones)
+          const finalHrZones = resolved.hrZones
+          const finalPowerZones = resolved.powerZones
 
-          if (finalPowerZones.length === 0 && user.ftp) {
+          if (resolved.computedPowerZones) {
             console.log(chalk.gray(`  Calculated Power Zones for ${user.email} (FTP: ${user.ftp})`))
-            finalPowerZones = calculatePowerZones(user.ftp)
           }
 
-          if (finalHrZones.length === 0 && (user.lthr || user.maxHr)) {
+          if (resolved.computedHrZones) {
             console.log(chalk.gray(`  Calculated HR Zones for ${user.email}`))
-            finalHrZones = calculateHrZones(user.lthr, user.maxHr)
           }
 
           if (existingDefault && !options.force) {
@@ -111,6 +192,10 @@ migrateZonesCommand
 
           if (existingDefault && options.force) {
             console.log(chalk.cyan(`Updating existing default profile for ${user.email}...`))
+            if (options.dryRun) {
+              migrated++
+              continue
+            }
             await prisma.sportSettings.update({
               where: { id: existingDefault.id },
               data: {
@@ -124,6 +209,10 @@ migrateZonesCommand
             })
           } else {
             console.log(chalk.green(`Creating default profile for ${user.email}...`))
+            if (options.dryRun) {
+              migrated++
+              continue
+            }
 
             // We can't use sportSettingsRepository.createDefault because it doesn't take our calculated zones
             // So we create manually

--- a/tests/unit/server/utils/zones.test.ts
+++ b/tests/unit/server/utils/zones.test.ts
@@ -7,6 +7,7 @@ import {
   identifyZone,
   type Zone
 } from '../../../../server/utils/zones'
+import { resolveZonesForMigration } from '../../../../cli/db/migrate-zones'
 
 /** Bands that contain `value` by their own [min, max] definition. */
 function containingBands(value: number, zones: Zone[]): Zone[] {
@@ -298,6 +299,74 @@ describe('Zone Utils', () => {
   describe('formatZoneRange', () => {
     it('formats watts correctly', () => {
       expect(formatZoneRange({ name: 'Z1', min: 100, max: 200 }, 'W')).toBe('100-200W')
+    })
+  })
+
+  /**
+   * CW-431: `cli/db/migrate-zones.ts` used to carry its own copy of the zone
+   * maths, with different HR band names and three different percentages. It now
+   * imports the canonical helpers; these tests fail the moment anyone
+   * reintroduces a second implementation.
+   */
+  describe('migration tool parity (CW-431)', () => {
+    it('derives byte-identical zone definitions to server/utils/zones for any references', () => {
+      for (const ftp of [null, 150, 200, 233, 250, 317, 400]) {
+        for (const lthr of [null, 140, 150, 160, 170, 185]) {
+          for (const maxHr of [null, 175, 190, 195, 200, 220]) {
+            const label = `ftp ${ftp} / lthr ${lthr} / maxHr ${maxHr}`
+            const resolved = resolveZonesForMigration({ ftp, lthr, maxHr })
+
+            expect(resolved.powerZones, `${label}: power`).toEqual(
+              ftp ? calculatePowerZones(ftp) : []
+            )
+            expect(resolved.hrZones, `${label}: hr`).toEqual(
+              lthr || maxHr ? calculateHrZones(lthr, maxHr) : []
+            )
+          }
+        }
+      }
+    })
+
+    it('emits the canonical Friel band names, not the pre-CW-431 Z5/Z6/Z7 ones', () => {
+      const { hrZones } = resolveZonesForMigration({ lthr: 160, maxHr: 195 })
+      expect(hrZones.map((zone) => zone.name)).toEqual([
+        'Z1 Recovery',
+        'Z2 Aerobic',
+        'Z3 Tempo',
+        'Z4 SubThreshold',
+        'Z5a SuperThreshold',
+        'Z5b Aerobic Capacity',
+        'Z5c Anaerobic'
+      ])
+    })
+
+    it('uses the five-band max-HR model when LTHR is absent instead of estimating one', () => {
+      // The old copy derived `lthr = round(maxHr * 0.85)` and always emitted
+      // seven Friel bands, so a max-HR-only athlete saw a different model from
+      // the one the app computes for them.
+      const { hrZones } = resolveZonesForMigration({ lthr: null, maxHr: 195 })
+      expect(hrZones).toEqual(calculateHrZones(null, 195))
+      expect(hrZones).toHaveLength(5)
+    })
+
+    it('carries existing zones over untouched rather than recomputing them', () => {
+      const custom: Zone[] = [{ name: 'My Zone', min: 0, max: 999 }]
+      const resolved = resolveZonesForMigration({ ftp: 250, lthr: 160, maxHr: 195 }, custom, custom)
+
+      expect(resolved.hrZones).toBe(custom)
+      expect(resolved.powerZones).toBe(custom)
+      expect(resolved.computedHrZones).toBe(false)
+      expect(resolved.computedPowerZones).toBe(false)
+    })
+
+    it('reports nothing to store when the athlete has no references at all', () => {
+      const resolved = resolveZonesForMigration({ ftp: null, lthr: null, maxHr: null })
+      expect(resolved).toEqual({
+        hrZones: [],
+        powerZones: [],
+        computedHrZones: false,
+        computedPowerZones: false
+      })
     })
   })
 


### PR DESCRIPTION
Fixes CW-431

`cli/db/migrate-zones.ts` carried a second copy of the zone maths. It now imports `calculatePowerZones` / `calculateHrZones` from `server/utils/zones.ts` (the canonical model, rebuilt by CW-416 on the shared `buildZones()` helper) via a small exported `resolveZonesForMigration()` helper that keeps the original legacy-custom > calculated > empty precedence. The tool stays registered and runnable — this is an alignment, not a deletion.

## What was divergent

| | canonical `server/utils/zones.ts` | old `cli/db/migrate-zones.ts` |
| --- | --- | --- |
| HR band names | Z1..Z4, **Z5a / Z5b / Z5c** | Z1..Z4, **Z5 SuperThreshold / Z6 Aerobic Capacity / Z7 Anaerobic** |
| Z1 upper | `lthr * 0.81` | `lthr * 0.80` |
| 6th band upper | `lthr * 1.06` | `lthr * 1.05` |
| top band max | `maxHr \|\| 220` | `threshold * 1.1` |
| no LTHR, has max HR | 5-band max-HR model | estimated `lthr = round(maxHr * 0.85)`, 7 Friel bands |

The last row was not in the ticket but is the largest divergence: a max-HR-only athlete got a completely different zone *model* from the migration than the app computes for them.

Power bands were already identical in both names and percentages (`[0.55, 0.75, 0.9, 1.05, 1.2, 1.5]`, Z1..Z7) and are byte-for-byte unchanged.

Also removed an unused `sportSettingsRepository` import.

## Exactly what an athlete would see change

Only for zones this tool *derives*. Carried-over custom zones are untouched.

LTHR 160 / max HR 195:

```
OLD                              NEW
Z1 Recovery          0-128       Z1 Recovery           0-130
Z2 Aerobic         129-142       Z2 Aerobic          131-142
Z3 Tempo           143-149       Z3 Tempo            143-149
Z4 SubThreshold    150-158       Z4 SubThreshold     150-158
Z5 SuperThreshold  159-163       Z5a SuperThreshold  159-163
Z6 Aerobic Capacity 164-168      Z5b Aerobic Capacity 164-170
Z7 Anaerobic       169-195       Z5c Anaerobic       171-195
```

No LTHR, max HR 195 — seven bands become five, with different names throughout:

```
OLD                              NEW
Z1 Recovery          0-133       Z1 Recovery           0-117
Z2 Aerobic         134-148       Z2 Endurance        118-137
Z3 Tempo           149-154       Z3 Tempo            138-156
Z4 SubThreshold    155-164       Z4 Threshold        157-176
Z5 SuperThreshold  165-169       Z5 Anaerobic        177-195
Z6 Aerobic Capacity 170-174
Z7 Anaerobic       175-195
```

## Decision: what happens to already-migrated athletes

**A plain run does not touch them, and nothing changes silently.** Without a flag the tool still skips any user who already has a default `SportSettings` profile, exactly as before, so rows written with the old band names and percentages stay as they are.

Leaving them is acceptable because the divergence is cosmetic-plus-1%: `intensity_zone` never reads stored zones (`interval-detection.ts:1211-1221` recomputes from `server/utils/zones.ts` on every call), so no analysis output changes. What stored zones *do* feed is band edges in `computeZoneTimesFromSamples` and `getZoneBoundsFromRefs`, where the difference is one or two bpm at two boundaries. Rewriting an athlete's zone settings under them — including anyone who has since tuned those bands by hand — is a worse trade than a stale label.

**Remediation is opt-in.** A new `--recompute-zones` flag walks existing profiles and rewrites `hrZones` / `powerZones` from each profile's own `ftp` / `lthr` / `maxHr` onto the canonical model, printing every band set it writes. It cannot distinguish a stale migrated band set from an athlete-customised one, so it replaces both — the help text and the code comment say so. A new `--dry-run` prints the same diff without writing. Neither flag runs unless asked for.

## `intensity_zone` is unchanged

No file outside `cli/` and the test was touched. `server/utils/interval-detection.ts` still computes zones fresh per call and never reads stored zones; this PR does not introduce any new read of `SportSettings.hrZones` / `powerZones`.

## Verification

```
$ pnpm test:unit tests/unit/server/utils/zones.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ pnpm typecheck:server
(clean, no output)
```

The 20 pre-existing CW-416 tests pass with **no expectation changes**. The 5 new ones in `describe('migration tool parity (CW-431)')` sweep 7 FTP x 6 LTHR x 6 max-HR reference combinations and assert the migration's output `toEqual` the canonical helpers' output, so a future second implementation of the zone maths fails the suite rather than drifting quietly.

eslint and prettier are clean on the changed files.
