### PR TITLE
fix(workouts): stop free-text step names overriding structured planned types (CW-414)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -565,20 +565,87 @@ type NormalizedPlannedDetectionStep = {
   ramp: boolean
 }
 
-function normalizePlannedStepType(type: unknown, name?: string): Interval['type'] {
-  const normalized = String(type || '').toLowerCase()
-  const normalizedName = String(name || '').toLowerCase()
-  const recoveryTokens = ['rest', 'recovery', 'cooldown', 'warmup', 'recuperación', 'enfriamiento']
+/**
+ * A planned step whose target sits at or above this fraction of threshold is
+ * working, whatever its label says. Shared by every planned-step classifier so
+ * the promotion and the demotion below use one number (CW-402, CW-414).
+ */
+export const PLANNED_WORK_INTENSITY_FACTOR = 0.8
 
-  if (normalized.includes('warm') || normalizedName.includes('calentamiento')) return 'WARMUP'
-  if (normalized.includes('cool') || normalizedName.includes('enfriamiento')) return 'COOLDOWN'
-  if (
-    recoveryTokens.some((t) => normalized.includes(t) || normalizedName.includes(t)) ||
-    normalizedName.includes('descanso')
-  ) {
-    return 'RECOVERY'
-  }
-  return 'WORK'
+const PLANNED_RECOVERY_TOKENS = [
+  'rest',
+  // 'recover' rather than 'recovery' so 'Recover', 'Recovery' and 'Recovering'
+  // all match — the type-side rule this replaced already used the short form.
+  'recover',
+  'cooldown',
+  'warmup',
+  'recuperación',
+  'recuperacion',
+  'enfriamiento',
+  'descanso'
+]
+
+export type PlannedStepTypeEvidence = {
+  /** The structured step type, e.g. 'Warmup' | 'Active' | 'Rest' | 'Cooldown'. */
+  type?: unknown
+  /**
+   * The step's free-text, user-authored name. Evidence, never an override: see
+   * the intensity veto below and the note on `flattenPlannedStepsForDetection`.
+   */
+  name?: unknown
+  /**
+   * This step's target expressed as a fraction of threshold
+   * (`toIntensityFactorFromTarget`). Pass it whenever the athlete's references
+   * are resolvable; leave it out when they are not — it only ever *vetoes* a
+   * recovery label, so its absence reproduces the label-only classification.
+   */
+  intensityFactor?: number | null
+}
+
+/**
+ * THE planned-step type normaliser. One rule, used by every path that has to
+ * decide whether a planned step is work.
+ *
+ * The rule (lifted from `flattenPlannedSteps` in `workout-analysis-facts.ts`,
+ * which has always had it right):
+ *
+ * 1. Warmup and cooldown are STRUCTURAL, not intensity-based — a warmup ramp
+ *    can pass through work intensity and is still a warmup — so a `warm`/`cool`
+ *    type wins outright.
+ * 2. A recovery token in the type OR in the name marks the step recovery...
+ * 3. ...unless the step's own numeric target contradicts it. A step prescribed
+ *    at >= 80% of threshold is work no matter what it is called.
+ *
+ * Rule 3 is the point. A step name is user-authored free text — the analysis
+ * prompt itself tells the model that step names carry stale labels and must
+ * never override the structured values — and this used to be the one place that
+ * let free text beat a structured numeric target. Two normalisers disagreed:
+ * the facts layer promoted a work-intensity `Recovery` step to WORK on its
+ * intensity factor (CW-402), and then detection re-derived the type from the
+ * name and demoted it straight back, which is most recovery-labelled steps
+ * ("Recovery", "Recovery Jog", "Rest"). CW-414 folded both into this function.
+ *
+ * Returns `undefined` only when there is no evidence at all (no type, no name).
+ */
+export function normalizePlannedStepType(
+  step: PlannedStepTypeEvidence
+): Interval['type'] | undefined {
+  const type = String(step.type ?? '').toLowerCase()
+  const name = String(step.name ?? '').toLowerCase()
+  if (!type && !name) return undefined
+
+  if (type.includes('warm') || name.includes('calentamiento')) return 'WARMUP'
+  if (type.includes('cool') || name.includes('enfriamiento')) return 'COOLDOWN'
+
+  const hasRecoveryLabel = PLANNED_RECOVERY_TOKENS.some(
+    (token) => type.includes(token) || name.includes(token)
+  )
+  if (!hasRecoveryLabel) return 'WORK'
+
+  const intensityFactor = Number(step.intensityFactor)
+  const targetSaysWork =
+    Number.isFinite(intensityFactor) && intensityFactor >= PLANNED_WORK_INTENSITY_FACTOR
+  return targetSaysWork ? 'WORK' : 'RECOVERY'
 }
 
 function getTargetMidpoint(
@@ -632,15 +699,32 @@ function flattenPlannedStepsForDetection(
       continue
     }
     if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) continue
+    // The free-text name is offered ONLY when the step carries no type at all.
+    //
+    // This layer cannot resolve an intensity factor — it never sees the
+    // athlete's references — so it has no way to check a name against the
+    // step's structured target, and `normalizePlannedStepType`'s intensity veto
+    // cannot fire here. A plan that reached detection through the facts layer
+    // has already been classified once by that same function WITH the intensity
+    // factor (`toDetectionPlannedSteps`), so its type is a resolved answer, not
+    // a raw label. Re-reading the name over it is exactly the bug: it demoted
+    // every step the CW-402 promotion had just moved to WORK, because those
+    // steps are named "Recovery" (CW-414). With no type, the name is the only
+    // evidence there is, and it is used as before.
+    const resolvedType =
+      normalizePlannedStepType({
+        type: step.type,
+        name: step.type ? undefined : step.name
+      }) ?? 'WORK'
     flattened.push({
       id: `${path}-${index}`,
       name: step.name,
       durationSeconds,
-      type: normalizePlannedStepType(step.type, step.name),
+      type: resolvedType,
       metricTarget: getPlannedTargetForMetric(step, metricType),
       cadence:
         typeof step.cadence === 'number' && Number.isFinite(step.cadence) ? step.cadence : null,
-      ramp: Boolean((step as any).ramp || normalizePlannedStepType(step.type) === 'COOLDOWN')
+      ramp: Boolean((step as any).ramp || resolvedType === 'COOLDOWN')
     })
   }
   return flattened

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -3,8 +3,10 @@ import { calculateRollingNormalizedPower } from './power-metrics'
 import { toIntensityFactorFromTarget } from './structured-workout-persistence'
 import {
   detectIntervals,
+  normalizePlannedStepType,
   resolveHrWorkThreshold,
   resolveProviderIntervalTypes,
+  PLANNED_WORK_INTENSITY_FACTOR,
   type Interval
 } from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
