### PR TITLE
chore(ai): consolidate report task analysis schemas (CW-425)

### DIFF
--- a/server/utils/services/report-analysis-schema.ts
+++ b/server/utils/services/report-analysis-schema.ts
@@ -1,0 +1,285 @@
+/**
+ * Shared response-schema builder for the athlete-facing *report* tasks.
+ *
+ * `trigger/generate-weekly-report.ts`, `trigger/generate-custom-report.ts` and
+ * `trigger/analyze-last-3-workouts.ts` each used to carry their own inline
+ * `const analysisSchema = { ... }` literal (CW-425). The three literals were
+ * near-copies of each other and of the workout-analysis schema in
+ * `./workout-analysis-prompt.ts`, and each restated the section-status
+ * vocabulary and the score bounds as hardcoded values.
+ *
+ * That is the exact duplication pattern that produced CW-403: the workout
+ * schema drifted to `fair`/`needs_attention`/`info` and 0-100 scores while the
+ * prompt still asked for `excellent`/.../`poor` and 1-10, and because Gemini
+ * enforces the schema rather than the prompt, every UI status->colour mapper
+ * fell through to grey. Nothing caught it.
+ *
+ * So the *values that can drift* live in one place only:
+ * - the section-status enum is always `ANALYSIS_SECTION_STATUSES`
+ * - the score bounds (and the "(1-10)" text inside the score descriptions) are
+ *   always derived from `ANALYSIS_SCORE_MIN` / `ANALYSIS_SCORE_MAX`
+ *
+ * What legitimately differs between the three reports is *copy* -- which
+ * example section titles to suggest, how verbose each score explanation should
+ * be, which metrics the period summary carries -- and whether a report has
+ * period scores at all (the last-3-workouts comparison does not). Those are the
+ * builder's parameters. This is deliberately NOT the workout `analysisSchema`
+ * from `./workout-analysis-prompt.ts`: reports ask the model for a different
+ * set of scores (`training_load`/`recovery`/`progress`/`consistency` rather
+ * than `technical`/`effort`/`pacing`/`execution`) and a different metrics
+ * summary, so forcing them onto that shape would change what the model is
+ * asked for.
+ *
+ * The "report analysis schemas match the prompts they are handed with (CW-425)"
+ * suite in `./workout-analysis-prompt.test.ts` reads the status vocabulary and
+ * the score scale back out of each task's *prompt source* and compares them to
+ * the schema that task builds, so a prompt and its schema cannot silently
+ * disagree again -- the same technique CW-403 introduced for the workout
+ * schema. A shared schema that can still drift from its prompt would only have
+ * moved the problem.
+ */
+import {
+  ANALYSIS_SCORE_MAX,
+  ANALYSIS_SCORE_MIN,
+  ANALYSIS_SECTION_STATUSES
+} from './workout-analysis-prompt'
+
+/** The `type` discriminator every report schema declares. */
+const REPORT_ANALYSIS_TYPES = ['workout', 'weekly_report', 'planning', 'comparison'] as const
+
+/**
+ * The period-score dimensions a report may ask for, in schema order.
+ *
+ * Distinct from the workout schema's `overall`/`technical`/`effort`/`pacing`/
+ * `execution`: a report scores a training *period*, not a session.
+ */
+export const REPORT_SCORE_KEYS = [
+  'overall',
+  'training_load',
+  'recovery',
+  'progress',
+  'consistency'
+] as const
+
+export type ReportScoreKey = (typeof REPORT_SCORE_KEYS)[number]
+
+/**
+ * How the score scale is named in prose, derived from the shared bounds.
+ *
+ * Report tasks interpolate this into their `scores` description and into their
+ * prompt text, so the sentence the model reads ("... on a 1-10 scale ...") and
+ * the `minimum`/`maximum` the schema enforces cannot say different things.
+ */
+export const REPORT_SCORE_SCALE_TEXT = `${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX} scale`
+
+/**
+ * The one-line description of each score value.
+ *
+ * The `(1-10)` suffix is interpolated from the shared bounds rather than typed
+ * out, so the prose the model reads can never contradict the `minimum` /
+ * `maximum` the schema enforces.
+ */
+const REPORT_SCORE_DESCRIPTIONS: Record<ReportScoreKey, string> = {
+  overall: `Overall period assessment (${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`,
+  training_load: `Training load management quality (${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`,
+  recovery: `Recovery adequacy score (${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`,
+  progress: `Progress and adaptation score (${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`,
+  consistency: `Training consistency score (${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`
+}
+
+/**
+ * Metrics every report summarises. Extra per-report fields (nutrition totals on
+ * the custom report) are appended after these, preserving schema key order.
+ */
+const BASE_METRICS_SUMMARY_KEYS = [
+  'total_duration_minutes',
+  'total_tss',
+  'avg_power',
+  'avg_heart_rate',
+  // NOTE: kept as kilometers (not renamed to a unit-agnostic name) because this exact
+  // field name/shape is a shared contract also consumed by app/pages/report/[id].vue,
+  // which independently converts to meters and re-formats via the user's distanceUnits
+  // client-side. Kilometers is treated as the canonical storage unit here; unit-aware
+  // formatting happens at render time.
+  'total_distance_km'
+] as const
+
+const ANALYSIS_POINTS_DESCRIPTION =
+  'Detailed analysis points for this section. Each point should be 1-2 sentences maximum as a separate array item.'
+
+const NO_PARAGRAPH_BLOCKS_DESCRIPTION = ' Do NOT combine multiple points into paragraph blocks.'
+
+export interface ReportAnalysisScoresOptions {
+  /** Description of the `scores` object itself. */
+  description: string
+  /**
+   * Per-dimension explanation copy. How much detail a report asks for in each
+   * `*_explanation` string is a product decision per report, so it is passed in
+   * rather than shared.
+   */
+  explanations: Record<ReportScoreKey, string>
+  /**
+   * When true the schema marks every score and explanation as required AND
+   * lists `scores` in the top-level `required` array -- i.e. the report is not
+   * valid without scores. The weekly report requires them; the custom report
+   * does not, because a nutrition-only custom report legitimately has none (its
+   * prompt only asks for scores when workout data is included).
+   */
+  required: boolean
+}
+
+export interface ReportAnalysisSchemaOptions {
+  /** Description of `sections[].title`, usually naming example section titles. */
+  sectionTitleDescription: string
+  /**
+   * Append "Do NOT combine multiple points into paragraph blocks." to the
+   * `analysis_points` description.
+   */
+  forbidParagraphBlocks: boolean
+  /** Omit entirely for reports that ask for no period scores. */
+  scores?: ReportAnalysisScoresOptions
+  /** Description of the `metrics_summary` object. */
+  metricsSummaryDescription: string
+  /** Extra numeric `metrics_summary` fields, appended after the base set. */
+  extraMetricsSummaryKeys?: readonly string[]
+}
+
+function buildScoresSchema(options: ReportAnalysisScoresOptions) {
+  const properties: Record<string, unknown> = {}
+  const required: string[] = []
+
+  for (const key of REPORT_SCORE_KEYS) {
+    properties[key] = {
+      type: 'number',
+      description: REPORT_SCORE_DESCRIPTIONS[key],
+      minimum: ANALYSIS_SCORE_MIN,
+      maximum: ANALYSIS_SCORE_MAX
+    }
+    properties[`${key}_explanation`] = {
+      type: 'string',
+      description: options.explanations[key]
+    }
+    required.push(key, `${key}_explanation`)
+  }
+
+  return {
+    type: 'object',
+    description: options.description,
+    properties,
+    ...(options.required ? { required } : {})
+  }
+}
+
+function buildMetricsSummarySchema(options: ReportAnalysisSchemaOptions) {
+  const properties: Record<string, unknown> = {}
+  for (const key of [...BASE_METRICS_SUMMARY_KEYS, ...(options.extraMetricsSummaryKeys ?? [])]) {
+    properties[key] = { type: 'number' }
+  }
+
+  return {
+    type: 'object',
+    description: options.metricsSummaryDescription,
+    properties
+  }
+}
+
+/**
+ * Build the structured-output schema a report task hands to
+ * `generateStructuredAnalysis`.
+ *
+ * Gemini enforces the returned schema, so it -- not the prompt text -- is what
+ * ultimately decides the vocabulary the model may emit. Keep it in lockstep
+ * with the prompt that describes it.
+ */
+export function buildReportAnalysisSchema(options: ReportAnalysisSchemaOptions) {
+  return {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        description: 'Type of analysis: workout, weekly_report, planning, comparison',
+        enum: [...REPORT_ANALYSIS_TYPES]
+      },
+      title: {
+        type: 'string',
+        description: 'Title of the analysis'
+      },
+      date: {
+        type: 'string',
+        description: 'Date or date range of the analysis'
+      },
+      executive_summary: {
+        type: 'string',
+        description: '2-3 sentence high-level summary of key findings'
+      },
+      sections: {
+        type: 'array',
+        description: 'Analysis sections with status and points',
+        items: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: options.sectionTitleDescription
+            },
+            status: {
+              type: 'string',
+              description: 'Overall assessment',
+              // The single source of the section-status vocabulary. Every UI
+              // status->colour mapper understands exactly this list (CW-403).
+              enum: [...ANALYSIS_SECTION_STATUSES]
+            },
+            status_label: {
+              type: 'string',
+              description: 'Display label for status'
+            },
+            analysis_points: {
+              type: 'array',
+              description: options.forbidParagraphBlocks
+                ? `${ANALYSIS_POINTS_DESCRIPTION}${NO_PARAGRAPH_BLOCKS_DESCRIPTION}`
+                : ANALYSIS_POINTS_DESCRIPTION,
+              items: {
+                type: 'string'
+              }
+            }
+          },
+          // Reports render `status_label` directly (see the markdown converters
+          // in the report tasks), so unlike the workout schema it is required.
+          required: ['title', 'status', 'status_label', 'analysis_points']
+        }
+      },
+      recommendations: {
+        type: 'array',
+        description: 'Actionable coaching recommendations',
+        items: {
+          type: 'object',
+          properties: {
+            title: {
+              type: 'string',
+              description: 'Recommendation title'
+            },
+            priority: {
+              type: 'string',
+              description: 'Priority level',
+              enum: ['high', 'medium', 'low']
+            },
+            description: {
+              type: 'string',
+              description: 'Detailed recommendation'
+            }
+          },
+          required: ['title', 'priority', 'description']
+        }
+      },
+      ...(options.scores ? { scores: buildScoresSchema(options.scores) } : {}),
+      metrics_summary: buildMetricsSummarySchema(options)
+    },
+    required: [
+      'type',
+      'title',
+      'executive_summary',
+      'sections',
+      ...(options.scores?.required ? ['scores'] : [])
+    ]
+  }
+}

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -861,6 +861,22 @@ describe('analysisSchema matches the prompt it is handed with', () => {
     expect(triggerSource).not.toContain('const analysisSchema')
     expect(serviceSource).not.toContain('interface StructuredAnalysis')
     expect(triggerSource).not.toContain('interface StructuredAnalysis')
+
+    // ...and neither by any of the three report tasks, which carried their own
+    // near-copies of the same shape until CW-425.
+    for (const reportTask of [
+      'generate-weekly-report.ts',
+      'generate-custom-report.ts',
+      'analyze-last-3-workouts.ts'
+    ]) {
+      const reportSource = fs.readFileSync(
+        new URL(`../../../trigger/${reportTask}`, import.meta.url),
+        'utf-8'
+      )
+      expect(reportSource, reportTask).not.toContain('const analysisSchema')
+      expect(reportSource, reportTask).not.toContain('interface StructuredAnalysis')
+    }
+
     // The service must import, never re-export: server/utils is Nitro auto-imported and
     // re-exporting produces "Duplicated imports" warnings (CW-392 NOTE, CW-404).
     expect(serviceSource).not.toMatch(/^export \{/m)
@@ -1118,5 +1134,217 @@ describe('interval segmentation provenance (CW-391)', () => {
       USER_PROFILE
     )
     expect(ridePrompt).not.toContain('- Avg Pace:')
+  })
+})
+
+/**
+ * CW-425 regression coverage: the three report tasks.
+ *
+ * `trigger/generate-weekly-report.ts`, `trigger/generate-custom-report.ts` and
+ * `trigger/analyze-last-3-workouts.ts` each carried their own inline
+ * `const analysisSchema = { ... }`, restating the section-status vocabulary and
+ * the score bounds as literals. They happened to agree with their prompts, but
+ * nothing held them there -- which is precisely the state the workout schema was
+ * in before CW-403 broke it.
+ *
+ * They now build from `buildReportAnalysisSchema`, so the enum and the bounds
+ * come from `ANALYSIS_SECTION_STATUSES` / `ANALYSIS_SCORE_MIN|MAX`. A shared
+ * schema that can still drift from its prompt has only moved the problem, so
+ * these tests extend the CW-403 technique to each report: they read the status
+ * vocabulary and the score scale back out of each task's own *prompt source*
+ * and compare them to the schema that task actually hands Gemini.
+ */
+describe('report analysis schemas match the prompts they are handed with (CW-425)', () => {
+  const REPORT_TASKS = [
+    { file: 'generate-weekly-report.ts', schemaExport: 'weeklyReportAnalysisSchema' },
+    { file: 'generate-custom-report.ts', schemaExport: 'customReportAnalysisSchema' },
+    { file: 'analyze-last-3-workouts.ts', schemaExport: 'lastThreeWorkoutsAnalysisSchema' }
+  ] as const
+
+  async function loadReportTask(task: (typeof REPORT_TASKS)[number]) {
+    const fs = await import('node:fs')
+    const source = fs.readFileSync(
+      new URL(`../../../trigger/${task.file}`, import.meta.url),
+      'utf-8'
+    )
+    const mod: Record<string, any> = await import(`../../../trigger/${task.file.slice(0, -3)}`)
+    return { source, schema: mod[task.schemaExport] as any }
+  }
+
+  /** Human label for a score key, as the prompts spell it ("training_load" -> "Training Load"). */
+  function scoreLabel(key: string): string {
+    return key
+      .split('_')
+      .map((word) => `${word[0]!.toUpperCase()}${word.slice(1)}`)
+      .join(' ')
+  }
+
+  it('builds from the shared builder instead of an inline literal', async () => {
+    for (const task of REPORT_TASKS) {
+      const { source, schema } = await loadReportTask(task)
+
+      expect(source, task.file).toContain('buildReportAnalysisSchema({')
+      // No re-declared vocabulary or bounds: those may only reach the schema
+      // through ANALYSIS_SECTION_STATUSES / ANALYSIS_SCORE_MIN|MAX.
+      expect(source, task.file).not.toContain("'needs_improvement'")
+      expect(source, task.file).not.toMatch(/^\s*minimum: \d+,$/m)
+      expect(source, task.file).not.toMatch(/^\s*maximum: \d+$/m)
+
+      expect(schema, task.file).toBeTruthy()
+      expect(schema.type, task.file).toBe('object')
+    }
+  })
+
+  it('hands that exact schema to generateStructuredAnalysis', async () => {
+    for (const task of REPORT_TASKS) {
+      const { source } = await loadReportTask(task)
+
+      const call = source.match(/generateStructuredAnalysis(?:<[^>]*>)?\(([\s\S]{0,200})/)
+      expect(call, task.file).not.toBeNull()
+      expect(call![1], task.file).toContain(task.schemaExport)
+    }
+  })
+
+  it('declares the shared section-status enum, and never the retired vocabulary', async () => {
+    for (const task of REPORT_TASKS) {
+      const { schema } = await loadReportTask(task)
+      const statusEnum = schema.properties.sections.items.properties.status.enum
+
+      expect(statusEnum, task.file).toEqual([...ANALYSIS_SECTION_STATUSES])
+      // The CW-403 failure mode: an enum the UI status->colour mappers do not
+      // understand, so problem sections render grey instead of red.
+      expect(statusEnum, task.file).not.toContain('fair')
+      expect(statusEnum, task.file).not.toContain('needs_attention')
+      expect(statusEnum, task.file).not.toContain('info')
+    }
+  })
+
+  it('declares the status vocabulary its own prompt instructs', async () => {
+    let vocabulariesFound = 0
+
+    for (const task of REPORT_TASKS) {
+      const { source, schema } = await loadReportTask(task)
+      const statusEnum = schema.properties.sections.items.properties.status.enum
+
+      // e.g. "- Provide a status assessment (excellent/good/moderate/needs_improvement/poor)"
+      for (const match of source.matchAll(/status assessment \(([a-z_/]+)\)/g)) {
+        vocabulariesFound += 1
+        expect(match[1]!.split('/'), task.file).toEqual(statusEnum)
+      }
+    }
+
+    // If every prompt stops naming the vocabulary this guard quietly stops
+    // guarding, so require that at least one still states it.
+    expect(vocabulariesFound).toBeGreaterThan(0)
+  })
+
+  it('declares scores exactly when its own prompt asks for them', async () => {
+    for (const task of REPORT_TASKS) {
+      const { source, schema } = await loadReportTask(task)
+
+      // A schema that declares scores the prompt never asks for makes Gemini
+      // invent numbers with no basis; a prompt that asks for scores the schema
+      // does not declare gets them silently dropped from the response.
+      expect(Boolean(schema.properties.scores), task.file).toBe(
+        source.includes('Performance Scores')
+      )
+      // ...and the top-level `required` may only demand scores that exist.
+      if (schema.required.includes('scores')) {
+        expect(schema.properties.scores, task.file).toBeTruthy()
+      }
+    }
+  })
+
+  it('declares the score scale its own prompt states', async () => {
+    let scalesFound = 0
+
+    for (const task of REPORT_TASKS) {
+      const { source, schema } = await loadReportTask(task)
+
+      // e.g. "**Performance Scores** (1-10 scale for tracking progress over time)"
+      for (const match of source.matchAll(/Performance Scores\*{0,2} \((\d+)-(\d+) scale/g)) {
+        scalesFound += 1
+        expect(Number(match[1]), task.file).toBe(ANALYSIS_SCORE_MIN)
+        expect(Number(match[2]), task.file).toBe(ANALYSIS_SCORE_MAX)
+      }
+
+      if (!schema.properties.scores) continue
+
+      for (const [key, prop] of Object.entries<any>(schema.properties.scores.properties)) {
+        if (key.endsWith('_explanation')) continue
+        expect(prop.minimum, `${task.file}:${key}`).toBe(ANALYSIS_SCORE_MIN)
+        expect(prop.maximum, `${task.file}:${key}`).toBe(ANALYSIS_SCORE_MAX)
+        expect(prop.description, `${task.file}:${key}`).toContain(
+          `(${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX})`
+        )
+      }
+      expect(schema.properties.scores.description, task.file).toContain(
+        `${ANALYSIS_SCORE_MIN}-${ANALYSIS_SCORE_MAX} scale`
+      )
+    }
+
+    expect(scalesFound).toBeGreaterThan(0)
+  })
+
+  it('names in the prompt every score dimension its schema declares', async () => {
+    for (const task of REPORT_TASKS) {
+      const { source, schema } = await loadReportTask(task)
+      if (!schema.properties.scores) continue
+
+      for (const key of Object.keys(schema.properties.scores.properties)) {
+        if (key.endsWith('_explanation')) continue
+        expect(source, `${task.file}:${key}`).toContain(scoreLabel(key))
+      }
+    }
+  })
+
+  it('keeps the per-report differences the tasks depend on', async () => {
+    const byFile = new Map<string, any>()
+    for (const task of REPORT_TASKS) {
+      byFile.set(task.file, (await loadReportTask(task)).schema)
+    }
+
+    for (const [file, schema] of byFile) {
+      // Reports render `status_label` directly (see each task's markdown
+      // converter), so unlike the workout schema it must be required.
+      expect(schema.properties.sections.items.required, file).toEqual([
+        'title',
+        'status',
+        'status_label',
+        'analysis_points'
+      ])
+      expect(schema.properties.recommendations.items.required, file).toEqual([
+        'title',
+        'priority',
+        'description'
+      ])
+    }
+
+    // Only the weekly report is invalid without scores.
+    expect(byFile.get('generate-weekly-report.ts').required).toEqual([
+      'type',
+      'title',
+      'executive_summary',
+      'sections',
+      'scores'
+    ])
+    // A nutrition-only custom report legitimately has none.
+    expect(byFile.get('generate-custom-report.ts').required).toEqual([
+      'type',
+      'title',
+      'executive_summary',
+      'sections'
+    ])
+    expect(byFile.get('generate-custom-report.ts').properties.scores.required).toBeUndefined()
+    // The three-workout comparison asks for no scores at all.
+    expect(byFile.get('analyze-last-3-workouts.ts').properties.scores).toBeUndefined()
+
+    // Nutrition metrics belong to the custom report only.
+    expect(
+      Object.keys(byFile.get('generate-custom-report.ts').properties.metrics_summary.properties)
+    ).toContain('avg_protein_g')
+    expect(
+      Object.keys(byFile.get('generate-weekly-report.ts').properties.metrics_summary.properties)
+    ).not.toContain('avg_protein_g')
   })
 })

--- a/trigger/analyze-last-3-workouts.ts
+++ b/trigger/analyze-last-3-workouts.ts
@@ -16,102 +16,24 @@ import {
   formatPromptHeight,
   formatPromptDistance
 } from '../server/utils/ai-prompt-format'
+import { buildReportAnalysisSchema } from '../server/utils/services/report-analysis-schema'
 
-// Reuse the flexible analysis schema (same as workout analysis)
-const analysisSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      description: 'Type of analysis: workout, weekly_report, planning, comparison',
-      enum: ['workout', 'weekly_report', 'planning', 'comparison']
-    },
-    title: {
-      type: 'string',
-      description: 'Title of the analysis'
-    },
-    date: {
-      type: 'string',
-      description: 'Date or date range of the analysis'
-    },
-    executive_summary: {
-      type: 'string',
-      description: '2-3 sentence high-level summary of key findings'
-    },
-    sections: {
-      type: 'array',
-      description: 'Analysis sections with status and points',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Section title (e.g., Training Progression, Recovery Patterns)'
-          },
-          status: {
-            type: 'string',
-            description: 'Overall assessment',
-            enum: ['excellent', 'good', 'moderate', 'needs_improvement', 'poor']
-          },
-          status_label: {
-            type: 'string',
-            description: 'Display label for status'
-          },
-          analysis_points: {
-            type: 'array',
-            description:
-              'Detailed analysis points for this section. Each point should be 1-2 sentences maximum as a separate array item. Do NOT combine multiple points into paragraph blocks.',
-            items: {
-              type: 'string'
-            }
-          }
-        },
-        required: ['title', 'status', 'status_label', 'analysis_points']
-      }
-    },
-    recommendations: {
-      type: 'array',
-      description: 'Actionable coaching recommendations',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Recommendation title'
-          },
-          priority: {
-            type: 'string',
-            description: 'Priority level',
-            enum: ['high', 'medium', 'low']
-          },
-          description: {
-            type: 'string',
-            description: 'Detailed recommendation'
-          }
-        },
-        required: ['title', 'priority', 'description']
-      }
-    },
-    metrics_summary: {
-      type: 'object',
-      description: 'Key metrics across the workouts',
-      properties: {
-        total_duration_minutes: { type: 'number' },
-        total_tss: { type: 'number' },
-        avg_power: { type: 'number' },
-        avg_heart_rate: { type: 'number' },
-        // NOTE: kept as kilometers (not renamed to a unit-agnostic name) because this exact
-        // field name/shape is a shared contract also consumed by app/pages/report/[id].vue
-        // (which independently converts to meters and re-formats via the user's distanceUnits
-        // client-side) and mirrored by the schemas in generate-weekly-report.ts and
-        // generate-custom-report.ts. Kilometers is treated as the canonical storage unit here;
-        // unit-aware formatting happens at render time (see convertStructuredToMarkdown below).
-        total_distance_km: { type: 'number' }
-      }
-    }
-  },
-  required: ['type', 'title', 'executive_summary', 'sections']
-}
+/**
+ * Analysis schema for structured JSON output.
+ *
+ * Built from the shared report builder so the section-status vocabulary comes
+ * from `ANALYSIS_SECTION_STATUSES` rather than from a literal that can drift
+ * from the prompt below (CW-425).
+ *
+ * No `scores` block: this is a three-workout comparison, and `buildAnalysisPrompt`
+ * never asks the model for performance scores. Declaring them would make Gemini
+ * invent numbers the prompt gives it no basis for and that nothing renders.
+ */
+export const lastThreeWorkoutsAnalysisSchema = buildReportAnalysisSchema({
+  sectionTitleDescription: 'Section title (e.g., Training Progression, Recovery Patterns)',
+  forbidParagraphBlocks: true,
+  metricsSummaryDescription: 'Key metrics across the workouts'
+})
 
 function buildAnalysisPrompt(workouts: any[], user: any, timezone: string, sportSettings?: any) {
   const dateRange =
@@ -317,12 +239,17 @@ export const analyzeLast3WorkoutsTask = task({
       logger.log('Generating structured analysis with Gemini 3.0 Flash')
 
       // Generate structured JSON analysis
-      const structuredAnalysis = await generateStructuredAnalysis(prompt, analysisSchema, 'flash', {
-        userId,
-        operation: 'last_3_workouts_analysis',
-        entityType: 'Workout',
-        entityId: undefined
-      })
+      const structuredAnalysis = await generateStructuredAnalysis(
+        prompt,
+        lastThreeWorkoutsAnalysisSchema,
+        'flash',
+        {
+          userId,
+          operation: 'last_3_workouts_analysis',
+          entityType: 'Workout',
+          entityId: undefined
+        }
+      )
 
       // Also generate markdown for fallback/export
       const markdownAnalysis = convertStructuredToMarkdown(structuredAnalysis, user?.distanceUnits)

--- a/trigger/generate-custom-report.ts
+++ b/trigger/generate-custom-report.ts
@@ -16,156 +16,41 @@ import {
   formatPromptHeight,
   formatPromptDistance
 } from '../server/utils/ai-prompt-format'
+import {
+  buildReportAnalysisSchema,
+  REPORT_SCORE_SCALE_TEXT
+} from '../server/utils/services/report-analysis-schema'
 
-// Analysis schema for structured JSON output
-const analysisSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      description: 'Type of analysis: workout, weekly_report, planning, comparison',
-      enum: ['workout', 'weekly_report', 'planning', 'comparison']
-    },
-    title: {
-      type: 'string',
-      description: 'Title of the analysis'
-    },
-    date: {
-      type: 'string',
-      description: 'Date or date range of the analysis'
-    },
-    executive_summary: {
-      type: 'string',
-      description: '2-3 sentence high-level summary of key findings'
-    },
-    sections: {
-      type: 'array',
-      description: 'Analysis sections with status and points',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Section title'
-          },
-          status: {
-            type: 'string',
-            description: 'Overall assessment',
-            enum: ['excellent', 'good', 'moderate', 'needs_improvement', 'poor']
-          },
-          status_label: {
-            type: 'string',
-            description: 'Display label for status'
-          },
-          analysis_points: {
-            type: 'array',
-            description:
-              'Detailed analysis points for this section. Each point should be 1-2 sentences maximum as a separate array item.',
-            items: {
-              type: 'string'
-            }
-          }
-        },
-        required: ['title', 'status', 'status_label', 'analysis_points']
-      }
-    },
-    recommendations: {
-      type: 'array',
-      description: 'Actionable coaching recommendations',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Recommendation title'
-          },
-          priority: {
-            type: 'string',
-            description: 'Priority level',
-            enum: ['high', 'medium', 'low']
-          },
-          description: {
-            type: 'string',
-            description: 'Detailed recommendation'
-          }
-        },
-        required: ['title', 'priority', 'description']
-      }
-    },
-    scores: {
-      type: 'object',
-      description: 'Performance scores on 1-10 scale',
-      properties: {
-        overall: {
-          type: 'number',
-          description: 'Overall period assessment (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        overall_explanation: {
-          type: 'string',
-          description: 'Detailed explanation of overall assessment'
-        },
-        training_load: {
-          type: 'number',
-          description: 'Training load management quality (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        training_load_explanation: {
-          type: 'string',
-          description: 'Training load analysis and recommendations'
-        },
-        recovery: {
-          type: 'number',
-          description: 'Recovery adequacy score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        recovery_explanation: {
-          type: 'string',
-          description: 'Recovery analysis and optimization strategies'
-        },
-        progress: {
-          type: 'number',
-          description: 'Progress and adaptation score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        progress_explanation: {
-          type: 'string',
-          description: 'Progress assessment and recommendations'
-        },
-        consistency: {
-          type: 'number',
-          description: 'Training consistency score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        consistency_explanation: {
-          type: 'string',
-          description: 'Consistency analysis and improvement strategies'
-        }
-      }
-    },
-    metrics_summary: {
-      type: 'object',
-      description: 'Key metrics across the period',
-      properties: {
-        total_duration_minutes: { type: 'number' },
-        total_tss: { type: 'number' },
-        avg_power: { type: 'number' },
-        avg_heart_rate: { type: 'number' },
-        total_distance_km: { type: 'number' },
-        total_calories: { type: 'number' },
-        avg_protein_g: { type: 'number' },
-        avg_carbs_g: { type: 'number' },
-        avg_fat_g: { type: 'number' }
-      }
+/**
+ * Analysis schema for structured JSON output.
+ *
+ * Built from the shared report builder so the section-status vocabulary and the
+ * score bounds come from `ANALYSIS_SECTION_STATUSES` / `ANALYSIS_SCORE_MIN|MAX`
+ * rather than from a literal that can drift from the prompt below (CW-425).
+ *
+ * `scores.required` is false here on purpose: a custom report scoped to
+ * nutrition only asks for no performance scores (see `buildAnalysisPrompt`,
+ * which emits the "Include Performance Scores" block only when workout data is
+ * in range), so neither the individual scores nor the `scores` object itself
+ * may be mandatory.
+ */
+export const customReportAnalysisSchema = buildReportAnalysisSchema({
+  sectionTitleDescription: 'Section title',
+  forbidParagraphBlocks: false,
+  scores: {
+    description: `Performance scores on ${REPORT_SCORE_SCALE_TEXT}`,
+    required: false,
+    explanations: {
+      overall: 'Detailed explanation of overall assessment',
+      training_load: 'Training load analysis and recommendations',
+      recovery: 'Recovery analysis and optimization strategies',
+      progress: 'Progress assessment and recommendations',
+      consistency: 'Consistency analysis and improvement strategies'
     }
   },
-  required: ['type', 'title', 'executive_summary', 'sections']
-}
+  metricsSummaryDescription: 'Key metrics across the period',
+  extraMetricsSummaryKeys: ['total_calories', 'avg_protein_g', 'avg_carbs_g', 'avg_fat_g']
+})
 
 function buildNutritionSummary(nutritionDays: any[], timezone: string): string {
   if (nutritionDays.length === 0) return 'No nutrition data available'
@@ -383,12 +268,17 @@ export const generateCustomReportTask = task({
       logger.log('Generating structured report with Gemini')
 
       // Generate structured analysis
-      const analysisJson = await generateStructuredAnalysis<any>(prompt, analysisSchema, 'flash', {
-        userId,
-        operation: 'custom_report_generation',
-        entityType: 'Report',
-        entityId: reportId
-      })
+      const analysisJson = await generateStructuredAnalysis<any>(
+        prompt,
+        customReportAnalysisSchema,
+        'flash',
+        {
+          userId,
+          operation: 'custom_report_generation',
+          entityType: 'Report',
+          entityId: reportId
+        }
+      )
 
       logger.log('Structured report generated successfully')
 

--- a/trigger/generate-weekly-report.ts
+++ b/trigger/generate-weekly-report.ts
@@ -24,170 +24,40 @@ import {
   formatPromptDistance
 } from '../server/utils/ai-prompt-format'
 import { bodyMetricResolver } from '../server/utils/services/bodyMetricResolver'
+import {
+  buildReportAnalysisSchema,
+  REPORT_SCORE_SCALE_TEXT
+} from '../server/utils/services/report-analysis-schema'
 
-// Analysis schema for structured JSON output
-const analysisSchema = {
-  type: 'object',
-  properties: {
-    type: {
-      type: 'string',
-      description: 'Type of analysis: workout, weekly_report, planning, comparison',
-      enum: ['workout', 'weekly_report', 'planning', 'comparison']
-    },
-    title: {
-      type: 'string',
-      description: 'Title of the analysis'
-    },
-    date: {
-      type: 'string',
-      description: 'Date or date range of the analysis'
-    },
-    executive_summary: {
-      type: 'string',
-      description: '2-3 sentence high-level summary of key findings'
-    },
-    sections: {
-      type: 'array',
-      description: 'Analysis sections with status and points',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Section title (e.g., Training Load Analysis, Recovery Trends)'
-          },
-          status: {
-            type: 'string',
-            description: 'Overall assessment',
-            enum: ['excellent', 'good', 'moderate', 'needs_improvement', 'poor']
-          },
-          status_label: {
-            type: 'string',
-            description: 'Display label for status'
-          },
-          analysis_points: {
-            type: 'array',
-            description:
-              'Detailed analysis points for this section. Each point should be 1-2 sentences maximum as a separate array item. Do NOT combine multiple points into paragraph blocks.',
-            items: {
-              type: 'string'
-            }
-          }
-        },
-        required: ['title', 'status', 'status_label', 'analysis_points']
-      }
-    },
-    recommendations: {
-      type: 'array',
-      description: 'Actionable coaching recommendations',
-      items: {
-        type: 'object',
-        properties: {
-          title: {
-            type: 'string',
-            description: 'Recommendation title'
-          },
-          priority: {
-            type: 'string',
-            description: 'Priority level',
-            enum: ['high', 'medium', 'low']
-          },
-          description: {
-            type: 'string',
-            description: 'Detailed recommendation'
-          }
-        },
-        required: ['title', 'priority', 'description']
-      }
-    },
-    scores: {
-      type: 'object',
-      description:
-        'Period performance scores on 1-10 scale for tracking over time, with detailed explanations',
-      properties: {
-        overall: {
-          type: 'number',
-          description: 'Overall period assessment (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        overall_explanation: {
-          type: 'string',
-          description:
-            'Detailed explanation of overall assessment: key highlights from the period, major achievements or concerns, and 2-3 specific actions for next period'
-        },
-        training_load: {
-          type: 'number',
-          description: 'Training load management quality (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        training_load_explanation: {
-          type: 'string',
-          description:
-            'Training load analysis: TSS trends, load appropriateness, fatigue vs fitness balance, and specific recommendations for load management'
-        },
-        recovery: {
-          type: 'number',
-          description: 'Recovery adequacy score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        recovery_explanation: {
-          type: 'string',
-          description:
-            'Recovery analysis: HRV trends, sleep quality observations, recovery adequacy relative to training load, and specific recovery optimization strategies'
-        },
-        progress: {
-          type: 'number',
-          description: 'Progress and adaptation score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        progress_explanation: {
-          type: 'string',
-          description:
-            'Progress assessment: performance trends, adaptation signals, whether training is effective, and recommendations for continued progress'
-        },
-        consistency: {
-          type: 'number',
-          description: 'Training consistency score (1-10)',
-          minimum: 1,
-          maximum: 10
-        },
-        consistency_explanation: {
-          type: 'string',
-          description:
-            'Consistency analysis: adherence patterns, missed sessions analysis, consistency relative to plan, and strategies to improve adherence'
-        }
-      },
-      required: [
-        'overall',
-        'overall_explanation',
-        'training_load',
-        'training_load_explanation',
-        'recovery',
-        'recovery_explanation',
-        'progress',
-        'progress_explanation',
-        'consistency',
-        'consistency_explanation'
-      ]
-    },
-    metrics_summary: {
-      type: 'object',
-      description: 'Key metrics across the period',
-      properties: {
-        total_duration_minutes: { type: 'number' },
-        total_tss: { type: 'number' },
-        avg_power: { type: 'number' },
-        avg_heart_rate: { type: 'number' },
-        total_distance_km: { type: 'number' }
-      }
+/**
+ * Analysis schema for structured JSON output.
+ *
+ * Built from the shared report builder so the section-status vocabulary and the
+ * score bounds come from `ANALYSIS_SECTION_STATUSES` / `ANALYSIS_SCORE_MIN|MAX`
+ * rather than from a literal that can drift from the prompt below (CW-425).
+ * Only this report's copy is declared here.
+ */
+export const weeklyReportAnalysisSchema = buildReportAnalysisSchema({
+  sectionTitleDescription: 'Section title (e.g., Training Load Analysis, Recovery Trends)',
+  forbidParagraphBlocks: true,
+  scores: {
+    description: `Period performance scores on ${REPORT_SCORE_SCALE_TEXT} for tracking over time, with detailed explanations`,
+    required: true,
+    explanations: {
+      overall:
+        'Detailed explanation of overall assessment: key highlights from the period, major achievements or concerns, and 2-3 specific actions for next period',
+      training_load:
+        'Training load analysis: TSS trends, load appropriateness, fatigue vs fitness balance, and specific recommendations for load management',
+      recovery:
+        'Recovery analysis: HRV trends, sleep quality observations, recovery adequacy relative to training load, and specific recovery optimization strategies',
+      progress:
+        'Progress assessment: performance trends, adaptation signals, whether training is effective, and recommendations for continued progress',
+      consistency:
+        'Consistency analysis: adherence patterns, missed sessions analysis, consistency relative to plan, and strategies to improve adherence'
     }
   },
-  required: ['type', 'title', 'executive_summary', 'sections', 'scores']
-}
+  metricsSummaryDescription: 'Key metrics across the period'
+})
 
 export const generateWeeklyReportTask = task({
   id: 'generate-weekly-report',
@@ -366,7 +236,7 @@ Maintain your **${aiSettings.aiPersona}** persona throughout. Be specific with n
       // Generate structured analysis
       const analysisJson = await generateStructuredAnalysis<any>(
         prompt,
-        analysisSchema,
+        weeklyReportAnalysisSchema,
         aiSettings.aiModelPreference,
         {
           userId,


### PR DESCRIPTION
Fixes CW-425

## What

`trigger/generate-weekly-report.ts`, `trigger/generate-custom-report.ts` and `trigger/analyze-last-3-workouts.ts` each carried their own inline `const analysisSchema = { ... }`, restating the section-status vocabulary and the 1-10 score bounds as hardcoded literals. They agreed with their prompts today, but nothing held them there -- the same latent state the workout schema was in before CW-403 broke it (schema said 0-100 / `fair`/`needs_attention`/`info`, prompt said 1-10 / `excellent`..`poor`, and every UI status-to-colour mapper fell through to grey).

All three now build from a new shared `buildReportAnalysisSchema` in `server/utils/services/report-analysis-schema.ts`, which takes the enum from `ANALYSIS_SECTION_STATUSES` and the bounds -- including the `(1-10)` text inside each score description -- from `ANALYSIS_SCORE_MIN`/`ANALYSIS_SCORE_MAX`.

## Why a parameterised builder rather than one shared constant

The three reports genuinely differ, and forcing them onto one frozen schema would change what the model is asked for:

| | weekly | custom | last-3 |
|---|---|---|---|
| section-title copy | examples | bare | examples |
| `analysis_points` "no paragraph blocks" clause | yes | no | yes |
| `scores` | required | optional | **absent** |
| score-explanation copy | verbose | terse | n/a |
| `metrics_summary` | 5 fields | 5 + nutrition macros | 5 fields |

They are also deliberately not folded onto the workout `analysisSchema`: reports score a training *period* (`training_load`/`recovery`/`progress`/`consistency`), not a session (`technical`/`effort`/`pacing`/`execution`).

## Behaviour is unchanged

Verified mechanically, not by eye: the three original literals were extracted from the pre-change sources and compared against the built schemas with `JSON.stringify(x, null, 2)`. All three are **byte-identical, key order included**. What each task hands `generateStructuredAnalysis` is exactly what it handed before. These generate athlete-facing documents, so that was the bar.

## Drift regression

A shared schema that can still drift from its prompt has only moved the problem, so CW-403's technique is extended to each remaining schema/prompt pair. New suite `report analysis schemas match the prompts they are handed with (CW-425)` in `workout-analysis-prompt.test.ts` reads each task's own **prompt source** and asserts:

- the `status assessment (a/b/c)` vocabulary the prompt instructs equals the schema's enum, and the retired CW-403 vocabulary never returns
- the `Performance Scores (N-M scale)` bounds the prompt states equal the schema's `minimum`/`maximum` and the shared constants
- **bidirectional**: a task declares `scores` exactly when its prompt asks for them (a schema-only scores block makes Gemini invent numbers; a prompt-only one gets silently dropped)
- every score dimension the schema declares is named in the prompt
- the per-report differences that behaviour depends on survive (`status_label` required, weekly-only `scores` in top-level `required`, nutrition metrics custom-only)
- the CW-403 `not.toContain('const analysisSchema')` guard now covers all three report files

Both guards were mutation-tested: swapping the weekly prompt to `excellent/good/fair/needs_attention/poor` fails exactly 1 test; adding a scores block to `analyze-last-3-workouts` fails 4.

## Verification

```
pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts
  Test Files  1 passed (1)
       Tests  47 passed (47)

pnpm typecheck:server
  exit 0

pnpm test:unit   (full suite)
  Test Files  375 passed (375)
       Tests  2360 passed (2360)

pnpm lint
  0 errors
```

Backend only, no user-visible surface -- UX critique round skipped per the ticket.