### PR TITLE
fix(workouts): allow a plausibility-checked first max HR detection (CW-446)

### DIFF
--- a/cli/backfill/thresholds.ts
+++ b/cli/backfill/thresholds.ts
@@ -87,6 +87,9 @@ backfillThresholdsCommand
                 lthr: true,
                 ftp: true,
                 maxHr: true,
+                // Needed for the first max-HR nomination's near-maximal floor
+                // (CW-446); without it the backfill can never nominate one.
+                dob: true,
                 distanceUnits: true
               }
             }

--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -7,6 +7,7 @@ import { logger } from '@trigger.dev/sdk/v3'
 import { workoutStreamRepository } from '../repositories/workoutStreamRepository'
 import { formatPromptPace } from '../ai-prompt-format'
 import { calculateHrZones, calculatePaceZones, calculatePowerZones } from '../zones'
+import { getHrStats, getPlausibleHrPeak } from '../workout-analysis-facts'
 
 /**
  * Threshold pace is taken directly off the best sustained 40 minute effort (no
@@ -324,29 +325,82 @@ export const thresholdDetectionService = {
       Array.isArray(workout.streams.time)
     ) {
       // MAX HR DETECTION
+      //
+      // The third instance of the never-fires-for-a-first-time-athlete guard
+      // (CW-446), and deliberately *not* fixed the way LTHR and FTP were. Those
+      // two infer a threshold from a 20 minute peak, so a first nomination needs
+      // corroborating effort or the coefficient mints a threshold off an easy
+      // segment. A session max HR infers nothing: it is an observed maximum, and
+      // asking an athlete to have worked hard before their highest recorded beat
+      // counts would reject the very sessions — a race, a hill sprint — where it
+      // is real. So the first nomination is simply allowed.
+      //
+      // What it is not allowed to do is nominate an artifact. An improvement is
+      // sanity-checked by the value it has to beat; a first nomination has
+      // nothing, so one 240 bpm sample of strap static would become the
+      // athlete's max HR and skew every HR zone derived from it, including
+      // interval detection's work bar (CW-383). CW-395 already knows what
+      // impossible heart rate looks like, at two levels, and both are used:
+      // `getHrStats` decides whether the workout's telemetry is trustworthy at
+      // all, and `getPlausibleHrPeak` picks the highest sample that survives the
+      // same band and rate-of-change rules. No second plausibility check is
+      // written here.
       const workoutMaxHr = workout.maxHr || Math.max(...(workout.streams.heartrate as number[]))
-      if (currentMaxHr && workoutMaxHr > currentMaxHr) {
-        results.maxHr = { old: currentMaxHr, new: workoutMaxHr, detected: true }
+      let nominatedMaxHr: number | null = null
+
+      if (hasPreviousValue(currentMaxHr)) {
+        // Improvement path, untouched: beating a stored max HR is its own
+        // evidence, and the value only ever ratchets upward.
+        if (workoutMaxHr > currentMaxHr) nominatedMaxHr = workoutMaxHr
+      } else {
+        const hrStats = getHrStats(workout)
+        // Note this reads the stream rather than `workout.maxHr`: the
+        // device-reported maximum is itself an unvetted raw maximum, which is
+        // precisely the number a first detection must not take on trust.
+        const plausiblePeak =
+          hrStats.usable && !hrStats.artifactFlag ? getPlausibleHrPeak(workout) : null
+
+        if (plausiblePeak) {
+          nominatedMaxHr = plausiblePeak
+        } else {
+          logger.log('First max HR nomination rejected: heart rate telemetry not trustworthy', {
+            workoutId: workout.id,
+            hrUsable: hrStats.usable,
+            hrArtifactFlag: hrStats.artifactFlag,
+            implausibleRatio: hrStats.implausibleRatio,
+            jumpRatio: hrStats.jumpRatio,
+            rawWorkoutMaxHr: workoutMaxHr
+          })
+        }
+      }
+
+      if (nominatedMaxHr) {
+        results.maxHr = { old: currentMaxHr || 0, new: nominatedMaxHr, detected: true }
         if (!dryRun && !noNotify) {
           await this.createThresholdRecommendation(
             workout.userId,
             workout.id,
             'MAX_HR',
-            currentMaxHr,
-            workoutMaxHr,
-            workoutMaxHr,
+            currentMaxHr || 0,
+            nominatedMaxHr,
+            nominatedMaxHr,
             sportName,
             workout.date,
             prisma,
             noNotify
           )
+          const workoutLabel = workout.title || workout.type || 'workout'
           await createUserNotification(workout.userId, {
             title: sportName
               ? `New Max Heart Rate Detected (${sportName})`
               : 'New Max Heart Rate Detected',
-            message: sportName
-              ? `We detected a new peak heart rate of ${workoutMaxHr} bpm for your ${sportName} profile during "${workout.title || workout.type || 'workout'}".`
-              : `We detected a new peak heart rate of ${workoutMaxHr} bpm during "${workout.title || workout.type || 'workout'}".`,
+            message: hasPreviousValue(currentMaxHr)
+              ? sportName
+                ? `We detected a new peak heart rate of ${nominatedMaxHr} bpm for your ${sportName} profile during "${workoutLabel}".`
+                : `We detected a new peak heart rate of ${nominatedMaxHr} bpm during "${workoutLabel}".`
+              : sportName
+                ? `We detected your ${sportName} profile max heart rate: ${nominatedMaxHr} bpm, based on "${workoutLabel}".`
+                : `We detected your max heart rate: ${nominatedMaxHr} bpm, based on "${workoutLabel}".`,
             icon: 'i-heroicons-heart',
             link: `/activities/${workout.id}`
           })

--- a/server/utils/services/thresholdDetectionService.ts
+++ b/server/utils/services/thresholdDetectionService.ts
@@ -8,6 +8,7 @@ import { workoutStreamRepository } from '../repositories/workoutStreamRepository
 import { formatPromptPace } from '../ai-prompt-format'
 import { calculateHrZones, calculatePaceZones, calculatePowerZones } from '../zones'
 import { getHrStats, getPlausibleHrPeak } from '../workout-analysis-facts'
+import { calculateAge } from '../date'
 
 /**
  * Threshold pace is taken directly off the best sustained 40 minute effort (no
@@ -38,6 +39,51 @@ const THRESHOLD_EFFORT_COVERAGE_MIN = 0.8
  */
 function hasPreviousValue(oldValue: number | null | undefined): boolean {
   return typeof oldValue === 'number' && Number.isFinite(oldValue) && oldValue > 0
+}
+
+/**
+ * Share of age-predicted max HR (`220 - age`) that a session's peak must reach
+ * before that peak is treated as evidence of the athlete's *maximum*, on a first
+ * nomination only (CW-446).
+ *
+ * Two error rates trade off here, and they are not symmetric.
+ *
+ * Too low, and a threshold or endurance session nominates its peak. That number
+ * is presented as "your max heart rate", the athlete has no reason to doubt it,
+ * and confirming it recomputes every HR zone — and, since CW-383, interval
+ * detection's work bar — from a number well under their real maximum.
+ *
+ * Too high, and athletes whose true maximum sits below what their age predicts
+ * never receive a first nomination at all. That failure is invisible rather than
+ * wrong, and it is recoverable: they can enter a max HR by hand, after which the
+ * improvement path takes over and ratchets normally. It leaves them exactly
+ * where they were before this ticket rather than worse off.
+ *
+ * So the floor sits at the conservative end. A near-maximal effort reaches
+ * within a few percent of true max; age prediction carries roughly +/- 11 bpm of
+ * population spread, so allowing about one standard deviation of downward
+ * prediction error below that lands here. For a 40 year old (predicted 180) the
+ * floor is 162 bpm — clear of any endurance or tempo peak, and reachable by any
+ * genuinely hard session. The cost is the few percent of athletes whose real
+ * maximum is more than 10% under prediction; the benefit is that a confirmed
+ * recommendation is worth confirming.
+ */
+const FIRST_MAX_HR_AGE_PREDICTED_FRACTION = 0.9
+
+/**
+ * The lowest session peak that can stand as a first max-HR nomination, or `null`
+ * when the athlete's age is unknown or nonsensical — in which case there is no
+ * non-circular reference and nothing is nominated.
+ *
+ * `220 - age` is the standard age-predicted maximum. It is used here for one
+ * property only: it is independent of every heart rate value this service is
+ * trying to establish, so it cannot vouch for a number with itself.
+ */
+function agePredictedMaxHrFloor(dob: Date | string | null | undefined): number | null {
+  const age = calculateAge(dob ? new Date(dob) : null)
+  if (age === null || !Number.isFinite(age) || age <= 0 || age >= 120) return null
+
+  return Math.round((220 - age) * FIRST_MAX_HR_AGE_PREDICTED_FRACTION)
 }
 
 /**
@@ -268,6 +314,9 @@ export const thresholdDetectionService = {
               lthr: true,
               ftp: true,
               maxHr: true,
+              // The non-circular reference a first max-HR nomination is
+              // measured against (CW-446); without it nothing is nominated.
+              dob: true,
               distanceUnits: true
             }
           }
@@ -327,24 +376,44 @@ export const thresholdDetectionService = {
       // MAX HR DETECTION
       //
       // The third instance of the never-fires-for-a-first-time-athlete guard
-      // (CW-446), and deliberately *not* fixed the way LTHR and FTP were. Those
-      // two infer a threshold from a 20 minute peak, so a first nomination needs
-      // corroborating effort or the coefficient mints a threshold off an easy
-      // segment. A session max HR infers nothing: it is an observed maximum, and
-      // asking an athlete to have worked hard before their highest recorded beat
-      // counts would reject the very sessions — a race, a hill sprint — where it
-      // is real. So the first nomination is simply allowed.
+      // (CW-446), and fixed differently from LTHR and FTP. Those two infer a
+      // threshold from a 20 minute peak, so a first nomination needs the effort
+      // corroborated on another axis or the coefficient mints a threshold off an
+      // easy segment. A max HR infers nothing — it is observed — so it needs no
+      // corroborating *axis*. What it does need is the session to be a session
+      // in which a maximum could plausibly have been reached, and two separate
+      // things have to be true of it.
       //
-      // What it is not allowed to do is nominate an artifact. An improvement is
-      // sanity-checked by the value it has to beat; a first nomination has
-      // nothing, so one 240 bpm sample of strap static would become the
-      // athlete's max HR and skew every HR zone derived from it, including
-      // interval detection's work bar (CW-383). CW-395 already knows what
-      // impossible heart rate looks like, at two levels, and both are used:
-      // `getHrStats` decides whether the workout's telemetry is trustworthy at
-      // all, and `getPlausibleHrPeak` picks the highest sample that survives the
-      // same band and rate-of-change rules. No second plausibility check is
-      // written here.
+      // 1. The telemetry has to be trustworthy. An improvement is sanity-checked
+      //    by the value it has to beat; a first nomination has nothing, so one
+      //    240 bpm sample of strap static would become the athlete's max HR and
+      //    skew every HR zone derived from it, including interval detection's
+      //    work bar (CW-383). CW-395 already knows what impossible heart rate
+      //    looks like, at two levels, and both are used: `getHrStats` decides
+      //    whether the workout's heart rate can be trusted at all, and
+      //    `getPlausibleHrPeak` picks the highest sample that survives the same
+      //    band and rate-of-change rules. No second plausibility check is
+      //    written here.
+      //
+      // 2. The peak has to be near-maximal. "Observed maximum" was the framing
+      //    this ticket started from and it is half a sentence short: what the
+      //    stream observes is the maximum of *one session*, and only a session
+      //    taken near the athlete's limit makes that the same number as their
+      //    maximum. Without this gate a recovery spin nominates its 142 bpm
+      //    peak, the copy asserts it as "your max heart rate", and an athlete
+      //    with no reason to doubt it confirms zones computed from 142.
+      //
+      // The reference for (2) must not be derived from the athlete's own heart
+      // rate: they have no max HR, so there is no zone model to read a floor
+      // from, and inventing one from this same session's numbers is the
+      // circularity CW-420 already hit for LTHR. Age-predicted max (220 - age)
+      // is independent of anything we are trying to establish, which is the
+      // property that matters. It is a rough estimate — roughly +/- 11 bpm
+      // across a population — so the floor sits below it rather than at it; see
+      // `FIRST_MAX_HR_AGE_PREDICTED_FRACTION`. No date of birth means no
+      // reference and therefore no nomination: a missing recommendation is
+      // invisible and the athlete can still set their max HR by hand, while a
+      // wrong one silently rewrites every zone they train by.
       const workoutMaxHr = workout.maxHr || Math.max(...(workout.streams.heartrate as number[]))
       let nominatedMaxHr: number | null = null
 
@@ -359,17 +428,25 @@ export const thresholdDetectionService = {
         // precisely the number a first detection must not take on trust.
         const plausiblePeak =
           hrStats.usable && !hrStats.artifactFlag ? getPlausibleHrPeak(workout) : null
+        const nearMaximalFloor = agePredictedMaxHrFloor((workout.user as any)?.dob)
 
-        if (plausiblePeak) {
+        if (plausiblePeak && nearMaximalFloor && plausiblePeak >= nearMaximalFloor) {
           nominatedMaxHr = plausiblePeak
         } else {
-          logger.log('First max HR nomination rejected: heart rate telemetry not trustworthy', {
+          logger.log('First max HR nomination rejected', {
             workoutId: workout.id,
             hrUsable: hrStats.usable,
             hrArtifactFlag: hrStats.artifactFlag,
             implausibleRatio: hrStats.implausibleRatio,
             jumpRatio: hrStats.jumpRatio,
-            rawWorkoutMaxHr: workoutMaxHr
+            plausiblePeak,
+            nearMaximalFloor,
+            rawWorkoutMaxHr: workoutMaxHr,
+            reason: !plausiblePeak
+              ? 'no_trustworthy_hr'
+              : !nearMaximalFloor
+                ? 'no_age_reference'
+                : 'below_near_maximal_floor'
           })
         }
       }

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -445,7 +445,21 @@ const HR_CORRUPTION_FLAG_RATIO = 0.02
 /** At 5% the artifacts are systemic, not isolated, and derived HR facts stop being safe. */
 const HR_CORRUPTION_UNUSABLE_RATIO = 0.05
 
