### PR TITLE
fix(workouts): stop coercing a null lap intensity to zero (CW-439)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2696,4 +2696,147 @@ describe('actual-interval source arbitration and hard-repeat scale (CW-408)', ()
       )
     ).toBe('raw')
   })
+
+  /**
+   * Nested inside the CW-408 suite to reuse its stream, plan and FTP: this is
+   * the same physical session and the same arbitration, asked one further
+   * question. Nothing above is modified — CW-408 deliberately left the `null`
+   * case unpinned, and these tests are what pin it.
+   *
+   * A provider that cannot compute a lap's intensity sends `intensity: null`.
+   * `Number(null)` is `0` and `0` is finite, so that lap used to arrive
+   * downstream claiming an intensity factor of zero. `getActualHardRepeats`
+   * reads `intensity !== null` as "this lap has a usable intensity signal" and
+   * only falls back to average power when it does not, so the fabricated `0`
+   * short-circuited the fallback and made the lap permanently un-hard — at any
+   * wattage. An ABSENT field never had the problem (`Number(undefined)` is
+   * `NaN`), which is the asymmetry these tests exist to document (CW-439).
+   */
+  describe('provider laps with an explicit null intensity (CW-439)', () => {
+    /**
+     * The same laps as `ACCURATE_PROVIDER_LAPS`, except the provider could not
+     * compute an intensity for the five reps and sent `null` for them.
+     *
+     * Types are stated explicitly rather than left as the provider's blanket
+     * `WORK`, so lap classification here comes from the labels alone and this
+     * test is measuring the hard-repeat predicate rather than the type
+     * re-derivation heuristic.
+     */
+    const NULL_INTENSITY_LAPS: Array<{
+      type: string
+      seconds: number
+      watts: number
+      intensity: number | null
+    }> = [
+      { type: 'WARMUP', seconds: 600, watts: 143, intensity: 55 },
+      { type: 'WORK', seconds: 240, watts: 276, intensity: null },
+      { type: 'RECOVERY', seconds: 180, watts: 135, intensity: 52 },
+      { type: 'WORK', seconds: 240, watts: 273, intensity: null },
+      { type: 'RECOVERY', seconds: 180, watts: 135, intensity: 52 },
+      { type: 'WORK', seconds: 240, watts: 271, intensity: null },
+      { type: 'RECOVERY', seconds: 180, watts: 133, intensity: 51 },
+      { type: 'WORK', seconds: 240, watts: 273, intensity: null },
+      { type: 'RECOVERY', seconds: 180, watts: 135, intensity: 52 },
+      { type: 'WORK', seconds: 240, watts: 268, intensity: null },
+      { type: 'RECOVERY', seconds: 180, watts: 133, intensity: 51 },
+      { type: 'WORK', seconds: 900, watts: 221, intensity: 85 },
+      { type: 'COOLDOWN', seconds: 300, watts: 117, intensity: 45 }
+    ]
+
+    function buildNullIntensityWorkout() {
+      const time: number[] = []
+      const watts: number[] = []
+      let cursor = 0
+      for (const block of ARBITRATION_STREAM_BLOCKS) {
+        for (let index = 0; index < block.seconds; index++) {
+          time.push(cursor)
+          watts.push(block.watts + ((index % 5) - 2))
+          cursor++
+        }
+      }
+
+      return makeWorkout({
+        title: 'VO2 5x4min',
+        type: 'Ride',
+        durationSec: time.length,
+        ftp: ARBITRATION_FIXTURE_FTP,
+        rawJson: {
+          icu_intervals: NULL_INTENSITY_LAPS.map((lap) => ({
+            type: lap.type,
+            moving_time: lap.seconds,
+            average_watts: lap.watts,
+            intensity: lap.intensity
+          }))
+        },
+        streams: { time, watts }
+      })
+    }
+
+    it('keeps a null intensity null instead of coercing it to a zero it never sent', () => {
+      // The unit boundary. `null` is "no intensity signal", exactly as an
+      // absent field already was; it is not an intensity factor of zero.
+      expect(toIntervalIntensityFactor(null)).toBeNull()
+      expect(toIntervalIntensityFactor(undefined)).toBeNull()
+
+      // Every other falsy non-number `Number()` would silently turn into 0.
+      expect(toIntervalIntensityFactor('')).toBeNull()
+      expect(toIntervalIntensityFactor('   ')).toBeNull()
+      expect(toIntervalIntensityFactor(false)).toBeNull()
+      expect(toIntervalIntensityFactor(true)).toBeNull()
+      expect(toIntervalIntensityFactor([])).toBeNull()
+      expect(toIntervalIntensityFactor({})).toBeNull()
+
+      // A real zero on the wire is still a real zero, and numeric strings from
+      // looser providers and older fixtures still convert.
+      expect(toIntervalIntensityFactor(0)).toBe(0)
+      expect(toIntervalIntensityFactor('101')).toBe(1.01)
+      expect(toIntervalIntensityFactor('0.52')).toBe(0.52)
+    })
+
+    it('carries the null through mapping instead of fabricating an intensity factor', () => {
+      const actual = getActualIntervalsForAnalysis(buildNullIntensityWorkout())
+
+      // The five reps and the endurance block are the work laps; the reps
+      // report no intensity, which is the truth the provider sent.
+      expect(workLapsOf(actual).map((interval) => interval.durationSeconds)).toEqual([
+        240, 240, 240, 240, 240, 900
+      ])
+      expect(
+        workLapsOf(actual)
+          .filter((interval) => interval.durationSeconds === 240)
+          .map((interval) => interval.intensity)
+      ).toEqual([null, null, null, null, null])
+
+      // The laps that did carry an intensity are untouched by the guard.
+      expect(actual.find((interval) => interval.durationSeconds === 900)?.intensity).toBe(0.85)
+    })
+
+    it('counts a null-intensity lap as a hard repeat on average power alone', () => {
+      const workout = buildNullIntensityWorkout()
+
+      // `getActualHardRepeats` is private; the arbitration is where its verdict
+      // becomes observable. Accurately lapped reps only beat the engine's
+      // ragged segmentation through `scoreHardRepeatDurationAccuracy`, and that
+      // discriminator needs the raw side to have hard repeats at all. With the
+      // reps' intensity fabricated as `0`, the `avgPower` fallback never ran,
+      // the raw side had zero hard repeats, and this session — whose laps are
+      // timed to the second — lost the arbitration to the detection engine.
+      expect(getActualIntervalsSourceForAnalysis(workout, arbitrationPlan)).toBe('raw')
+
+      // 'raw' means the provider's own laps are what every downstream fact,
+      // the prompt and the athlete's interval chart are built from.
+      const chosen = getActualIntervalsForAnalysis(workout, arbitrationPlan)
+      expect(chosen.map((interval) => interval.durationSeconds)).toEqual(
+        NULL_INTENSITY_LAPS.map((lap) => lap.seconds)
+      )
+
+      // Each rep is well above 0.95 x FTP (247W), which is the whole reason the
+      // power fallback is the right answer for these laps.
+      expect(
+        workLapsOf(chosen)
+          .filter((interval) => interval.durationSeconds === 240)
+          .every((interval) => (interval.avgPower ?? 0) >= ARBITRATION_FIXTURE_FTP * 0.95)
+      ).toBe(true)
+    })
+  })
 })

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1717,9 +1717,28 @@ function mapProviderIntervalsToActual(intervals: any[]): ActualInterval[] {
  *
  * Engine-detected intervals (`detectIntervals`) carry no intensity field at
  * all, so they stay `null` — there is no second unit to reconcile.
+ *
+ * Non-numeric input is rejected BEFORE coercion rather than after, because
+ * `Number(null)`, `Number('')` and `Number(false)` are all a perfectly finite
+ * `0` that `Number.isFinite` waves through (the same trap `medianOf` guards
+ * against, CW-396). A fabricated `0` is not merely a wrong number here: it is
+ * an intensity signal where the provider stated there is none, and
+ * `getActualHardRepeats` reads `intensity !== null` as "this lap has a usable
+ * intensity" before falling back to average power. So a lap the provider sent
+ * as an explicit `intensity: null` could never be a hard repeat no matter how
+ * many watts it carried, while an ABSENT field (`Number(undefined)` is `NaN`)
+ * behaved correctly — an asymmetry with no defensible meaning (CW-439).
  */
 export function toIntervalIntensityFactor(value: unknown): number | null {
-  const numeric = Number(value)
+  // A numeric string is accepted because fixtures and looser providers send
+  // one; everything else (null, undefined, '', booleans, objects) is "no
+  // intensity", not zero intensity.
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim() !== ''
+        ? Number(value)
+        : Number.NaN
   if (!Number.isFinite(numeric)) return null
   return numeric > 5 ? numeric / 100 : numeric
 }


### PR DESCRIPTION
Fixes CW-439

## The bug

`Number(null)` is `0` and `0` is finite, so `toIntervalIntensityFactor(null)` returned `0` rather than `null`. That fabricated `0` then passed the `interval.intensity !== null` guard in `getActualHardRepeats`, which reads that guard as "this lap has a usable intensity signal" and only falls back to average power when it does not. So a lap the provider sent as an explicit `intensity: null` could never be counted as a hard repeat at any wattage.

An **absent** field was always fine (`Number(undefined)` is `NaN`). Only an explicit `null` was affected -- which is exactly what a provider sends for a lap whose intensity it could not compute. Same `Number(null) === 0` trap CW-396 hit in `medianOf`; the same guard-before-coercion shape is used here.

## The fix

`toIntervalIntensityFactor` now rejects non-numeric input **before** coercing instead of relying on `Number.isFinite` afterwards. Numbers and non-blank numeric strings convert; `null`, `undefined`, `''`, `'   '`, booleans, arrays and objects all return `null`. A real `0` on the wire is still a real `0`.

## Blast radius

Every reader of `ActualInterval.intensity` was checked; `getActualHardRepeats` is the only one whose behaviour changes, and it changes in the intended direction:

| Reader | Effect |
| --- | --- |
| `getActualHardRepeats` (L2430) | **The fix.** The `avgPower` fallback now runs for a null-intensity lap. |
| `medianOf(actualWorkIntervals...)` (L2731) | Strictly better -- `medianOf` already drops nulls, so a fabricated `0` used to drag the median of real intensity factors toward zero. |
| `resolveRepEfforts` channels (L3153/3157) | No change -- reads through `positiveOrNull`, which already collapsed `0` to `null`. |
| `firstVsLastRepDeltaPct` (L3405) | No change -- `0` was falsy at the `firstMetric && lastMetric` gate and returned `null`, same as now. |
| `pairMetric` RPE branch (L3856, CW-385) | No change -- `0` failed the `actualValue > 0` comparability gate, so the step was excluded either way. |
| `workout-analysis-prompt.ts` L547 / L1621 | Improvement -- the prompt JSON emitted `"intensity": 0`, telling the model a lap was ridden at 0% of threshold. It now emits `null`. The rendered line used a truthy check, so it omitted the field before and after. |

`deriveDurabilitySignals` reaches intensity only through `resolveRepEfforts` and `firstVsLastRepDeltaPct`, both unaffected.

## Tests

Three tests added, nested inside the CW-408 suite so they reuse its stream, plan and FTP: the unit boundary, the null surviving `mapIntervalsToActual`, and the behavioural one -- a session whose five reps carry `intensity: null` but 268-276W against a 260W FTP now arbitrates to `'raw'` instead of losing to the detection engine.

All three were confirmed to **fail** against the pre-fix source (the behavioural one returned `'detected'`), and the 78 pre-existing tests were confirmed to pass unchanged on the pre-fix source -- no CW-408 assertion moved.

## Verification

```
pnpm typecheck                                          -> exit 0
pnpm test:unit server/utils/workout-analysis-facts.test.ts -> 81 passed (81)
```

Also green: `workout-analysis-prompt.test.ts` + `interval-detection.test.ts`, 93 passed.