### PR TITLE
fix(workouts): centre the smoothing window so detection does not lag edges (CW-432)

### DIFF
--- a/server/utils/interval-detection.ts
+++ b/server/utils/interval-detection.ts
@@ -1222,11 +1222,38 @@ export function findPeakEfforts(
 
 // --- Helper Functions ---
 
+/**
+ * Centred moving average — the smoothed value at `i` is the mean of a window
+ * whose centre of mass is `i` itself, so a smoothed edge sits where the real
+ * edge sits.
+ *
+ * This used to take `[i - floor(w/2) .. i + ceil(w/2) - 1]`. For the `w = 10`
+ * both call sites use, that is `[i-5 .. i+4]`: ten samples centred on `i - 0.5`.
+ * Half a sample of lag is small, but it is a lag in one direction only, so it
+ * moved every detected rising edge early and every falling edge late — and the
+ * detector runs on this signal, so the shift lands directly in rep boundaries
+ * and therefore in every per-rep statistic (CW-432).
+ *
+ * Even/odd `windowSize` (CW-432 acceptance criterion): the window is always
+ * `[i - half .. i + half]` inclusive with `half = floor(windowSize / 2)`, i.e.
+ * `2 * half + 1` samples. An ODD window is therefore exactly `windowSize`
+ * samples wide, as asked. An EVEN window cannot be centred on an integer index
+ * at its requested width — any 10-sample window is centred on a half-sample —
+ * so it is widened by one to 11. Widening rather than narrowing keeps at least
+ * the smoothing strength the caller asked for; the alternative (dropping to 9)
+ * would quietly under-smooth. Callers that need an exact width should pass an
+ * odd one.
+ *
+ * Near the array ends the window is clipped to the available data, so the first
+ * and last `half` outputs are means of fewer samples. That is unchanged, and is
+ * the standard trade for not inventing data outside the stream.
+ */
 function smoothData(data: number[], windowSize: number): number[] {
+  const half = Math.floor(windowSize / 2)
   const result: number[] = []
   for (let i = 0; i < data.length; i++) {
-    const start = Math.max(0, i - Math.floor(windowSize / 2))
-    const end = Math.min(data.length, i + Math.ceil(windowSize / 2))
+    const start = Math.max(0, i - half)
+    const end = Math.min(data.length, i + half + 1)
     const subset = data.slice(start, end)
     const avg = subset.reduce((a, b) => a + (b || 0), 0) / subset.length
     result.push(avg)

--- a/tests/unit/server/utils/interval-detection.test.ts
+++ b/tests/unit/server/utils/interval-detection.test.ts
@@ -489,6 +489,69 @@ describe('detectIntervals', () => {
       expect(workDurations).toEqual([239, 239, 239, 239])
     })
   })
+
+  /* ------------------------------------------------------------------ */
+  /* Centred smoothing window (CW-432)                                   */
+  /* ------------------------------------------------------------------ */
+
+  describe('centred smoothing window (CW-432)', () => {
+    /**
+     * A perfectly square block occupying samples 600..839 in an otherwise flat
+     * stream. Nothing about this signal is ambiguous: every sample is either in
+     * the block or out of it, so a detector that reports anything other than
+     * 600..839 is reporting its own smoothing lag.
+     *
+     * The engine's internal smoother (`smoothData(values, 10)`) used to average
+     * `[i-5 .. i+4]` — ten samples centred on `i - 0.5`. Half a sample of lag,
+     * always in the same direction, is enough to carry one recovery sample into
+     * the end of every rep: this fixture detected 600..840. It is now centred,
+     * so both edges land where they actually are.
+     *
+     * No plan is passed, so this is the candidate/merge pass, and HR is used
+     * because that path takes the engine's own smoothing (the power path is
+     * handed rolling normalized power by its caller instead).
+     */
+    const buildSquareBlock = (hi: number, lo: number) => {
+      const values = Array.from({ length: 1500 }, (_, index) =>
+        index >= 600 && index <= 839 ? hi : lo
+      )
+      return { values, time: values.map((_, index) => index) }
+    }
+
+    it('places both edges of a sharp block exactly, with no linked plan', () => {
+      const { values, time } = buildSquareBlock(170, 120)
+
+      const detected = detectIntervals(time, values, 'heartrate', 145)
+      const work = detected.filter((interval) => interval.type === 'WORK')
+
+      expect(work).toHaveLength(1)
+      // Was [600, 840] with the asymmetric window: sample 840 is a 120 bpm
+      // recovery sample, and it was the single worst input to a CoV taken
+      // inside the rep.
+      expect([work[0]?.start_index, work[0]?.end_index]).toEqual([600, 839])
+    })
+
+    it('places the edges independently of how far the block clears the bar', () => {
+      // The lag was a property of the window, not of the contrast, so it showed
+      // up identically at every amplitude. Guard all three.
+      for (const [hi, lo, bar] of [
+        [170, 120, 145],
+        [180, 120, 150],
+        [160, 130, 145]
+      ] as const) {
+        const { values, time } = buildSquareBlock(hi, lo)
+        const work = detectIntervals(time, values, 'heartrate', bar).filter(
+          (interval) => interval.type === 'WORK'
+        )
+
+        expect({ hi, lo, bounds: [work[0]?.start_index, work[0]?.end_index] }).toEqual({
+          hi,
+          lo,
+          bounds: [600, 839]
+        })
+      }
+    })
+  })
 })
 
 describe('resolveHrWorkThreshold', () => {


### PR DESCRIPTION
Fixes CW-432

`smoothData` averaged `[i - floor(w/2) .. i + ceil(w/2) - 1]`. For the `w = 10` both call sites use that is `[i-5 .. i+4]` — ten samples whose centre of mass is `i - 0.5`, not `i`. Detection runs on that signal, so every edge it found was shifted half a sample in one direction. The window is now `[i - half .. i + half]` inclusive with `half = floor(w / 2)`, centred on `i`.

## Re-measurement first, as the ticket required

Measured on `develop` @ `eb23d40d`, before any change, on a faithful reconstruction of CW-393's threshold fixture (blocks 150/271/140/274/140/276/140/223/120 W, FTP 280):

| path | `executionStabilityScore` at filing | re-measured before | after this PR |
| --- | --- | --- | --- |
| plan-guided | 96.9 | **96.9** | **96.9** |
| provider laps, no plan | — | **96.9** | **96.9** |
| candidate/merge (no plan, no laps) | 78.5 | **22.8** | **22.8** |

**The gap has not closed — it is wider than believed (74 points, not ~18) — but it is not `smoothData`, and this PR does not move it.** The detected boundaries on that fixture are byte-identical before and after this change.

### Why: the power path never calls `smoothData`

`buildDetectedIntervalCandidate` (`workout-analysis-facts.ts`) hands the power branch `calculateRollingNormalizedPower(power)` as `smoothedValues`, so the `smoothedValues || smoothData(values, 10)` fallback never fires for a ride. Rolling NP is a **trailing** 30-sample mean (`power-metrics.ts:49`), centre of mass at `i - 14.5`.

That accounts for the whole error, to the sample. Work bar = `0.7 x 280 = 196 W`:

- rising `150 -> 271`: the trailing mean crosses 196 once `(196-150)/121 = 38%` of the window is inside the block → **11.4 samples late**. Observed rising edges: 611, 1092, 1572 against truth 600, 1080, 1560 → **11, 12, 12 late**.
- falling `271 -> 140`: the mean stays above 196 while `(271-196)/131 = 57.2%` of the window is still inside → **17.2 samples late**. Observed falling edges: 856, 1336, 1816 against truth 839, 1319, 1799 → **17 late**.

Both edges late is the signature of a trailing window. `smoothData`'s asymmetry would have moved them in *opposite* directions and by half a sample, not eleven.

So acceptance criteria 3 and 4 as written are not satisfiable from this ticket's owned paths — the fix they describe lives in `server/utils/power-metrics.ts`, which is out of scope here and has a much wider blast radius (rolling NP also feeds chart rendering). Reported back for a separate ticket rather than widened into this one.

## What this PR does fix

`smoothData` still governs the **pace and heart-rate** detection paths, where no pre-smoothed stream is supplied. On a perfectly square HR block occupying samples 600..839 in an otherwise flat stream, with no linked plan (candidate/merge pass):

| amplitude / bar | before | after |
| --- | --- | --- |
| 170 / 120 bpm, bar 145 | `[600..840]` | **`[600..839]`** |
| 180 / 120 bpm, bar 150 | `[600..840]` | **`[600..839]`** |
| 160 / 130 bpm, bar 145 | `[600..840]` | **`[600..839]`** |

Sample 840 is a recovery sample. Carrying it into the rep is exactly the contamination the ticket describes — it is the single worst input to a coefficient of variation computed inside that rep — and it is now gone. Both new regression tests fail on `develop` and pass here.

## Even/odd `windowSize`

Defined in the function's doc comment and in code: the window is always `2 * half + 1` samples.

- **Odd** `w` → exactly `w` samples, centred. (The acceptance criterion: an odd window still gets a centred window.)
- **Even** `w` → cannot be centred on an integer index at its requested width, so it is widened by one (10 → 11). Widening rather than narrowing to 9 keeps at least the smoothing strength the caller asked for instead of quietly under-smoothing.

Near the array ends the window is still clipped to available data, unchanged.

## Verification

Ticket's verification command:

```
Test Files  3 passed (3)
     Tests  137 passed (137)
```

Full unit suite (this change can reach anything that consumes detection):

```
Test Files  376 passed (376)
     Tests  2390 passed (2390)
```

`eslint` and `prettier --check` clean on both changed files.

**No pinned expectation moved anywhere in the repository.** Specifically re-run and green, as the ticket required:

- **CW-401 pace tests** — `separates run work reps from a realistic 70%-of-threshold recovery jog`, `holds the work/recovery split across the realistic 60-75% recovery-jog range`, `still collapses into one block when no threshold pace is available`.
- **CW-383 HR tests** — `segments an HR interval session against a profile-sourced work bar`, `classifies a long steady HR session with no candidates as STEADY`, the `heart-rate intensity zones` block, `resolveHrWorkThreshold`, and `thresholdDetectionService` in full.

The stop condition was never reached: nothing needed retuning, and no expectation was adjusted.