-function getHrStats(workout: any) {
+/**
+ * A live reading inside CW-395's plausible band. Dropouts (zero / non-finite)
+ * and out-of-band artifacts are neither: they are counted by their own ratios in
+ * `getHrStats`, so nothing here judges them twice.
+ */
+function isPlausibleHrSample(value: number | undefined): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= HR_MIN_PLAUSIBLE_BPM &&
+    value <= HR_MAX_PLAUSIBLE_BPM
+  )
+}
+
+export function getHrStats(workout: any) {
   const hrStream = asNumberArray(workout?.streams?.heartrate)
   if (hrStream.length === 0) {
     return {
@@ -484,11 +498,7 @@ function getHrStats(workout: any) {
   // counting them here too would charge one defect to two ratios and push streams past
   // the degrade threshold on the strength of a single artifact. The two checks therefore
   // stay orthogonal: this one catches impossible movement between believable values.
-  const isLivePlausible = (value: number | undefined): value is number =>
-    typeof value === 'number' &&
-    Number.isFinite(value) &&
-    value >= HR_MIN_PLAUSIBLE_BPM &&
-    value <= HR_MAX_PLAUSIBLE_BPM
+  const isLivePlausible = isPlausibleHrSample
   const timeStream = asNumberArray(workout?.streams?.time)
   const hasAlignedTime = timeStream.length === hrStream.length
   let jumpCount = 0
@@ -527,6 +537,77 @@ function getHrStats(workout: any) {
     artifactFlag,
     usable
   }
+}
+
+/**
+ * The highest heart-rate sample in `workout` that CW-395's plausibility rules
+ * accept, or `null` when the stream carries none.
+ *
+ * `getHrStats` asks "is this stream trustworthy as a whole", and answers in
+ * ratios. That is the wrong question for a peak, which is decided by a single
+ * sample: one 240 bpm artifact in an hour of clean telemetry moves no ratio past
+ * its threshold, so the stream stays `usable` while its raw `Math.max` is strap
+ * static. The two are companions on the same two rules and the same constants —
+ * no second plausibility standard is introduced here:
+ *
+ * 1. The sample sits inside the plausible band (`HR_MIN/MAX_PLAUSIBLE_BPM`).
+ * 2. It is not an isolated spike. A sample the stream both jumps *to* and jumps
+ *    away *from* faster than `HR_MAX_DELTA_BPM_PER_SEC` is electrical noise, not
+ *    a heart rate. Both sides are required on purpose: the start of a hard
+ *    interval arrives just as abruptly, but it is then *held*, so it departs
+ *    within the rate limit and is kept. A sample that arrives implausibly at the
+ *    very end of the stream has nothing to corroborate it and is dropped.
+ *
+ * Dropouts are skipped rather than compared against — a zero is a missing
+ * sample, not a heart rate — and deltas are measured against real elapsed time
+ * rather than sample index, both matching `getHrStats`.
+ *
+ * Read this for a value that will be shown to, or acted on by, an athlete (the
+ * first max-HR nomination in `thresholdDetectionService`, CW-446). It is not a
+ * substitute for `getHrStats`: a stream flagged unusable there should not be
+ * nominating anything, whatever its cleanest sample says.
+ */
+export function getPlausibleHrPeak(workout: any): number | null {
+  const hrStream = asNumberArray(workout?.streams?.heartrate)
+  if (hrStream.length === 0) return null
+
+  const timeStream = asNumberArray(workout?.streams?.time)
+  const hasAlignedTime = timeStream.length === hrStream.length
+
+  const live: { value: number; timeSec: number }[] = []
+  for (let index = 0; index < hrStream.length; index += 1) {
+    const value = hrStream[index]
+    if (!isPlausibleHrSample(value)) continue
+    const stamp = hasAlignedTime ? timeStream[index] : undefined
+    live.push({
+      value,
+      timeSec: typeof stamp === 'number' && Number.isFinite(stamp) ? stamp : index
+    })
+  }
+  if (live.length === 0) return null
+
+  const exceedsRate = (
+    from: { value: number; timeSec: number },
+    to: { value: number; timeSec: number }
+  ) => {
+    const rawDelta = to.timeSec - from.timeSec
+    const seconds = Number.isFinite(rawDelta) && rawDelta > 0 ? rawDelta : 1
+    return Math.abs(to.value - from.value) / seconds > HR_MAX_DELTA_BPM_PER_SEC
+  }
+
+  let peak: number | null = null
+  for (let index = 0; index < live.length; index += 1) {
+    const sample = live[index]!
+    const previous = live[index - 1]
+    const next = live[index + 1]
+    // The first live sample is the baseline: it has not jumped from anything.
+    const arrivedImplausibly = previous ? exceedsRate(previous, sample) : false
+    const departedImplausibly = next ? exceedsRate(sample, next) : true
+    if (arrivedImplausibly && departedImplausibly) continue
+    if (peak === null || sample.value > peak) peak = sample.value
+  }
+
+  return peak
 }
 
 function getAnalysisMode(params: {

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -134,6 +134,27 @@ function sessionWith20mEffort(options: {
   return streams
 }
 
+/**
+ * The metrics one run of the service actually recommended, and logged.
+ *
+ * Since CW-446 a trustworthy heart rate stream nominates a first max HR on its
+ * own, with no effort corroboration — an observed maximum needs none. So "this
+ * branch did not fire" has to name the branch: a bare `not.toHaveBeenCalled()`
+ * on the recommendation mock would silently also assert that the unrelated
+ * max-HR branch stayed quiet, and fail for the wrong reason.
+ */
+function recommendedMetrics(): unknown[] {
+  return vi
+    .mocked(prisma.recommendation.create)
+    .mock.calls.map((call) => (call[0] as any)?.data?.metric)
+}
+
+function loggedMetrics(): unknown[] {
+  return vi
+    .mocked(prisma.metricHistory.create)
+    .mock.calls.map((call) => (call[0] as any)?.data?.type)
+}
+
 describe('thresholdDetectionService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -331,8 +352,8 @@ describe('thresholdDetectionService', () => {
 
       expect(results?.thresholdPace?.detected).toBe(false)
       expect(results?.thresholdPace?.old).toBe(0)
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
-      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('THRESHOLD_PACE')
+      expect(loggedMetrics()).not.toContain('THRESHOLD_PACE')
     })
 
     it('nominates one from a sustained 40 minute effort at threshold heart rate', async () => {
@@ -401,7 +422,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.thresholdPace?.detected).toBe(false)
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('THRESHOLD_PACE')
     })
 
     it('leaves the improvement path ungated for an athlete who already has a pace', async () => {
@@ -507,8 +528,8 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.ftp).toMatchObject({ old: 0, new: 266, detected: false })
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
-      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('FTP')
+      expect(loggedMetrics()).not.toContain('FTP')
     })
 
     it('does not nominate one when the ride carries no heart rate stream', async () => {
@@ -554,7 +575,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.ftp?.detected).toBe(false)
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('FTP')
     })
 
     it('leaves the improvement path ungated for an athlete who already has an FTP', async () => {
@@ -704,8 +725,8 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr).toMatchObject({ old: 0, detected: false })
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
-      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('LTHR')
+      expect(loggedMetrics()).not.toContain('LTHR')
     })
 
     it('does not nominate one when there is no power or pace axis to corroborate with', async () => {
@@ -727,7 +748,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr).toMatchObject({ old: 0, new: 171, detected: false })
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('LTHR')
     })
 
     it('does not nominate one when the athlete has a stored FTP but the ride has no power', async () => {
@@ -748,7 +769,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr?.detected).toBe(false)
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('LTHR')
     })
 
     it('leaves the improvement path ungated for an athlete who already has an LTHR', async () => {
@@ -813,7 +834,208 @@ describe('thresholdDetectionService', () => {
 
       expect(results?.minDurationMet).toBe(false)
       expect(results?.lthr?.detected).toBe(false)
-      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(recommendedMetrics()).not.toContain('LTHR')
+    })
+  })
+
+  // Max HR was the third branch guarded by `currentMaxHr &&`, so an athlete with
+  // no stored max HR never received a first detection (CW-446). Unlike LTHR and
+  // FTP it is fixed without effort corroboration — a session max is an observed
+  // maximum, not an inferred threshold — but it must not nominate an artifact,
+  // because a first nomination has no prior value to be sanity-checked against.
+  describe('first max HR nomination (athlete has none)', () => {
+    /** A flat 1Hz heart rate stream, with artifacts spliced in by timestamp. */
+    function flatHrSession(options: {
+      sec: number
+      bpm: number
+      artifacts?: Record<number, number>
+    }) {
+      const time: number[] = []
+      const heartrate: number[] = []
+      for (let t = 0; t <= options.sec; t++) {
+        time.push(t)
+        heartrate.push(options.artifacts?.[t] ?? options.bpm)
+      }
+      return { time, heartrate }
+    }
+
+    it('nominates one from a clean heart rate stream', async () => {
+      const workoutDate = new Date('2025-06-01T06:00:00Z')
+
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // The 115 -> 178 bpm step into the effort is far faster than any real
+      // heart rate ramps, but it is then *held*, so it is a hard interval and
+      // not an artifact. The nominated value has to be the 178 it reached.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-first',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Hill Repeats',
+        durationSec: 1800,
+        date: workoutDate,
+        streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 178 }),
+        user: {}
+      })
+
+      expect(results?.maxHr).toMatchObject({ old: 0, new: 178, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'MAX_HR',
+          description: 'We detected your max heart rate: 178 bpm.'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          title: 'New Max Heart Rate Detected (Cycling)',
+          message:
+            'We detected your Cycling profile max heart rate: 178 bpm, based on "Hill Repeats".'
+        })
+      )
+      // Nothing is written to the athlete's profile or sport settings; the
+      // recommendation is theirs to confirm.
+      expect(prisma.metricHistory.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ type: 'MAX_HR', value: 178, oldValue: 0 })
+      })
+    })
+
+    it('does not nominate one from artifact-flagged heart rate telemetry', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // 100 of 1801 samples read 250 bpm — dry-electrode strap static. That is
+      // 5.5% of the stream, past CW-395's unusable ratio, so `getHrStats` marks
+      // the telemetry untrustworthy and no max HR is nominated at all: not the
+      // 250, and not the 165 the rest of the stream held either.
+      const artifacts: Record<number, number> = {}
+      for (let t = 100; t < 200; t++) artifacts[t] = 250
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-artifact',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Noisy Strap',
+        durationSec: 1800,
+        date: new Date('2025-06-02T06:00:00Z'),
+        streams: flatHrSession({ sec: 1800, bpm: 165, artifacts }),
+        user: {}
+      })
+
+      expect(results?.maxHr).toBeNull()
+      expect(recommendedMetrics()).not.toContain('MAX_HR')
+      expect(loggedMetrics()).not.toContain('MAX_HR')
+    })
+
+    it('does not nominate an out-of-band spike the stream is otherwise clean around', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // One 240 bpm sample in half an hour moves no ratio in `getHrStats` past
+      // its threshold, so the stream stays usable — which is exactly why the
+      // nominated value cannot be the raw `Math.max`.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-spike',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'One Bad Sample',
+        durationSec: 1800,
+        date: new Date('2025-06-03T06:00:00Z'),
+        streams: flatHrSession({ sec: 1800, bpm: 165, artifacts: { 900: 240 } }),
+        user: {}
+      })
+
+      expect(results?.maxHr).toMatchObject({ old: 0, new: 165, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'MAX_HR',
+          description: 'We detected your max heart rate: 165 bpm.'
+        })
+      })
+    })
+
+    it('does not nominate an isolated in-band spike either', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // 205 bpm is inside the plausible band, so the band alone would take it.
+      // The stream jumps to it and straight back off it at 40 bpm/s, which is
+      // the rate-of-change rule CW-395 already counts corruption by.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-inband-spike',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Cadence Lock-On',
+        durationSec: 1800,
+        date: new Date('2025-06-04T06:00:00Z'),
+        streams: flatHrSession({ sec: 1800, bpm: 165, artifacts: { 900: 205 } }),
+        user: {}
+      })
+
+      expect(results?.maxHr).toMatchObject({ old: 0, new: 165, detected: true })
+    })
+
+    it('leaves the improvement path ungated for an athlete who already has a max HR', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        maxHr: 180
+      } as any)
+
+      // The improvement path is untouched by CW-446: it still reads the
+      // device-reported maximum ahead of the stream, and still frames the copy
+      // as beating a previous value.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-improve',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Race Day',
+        durationSec: 1800,
+        date: new Date('2025-06-05T06:00:00Z'),
+        maxHr: 191,
+        streams: flatHrSession({ sec: 1800, bpm: 165 }),
+        user: { maxHr: 180 }
+      })
+
+      expect(results?.maxHr).toMatchObject({ old: 180, new: 191, detected: true })
+      expect(prisma.recommendation.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          metric: 'MAX_HR',
+          description: 'We detected a new max heart rate of 191 bpm (previous: 180 bpm).'
+        })
+      })
+      expect(createUserNotification).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          message:
+            'We detected a new peak heart rate of 191 bpm for your Cycling profile during "Race Day".'
+        })
+      )
+    })
+
+    it('still reports no improvement when the session did not beat the stored max HR', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling',
+        maxHr: 190
+      } as any)
+
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-no-improve',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Endurance Ride',
+        durationSec: 1800,
+        date: new Date('2025-06-06T06:00:00Z'),
+        streams: flatHrSession({ sec: 1800, bpm: 165 }),
+        user: { maxHr: 190 }
+      })
+
+      expect(results?.maxHr).toBeNull()
+      expect(recommendedMetrics()).not.toContain('MAX_HR')
     })
   })
 

