### PR TITLE
refactor: consolidate the m/s to km/h conversion (CW-406)

### DIFF
--- a/app/pages/analytics/workout-explorer.vue
+++ b/app/pages/analytics/workout-explorer.vue
@@ -9,6 +9,7 @@
   } from '~/utils/workout-explorer-presets'
   import { useAnalyticsBus } from '~/composables/useAnalyticsBus'
   import { formatElevation } from '~/utils/metrics'
+  import { workoutExplorerMetricUnits } from '#shared/workout-explorer-metrics'
 
   type ExplorerSummaryChartType = 'bar' | 'line' | 'combo' | 'radar' | 'scatter'
   type ExplorerStreamField =
@@ -125,32 +126,6 @@
       if (newMode !== oldMode) activeRange.value = null
     }
   )
-
-  const workoutMetricUnits: Record<string, string> = {
-    trainingLoad: 'load',
-    tss: 'tss',
-    durationSec: 'duration',
-    elapsedTimeSec: 'duration',
-    distanceMeters: 'm',
-    elevationGain: 'm',
-    averageWatts: 'W',
-    maxWatts: 'W',
-    normalizedPower: 'W',
-    averageHr: 'bpm',
-    maxHr: 'bpm',
-    averageCadence: 'rpm',
-    averageSpeed: 'km/h',
-    intensity: '',
-    calories: 'kcal',
-    efficiencyFactor: '',
-    decoupling: '%',
-    powerHrRatio: '',
-    kilojoules: 'kJ',
-    variabilityIndex: '',
-    trimp: 'load',
-    hrLoad: 'load',
-    workAboveFtp: 'kJ'
-  }
 
   const streamFieldUnits: Record<string, string> = {
     watts: 'W',
@@ -614,7 +589,7 @@
           datasets:
             options.preset.summary?.type === 'advanced'
               ? []
-              : metrics.map((metric) => workoutMetricUnits[metric.field] || '')
+              : metrics.map((metric) => workoutExplorerMetricUnits[metric.field] || '')
         },
         scales: isMmp ? { x: { type: 'logarithmic' as const } } : options.preset.scales,
         metrics,

--- a/app/utils/metrics.ts
+++ b/app/utils/metrics.ts
@@ -1,6 +1,7 @@
+import { MPS_TO_KPH } from '#shared/units'
+
 export const KG_TO_LBS = 2.20462262185
 export const LBS_TO_KG = 0.45359237
-const MPS_TO_KPH = 3.6
 const MPS_TO_MPH = 2.2369362921
 const KM_TO_MILE_PACE_FACTOR = 1.609344
 const METERS_TO_FEET = 3.28084

--- a/server/api/analytics/workout-explorer/streams.post.ts
+++ b/server/api/analytics/workout-explorer/streams.post.ts
@@ -5,6 +5,7 @@ import { lttb } from '../../../utils/analytics/lttb'
 import { calculateVirtualStream, type VirtualField } from '../../../utils/analytics/virtual-streams'
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
 import { formatAlignmentLabel } from '../../../utils/analytics/format-alignment-label'