@@ -1540,6 +1542,11 @@ function flattenPlannedSteps(
       else if (metric === 'rpe' && typeof step.rpe === 'number')
         intensityFactor = clamp(step.rpe / 10, 0.3, 1.5)
 
+      // Same rule as the shared `normalizePlannedStepType` (which was lifted
+      // from here): a recovery label only sticks when the step's own numeric
+      // target does not contradict it. Kept inline because this path needs the
+      // work/recovery split rather than the four detection types, but the
+      // threshold is the shared constant so the two cannot drift apart.
       const hasRecoveryLabel = recoveryTokens.some(
         (token) => normalizedType.includes(token) || stepName.includes(token)
       )
@@ -1547,7 +1554,9 @@ function flattenPlannedSteps(
       const isRecovery =
         isWarmOrCool ||
         (hasRecoveryLabel &&
-          (intensityFactor === null || !Number.isFinite(intensityFactor) || intensityFactor < 0.8))
+          (intensityFactor === null ||
+            !Number.isFinite(intensityFactor) ||
+            intensityFactor < PLANNED_WORK_INTENSITY_FACTOR))
 
       flattened.push({
         type: stepType,
@@ -1696,17 +1705,6 @@ function mapIntervalsToActual(intervals: any[]): ActualInterval[] {
     .filter((interval) => interval.durationSeconds > 0)
 }
 
-function normalizePlannedStepType(
-  type: unknown
-): 'WORK' | 'RECOVERY' | 'WARMUP' | 'COOLDOWN' | undefined {
-  const normalized = String(type || '').toLowerCase()
-  if (!normalized) return undefined
-  if (normalized.includes('warm')) return 'WARMUP'
-  if (normalized.includes('cool')) return 'COOLDOWN'
-  if (normalized.includes('rest') || normalized.includes('recover')) return 'RECOVERY'
-  return 'WORK'
-}
-
 /**
  * Flatten a structured workout into the shape `detectIntervals` consumes.
  *
@@ -1719,6 +1717,13 @@ function normalizePlannedStepType(
  * wrong session shape (CW-402). Callers without references may still pass a
  * zeroed refs object: the promotion then simply cannot fire, which is the
  * pre-fix behaviour.
+ *
+ * This is also the ONLY place in the detection pipeline that classifies a step:
+ * it is the last layer that can resolve an intensity factor, so it runs the
+ * shared `normalizePlannedStepType` with the name AND that intensity factor and
+ * emits a resolved type. `flattenPlannedStepsForDetection` downstream then
+ * takes that type as the answer instead of re-deriving it from the free-text
+ * name, which is what used to undo the promotion (CW-414).
  */
 function toDetectionPlannedSteps(
   steps: any[],
@@ -1766,14 +1771,17 @@ function toDetectionPlannedSteps(
               : metric === 'rpe' && typeof step.rpe === 'number'
                 ? clamp(step.rpe / 10, 0.3, 1.5)
                 : null
-      const normalizedType = normalizePlannedStepType(step.type)
-      const type =
-        normalizedType === 'RECOVERY' &&
-        intensity !== null &&
-        Number.isFinite(intensity) &&
-        intensity >= 0.8
-          ? 'WORK'
-          : normalizedType
+      // One call, one rule: the recovery label (from the type or the name) is
+      // honoured unless this step's own numeric target says otherwise. The
+      // RECOVERY -> WORK promotion of CW-402 is the intensity veto inside
+      // `normalizePlannedStepType`; the name demotion the adherence path has
+      // always applied now happens here too, gated by the same intensity, so
+      // both sides of the analysis classify a step identically (CW-414).
+      const type = normalizePlannedStepType({
+        type: step.type,
+        name: step.name,
+        intensityFactor: intensity
+      })
 
       planned.push({
         name: step.name,

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -3,10 +3,12 @@ import {
   DEFAULT_PEAK_DURATIONS,
   detectIntervals,
   findPeakEfforts,
+  normalizePlannedStepType,
   resolveHrWorkThreshold,
   resolveProviderIntervalTypes,
   timeWeightedMean
 } from '../../../../server/utils/interval-detection'
+import { getActualIntervalsForAnalysis } from '../../../../server/utils/workout-analysis-facts'
 
 describe('detectIntervals', () => {
   it('preserves the final recovery block before cooldown for plan-guided detection', () => {
@@ -819,5 +821,303 @@ describe('findPeakEfforts', () => {
     }
 
     expect(findPeakEfforts(times, velocity, 'pace', [{ sec: 2400, label: '40m' }])).toEqual([])
+  })
+})
+
+/**
+ * CW-414: one normaliser, one rule set.
+ *
+ * Detection used to classify a planned step twice with two different rules. The
+ * facts layer promoted a RECOVERY-labelled step to WORK when its target was at
+ * work intensity (CW-402), and then `flattenPlannedStepsForDetection` re-derived
+ * the type from `type` AND the free-text `name` and demoted it straight back —
+ * which hit essentially every promoted step, because they are named "Recovery",
+ * "Recovery Jog" or "Rest". A step name is user-authored free text and must
+ * never override a structured numeric target.
+ */
+describe('normalizePlannedStepType (CW-414)', () => {
+  it('lets a structured numeric target stand against a contradicting free-text name', () => {
+    // The step the CW-402 promotion is about: labelled recovery in both the
+    // type and the name, but prescribed at 85% of threshold.
+    expect(
+      normalizePlannedStepType({ type: 'Recovery', name: 'Recovery', intensityFactor: 0.85 })
+    ).toBe('WORK')
+    expect(
+      normalizePlannedStepType({ type: 'Active', name: 'Recovery Jog', intensityFactor: 0.9 })
+    ).toBe('WORK')
+    // The name is evidence, not an override, and with no target to check it
+    // against it is the only evidence there is — so it is still honoured here.
+    // What the detection layer must not do is consult it over a type that was
+    // already resolved with an intensity factor; that is a call-site decision
+    // (`flattenPlannedStepsForDetection`), covered by the next describe block.
+    expect(normalizePlannedStepType({ type: 'Active', name: 'Recovery' })).toBe('RECOVERY')
+  })
+
+  it('demotes on a name only when the numeric target does not contradict it', () => {
+    // No intensity factor to check against: the label is all the evidence there
+    // is, so it is honoured (this is the adherence path's long-standing rule).
+    expect(normalizePlannedStepType({ type: 'Active', name: 'Recovery' })).toBe('RECOVERY')
+    expect(
+      normalizePlannedStepType({ type: 'Active', name: 'Recovery', intensityFactor: 0.5 })
+    ).toBe('RECOVERY')
+    // 85% of threshold is work whatever it is called.
+    expect(
+      normalizePlannedStepType({ type: 'Active', name: 'Recovery', intensityFactor: 0.85 })
+    ).toBe('WORK')
+    expect(
+      normalizePlannedStepType({ type: 'Recovery', name: 'Recovery', intensityFactor: 0.85 })
+    ).toBe('WORK')
+    // ...and the boundary is inclusive, matching `flattenPlannedSteps`.
+    expect(normalizePlannedStepType({ type: 'Rest', intensityFactor: 0.8 })).toBe('WORK')
+    expect(normalizePlannedStepType({ type: 'Rest', intensityFactor: 0.79 })).toBe('RECOVERY')
+  })
+
+  it('keeps warmup and cooldown structural — intensity never overrides them', () => {
+    expect(normalizePlannedStepType({ type: 'Warmup', name: 'Warm up' })).toBe('WARMUP')
+    expect(normalizePlannedStepType({ type: 'Cooldown', name: 'Spin down' })).toBe('COOLDOWN')
+    // A warmup ramp can pass through work intensity and is still a warmup.
+    expect(normalizePlannedStepType({ type: 'Warmup', intensityFactor: 0.95 })).toBe('WARMUP')
+    expect(normalizePlannedStepType({ type: 'Cooldown', intensityFactor: 0.95 })).toBe('COOLDOWN')
+  })
+
+  it('reads Spanish labels', () => {
+    expect(normalizePlannedStepType({ name: 'calentamiento' })).toBe('WARMUP')
+    expect(normalizePlannedStepType({ name: 'enfriamiento' })).toBe('COOLDOWN')
+    expect(normalizePlannedStepType({ name: 'recuperación' })).toBe('RECOVERY')
+    expect(normalizePlannedStepType({ name: 'descanso' })).toBe('RECOVERY')
+    // Same intensity veto as the English tokens.
+    expect(normalizePlannedStepType({ name: 'recuperación', intensityFactor: 0.9 })).toBe('WORK')
+  })
+
+  it('returns undefined only when there is no evidence at all', () => {
+    expect(normalizePlannedStepType({})).toBeUndefined()
+    expect(normalizePlannedStepType({ type: '', name: '' })).toBeUndefined()
+    expect(normalizePlannedStepType({ name: 'Effort 1' })).toBe('WORK')
+  })
+})
+
+describe('plan-guided detection does not re-read the step name (CW-414)', () => {
+  const STEP_SECONDS = 300
+  const FTP = 200
+
+  function block(watts: number) {
+    return Array.from({ length: STEP_SECONDS }, () => watts)
+  }
+
+  it('keeps a step the facts layer resolved to WORK as WORK, even when it is named Recovery', () => {
+    // These are planned steps in the shape `toDetectionPlannedSteps` hands to
+    // the engine: the type is already the resolved answer. Step 2 is the
+    // promoted one — labelled "Recovery", prescribed at 170 W (85% of FTP).
+    // Before this fix the name demoted it back to RECOVERY here.
+    const plannedSteps = [
+      { type: 'WARMUP', name: 'Warm up', durationSeconds: STEP_SECONDS, power: { value: 120 } },
+      { type: 'WORK', name: 'Effort 1', durationSeconds: STEP_SECONDS, power: { value: 240 } },
+      { type: 'WORK', name: 'Recovery', durationSeconds: STEP_SECONDS, power: { value: 170 } },
+      { type: 'WORK', name: 'Effort 2', durationSeconds: STEP_SECONDS, power: { value: 240 } },
+      { type: 'RECOVERY', name: 'Recovery', durationSeconds: STEP_SECONDS, power: { value: 100 } },
+      { type: 'COOLDOWN', name: 'Cool down', durationSeconds: STEP_SECONDS, power: { value: 110 } }
+    ]
+    const watts = [
+      ...block(120),
+      ...block(240),
+      ...block(170),
+      ...block(240),
+      ...block(100),
+      ...block(110)
+    ]
+    const time = watts.map((_, index) => index)
+
+    const intervals = detectIntervals(time, watts, 'power', FTP, plannedSteps)
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'WORK',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+    // The name is still carried through as the segment label — it just no
+    // longer decides the type.
+    expect(intervals[2]?.label).toBe('Recovery')
+  })
+
+  it('still classifies from the name when the step carries no type at all', () => {
+    const plannedSteps = [
+      { name: 'calentamiento', durationSeconds: STEP_SECONDS, power: { value: 120 } },
+      { name: 'Effort 1', durationSeconds: STEP_SECONDS, power: { value: 240 } },
+      { name: 'descanso', durationSeconds: STEP_SECONDS, power: { value: 100 } },
+      { name: 'Effort 2', durationSeconds: STEP_SECONDS, power: { value: 240 } },
+      { name: 'recuperación', durationSeconds: STEP_SECONDS, power: { value: 100 } },
+      { name: 'enfriamiento', durationSeconds: STEP_SECONDS, power: { value: 110 } }
+    ]
+    const watts = [
+      ...block(120),
+      ...block(240),
+      ...block(100),
+      ...block(240),
+      ...block(100),
+      ...block(110)
+    ]
+    const time = watts.map((_, index) => index)
+
+    const intervals = detectIntervals(time, watts, 'power', FTP, plannedSteps)
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+
+  it('promotes a work-intensity step named Recovery end to end, and leaves a genuine one alone', () => {
+    // Plan -> toDetectionPlannedSteps (which resolves the type against the
+    // athlete's FTP) -> detectIntervals. Every step here is BOTH typed
+    // Recovery-ish AND named "Recovery": only the numeric target separates them.
+    const steps = [
+      {
+        type: 'Warmup',
+        name: 'Warm up',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 120, units: 'w' }
+      },
+      {
+        type: 'Interval',
+        name: 'Effort 1',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 240, units: 'w' }
+      },
+      // 170 W is 85% of a 200 W FTP: work, whatever the type and name say.
+      {
+        type: 'Recovery',
+        name: 'Recovery',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 170, units: 'w' }
+      },
+      {
+        type: 'Interval',
+        name: 'Effort 2',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 240, units: 'w' }
+      },
+      // 100 W is 50% of FTP: a genuine recovery step, and it stays one.
+      {
+        type: 'Recovery',
+        name: 'Recovery',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 100, units: 'w' }
+      },
+      {
+        type: 'Cooldown',
+        name: 'Cool down',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 110, units: 'w' }
+      }
+    ]
+    const watts = [
+      ...block(120),
+      ...block(240),
+      ...block(170),
+      ...block(240),
+      ...block(100),
+      ...block(110)
+    ]
+
+    const intervals = getActualIntervalsForAnalysis(
+      {
+        id: 'workout-cw-414',
+        title: '2 x 5min with tempo floats',
+        type: 'Ride',
+        durationSec: watts.length,
+        streams: { time: watts.map((_, index) => index), watts }
+      },
+      { structuredWorkout: { steps } },
+      { ftp: FTP, lthr: 0, maxHr: 0, thresholdPace: 0 }
+    )
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'WORK',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
+  })
+
+  it('leaves both steps as RECOVERY when there is no FTP to judge the target against', () => {
+    // The same plan with no usable reference: no intensity factor can be built,
+    // so nothing contradicts the labels and both steps stay recovery. This is
+    // what makes the promotion evidence-based rather than a blanket rule.
+    const steps = [
+      {
+        type: 'Warmup',
+        name: 'Warm up',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 120, units: 'w' }
+      },
+      {
+        type: 'Interval',
+        name: 'Effort 1',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 240, units: 'w' }
+      },
+      {
+        type: 'Recovery',
+        name: 'Recovery',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 170, units: 'w' }
+      },
+      {
+        type: 'Interval',
+        name: 'Effort 2',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 240, units: 'w' }
+      },
+      {
+        type: 'Recovery',
+        name: 'Recovery',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 100, units: 'w' }
+      },
+      {
+        type: 'Cooldown',
+        name: 'Cool down',
+        durationSeconds: STEP_SECONDS,
+        power: { value: 110, units: 'w' }
+      }
+    ]
+    const watts = [
+      ...block(120),
+      ...block(240),
+      ...block(170),
+      ...block(240),
+      ...block(100),
+      ...block(110)
+    ]
+
+    const intervals = getActualIntervalsForAnalysis(
+      {
+        id: 'workout-cw-414-no-ftp',
+        title: '2 x 5min with tempo floats',
+        type: 'Ride',
+        durationSec: watts.length,
+        streams: { time: watts.map((_, index) => index), watts }
+      },
+      { structuredWorkout: { steps } },
+      { ftp: 0, lthr: 0, maxHr: 0, thresholdPace: 0 }
+    )
+
+    expect(intervals.map((interval) => interval.type)).toEqual([
+      'WARMUP',
+      'WORK',
+      'RECOVERY',
+      'WORK',
+      'RECOVERY',
+      'COOLDOWN'
+    ])
   })
 })