--- a/tests/unit/server/utils/services/thresholdDetectionService.test.ts
+++ b/tests/unit/server/utils/services/thresholdDetectionService.test.ts
@@ -134,15 +134,7 @@ function sessionWith20mEffort(options: {
   return streams
 }
 
-/**
- * The metrics one run of the service actually recommended, and logged.
- *
- * Since CW-446 a trustworthy heart rate stream nominates a first max HR on its
- * own, with no effort corroboration — an observed maximum needs none. So "this
- * branch did not fire" has to name the branch: a bare `not.toHaveBeenCalled()`
- * on the recommendation mock would silently also assert that the unrelated
- * max-HR branch stayed quiet, and fail for the wrong reason.
- */
+/** The metrics one run of the service actually recommended, and logged. */
 function recommendedMetrics(): unknown[] {
   return vi
     .mocked(prisma.recommendation.create)
@@ -352,8 +344,8 @@ describe('thresholdDetectionService', () => {
 
       expect(results?.thresholdPace?.detected).toBe(false)
       expect(results?.thresholdPace?.old).toBe(0)
-      expect(recommendedMetrics()).not.toContain('THRESHOLD_PACE')
-      expect(loggedMetrics()).not.toContain('THRESHOLD_PACE')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
     })
 
     it('nominates one from a sustained 40 minute effort at threshold heart rate', async () => {
@@ -422,7 +414,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.thresholdPace?.detected).toBe(false)
-      expect(recommendedMetrics()).not.toContain('THRESHOLD_PACE')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
     })
 
     it('leaves the improvement path ungated for an athlete who already has a pace', async () => {
@@ -528,8 +520,8 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.ftp).toMatchObject({ old: 0, new: 266, detected: false })
-      expect(recommendedMetrics()).not.toContain('FTP')
-      expect(loggedMetrics()).not.toContain('FTP')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
     })
 
     it('does not nominate one when the ride carries no heart rate stream', async () => {
@@ -575,7 +567,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.ftp?.detected).toBe(false)
-      expect(recommendedMetrics()).not.toContain('FTP')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
     })
 
     it('leaves the improvement path ungated for an athlete who already has an FTP', async () => {
@@ -725,8 +717,8 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr).toMatchObject({ old: 0, detected: false })
-      expect(recommendedMetrics()).not.toContain('LTHR')
-      expect(loggedMetrics()).not.toContain('LTHR')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
+      expect(prisma.metricHistory.create).not.toHaveBeenCalled()
     })
 
     it('does not nominate one when there is no power or pace axis to corroborate with', async () => {
@@ -748,7 +740,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr).toMatchObject({ old: 0, new: 171, detected: false })
-      expect(recommendedMetrics()).not.toContain('LTHR')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
     })
 
     it('does not nominate one when the athlete has a stored FTP but the ride has no power', async () => {
@@ -769,7 +761,7 @@ describe('thresholdDetectionService', () => {
       })
 
       expect(results?.lthr?.detected).toBe(false)
-      expect(recommendedMetrics()).not.toContain('LTHR')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
     })
 
     it('leaves the improvement path ungated for an athlete who already has an LTHR', async () => {
@@ -834,15 +826,20 @@ describe('thresholdDetectionService', () => {
 
       expect(results?.minDurationMet).toBe(false)
       expect(results?.lthr?.detected).toBe(false)
-      expect(recommendedMetrics()).not.toContain('LTHR')
+      expect(prisma.recommendation.create).not.toHaveBeenCalled()
     })
   })
 
   // Max HR was the third branch guarded by `currentMaxHr &&`, so an athlete with