+import { metresPerSecondToKmh } from '../../../../shared/units'
 
 const schema = z.object({
   analysis: z.object({
@@ -203,7 +204,8 @@ export default defineEventHandler(async (event) => {
     if (rawFields.includes(field)) {
       let values = rawStreams[field as keyof typeof rawStreams] || []
       if (field === 'velocity') {
-        values = values.map((v) => Number((v * 3.6).toFixed(1)))
+        // The velocity stream is persisted in m/s; the explorer charts km/h.
+        values = values.map((v) => Number(metresPerSecondToKmh(v).toFixed(1)))
       }
       return values
     }

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -15,6 +15,7 @@ import {
   normalizeStressScore
 } from './wellness'
 import { formatPromptDistance } from './ai-prompt-format'
+import { metresPerSecondToKmh } from '../../shared/units'
 
 import type { GeminiModel } from './ai-config'
 import { MODEL_NAMES, calculateLlmCost, resolveModelId } from './ai-config'
@@ -696,7 +697,8 @@ export function buildWorkoutSummary(
       if (w.distanceMeters)
         lines.push(`- **Distance**: ${formatPromptDistance(w.distanceMeters, distanceUnits)}`)
       if (w.elevationGain) lines.push(`- **Elevation**: ${w.elevationGain}m`)
-      if (w.averageSpeed) lines.push(`- **Avg Speed**: ${(w.averageSpeed * 3.6).toFixed(1)} km/h`)
+      if (w.averageSpeed)
+        lines.push(`- **Avg Speed**: ${metresPerSecondToKmh(w.averageSpeed).toFixed(1)} km/h`)
 
       // Performance metrics
       if (w.variabilityIndex)

--- a/server/utils/workoutExplorer.ts
+++ b/server/utils/workoutExplorer.ts
@@ -1,57 +1,12 @@
-export const workoutExplorerMetricLabels: Record<string, string> = {
-  durationSec: 'Duration',
-  elapsedTimeSec: 'Elapsed Time',
-  distanceMeters: 'Distance',
-  elevationGain: 'Elevation Gain',
-  trainingLoad: 'Training Load',
-  tss: 'TSS',
-  kilojoules: 'Kilojoules',
-  calories: 'Calories',
-  averageWatts: 'Average Power',
-  maxWatts: 'Max Power',
-  normalizedPower: 'Normalized Power',
-  averageHr: 'Average HR',
-  maxHr: 'Max HR',
-  averageCadence: 'Average Cadence',
-  averageSpeed: 'Average Speed',
-  intensity: 'Intensity',
-  efficiencyFactor: 'Efficiency Factor',
-  decoupling: 'Decoupling',
-  powerHrRatio: 'Power / HR Ratio',
-  variabilityIndex: 'Variability Index',
-  trimp: 'TRIMP',
-  hrLoad: 'HR Load',
-  workAboveFtp: 'Work Above FTP'
-}
+import { metresPerSecondToKmh } from '../../shared/units'
+import {
+  workoutExplorerMetricLabels,
+  workoutExplorerMetricUnits
+} from '../../shared/workout-explorer-metrics'
 
-export const workoutExplorerMetricUnits: Record<string, string> = {
-  durationSec: 'duration',
-  elapsedTimeSec: 'duration',
-  distanceMeters: 'm',
-  elevationGain: 'm',
-  trainingLoad: 'load',
-  tss: 'tss',
-  kilojoules: 'kJ',
-  calories: 'kcal',
-  averageWatts: 'W',
-  maxWatts: 'W',
-  normalizedPower: 'W',
-  averageHr: 'bpm',
-  maxHr: 'bpm',
-  averageCadence: 'rpm',
-  // Correct as-is: `Workout.averageSpeed` is stored in m/s, but
-  // `normalizeWorkoutMetricValue` converts it to km/h before it ever reaches a consumer,
-  // so the unit that goes with the emitted value really is km/h (CW-382).
-  averageSpeed: 'km/h',
-  intensity: '',
-  efficiencyFactor: '',
-  decoupling: '%',
-  powerHrRatio: '',
-  variabilityIndex: '',
-  trimp: 'load',
-  hrLoad: 'load',
-  workAboveFtp: 'kJ'
-}
+// The label/unit maps live in `shared/` so the explorer page can consume the
+// same source (`#shared/workout-explorer-metrics`) instead of keeping a copy.
+export { workoutExplorerMetricLabels, workoutExplorerMetricUnits }
 
 export const allowedWorkoutExplorerSummaryMetrics = new Set(
   Object.keys(workoutExplorerMetricLabels)
@@ -62,6 +17,6 @@ export function normalizeWorkoutMetricValue(field: string, value: unknown) {
   const numeric = Number(value)
   if (Number.isNaN(numeric)) return null
   // averageSpeed is persisted in m/s; the explorer charts it in km/h.
-  if (field === 'averageSpeed') return Number((numeric * 3.6).toFixed(1))
+  if (field === 'averageSpeed') return Number(metresPerSecondToKmh(numeric).toFixed(1))
   return numeric
 }

--- a/shared/units.ts
+++ b/shared/units.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared unit conversions.
+ *
+ * Single home for conversion factors that both the Nuxt app and the Nitro
+ * server need, so the convention is stated once instead of being re-derived at
+ * every call site.
+ */
+
+/**
+ * Metres per second -> kilometres per hour.
+ *
+ * Storage convention: `Workout.averageSpeed` and the `velocity` stream are
+ * persisted in **metres per second**. Every user-facing surface (explorer
+ * charts, AI prompts, workout summaries) displays km/h, so the stored value
+ * must be multiplied by this factor on the way out — and divided by it on the
+ * way in.
+ */
+export const MPS_TO_KPH = 3.6
+
+/**
+ * Convert a persisted speed/velocity from m/s to km/h.
+ *
+ * `Workout.averageSpeed` and the `velocity` stream are stored in m/s; this is
+ * the only correct direction for display. CW-382 is why this lives in one
+ * place: the AI payload builder divided instead of multiplying for years,
+ * telling the model every athlete moved 3.6x slower than they did, because the
+ * convention only existed in scattered comments next to bare `* 3.6` literals.
+ *
+ * Pure multiplication — no rounding and no guarding. Non-finite input
+ * propagates (`NaN` -> `NaN`, `Infinity` -> `Infinity`) rather than being
+ * coerced, because callers differ in how they format and validate: the
+ * explorer rejects `NaN` before converting and rounds to one decimal, while
+ * `convertVelocity` returns the raw product and lets the formatter decide.
+ * Callers convert; callers format.
+ */
+export function metresPerSecondToKmh(metresPerSecond: number): number {
+  return metresPerSecond * MPS_TO_KPH
+}

--- a/shared/workout-explorer-metrics.ts
+++ b/shared/workout-explorer-metrics.ts
@@ -1,0 +1,65 @@
+/**
+ * Display metadata for the workout explorer's summary metrics.
+ *
+ * Lives in `shared/` because both sides need it: the Nitro API labels the
+ * series it emits, and `app/pages/analytics/workout-explorer.vue` labels the
+ * chart axes. It used to be declared twice — once here (server) and once as a
+ * hand-maintained copy in the page — which is exactly how the two drift.
+ */
+
+export const workoutExplorerMetricLabels: Record<string, string> = {
+  durationSec: 'Duration',
+  elapsedTimeSec: 'Elapsed Time',
+  distanceMeters: 'Distance',
+  elevationGain: 'Elevation Gain',
+  trainingLoad: 'Training Load',
+  tss: 'TSS',
+  kilojoules: 'Kilojoules',
+  calories: 'Calories',
+  averageWatts: 'Average Power',
+  maxWatts: 'Max Power',
+  normalizedPower: 'Normalized Power',
+  averageHr: 'Average HR',
+  maxHr: 'Max HR',
+  averageCadence: 'Average Cadence',
+  averageSpeed: 'Average Speed',
+  intensity: 'Intensity',
+  efficiencyFactor: 'Efficiency Factor',
+  decoupling: 'Decoupling',
+  powerHrRatio: 'Power / HR Ratio',
+  variabilityIndex: 'Variability Index',
+  trimp: 'TRIMP',
+  hrLoad: 'HR Load',
+  workAboveFtp: 'Work Above FTP'
+}
+
+export const workoutExplorerMetricUnits: Record<string, string> = {
+  durationSec: 'duration',
+  elapsedTimeSec: 'duration',
+  distanceMeters: 'm',
+  elevationGain: 'm',
+  trainingLoad: 'load',
+  tss: 'tss',
+  kilojoules: 'kJ',
+  calories: 'kcal',
+  averageWatts: 'W',
+  maxWatts: 'W',
+  normalizedPower: 'W',
+  averageHr: 'bpm',
+  maxHr: 'bpm',
+  averageCadence: 'rpm',
+  // Correct as-is: `Workout.averageSpeed` is stored in m/s (see
+  // `metresPerSecondToKmh` in `shared/units.ts`), but
+  // `normalizeWorkoutMetricValue` converts it to km/h before it ever reaches a
+  // consumer, so the unit that goes with the emitted value really is km/h
+  // (CW-382).
+  averageSpeed: 'km/h',
+  intensity: '',
+  efficiencyFactor: '',
+  decoupling: '%',
+  powerHrRatio: '',
+  variabilityIndex: '',
+  trimp: 'load',
+  hrLoad: 'load',
+  workAboveFtp: 'kJ'
+}

--- a/tests/unit/shared/units.test.ts
+++ b/tests/unit/shared/units.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { MPS_TO_KPH, metresPerSecondToKmh } from '../../../shared/units'
+
+describe('MPS_TO_KPH', () => {
+  it('is the m/s -> km/h factor, not its reciprocal', () => {
+    expect(MPS_TO_KPH).toBe(3.6)
+  })
+})
+
+describe('metresPerSecondToKmh', () => {
+  it('converts in the display direction (CW-382 regression)', () => {
+    // 3 m/s is a jog, 10.8 km/h. Dividing instead of multiplying would yield
+    // 0.83, which is what the AI payload builder reported for years.
+    expect(metresPerSecondToKmh(3)).toBeCloseTo(10.8, 10)
+    expect(metresPerSecondToKmh(10)).toBeCloseTo(36, 10)
+    expect(metresPerSecondToKmh(1)).toBeCloseTo(3.6, 10)
+  })
+
+  it('maps zero to zero', () => {
+    expect(metresPerSecondToKmh(0)).toBe(0)
+  })
+
+  it('is monotonic and sign-preserving', () => {
+    expect(metresPerSecondToKmh(5)).toBeGreaterThan(metresPerSecondToKmh(4))
+    expect(metresPerSecondToKmh(-2)).toBeLessThan(0)
+  })
+
+  it('propagates non-finite input instead of coercing it', () => {
+    // Callers guard: normalizeWorkoutMetricValue rejects NaN before converting,
+    // and gemini.ts only converts a truthy averageSpeed.
+    expect(Number.isNaN(metresPerSecondToKmh(Number.NaN))).toBe(true)
+    expect(metresPerSecondToKmh(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY)
+    expect(metresPerSecondToKmh(Number.NEGATIVE_INFINITY)).toBe(Number.NEGATIVE_INFINITY)
+  })
+
+  it('is bit-identical to the inline `* 3.6` the call sites used to do', () => {
+    // Guards the refactor itself: any displayed number must be unchanged,
+    // including after each call site's own .toFixed(1) formatting.
+    const samples = [
+      0,
+      1,
+      2.5,
+      3,
+      4.16667,
+      5,
+      8.333333333333334,
+      9.7,
+      11.11111,
+      0.05,
+      0.001,
+      1e-8,
+      1e8,
+      12.3456789,
+      7.777777777777777,
+      -3.5,
+      Number.EPSILON,
+      Number.MAX_SAFE_INTEGER
+    ]
+    for (const v of samples) {
+      expect(Object.is(metresPerSecondToKmh(v), v * 3.6)).toBe(true)
+      expect(metresPerSecondToKmh(v).toFixed(1)).toBe((v * 3.6).toFixed(1))
+    }
+    // Wider randomised sweep over the plausible speed range.
+    for (let i = 0; i < 20000; i++) {
+      const v = Math.random() * 40
+      expect(Object.is(metresPerSecondToKmh(v), v * 3.6)).toBe(true)
+      expect(metresPerSecondToKmh(v).toFixed(1)).toBe((v * 3.6).toFixed(1))
+    }
+  })
+})


### PR DESCRIPTION
Fixes CW-406

The knowledge that `Workout.averageSpeed` and the `velocity` stream are persisted in m/s and must be multiplied by 3.6 for display was re-derived independently at four call sites plus a private constant in a fifth file. CW-382 was this defect class: a sixth site applied the conversion in the wrong direction for years because the convention lived only in scattered comments next to bare `* 3.6` literals. This consolidates it into one documented helper.

## What changed

New `shared/units.ts` exports `MPS_TO_KPH` and `metresPerSecondToKmh(value)`. The storage convention is documented once, on the helper, with CW-382 named as the reason. The helper is a pure multiplication: it converts, callers format.

All four display sites now call it:

- `server/utils/workoutExplorer.ts` — `normalizeWorkoutMetricValue`
- `server/utils/gemini.ts` — the `Avg Speed` prompt line (mechanical one-line change plus one import)
- `server/api/analytics/workout-explorer/streams.post.ts` — the `velocity` stream mapping
- `app/utils/metrics.ts` — the private `MPS_TO_KPH` is replaced by the shared constant; `convertVelocity` keeps its imperial ternary

Rounding is untouched per call site: the three sites that did `.toFixed(1)` still do, and `convertVelocity` still returns the raw product.

## The unwired units map

`workoutExplorerMetricUnits` was exported with zero importers, while `app/pages/analytics/workout-explorer.vue` hand-maintained a near-verbatim copy — an unwired consumer, not dead code. Both it and `workoutExplorerMetricLabels` move to `shared/workout-explorer-metrics.ts`. `server/utils/workoutExplorer.ts` re-exports them so `summary.post.ts` is unchanged, and the page now imports the units map via `#shared/…` with its local 23-key literal deleted. The comment explaining why the unit is km/h despite m/s storage travels with the map.

## Proof that display output is unchanged

This is a refactor, so identical output was verified rather than assumed. A script captured a JSON baseline before any edit — `normalizeWorkoutMetricValue` over 25 numeric samples (including 0, negatives, `NaN`, both infinities, `MIN_VALUE`, `MAX_SAFE_INTEGER`, `EPSILON`) plus 6 non-numeric ones, the rendered `- **Avg Speed**: … km/h` line, the velocity stream mapping, and both maps — then the same script was re-run against the refactored code. **The diff is empty.**

Separately, the original page literal was extracted from `git show HEAD` and compared key-by-key against the new shared map: 23 keys each, no missing keys, no added keys, no value differences.

`tests/unit/shared/units.test.ts` covers the helper (3 m/s to 10.8 km/h, zero, monotonicity, non-finite propagation) and includes a differential test asserting `Object.is(metresPerSecondToKmh(v), v * 3.6)` and equal `.toFixed(1)` output across fixed samples plus a 20,000-value randomised sweep — so the substitution is proven bit-identical, not just close.

## Verification

```
pnpm test:unit tests/unit/shared/units.test.ts server/utils/services/workout-analysis-prompt.test.ts
  Test Files  2 passed (2)
       Tests  45 passed (45)

pnpm typecheck
  exit 0, no errors

pnpm test:unit tests/unit/shared server/utils   (wider regression sweep)
  Test Files  225 passed (225)
       Tests  1722 passed (1722)
```

`nuxt prepare` emits no new "Duplicated imports" warning from the `server/utils` re-export. No UX critique round: no visual change is intended, and the differential above is the evidence there isn't one.