### PR DESCRIPTION
Fixes CW-414

## The defect

Detection classified the same planned step twice, with two different rules.

`toDetectionPlannedSteps` (`workout-analysis-facts.ts`) normalised the step TYPE and promoted a RECOVERY-labelled step to WORK when its intensity factor was high enough — the CW-402 fix. Then `flattenPlannedStepsForDetection` (`interval-detection.ts`) re-derived the type via `normalizePlannedStepType(step.type, step.name)`, which matched recovery tokens against the type AND the free-text name, with the name winning unconditionally. So a step correctly promoted to WORK was demoted straight back whenever its name contained "recovery"/"rest" — which is most of them ("Recovery", "Recovery Jog", "Rest"). CW-402's promotion only survived for steps whose name happened to avoid those tokens.

A step's `name` is user-authored free text, and the analysis prompt already tells the model that step names carry stale labels and must never override the structured values. Detection was the one place that let free text beat a structured numeric target.

## The rule settled on

One exported `normalizePlannedStepType({ type, name, intensityFactor })` in `interval-detection.ts` replaces both divergent copies. The rule is the one `flattenPlannedSteps` (the adherence path) has always had:

1. Warmup and cooldown are STRUCTURAL, not intensity-based — a warmup ramp can pass through work intensity and is still a warmup — so a `warm`/`cool` type wins outright.
2. A recovery token in the type OR in the name marks the step recovery...
3. ...unless the step's own numeric target contradicts it. At or above `PLANNED_WORK_INTENSITY_FACTOR` (0.8) of threshold the step is work, whatever it is called. This is exactly the CW-402 promotion, now expressed as one veto instead of a separate post-step.