-  // no stored max HR never received a first detection (CW-446). Unlike LTHR and
-  // FTP it is fixed without effort corroboration — a session max is an observed
-  // maximum, not an inferred threshold — but it must not nominate an artifact,
-  // because a first nomination has no prior value to be sanity-checked against.
+  // no stored max HR never received a first detection (CW-446). It is fixed
+  // without the effort *corroboration* LTHR and FTP needed — a max HR is
+  // observed, not inferred — but a first nomination still has to clear two
+  // gates: the telemetry has to be trustworthy (CW-395), and the session peak
+  // has to be near-maximal, because what a stream observes is the maximum of one
+  // session and only a near-maximal session makes that the athlete's maximum.
+  //
+  // A 40 year old's age-predicted max is 180 bpm, so the floor these fixtures
+  // are measured against is 162 bpm.
   describe('first max HR nomination (athlete has none)', () => {
     /** A flat 1Hz heart rate stream, with artifacts spliced in by timestamp. */
     function flatHrSession(options: {
@@ -859,7 +856,21 @@ describe('thresholdDetectionService', () => {
       return { time, heartrate }
     }
 
-    it('nominates one from a clean heart rate stream', async () => {
+    /**
+     * A date of birth that makes the athlete exactly `years` old today. Derived
+     * from the clock rather than hard-coded, because `calculateAge` reads the
+     * current date and a fixed date of birth would drift into a different age —
+     * and a different floor — as the suite ages.
+     */
+    function dobForAge(years: number) {
+      const dob = new Date()
+      dob.setFullYear(dob.getFullYear() - years)
+      // A day clear of the birthday, so a leap year cannot round the age down.
+      dob.setDate(dob.getDate() - 1)
+      return dob
+    }
+
+    it('nominates one from a clean, near-maximal heart rate stream', async () => {
       const workoutDate = new Date('2025-06-01T06:00:00Z')
 
       vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
@@ -868,7 +879,8 @@ describe('thresholdDetectionService', () => {
 
       // The 115 -> 178 bpm step into the effort is far faster than any real
       // heart rate ramps, but it is then *held*, so it is a hard interval and
-      // not an artifact. The nominated value has to be the 178 it reached.
+      // not an artifact. 178 also clears the 162 bpm floor comfortably, which is
+      // what makes it evidence of a maximum rather than of one hard session.
       const results = await thresholdDetectionService.detectThresholdIncreases({
         id: 'workout-maxhr-first',
         userId: 'user-1',
@@ -877,7 +889,7 @@ describe('thresholdDetectionService', () => {
         durationSec: 1800,
         date: workoutDate,
         streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 178 }),
-        user: {}
+        user: { dob: dobForAge(40) }
       })
 
       expect(results?.maxHr).toMatchObject({ old: 0, new: 178, detected: true })
@@ -922,7 +934,7 @@ describe('thresholdDetectionService', () => {
         durationSec: 1800,
         date: new Date('2025-06-02T06:00:00Z'),
         streams: flatHrSession({ sec: 1800, bpm: 165, artifacts }),
-        user: {}
+        user: { dob: dobForAge(40) }
       })
 
       expect(results?.maxHr).toBeNull()
@@ -946,7 +958,7 @@ describe('thresholdDetectionService', () => {
         durationSec: 1800,
         date: new Date('2025-06-03T06:00:00Z'),
         streams: flatHrSession({ sec: 1800, bpm: 165, artifacts: { 900: 240 } }),
-        user: {}
+        user: { dob: dobForAge(40) }
       })
 
       expect(results?.maxHr).toMatchObject({ old: 0, new: 165, detected: true })
@@ -974,10 +986,64 @@ describe('thresholdDetectionService', () => {
         durationSec: 1800,
         date: new Date('2025-06-04T06:00:00Z'),
         streams: flatHrSession({ sec: 1800, bpm: 165, artifacts: { 900: 205 } }),
-        user: {}
+        user: { dob: dobForAge(40) }
       })
 
       expect(results?.maxHr).toMatchObject({ old: 0, new: 165, detected: true })
+    })
+
+    // The case this gate exists for. Before it, a recovery spin's peak was
+    // nominated and the copy asserted it as "your max heart rate" — an athlete
+    // with no reason to doubt it would confirm zones computed from 142 bpm, and
+    // since CW-383 that number also sets interval detection's work bar.
+    it('does not nominate a peak that never came near a maximal effort', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // Clean telemetry, nothing artifact-flagged, nothing spiky — the stream is
+      // beyond reproach. It is the *session* that is not evidence: 142 bpm is
+      // 79% of a 40 year old's age-predicted maximum, an easy aerobic ride.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-easy',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Recovery Spin',
+        durationSec: 1800,
+        date: new Date('2025-06-05T06:00:00Z'),
+        streams: flatHrSession({ sec: 1800, bpm: 142 }),
+        user: { dob: dobForAge(40) }
+      })
+
+      expect(results?.maxHr).toBeNull()
+      expect(recommendedMetrics()).not.toContain('MAX_HR')
+      expect(loggedMetrics()).not.toContain('MAX_HR')
+      expect(createUserNotification).not.toHaveBeenCalled()
+    })
+
+    it('does not nominate one when the athlete has no date of birth', async () => {
+      vi.mocked(sportSettingsRepository.getForActivityType).mockResolvedValue({
+        name: 'Cycling'
+      } as any)
+
+      // The same session that nominates 178 bpm for a 40 year old. Without a
+      // date of birth there is no reference the floor can be built from that is
+      // not derived from the athlete's own heart rate — and a reference derived
+      // from their heart rate would be vouching for the number with itself. No
+      // reference, no nomination.
+      const results = await thresholdDetectionService.detectThresholdIncreases({
+        id: 'workout-maxhr-no-dob',
+        userId: 'user-1',
+        type: 'Ride',
+        title: 'Hill Repeats',
+        durationSec: 1800,
+        date: new Date('2025-06-06T06:00:00Z'),
+        streams: sessionWith20mEffort({ warmupHr: 115, effortHr: 178 }),
+        user: {}
+      })
+
+      expect(results?.maxHr).toBeNull()
+      expect(recommendedMetrics()).not.toContain('MAX_HR')
     })
 
     it('leaves the improvement path ungated for an athlete who already has a max HR', async () => {
@@ -988,7 +1054,9 @@ describe('thresholdDetectionService', () => {
 
       // The improvement path is untouched by CW-446: it still reads the
       // device-reported maximum ahead of the stream, and still frames the copy
-      // as beating a previous value.
+      // as beating a previous value. Note the deliberate absence of a date of
+      // birth — neither the near-maximal floor nor the plausibility filter
+      // applies here, because the stored value it has to beat is the check.
       const results = await thresholdDetectionService.detectThresholdIncreases({
         id: 'workout-maxhr-improve',
         userId: 'user-1',


### PR DESCRIPTION
Fixes CW-446

`thresholdDetectionService` guarded max-HR detection with `if (currentMaxHr && workoutMaxHr > currentMaxHr)`, so an athlete with no stored max HR never received a first detection — the third instance of the pattern in this file, after CW-420 fixed FTP and LTHR.

## What a first nomination has to clear

Unlike LTHR and FTP, max HR does not need effort corroborated on a *second axis* — those two infer a threshold from a 20 minute peak, and the coefficient will happily mint one off an easy segment. A max HR is observed, not inferred. But two other things must be true.

### 1. The telemetry has to be trustworthy (CW-395, both levels)

An improvement is sanity-checked by the value it has to beat. A first nomination has nothing, so one 240 bpm sample of strap static becomes the athlete's max HR and skews every HR zone derived from it, including interval detection's work bar (CW-383). Both CW-395 signals are reused, neither is reimplemented:

- **`getHrStats(workout).usable && !artifactFlag`** — is the workout's HR trustworthy at all? Systemic corruption means no nomination.
- **`getPlausibleHrPeak(workout)`** — a new sample-level companion beside `getHrStats`, built from the same two constants (`HR_MIN/MAX_PLAUSIBLE_BPM`, `HR_MAX_DELTA_BPM_PER_SEC`). `getHrStats` answers in ratios, which is the wrong instrument for a peak decided by one sample: one bad sample in an hour moves no ratio past its threshold, so the stream stays `usable` while its raw `Math.max` is static.

A sample is rejected as a spike only when the stream both jumps *to* it and jumps away *from* it faster than the rate limit. Both sides are required: the start of a hard interval arrives just as abruptly, but it is then held, so it survives.

### 2. The session has to be near-maximal

"A session max HR is an observed maximum" — the framing this ticket started from — is half a sentence short. What the stream observes is the maximum of *one session*, and only a session taken near the athlete's limit makes that the same number as their maximum. Without this gate a recovery spin nominates its 142 bpm peak, the copy asserts it as "your max heart rate", and an athlete with no reason to doubt it confirms zones computed from 142.

The reference has to be non-circular. Anything derived from the athlete's own HR zones is out — they have no max HR, so there is no zone model, which is exactly the circularity CW-420 hit for LTHR. **Age-predicted max (`220 - age`, via the existing `calculateAge`) is independent of every value this service is trying to establish**, which is the property that matters.

**The floor is 90% of age-predicted max.** For a 40 year old (predicted 180) that is 162 bpm — clear of any endurance or tempo peak, reachable by any genuinely hard session. The two error rates are not symmetric, which is why it sits at the conservative end of the range:

- **Too low** and a threshold session's peak is presented as a maximum, is confirmed, and silently recomputes every zone the athlete trains by.
- **Too high** and athletes whose true max sits below their age prediction get no first nomination. That failure is invisible rather than wrong, and it is *recoverable*: they can enter a max HR by hand, after which the improvement path ratchets normally. It leaves them where they were before this ticket rather than worse off.

A near-maximal effort reaches within a few percent of true max; age prediction carries roughly ±11 bpm of population spread, so allowing about one standard deviation of downward prediction error below that lands at 90%. The cost is the few percent of athletes whose real maximum is more than 10% under prediction.

**No date of birth means no nomination.** Prefer no recommendation over a wrong one — the principle CW-413 and CW-420 already run on.

The **improvement path is untouched**: `workout.maxHr` still wins over the stream max, it still only ratchets upward, neither new gate applies to it (the stored value it has to beat *is* the check), and there are tests asserting it in both directions.

## Copy (backend-only ticket, so please review the wording)

`createThresholdRecommendation` already branched on `hasPreviousValue`, so the recommendation body was correct; the push notification was not, and now branches on the same module-scope predicate (CW-420/CW-421) rather than a third copy of the check.

Recommendation body, first detection:

> We detected your max heart rate: 178 bpm.

Push notification, first detection (with and without a sport profile):

> We detected your Cycling profile max heart rate: 178 bpm, based on "Hill Repeats".
> We detected your max heart rate: 178 bpm, based on "Hill Repeats".

Improvement copy is unchanged:

> We detected a new max heart rate of 191 bpm (previous: 180 bpm).
> We detected a new peak heart rate of 191 bpm for your Cycling profile during "Race Day".

Recommendation-to-confirm only — nothing writes to the profile or sport settings.

## Tests

New `first max HR nomination (athlete has none)` block, all against a 40 year old (floor 162 bpm):

- clean near-maximal stream (peak 178) nominates 178;
- **recovery spin at a flat 142 bpm nominates nothing** — clean telemetry, nothing artifact-flagged, nothing spiky; it is the *session* that is not evidence;
- no date of birth → no nomination, from the same stream that nominates 178 for a 40 year old;
- artifact-flagged telemetry (5.5% of samples at 250 bpm) nominates nothing at all;
- a 240 bpm out-of-band spike in an otherwise clean stream nominates 165, not 240;
- an isolated *in-band* 205 bpm spike likewise nominates 165;
- improvement path asserted unchanged, both when it fires and when it does not.

The eight pre-existing `not.toHaveBeenCalled()` assertions in the LTHR/FTP/pace blocks are **unchanged from `develop`** — their fixtures carry no date of birth, so the max-HR branch stays quiet on its own. `interval-detection` stays unmocked (CW-405).

## Verification

```
pnpm typecheck                                                exit 0
pnpm test:unit tests/.../thresholdDetectionService.test.ts    51 passed (51)
pnpm test:unit (full suite)                                   375 files, 2365 tests, all passed
```

## Scope notes

Two files outside the ticket's Owned Paths, both deliberate:

- `server/utils/workout-analysis-facts.ts` — additive and behaviour-preserving: `getHrStats` gained an `export`, its inline `isLivePlausible` predicate was lifted to module scope unchanged, and `getPlausibleHrPeak` was added beside it. Anywhere else would have meant a second copy of CW-395's constants.
- `cli/backfill/thresholds.ts` — one line adding `dob` to its user select, without which the backfill could never nominate a first max HR.

Known and deliberately left alone: the *improvement* branch still ratchets on an unfiltered raw max, so a 240 bpm artifact can still push an existing max HR upward. Same class of defect, being filed separately to keep this PR scoped.