So the name stays evidence — it is never an override. Two call-site decisions make that hold:

- `toDetectionPlannedSteps` is the last layer that can resolve an intensity factor, so it calls the normaliser with the name AND that intensity factor and emits a resolved type. The name demotion the adherence path always applied now happens here too, gated by the same intensity, so adherence and detection classify a step identically.
- `flattenPlannedStepsForDetection` calls the same function but offers the free-text name only when the step carries no type at all. That layer never sees the athlete's references, so the intensity veto cannot fire there and it has no way to check a name against the structured target; re-reading the name over an already-resolved type is precisely the bug. With no type, the name is the only evidence there is and is used as before.

`flattenPlannedSteps` is untouched apart from taking the 0.8 threshold from the new shared constant, so the two cannot drift apart.

## What now classifies differently

- Typed `Recovery`/`Rest`, named "Recovery"/"Rest", target at or above 80% of threshold -> **WORK** (was RECOVERY). The headline fix: CW-402's promotion now survives detection.
- Any non-warm/cool type, named with a recovery token, target at or above 80% -> **WORK** (was RECOVERY). Same defect, second flavour.
- Everything else is unchanged, including: genuine recovery below 80% stays RECOVERY; a recovery label with no resolvable intensity stays RECOVERY; WARMUP/COOLDOWN; the Spanish tokens (`recuperación`, `enfriamiento`, `descanso`, `calentamiento`), which now sit in the shared token list and are subject to the same intensity veto.
- Small consistency gain: a step with no type at all is now fully resolved once, upstream, instead of arriving at detection untyped.

## On test expectations

**No existing expectation changed.** All 2366 unit tests pass as written, including the CW-402 assertions in `workout-analysis-facts.test.ts` and the CW-435 assertion in `intervals.get.test.ts`. Both new end-to-end tests were confirmed to FAIL against the old name-override behaviour before the fix.

## Verification

```
npx vitest run
 Test Files  375 passed (375)
      Tests  2366 passed (2366)

npx eslint server/utils/interval-detection.ts server/utils/workout-analysis-facts.ts tests/unit/server/utils/interval-detection.test.ts   # clean
npx tsc -p .nuxt/tsconfig.server.json --noEmit                                                                                           # clean
```

Run after rebasing onto `origin/develop` @ ee12bbfc. Backend only, no user-visible surface, so no UX critique round.
