### PR TITLE
feat(cli): selective prod → testing user data transfer (CW-452)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 DATABASE_URL="postgresql://username:password@localhost:5439/dbname?connection_limit=20&pool_timeout=10&connect_timeout=10"
 # E2E tests use a dedicated stack (Postgres + Redis + app) — see .env.e2e.example, docs/04-guides/e2e-testing.md, and `pnpm e2e:setup`
 DATABASE_URL_PROD="postgresql://username:password@localhost:5439/dbname"
+# Testing instance database — target of `pnpm cw:cli users data transfer` (see docs/04-guides/user-data-transfer.md)
+DATABASE_URL_TESTING="postgresql://username:password@localhost:5439/dbname"
 
 # PostgreSQL Connection (for scripts/tools)
 POSTGRES_HOST=localhost

--- a/cli/users/data-transfer.ts
+++ b/cli/users/data-transfer.ts
@@ -1,0 +1,283 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import readline from 'readline/promises'
+import 'dotenv/config'
+import { PrismaClient } from '@prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import pg from 'pg'
+import Table from 'cli-table3'
+import {
+  ALL_SECTIONS,
+  DEFAULT_SECTIONS,
+  EXCLUDED_TABLES,
+  TRANSFER_SECTIONS,
+  type TransferSection
+} from '../../server/utils/data-management/transfer-plan'
+import { transferUserData } from '../../server/utils/data-management/user-data-transfer'
+
+const DEFAULT_SOURCE = 'DATABASE_URL_PROD'
+const DEFAULT_TARGET = 'DATABASE_URL_TESTING'
+
+interface Connection {
+  prisma: PrismaClient
+  pool: pg.Pool
+  url: string
+  label: string
+}
+
+/** Accepts either an env var name (`DATABASE_URL_PROD`) or a literal postgres URL. */
+function resolveUrl(ref: string): { url: string; label: string } {
+  if (ref.startsWith('postgres://') || ref.startsWith('postgresql://')) {
+    return { url: ref, label: describe(ref) }
+  }
+  const url = process.env[ref]
+  if (!url) {
+    throw new Error(`${ref} is not set in .env (and is not a postgres:// URL)`)
+  }
+  return { url: url.replace(/^"|"$/g, ''), label: `${ref} → ${describe(url)}` }
+}
+
+/** host:port/database — never the credentials. */
+function describe(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.hostname}:${parsed.port || '5432'}${parsed.pathname}`
+  } catch {
+    return '<unparseable url>'
+  }
+}
+
+function connect(url: string, label: string): Connection {
+  const pool = new pg.Pool({ connectionString: url })
+  const prisma = new PrismaClient({ adapter: new PrismaPg(pool) })
+  return { prisma, pool, url, label }
+}
+
+async function close(conn?: Connection) {
+  if (!conn) return
+  await conn.prisma.$disconnect()
+  await conn.pool.end()
+}
+
+function parseSections(value: string | undefined, fallback: TransferSection[]): TransferSection[] {
+  if (!value) return fallback
+  if (value.trim() === 'all') return [...ALL_SECTIONS]
+  const requested = value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  const unknown = requested.filter((s) => !ALL_SECTIONS.includes(s as TransferSection))
+  if (unknown.length) {
+    throw new Error(
+      `Unknown section(s): ${unknown.join(', ')}. Known: ${ALL_SECTIONS.join(', ')} (or "all")`
+    )
+  }
+  return requested as TransferSection[]
+}
+
+function parseDate(value: string | undefined, what: string): Date | undefined {
+  if (!value) return undefined
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid ${what} date: ${value}`)
+  return date
+}
+
+async function findUser(prisma: PrismaClient, identifier: string) {
+  return prisma.user.findFirst({
+    where: { OR: [{ id: identifier }, { email: identifier }] },
+    select: { id: true, email: true, name: true }
+  })
+}
+
+function printSections() {
+  const table = new Table({ head: ['Section', 'Default', 'Contents'], wordWrap: true })
+  for (const section of TRANSFER_SECTIONS) {
+    table.push([
+      section.key,
+      section.optIn ? chalk.dim('opt-in') : chalk.green('yes'),
+      section.description
+    ])
+  }
+  console.log(table.toString())
+  console.log(chalk.bold('\nNever transferred:'))
+  for (const excluded of EXCLUDED_TABLES) {
+    console.log(`  ${chalk.dim('·')} ${excluded.name} ${chalk.dim(`— ${excluded.reason}`)}`)
+  }
+}
+
+const transferCommand = new Command('transfer')
+  .description("Copy a user's data from one instance's database into another (e.g. prod → testing)")
+  .option('--user <identifier>', 'Source user email or id')
+  .option('--target-user <identifier>', 'Target user id or email (defaults to the same id)')
+  .option('--from <envVarOrUrl>', 'Source database', DEFAULT_SOURCE)
+  .option('--to <envVarOrUrl>', 'Target database', DEFAULT_TARGET)
+  .option(
+    '--sections <list>',
+    `Comma-separated sections, or "all" (default: ${DEFAULT_SECTIONS.join(',')})`
+  )
+  .option('--skip <list>', 'Comma-separated sections to exclude')
+  .option('--since <date>', 'Only date-ranged records on or after this date (YYYY-MM-DD)')
+  .option('--until <date>', 'Only date-ranged records on or before this date (YYYY-MM-DD)')
+  .option('--replace', "Delete the target user's rows in the selected sections first")
+  .option('--dry-run', 'Report what would be copied and write nothing')
+  .option('-y, --yes', 'Skip the confirmation prompt')
+  .option('--list-sections', 'Print the available sections and exit')
+  .action(async (options) => {
+    if (options.listSections) {
+      printSections()
+      return
+    }
+
+    let source: Connection | undefined
+    let target: Connection | undefined
+
+    try {
+      if (!options.user) throw new Error('--user is required (source user email or id)')
+
+      const selected = parseSections(options.sections, [...DEFAULT_SECTIONS])
+      const skipped = parseSections(options.skip, [])
+      const sections = selected.filter((s) => !skipped.includes(s))
+      if (sections.length === 0) throw new Error('No sections selected')
+
+      const range = {
+        from: parseDate(options.since, '--since'),
+        to: parseDate(options.until, '--until')
+      }
+
+      const from = resolveUrl(options.from)
+      const to = resolveUrl(options.to)
+
+      // Guardrails: this tool must never write to the source, or to production.
+      if (from.url === to.url) {
+        throw new Error('Source and target databases are the same — refusing to run')
+      }
+      const prodUrl = process.env.DATABASE_URL_PROD?.replace(/^"|"$/g, '')
+      if (prodUrl && to.url === prodUrl) {
+        throw new Error('Target resolves to DATABASE_URL_PROD — refusing to write to production')
+      }
+
+      source = connect(from.url, from.label)
+      target = connect(to.url, to.label)
+
+      const sourceUser = await findUser(source.prisma, options.user)
+      if (!sourceUser) throw new Error(`Source user "${options.user}" not found in ${from.label}`)
+
+      const targetIdentifier = options.targetUser || sourceUser.id
+      const targetUser = await findUser(target.prisma, targetIdentifier)
+      if (!targetUser) {
+        throw new Error(
+          `Target user "${targetIdentifier}" not found in ${to.label}. ` +
+            'Create the user on the target instance first (sign in there once), then pass its id with --target-user.'
+        )
+      }
+
+      console.log()
+      console.log(`${chalk.bold('Source')}  ${chalk.yellow(from.label)}`)
+      console.log(`        ${sourceUser.email} ${chalk.dim(sourceUser.id)}`)
+      console.log(`${chalk.bold('Target')}  ${chalk.cyan(to.label)}`)
+      console.log(`        ${targetUser.email} ${chalk.dim(targetUser.id)}`)
+      console.log(`${chalk.bold('Sections')} ${sections.join(', ')}`)
+      if (range.from || range.to) {
+        console.log(
+          `${chalk.bold('Range')}   ${range.from?.toISOString().slice(0, 10) ?? '…'} → ${
+            range.to?.toISOString().slice(0, 10) ?? '…'
+          }`
+        )
+      }
+      if (options.replace) {
+        console.log(
+          chalk.red(`${chalk.bold('Replace')} target rows in these sections are DELETED first`)
+        )
+      }
+      console.log()
+
+      if (options.dryRun) {
+        const report = await transferUserData(source.prisma, target.prisma, {
+          sourceUserId: sourceUser.id,
+          targetUserId: targetUser.id,
+          sections,
+          range,
+          dryRun: true
+        })
+        const table = new Table({ head: ['Section', 'Table', 'Rows in source'] })
+        for (const row of report.tables) {
+          table.push([row.section, row.label, row.fetched.toLocaleString()])
+        }
+        console.log(table.toString())
+        console.log(chalk.bold(`Total: ${report.totals.fetched.toLocaleString()} rows`))
+        console.log(chalk.dim('Dry run — nothing was written.'))
+        return
+      }
+
+      if (!options.yes) {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+        const answer = await rl.question(
+          chalk.yellow(`Write this data into ${to.label} as ${targetUser.email}? [y/N] `)
+        )
+        rl.close()
+        if (answer.trim().toLowerCase() !== 'y') {
+          console.log('Aborted.')
+          return
+        }
+      }
+
+      const started = Date.now()
+      const report = await transferUserData(source.prisma, target.prisma, {
+        sourceUserId: sourceUser.id,
+        targetUserId: targetUser.id,
+        sections,
+        range,
+        replace: options.replace,
+        pools: { source: source.pool, target: target.pool },
+        onProgress: (message) => console.log(chalk.dim(`  ${message}`))
+      })
+
+      console.log()
+      const table = new Table({
+        head: ['Table', 'Source', 'Inserted', 'Existing', 'Dropped', 'Failed', 'Deleted']
+      })
+      for (const row of report.tables) {
+        if (!row.fetched && !row.deleted) continue
+        table.push([
+          row.label,
+          row.fetched.toLocaleString(),
+          row.inserted.toLocaleString(),
+          row.skippedExisting.toLocaleString(),
+          row.droppedRefs ? chalk.yellow(row.droppedRefs.toLocaleString()) : '0',
+          row.failed ? chalk.red(row.failed.toLocaleString()) : '0',
+          row.deleted.toLocaleString()
+        ])
+      }
+      console.log(table.toString())
+
+      const failures = report.tables.filter((t) => t.errors.length)
+      if (failures.length) {
+        console.log(chalk.red('\nProblems:'))
+        for (const row of failures) {
+          for (const error of row.errors) console.log(`  ${row.label}: ${error}`)
+        }
+      }
+
+      console.log()
+      console.log(
+        chalk.green(
+          `✅ ${report.totals.inserted.toLocaleString()} rows written in ${(
+            (Date.now() - started) /
+            1000
+          ).toFixed(1)}s` + (report.profileUpdated ? ' (profile updated)' : '')
+        )
+      )
+      if (report.totals.failed) {
+        console.log(chalk.red(`${report.totals.failed} rows failed — see above.`))
+        process.exitCode = 1
+      }
+    } catch (e) {
+      console.error(chalk.red(`\n❌ ${(e as Error).message}`))
+      process.exitCode = 1
+    } finally {
+      await close(source)
+      await close(target)
+    }
+  })
+
+export default transferCommand

--- a/cli/users/data.ts
+++ b/cli/users/data.ts
@@ -9,8 +9,11 @@ import path from 'path'
 import zlib from 'zlib'
 import { UserUniverseCollector } from '../../server/utils/data-management/collector'
 import { UserUniverseImporter } from '../../server/utils/data-management/importer'
+import transferCommand from './data-transfer'
 
 const dataCommand = new Command('data').description('Export and import user data universes')
+
+dataCommand.addCommand(transferCommand)
 
 async function getPrisma(isProd: boolean) {
   const connectionString = isProd ? process.env.DATABASE_URL_PROD : process.env.DATABASE_URL

--- a/docs/04-guides/cli-reference.md
+++ b/docs/04-guides/cli-reference.md
@@ -68,6 +68,8 @@ Manage user accounts, statistics, and quotas.
 - `location`: Manage user countries based on last login IP.
 - `quota`: View or manage user AI/API usage quotas.
 - `reset-quota`: Reset usage quotas for specific users.
+- `data export|api-pull|import`: Export a user universe to a file and import it as a new user.
+- `data transfer`: Selectively copy a user's data from one instance's database onto an existing user in another (prod → testing). See [Data Management](./data-management.md#developer-workflow-prod-to-testing-transfer).
 
 #### 2b. Subscriptions (`subscriptions`)
 

--- a/docs/04-guides/data-management.md
+++ b/docs/04-guides/data-management.md
@@ -63,6 +63,88 @@ The import process automatically **sanitizes** sensitive production data:
 
 ---
 
+## Developer Workflow: Prod-to-Testing Transfer
+
+The export/import pair above always creates a **new** user from a file. To load production data onto a user that **already exists** on another instance — typically your account on `testing.coachwatts.com` — use `users data transfer`. It copies straight from one database to the other, remaps every `userId` onto the target user, and can be narrowed to the sections and date range you actually need.
+
+### 1. Prerequisites
+
+- Network access to both databases.
+- `DATABASE_URL_PROD` and `DATABASE_URL_TESTING` in `.env` (either option also accepts a literal `postgresql://…` URL).
+- The target user must already exist on the target instance. Sign in there once, then look up the id:
+
+```bash
+pnpm cw:cli users search you@example.com
+```
+
+### 2. See what would move
+
+```bash
+pnpm cw:cli users data transfer --user you@example.com --target-user <target-user-id> --dry-run
+```
+
+Nothing is written; you get a per-table row count for the selected sections.
+
+### 3. Run it
+
+```bash
+pnpm cw:cli users data transfer --user you@example.com --target-user <target-user-id>
+```
+
+The command prints source, target, sections and date range, then asks for confirmation (`--yes` skips it). Inserts use `skipDuplicates`, so **re-running is safe** — a second run copies only what is new.
+
+### Options
+
+| Option                      | Default                | Description                                                                    |
+| :-------------------------- | :--------------------- | :----------------------------------------------------------------------------- |
+| `--user <email\|id>`        | —                      | Source user (required).                                                        |
+| `--target-user <id\|email>` | same id as source      | User in the target database that receives the data.                            |
+| `--from <envVar\|url>`      | `DATABASE_URL_PROD`    | Source database.                                                               |
+| `--to <envVar\|url>`        | `DATABASE_URL_TESTING` | Target database.                                                               |
+| `--sections <list>`         | everything but opt-ins | Comma-separated section keys, or `all`.                                        |
+| `--skip <list>`             | —                      | Sections to exclude from the selection.                                        |
+| `--since` / `--until`       | —                      | Bound date-ranged tables (`YYYY-MM-DD`).                                       |
+| `--replace`                 | off                    | Delete the target user's rows in the selected sections (and date range) first. |
+| `--dry-run`                 | off                    | Count only, write nothing.                                                     |
+| `--list-sections`           | —                      | Print sections and what is never transferred.                                  |
+| `-y, --yes`                 | off                    | Skip the confirmation prompt.                                                  |
+
+### Sections
+
+`profile`, `settings`, `goals`, `events`, `plans`, `planned`, `workouts`, `streams`, `wellness`, `metrics`, `nutrition`, `calendar`, `memories`, `ai` are transferred by default. `fitfiles` (raw `.fit` blobs) and `chat` (full AI conversation history) are **opt-in** because of their size:
+
+```bash
+# Last three months of training data only
+pnpm cw:cli users data transfer --user you@example.com --target-user <id> \
+  --sections workouts,streams,planned,wellness --since 2026-05-01
+
+# Everything, including chat history and FIT files
+pnpm cw:cli users data transfer --user you@example.com --target-user <id> --sections all
+```
+
+Run `--list-sections` for the full table.
+
+### Safety
+
+- **Never writes to the source**, and refuses to run if the target resolves to `DATABASE_URL_PROD` or to the same URL as the source.
+- Credentials are never printed — only `host:port/database`.
+- Auth material (`Account`, `Session`, `ApiKey`, OAuth tables), provider tokens (`Integration`), push tokens, billing rows and operational logs are **not** transferred. Re-connect integrations on the target instance if you need live syncing there.
+- The profile section copies training and preference columns only. Email, name, admin flag, subscription state and public profile slugs on the target user are left untouched.
+- Globally unique artefacts are cleared on the way in: workout and planned-workout share tokens, and training plan slugs (transferred plans also arrive as non-public).
+
+### How partial selections stay consistent
+
+Skipping a section, or applying a date range, can leave foreign keys pointing at rows that are not in the target. Each is handled explicitly:
+
+- Optional references are **nulled** — a workout whose planned workout was not transferred simply arrives unlinked.
+- Required references cause the row to be **dropped**, and the count shows up in the `Dropped` column.
+- Rows that already exist in the target (from an earlier run) still satisfy references, so incremental runs link up correctly.
+- The strength `Exercise` library is shared reference data; entries your workouts need are copied automatically if the target lacks them.
+
+`WorkoutStreamV2` is copied with plain SQL rather than Prisma: production rows contain NULL elements inside the `Int[]` / `Float[]` time-series columns, which the Prisma client refuses to decode.
+
+---
+
 ## User Feature: Self-Service Export
 
 Regular users can download their data directly from the application for portability or compliance (GDPR).
@@ -78,11 +160,12 @@ Regular users can download their data directly from the application for portabil
 
 ## CLI Reference: `cw:cli users data`
 
-| Command    | Arguments | Options                       | Description                                              |
-| :--------- | :-------- | :---------------------------- | :------------------------------------------------------- |
-| `export`   | `<id>`    | `--prod`, `--output`          | Direct DB export to a local file. Supports `.gz`.        |
-| `api-pull` |           | `--key`, `--host`, `--output` | API-based export from a remote instance. Supports `.gz`. |
-| `import`   | `<path>`  | `--clear`, `--email`          | Injects an export package into the local database.       |
+| Command    | Arguments | Options                                                                                                                                         | Description                                                                 |
+| :--------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| `export`   | `<id>`    | `--prod`, `--output`                                                                                                                            | Direct DB export to a local file. Supports `.gz`.                           |
+| `api-pull` |           | `--key`, `--host`, `--output`                                                                                                                   | API-based export from a remote instance. Supports `.gz`.                    |
+| `import`   | `<path>`  | `--clear`, `--email`                                                                                                                            | Injects an export package into the local database.                          |
+| `transfer` |           | `--user`, `--target-user`, `--from`, `--to`, `--sections`, `--skip`, `--since`, `--until`, `--replace`, `--dry-run`, `--list-sections`, `--yes` | Selective database-to-database copy onto an existing user (prod → testing). |
 
 ---
 

--- a/server/utils/data-management/transfer-plan.ts
+++ b/server/utils/data-management/transfer-plan.ts
@@ -1,0 +1,621 @@
+/**
+ * Declarative plan for a selective user-data transfer between two Coach Watts
+ * databases (typically production → testing).
+ *
+ * Every table is described once, in dependency order, with:
+ * - the Prisma `where` that selects one user's rows (also reused for counting
+ *   and for `--replace` deletes against the target DB),
+ * - which columns hold the owning user id (they get remapped to the target user),
+ * - which foreign keys may dangle when a section is skipped or a date range is
+ *   applied, and what to do about them (null the column, or drop the row).
+ *
+ * Order matters: a table may only reference tables declared before it.
+ */
+
+export type TransferSection =
+  | 'profile'
+  | 'settings'
+  | 'goals'
+  | 'events'
+  | 'plans'
+  | 'planned'
+  | 'workouts'
+  | 'streams'
+  | 'fitfiles'
+  | 'wellness'
+  | 'metrics'
+  | 'nutrition'
+  | 'calendar'
+  | 'chat'
+  | 'memories'
+  | 'ai'
+
+export interface SectionInfo {
+  key: TransferSection
+  description: string
+  /** Excluded unless explicitly asked for (huge, or carries little test value). */
+  optIn?: boolean
+}
+
+export const TRANSFER_SECTIONS: SectionInfo[] = [
+  {
+    key: 'profile',
+    description: 'User profile scalars: FTP, zones, units, AI + display preferences'
+  },
+  {
+    key: 'settings',
+    description: 'Sport settings, nutrition settings, availability, email preferences'
+  },
+  { key: 'goals', description: 'Goals' },
+  { key: 'events', description: 'Events (races, target dates)' },
+  { key: 'plans', description: 'Training plans, blocks, weeks, weekly AI plans' },
+  { key: 'planned', description: 'Planned workouts and their publish targets' },
+  { key: 'workouts', description: 'Workouts, strength exercises/sets, plan adherence' },
+  { key: 'streams', description: 'Workout time-series streams (large)' },
+  { key: 'fitfiles', description: 'Raw .fit file blobs (very large)', optIn: true },
+  {
+    key: 'wellness',
+    description: 'Wellness, daily metrics, check-ins, body measurements, journey events'
+  },
+  { key: 'metrics', description: 'Metric history (FTP/LTHR changes) and personal bests' },
+  { key: 'nutrition', description: 'Nutrition days, nutrition plans + meals, recommendations' },
+  { key: 'calendar', description: 'Calendar notes' },
+  {
+    key: 'chat',
+    description: 'AI chat rooms, turns, messages, tool executions (large)',
+    optIn: true
+  },
+  { key: 'memories', description: 'AI user memories' },
+  { key: 'ai', description: 'Recommendations, score explanations, reports' }
+]
+
+export const DEFAULT_SECTIONS: TransferSection[] = TRANSFER_SECTIONS.filter((s) => !s.optIn).map(
+  (s) => s.key
+)
+
+export const ALL_SECTIONS: TransferSection[] = TRANSFER_SECTIONS.map((s) => s.key)
+
+export interface DateRange {
+  from?: Date
+  to?: Date
+}
+
+export interface WhereCtx {
+  userId: string
+  range: DateRange
+}
+
+export interface TransferRef {
+  /** Column holding the foreign key. */
+  field: string
+  /** Prisma delegate name of the referenced table. */
+  model: string
+  /** What to do when the referenced row is in neither the batch nor the target DB. */
+  onMissing: 'null' | 'drop'
+  /**
+   * How to look the id up in the target database when it was not part of this
+   * transfer: 'user' restricts to the target user's rows, 'global' does not
+   * (shared/library tables such as Exercise or system report templates).
+   */
+  scope?: 'user' | 'global'
+  /**
+   * Copy the referenced rows from the source when the target does not have
+   * them. Only for shared reference data that is not user-owned — the strength
+   * exercise library, which a testing instance may never have been seeded with.
+   */
+  copyMissing?: boolean
+}
+
+export interface TransferTable {
+  /** Prisma delegate name, e.g. `workoutStreamV2`. */
+  model: string
+  section: TransferSection
+  label: string
+  where: (ctx: WhereCtx) => Record<string, unknown>
+  /** Columns holding the source user's id; remapped to the target user. Default `['userId']`. */
+  userFields?: string[]
+  /** Columns forced to null before insert (globally unique tokens, foreign refs we never carry). */
+  nullify?: string[]
+  /** Columns forced to a fixed value before insert. */
+  set?: Record<string, unknown>
+  refs?: TransferRef[]
+  /** Self-referencing FKs: nulled on insert, then patched once the table is done. */
+  selfRefs?: string[]
+  /** Rows fetched (and inserted) per batch. */
+  pageSize?: number
+  /** `true` when the table has no `userId` column, so `--replace` cannot delete by user directly. */
+  deleteViaRelation?: boolean
+  /**
+   * Copy this table with plain SQL instead of Prisma.
+   *
+   * Needed for `WorkoutStreamV2`: its time-series columns are typed `Int[]` /
+   * `Float[]`, but production rows contain NULL *elements* inside those arrays,
+   * which the Prisma client refuses to decode. Raw reads and writes pass the
+   * arrays through node-postgres untouched. Rows are selected by the ids
+   * already transferred for `parentModel`.
+   */
+  raw?: { table: string; parentModel: string; parentColumn: string }
+}
+
+const between = (field: string, range: DateRange): Record<string, unknown> => {
+  const clause: Record<string, Date> = {}
+  if (range.from) clause.gte = range.from
+  if (range.to) clause.lte = range.to
+  return Object.keys(clause).length ? { [field]: clause } : {}
+}
+
+/**
+ * Profile columns copied onto the existing target user.
+ *
+ * Deliberately excluded: identity and auth (`email`, `name`, `image`,
+ * `emailVerified`, `isAdmin`), billing (`stripe*`, `subscription*`, `trialEndsAt`),
+ * referrals, public profile slugs (globally unique), login/registration
+ * telemetry, and consent timestamps.
+ */
+export const PROFILE_FIELDS = [
+  // Physiology
+  'ftp',
+  'maxHr',
+  'lthr',
+  'restingHr',
+  'weight',
+  'height',
+  'dob',
+  'sex',
+  'altitude',
+  'hrZones',
+  'powerZones',
+  'weightSourceMode',
+  // Units and locale
+  'distanceUnits',
+  'heightUnits',
+  'weightUnits',
+  'temperatureUnits',
+  'language',
+  'uiLanguage',
+  'timezone',
+  'city',
+  'country',
+  'state',
+  'form',
+  // Scores and explanations
+  'currentFitnessScore',
+  'recoveryCapacityScore',
+  'nutritionComplianceScore',
+  'trainingConsistencyScore',
+  'hrPowerAlignmentScore',
+  'currentFitnessExplanation',
+  'recoveryCapacityExplanation',
+  'nutritionComplianceExplanation',
+  'trainingConsistencyExplanation',
+  'hrPowerAlignmentExplanation',
+  'currentFitnessExplanationJson',
+  'recoveryCapacityExplanationJson',
+  'nutritionComplianceExplanationJson',
+  'trainingConsistencyExplanationJson',
+  'hrPowerAlignmentExplanationJson',
+  'profileLastUpdated',
+  'personalBestsBackfilledAt',
+  // Product preferences
+  'nickname',
+  'visibility',
+  'teamVisibility',
+  'dashboardSettings',
+  'featureFlags',
+  'nutritionTrackingEnabled',
+  'recoverySensitivity',
+  'updateWorkoutNotesEnabled',
+  // AI preferences
+  'aiContext',
+  'aiPersona',
+  'aiModelPreference',
+  'aiAutoAnalyzeWorkouts',
+  'aiAutoAnalyzeNutrition',
+  'aiAutoAnalyzeReadiness',
+  'aiDeepAnalysisEnabled',
+  'aiProactivityEnabled',
+  'aiRequireToolApproval',
+  'aiConversationalEngagement',
+  'aiMemoryEnabled',
+  'aiTtsStyle',
+  'aiTtsVoiceName',
+  'aiTtsSpeed',
+  'aiTtsAutoReadMessages'
+] as const
+
+export const TRANSFER_TABLES: TransferTable[] = [
+  // ---------------------------------------------------------------- settings
+  {
+    model: 'sportSettings',
+    section: 'settings',
+    label: 'Sport settings',
+    where: ({ userId }) => ({ userId })
+  },
+  {
+    model: 'userNutritionSettings',
+    section: 'settings',
+    label: 'Nutrition settings',
+    where: ({ userId }) => ({ userId })
+  },
+  {
+    model: 'trainingAvailability',
+    section: 'settings',
+    label: 'Training availability',
+    where: ({ userId }) => ({ userId })
+  },
+  {
+    model: 'emailPreference',
+    section: 'settings',
+    label: 'Email preferences',
+    where: ({ userId }) => ({ userId })
+  },
+
+  // ------------------------------------------------------------------- goals
+  { model: 'goal', section: 'goals', label: 'Goals', where: ({ userId }) => ({ userId }) },
+
+  // ------------------------------------------------------------------ events
+  { model: 'event', section: 'events', label: 'Events', where: ({ userId }) => ({ userId }) },
+
+  // ------------------------------------------------------------------- plans
+  {
+    model: 'trainingPlan',
+    section: 'plans',
+    label: 'Training plans',
+    where: ({ userId }) => ({ userId }),
+    // `slug` is globally unique; folders/teams are never transferred.
+    nullify: ['slug', 'folderId', 'teamId'],
+    set: { isPublic: false, isFeatured: false },
+    refs: [{ field: 'goalId', model: 'goal', onMissing: 'null' }],
+    selfRefs: ['fromTemplateId']
+  },
+  {
+    model: 'trainingBlock',
+    section: 'plans',
+    label: 'Training blocks',
+    where: ({ userId }) => ({ plan: { userId } }),
+    userFields: [],
+    refs: [{ field: 'trainingPlanId', model: 'trainingPlan', onMissing: 'drop' }],
+    deleteViaRelation: true
+  },
+  {
+    model: 'trainingWeek',
+    section: 'plans',
+    label: 'Training weeks',
+    where: ({ userId }) => ({ block: { plan: { userId } } }),
+    userFields: [],
+    refs: [{ field: 'blockId', model: 'trainingBlock', onMissing: 'drop' }],
+    deleteViaRelation: true
+  },
+  {
+    model: 'weeklyTrainingPlan',
+    section: 'plans',
+    label: 'Weekly AI plans',
+    where: ({ userId, range }) => ({ userId, ...between('weekStartDate', range) })
+  },
+
+  // ---------------------------------------------------------------- planned
+  {
+    model: 'plannedWorkout',
+    section: 'planned',
+    label: 'Planned workouts',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) }),
+    nullify: ['shareToken'],
+    refs: [{ field: 'trainingWeekId', model: 'trainingWeek', onMissing: 'null' }]
+  },
+  {
+    model: 'plannedWorkoutPublishTarget',
+    section: 'planned',
+    label: 'Planned workout publish targets',
+    where: ({ userId, range }) => ({ plannedWorkout: { userId, ...between('date', range) } }),
+    userFields: [],
+    refs: [{ field: 'plannedWorkoutId', model: 'plannedWorkout', onMissing: 'drop' }],
+    deleteViaRelation: true
+  },
+
+  // --------------------------------------------------------------- workouts
+  {
+    model: 'workout',
+    section: 'workouts',
+    label: 'Workouts',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) }),
+    nullify: ['shareToken'],
+    refs: [
+      { field: 'plannedWorkoutId', model: 'plannedWorkout', onMissing: 'null' },
+      { field: 'oauthAppId', model: 'oAuthApp', onMissing: 'null', scope: 'global' }
+    ],
+    selfRefs: ['duplicateOf'],
+    pageSize: 200
+  },
+  {
+    model: 'workoutExercise',
+    section: 'workouts',
+    label: 'Strength exercises',
+    where: ({ userId, range }) => ({ workout: { userId, ...between('date', range) } }),
+    userFields: [],
+    refs: [
+      { field: 'workoutId', model: 'workout', onMissing: 'drop' },
+      // The Exercise library is shared reference data; copy the entries this
+      // user's workouts need if the target instance lacks them.
+      {
+        field: 'exerciseId',
+        model: 'exercise',
+        onMissing: 'drop',
+        scope: 'global',
+        copyMissing: true
+      }
+    ],
+    deleteViaRelation: true
+  },
+  {
+    model: 'workoutSet',
+    section: 'workouts',
+    label: 'Strength sets',
+    where: ({ userId, range }) => ({
+      workoutExercise: { workout: { userId, ...between('date', range) } }
+    }),
+    userFields: [],
+    refs: [{ field: 'workoutExerciseId', model: 'workoutExercise', onMissing: 'drop' }],
+    deleteViaRelation: true
+  },
+  {
+    model: 'planAdherence',
+    section: 'workouts',
+    label: 'Plan adherence',
+    where: ({ userId, range }) => ({ workout: { userId, ...between('date', range) } }),
+    userFields: [],
+    refs: [
+      { field: 'workoutId', model: 'workout', onMissing: 'drop' },
+      { field: 'plannedWorkoutId', model: 'plannedWorkout', onMissing: 'drop' }
+    ],
+    deleteViaRelation: true
+  },
+
+  // ---------------------------------------------------------------- streams
+  {
+    model: 'workoutStreamV2',
+    section: 'streams',
+    label: 'Workout streams',
+    where: ({ userId, range }) => ({ workout: { userId, ...between('date', range) } }),
+    userFields: [],
+    refs: [{ field: 'workoutId', model: 'workout', onMissing: 'drop' }],
+    pageSize: 25,
+    deleteViaRelation: true,
+    raw: { table: 'WorkoutStreamV2', parentModel: 'workout', parentColumn: 'workoutId' }
+  },
+
+  // --------------------------------------------------------------- fitfiles
+  {
+    model: 'fitFile',
+    section: 'fitfiles',
+    label: 'FIT files',
+    where: ({ userId, range }) => ({ userId, ...between('createdAt', range) }),
+    refs: [{ field: 'workoutId', model: 'workout', onMissing: 'null' }],
+    pageSize: 10
+  },
+
+  // --------------------------------------------------------------- wellness
+  {
+    model: 'wellness',
+    section: 'wellness',
+    label: 'Wellness days',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) })
+  },
+  {
+    model: 'dailyMetric',
+    section: 'wellness',
+    label: 'Daily metrics',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) })
+  },
+  {
+    model: 'dailyCheckin',
+    section: 'wellness',
+    label: 'Daily check-ins',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) })
+  },
+  {
+    model: 'bodyMeasurementEntry',
+    section: 'wellness',
+    label: 'Body measurements',
+    where: ({ userId, range }) => ({ userId, ...between('recordedAt', range) })
+  },
+  {
+    model: 'athleteJourneyEvent',
+    section: 'wellness',
+    label: 'Journey events',
+    where: ({ userId, range }) => ({ userId, ...between('timestamp', range) })
+  },
+
+  // ---------------------------------------------------------------- metrics
+  {
+    model: 'metricHistory',
+    section: 'metrics',
+    label: 'Metric history',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) }),
+    refs: [{ field: 'workoutId', model: 'workout', onMissing: 'null' }]
+  },
+  {
+    model: 'personalBest',
+    section: 'metrics',
+    label: 'Personal bests',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) }),
+    refs: [{ field: 'workoutId', model: 'workout', onMissing: 'null' }]
+  },
+
+  // -------------------------------------------------------------- nutrition
+  {
+    model: 'nutrition',
+    section: 'nutrition',
+    label: 'Nutrition days',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) })
+  },
+  {
+    model: 'nutritionPlan',
+    section: 'nutrition',
+    label: 'Nutrition plans',
+    where: ({ userId, range }) => ({ userId, ...between('startDate', range) })
+  },
+  {
+    model: 'nutritionPlanMeal',
+    section: 'nutrition',
+    label: 'Nutrition plan meals',
+    where: ({ userId, range }) => ({ plan: { userId, ...between('startDate', range) } }),
+    userFields: [],
+    refs: [{ field: 'planId', model: 'nutritionPlan', onMissing: 'drop' }],
+    deleteViaRelation: true
+  },
+  {
+    model: 'nutritionRecommendation',
+    section: 'nutrition',
+    label: 'Nutrition recommendations',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) })
+  },
+
+  // --------------------------------------------------------------- calendar
+  {
+    model: 'calendarNote',
+    section: 'calendar',
+    label: 'Calendar notes',
+    where: ({ userId, range }) => ({ userId, ...between('startDate', range) })
+  },
+
+  // ------------------------------------------------------------------- chat
+  {
+    model: 'chatRoom',
+    section: 'chat',
+    label: 'Chat rooms',
+    where: ({ userId, range }) => ({
+      users: { some: { userId } },
+      ...between('createdAt', range)
+    }),
+    userFields: [],
+    deleteViaRelation: true
+  },
+  {
+    model: 'chatParticipant',
+    section: 'chat',
+    label: 'Chat participants',
+    where: ({ userId, range }) => ({ userId, room: between('createdAt', range) }),
+    refs: [{ field: 'roomId', model: 'chatRoom', onMissing: 'drop' }]
+  },
+  {
+    model: 'chatTurn',
+    section: 'chat',
+    label: 'Chat turns',
+    where: ({ userId, range }) => ({ userId, room: between('createdAt', range) }),
+    refs: [{ field: 'roomId', model: 'chatRoom', onMissing: 'drop' }]
+  },
+  {
+    model: 'chatMessage',
+    section: 'chat',
+    label: 'Chat messages',
+    where: ({ userId, range }) => ({
+      room: { users: { some: { userId } }, ...between('createdAt', range) }
+    }),
+    // `senderId` has no FK; it holds the author's user id for human messages.
+    userFields: ['senderId'],
+    refs: [
+      { field: 'roomId', model: 'chatRoom', onMissing: 'drop' },
+      { field: 'turnId', model: 'chatTurn', onMissing: 'null' }
+    ],
+    deleteViaRelation: true,
+    pageSize: 200
+  },
+  {
+    model: 'chatTurnEvent',
+    section: 'chat',
+    label: 'Chat turn events',
+    where: ({ userId, range }) => ({ turn: { userId, room: between('createdAt', range) } }),
+    userFields: [],
+    refs: [{ field: 'turnId', model: 'chatTurn', onMissing: 'drop' }],
+    deleteViaRelation: true,
+    pageSize: 200
+  },
+  {
+    model: 'chatTurnToolExecution',
+    section: 'chat',
+    label: 'Chat tool executions',
+    where: ({ userId, range }) => ({ turn: { userId, room: between('createdAt', range) } }),
+    userFields: [],
+    refs: [{ field: 'turnId', model: 'chatTurn', onMissing: 'drop' }],
+    deleteViaRelation: true,
+    pageSize: 200
+  },
+
+  // --------------------------------------------------------------- memories
+  {
+    model: 'userMemory',
+    section: 'memories',
+    label: 'AI memories',
+    where: ({ userId }) => ({ userId }),
+    refs: [{ field: 'roomId', model: 'chatRoom', onMissing: 'null' }]
+  },
+
+  // --------------------------------------------------------------------- ai
+  {
+    model: 'recommendation',
+    section: 'ai',
+    label: 'Recommendations',
+    where: ({ userId, range }) => ({ userId, ...between('generatedAt', range) })
+  },
+  {
+    model: 'activityRecommendation',
+    section: 'ai',
+    label: 'Activity recommendations',
+    where: ({ userId, range }) => ({ userId, ...between('date', range) }),
+    refs: [{ field: 'plannedWorkoutId', model: 'plannedWorkout', onMissing: 'null' }]
+  },
+  {
+    model: 'scoreTrendExplanation',
+    section: 'ai',
+    label: 'Score trend explanations',
+    where: ({ userId, range }) => ({ userId, ...between('createdAt', range) })
+  },
+  {
+    model: 'report',
+    section: 'ai',
+    label: 'Reports',
+    where: ({ userId, range }) => ({ userId, ...between('createdAt', range) }),
+    refs: [{ field: 'templateId', model: 'reportTemplate', onMissing: 'null', scope: 'global' }]
+  },
+  {
+    model: 'reportWorkout',
+    section: 'ai',
+    label: 'Report ↔ workout links',
+    where: ({ userId, range }) => ({ report: { userId, ...between('createdAt', range) } }),
+    userFields: [],
+    refs: [
+      { field: 'reportId', model: 'report', onMissing: 'drop' },
+      { field: 'workoutId', model: 'workout', onMissing: 'drop' }
+    ],
+    deleteViaRelation: true
+  },
+  {
+    model: 'reportNutrition',
+    section: 'ai',
+    label: 'Report ↔ nutrition links',
+    where: ({ userId, range }) => ({ report: { userId, ...between('createdAt', range) } }),
+    userFields: [],
+    refs: [
+      { field: 'reportId', model: 'report', onMissing: 'drop' },
+      { field: 'nutritionId', model: 'nutrition', onMissing: 'drop' }
+    ],
+    deleteViaRelation: true
+  }
+]
+
+/**
+ * Tables that are intentionally never transferred, and why. Surfaced by
+ * `--list-sections` so the omission is visible rather than silent.
+ */
+export const EXCLUDED_TABLES: { name: string; reason: string }[] = [
+  { name: 'Integration', reason: 'holds provider OAuth access/refresh tokens' },
+  { name: 'Account / Session / ApiKey', reason: 'authentication material' },
+  { name: 'OAuthApp / OAuthToken / OAuthConsent', reason: 'authentication material' },
+  { name: 'MobilePushDevice', reason: 'push tokens bound to the production install' },
+  { name: 'ProviderSubscription / SubscriptionLifecycleEvent', reason: 'billing state' },
+  { name: 'SyncQueue', reason: 'transient provider sync jobs' },
+  { name: 'AuditLog / WebhookLog / LlmUsage / QuotaDenial', reason: 'operational logs' },
+  { name: 'ShareToken / UserNotification', reason: 'environment-specific artefacts' },
+  { name: 'WorkoutStream (v1)', reason: 'superseded by WorkoutStreamV2' },
+  { name: 'Event ↔ Goal links', reason: 'implicit many-to-many, not carried' }
+]

--- a/server/utils/data-management/user-data-transfer.ts
+++ b/server/utils/data-management/user-data-transfer.ts
@@ -1,0 +1,465 @@
+import {
+  PROFILE_FIELDS,
+  TRANSFER_TABLES,
+  type DateRange,
+  type TransferRef,
+  type TransferSection,
+  type TransferTable
+} from './transfer-plan'
+
+/**
+ * Copies one user's data between two Coach Watts databases, section by section,
+ * remapping it onto a user that already exists in the target database.
+ *
+ * Unlike `UserUniverseImporter` (which creates a brand new user from an export
+ * file inside a single transaction), this engine merges into an existing user,
+ * streams table by table, and tolerates partial data: foreign keys that would
+ * dangle are either nulled or their rows dropped, and inserts use
+ * `skipDuplicates` so a run can be repeated safely.
+ *
+ * It never writes to the source database.
+ */
+
+export interface TransferOptions {
+  sourceUserId: string
+  targetUserId: string
+  sections: TransferSection[]
+  range?: DateRange
+  /** Delete the target user's rows in the selected sections before inserting. */
+  replace?: boolean
+  /** Count only; perform no writes. */
+  dryRun?: boolean
+  onProgress?: (message: string) => void
+  /** node-postgres pools behind the two clients; required for raw-copied tables. */
+  pools?: { source: RawPool; target: RawPool }
+}
+
+/** The slice of a `pg.Pool` this module needs. */
+export interface RawPool {
+  query: (
+    text: string,
+    values?: unknown[]
+  ) => Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>
+}
+
+export interface TableResult {
+  model: string
+  label: string
+  section: TransferSection
+  /** Rows found in the source for this user (and date range). */
+  fetched: number
+  /** Rows newly written to the target. */
+  inserted: number
+  /** Rows the target already had (unique constraint hit). */
+  skippedExisting: number
+  /** Rows dropped because a required foreign key was not present in the target. */
+  droppedRefs: number
+  /** Columns nulled because an optional foreign key was not present in the target. */
+  nulledRefs: number
+  /** Rows the database refused. */
+  failed: number
+  /** Rows removed by `--replace`. */
+  deleted: number
+  errors: string[]
+}
+
+export interface TransferReport {
+  profileUpdated: boolean
+  tables: TableResult[]
+  totals: { fetched: number; inserted: number; failed: number; deleted: number }
+}
+
+type AnyPrisma = Record<string, any>
+
+const MAX_ERRORS_PER_TABLE = 5
+const DEFAULT_PAGE_SIZE = 500
+
+const userFieldsOf = (table: TransferTable): string[] => table.userFields ?? ['userId']
+
+/** Models in the plan that carry a `userId` column, so target lookups can be user-scoped. */
+const USER_SCOPED_MODELS = new Set(
+  TRANSFER_TABLES.filter((t) => userFieldsOf(t).includes('userId')).map((t) => t.model)
+)
+
+const refScope = (ref: TransferRef): 'user' | 'global' =>
+  ref.scope ?? (USER_SCOPED_MODELS.has(ref.model) ? 'user' : 'global')
+
+export function tablesForSections(sections: TransferSection[]): TransferTable[] {
+  const wanted = new Set(sections)
+  return TRANSFER_TABLES.filter((t) => wanted.has(t.section))
+}
+
+export async function transferUserData(
+  source: AnyPrisma,
+  target: AnyPrisma,
+  opts: TransferOptions
+): Promise<TransferReport> {
+  const log = opts.onProgress ?? (() => {})
+  const range = opts.range ?? {}
+  const sourceCtx = { userId: opts.sourceUserId, range }
+  const targetCtx = { userId: opts.targetUserId, range }
+  const tables = tablesForSections(opts.sections)
+
+  const report: TransferReport = {
+    profileUpdated: false,
+    tables: [],
+    totals: { fetched: 0, inserted: 0, failed: 0, deleted: 0 }
+  }
+
+  // Ids known to exist in the target: everything this run wrote (or found
+  // already present), plus per-model lookups cached from the target database.
+  const knownIds = new Map<string, Set<string>>()
+  const missingIds = new Map<string, Set<string>>()
+
+  const remember = (model: string, id: string) => {
+    let set = knownIds.get(model)
+    if (!set) knownIds.set(model, (set = new Set()))
+    set.add(id)
+  }
+
+  /** Which of these ids exist in the target for this model? */
+  const resolvePresence = async (ref: TransferRef, ids: string[]): Promise<Set<string>> => {
+    const known = knownIds.get(ref.model) ?? new Set<string>()
+    const missing = missingIds.get(ref.model) ?? new Set<string>()
+    const unknown = ids.filter((id) => !known.has(id) && !missing.has(id))
+
+    if (unknown.length && !opts.dryRun) {
+      const where: Record<string, unknown> = { id: { in: unknown } }
+      if (refScope(ref) === 'user') where.userId = opts.targetUserId
+      const rows: { id: string }[] = await target[ref.model].findMany({
+        where,
+        select: { id: true }
+      })
+      const found = new Set(rows.map((r) => r.id))
+      const absent = unknown.filter((id) => !found.has(id))
+
+      // Shared reference data the target has never been seeded with.
+      if (absent.length && ref.copyMissing) {
+        const sourceRows: Record<string, unknown>[] = await source[ref.model].findMany({
+          where: { id: { in: absent } }
+        })
+        if (sourceRows.length) {
+          await target[ref.model].createMany({ data: sourceRows, skipDuplicates: true })
+          log(`Copied ${sourceRows.length} shared ${ref.model} rows`)
+          for (const row of sourceRows) found.add(row.id as string)
+        }
+      }
+
+      for (const id of unknown) {
+        if (found.has(id)) remember(ref.model, id)
+        else {
+          let set = missingIds.get(ref.model)
+          if (!set) missingIds.set(ref.model, (set = new Set()))
+          set.add(id)
+        }
+      }
+    }
+
+    return knownIds.get(ref.model) ?? new Set<string>()
+  }
+
+  // ------------------------------------------------------------------ profile
+  if (opts.sections.includes('profile')) {
+    const sourceUser = await source.user.findUnique({ where: { id: opts.sourceUserId } })
+    if (!sourceUser) throw new Error(`Source user ${opts.sourceUserId} not found`)
+
+    const data: Record<string, unknown> = {}
+    for (const field of PROFILE_FIELDS) {
+      if (field in sourceUser) data[field] = sourceUser[field]
+    }
+
+    if (!opts.dryRun) {
+      await target.user.update({ where: { id: opts.targetUserId }, data })
+      report.profileUpdated = true
+      log(`Profile: ${Object.keys(data).length} fields updated`)
+    }
+  }
+
+  // ------------------------------------------------------------------ replace
+  const deletedByModel = new Map<string, number>()
+  if (opts.replace && !opts.dryRun) {
+    // Children first, so a failed parent delete cannot orphan anything.
+    for (const table of [...tables].reverse()) {
+      try {
+        const { count } = await target[table.model].deleteMany({ where: table.where(targetCtx) })
+        deletedByModel.set(table.model, count)
+        if (count) log(`Cleared ${count} × ${table.label}`)
+      } catch (e) {
+        log(`Could not clear ${table.label}: ${(e as Error).message}`)
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------- tables
+  for (const table of tables) {
+    const result = emptyResult(table)
+    result.deleted = deletedByModel.get(table.model) ?? 0
+    const pageSize = table.pageSize ?? DEFAULT_PAGE_SIZE
+    const where = table.where(sourceCtx)
+    const deferred: { id: string; field: string; value: string }[] = []
+
+    result.fetched = await source[table.model].count({ where })
+
+    if (opts.dryRun) {
+      report.tables.push(result)
+      continue
+    }
+
+    if (result.fetched === 0) {
+      report.tables.push(result)
+      continue
+    }
+
+    log(`${table.label}: ${result.fetched} rows`)
+
+    if (table.raw) {
+      if (!opts.pools) {
+        pushError(result, 'raw copy requires database pools; table skipped')
+        report.tables.push(result)
+        continue
+      }
+
+      // Raw tables are driven by their parent's ids: fetch the parent ids this
+      // run covers, keep the ones that exist in the target (from this run or an
+      // earlier one), and copy their rows.
+      const parentSpec = TRANSFER_TABLES.find((t) => t.model === table.raw!.parentModel)
+      const parentIds: string[] = parentSpec
+        ? (
+            await source[parentSpec.model].findMany({
+              where: parentSpec.where(sourceCtx),
+              select: { id: true }
+            })
+          ).map((r: { id: string }) => r.id)
+        : []
+      const parentRef: TransferRef = (table.refs ?? []).find(
+        (r) => r.field === table.raw!.parentColumn
+      ) ?? { field: table.raw!.parentColumn, model: table.raw!.parentModel, onMissing: 'drop' }
+      const present = await resolvePresence(parentRef, parentIds)
+
+      await copyRawTable(
+        opts.pools,
+        table,
+        parentIds.filter((id) => present.has(id)),
+        result
+      )
+      report.tables.push(result)
+      continue
+    }
+
+    let cursor: string | undefined
+    let processed = 0
+
+    while (processed < result.fetched) {
+      const rows: Record<string, any>[] = await source[table.model].findMany({
+        where,
+        orderBy: { id: 'asc' },
+        take: pageSize,
+        ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {})
+      })
+      const last = rows[rows.length - 1]
+      if (!last) break
+      cursor = last.id as string
+      processed += rows.length
+
+      // Resolve foreign keys for the whole page in one query per ref.
+      const presence = new Map<string, Set<string>>()
+      for (const ref of table.refs ?? []) {
+        const ids = rows
+          .map((r) => r[ref.field])
+          .filter((v): v is string => typeof v === 'string' && v.length > 0)
+        presence.set(ref.field, await resolvePresence(ref, Array.from(new Set(ids))))
+      }
+
+      const prepared: Record<string, any>[] = []
+      for (const row of rows) {
+        const copy: Record<string, any> = { ...row }
+        let drop = false
+
+        for (const ref of table.refs ?? []) {
+          const value = copy[ref.field]
+          if (typeof value !== 'string' || value.length === 0) continue
+          if (presence.get(ref.field)?.has(value)) continue
+          if (ref.onMissing === 'drop') {
+            drop = true
+            break
+          }
+          copy[ref.field] = null
+          result.nulledRefs++
+        }
+        if (drop) {
+          result.droppedRefs++
+          continue
+        }
+
+        for (const field of userFieldsOf(table)) {
+          if (copy[field] === opts.sourceUserId) copy[field] = opts.targetUserId
+        }
+        for (const field of table.nullify ?? []) copy[field] = null
+        Object.assign(copy, table.set ?? {})
+        for (const field of table.selfRefs ?? []) {
+          const value = copy[field]
+          if (typeof value === 'string' && value.length > 0) {
+            deferred.push({ id: copy.id as string, field, value })
+            copy[field] = null
+          }
+        }
+
+        prepared.push(copy)
+      }
+
+      if (prepared.length) {
+        const { written, failedIds } = await insertRows(target, table.model, prepared, result)
+        result.inserted += written
+        // Rows skipped as duplicates are present in the target too, so later
+        // foreign keys pointing at them still resolve. Failed rows are not.
+        for (const row of prepared) {
+          const id = row.id as string
+          if (!failedIds.has(id)) remember(table.model, id)
+        }
+      }
+    }
+
+    // Self-references are nulled during insert so chunking cannot break them,
+    // then restored once every row of the table is present.
+    const present = knownIds.get(table.model) ?? new Set<string>()
+    for (const patch of deferred) {
+      if (!present.has(patch.value)) continue
+      try {
+        await target[table.model].update({
+          where: { id: patch.id },
+          data: { [patch.field]: patch.value }
+        })
+      } catch (e) {
+        pushError(result, `self-ref ${patch.field} on ${patch.id}: ${(e as Error).message}`)
+      }
+    }
+
+    result.skippedExisting = Math.max(
+      0,
+      result.fetched - result.droppedRefs - result.inserted - result.failed
+    )
+    report.tables.push(result)
+  }
+
+  for (const t of report.tables) {
+    report.totals.fetched += t.fetched
+    report.totals.inserted += t.inserted
+    report.totals.failed += t.failed
+    report.totals.deleted += t.deleted
+  }
+
+  return report
+}
+
+/**
+ * Copies a table with plain SQL, one row at a time, for data the Prisma client
+ * cannot decode (see `TransferTable.raw`). `SELECT *` is safe here because both
+ * databases run the same migrations.
+ */
+async function copyRawTable(
+  pools: { source: RawPool; target: RawPool },
+  table: TransferTable,
+  parentIds: string[],
+  result: TableResult
+): Promise<void> {
+  const spec = table.raw!
+  const batchSize = table.pageSize ?? 25
+  let read = 0
+
+  // node-postgres hands json/jsonb back as JS values; an array would otherwise
+  // be re-encoded as a Postgres array literal, so those columns are stringified.
+  const { rows: columnTypes } = await pools.target.query(
+    `SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1`,
+    [spec.table]
+  )
+  const jsonColumns = new Set(
+    columnTypes
+      .filter((c) => c.data_type === 'json' || c.data_type === 'jsonb')
+      .map((c) => String(c.column_name))
+  )
+
+  for (let i = 0; i < parentIds.length; i += batchSize) {
+    const batch = parentIds.slice(i, i + batchSize)
+    const { rows } = await pools.source.query(
+      `SELECT * FROM "${spec.table}" WHERE "${spec.parentColumn}" = ANY($1::text[])`,
+      [batch]
+    )
+    read += rows.length
+
+    for (const row of rows) {
+      const columns = Object.keys(row)
+      const placeholders = columns.map((_, index) => `$${index + 1}`).join(', ')
+      const quoted = columns.map((c) => `"${c}"`).join(', ')
+      try {
+        const inserted = await pools.target.query(
+          `INSERT INTO "${spec.table}" (${quoted}) VALUES (${placeholders}) ON CONFLICT DO NOTHING`,
+          columns.map((c) =>
+            jsonColumns.has(c) && row[c] !== null && row[c] !== undefined
+              ? JSON.stringify(row[c])
+              : row[c]
+          )
+        )
+        if (inserted.rowCount) result.inserted++
+        else result.skippedExisting++
+      } catch (e) {
+        result.failed++
+        pushError(result, `${String(row.id)}: ${(e as Error).message}`)
+      }
+    }
+  }
+
+  result.droppedRefs = Math.max(0, result.fetched - read)
+}
+
+function emptyResult(table: TransferTable): TableResult {
+  return {
+    model: table.model,
+    label: table.label,
+    section: table.section,
+    fetched: 0,
+    inserted: 0,
+    skippedExisting: 0,
+    droppedRefs: 0,
+    nulledRefs: 0,
+    failed: 0,
+    deleted: 0,
+    errors: []
+  }
+}
+
+function pushError(result: TableResult, message: string) {
+  if (result.errors.length < MAX_ERRORS_PER_TABLE) result.errors.push(message)
+}
+
+/**
+ * Bulk insert with `skipDuplicates`, falling back to row-by-row on failure so a
+ * single bad record cannot lose the whole batch.
+ */
+async function insertRows(
+  target: AnyPrisma,
+  model: string,
+  rows: Record<string, unknown>[],
+  result: TableResult
+): Promise<{ written: number; failedIds: Set<string> }> {
+  const failedIds = new Set<string>()
+
+  try {
+    const { count } = await target[model].createMany({ data: rows, skipDuplicates: true })
+    return { written: count, failedIds }
+  } catch (e) {
+    pushError(result, `batch insert failed, retrying row by row: ${(e as Error).message}`)
+  }
+
+  let written = 0
+  for (const row of rows) {
+    try {
+      const { count } = await target[model].createMany({ data: [row], skipDuplicates: true })
+      written += count
+    } catch (e) {
+      result.failed++
+      failedIds.add((row as { id?: string }).id ?? '')
+      pushError(result, `${(row as { id?: string }).id}: ${(e as Error).message}`)
+    }
+  }
+  return { written, failedIds }
+}


### PR DESCRIPTION
Fixes CW-452

## What

Adds `pnpm cw:cli users data transfer` — a database-to-database copy of one user's data onto a user that **already exists** in the target instance (production → `testing.coachwatts.com`).

The existing `users data export|import` pair cannot do this: it always creates a *new* user from a file, keyed by email, and imports only into the local database.

## How

- `server/utils/data-management/transfer-plan.ts` — declarative, dependency-ordered table plan. Each table declares the Prisma `where` that selects one user's rows (reused for counting, and for `--replace` deletes against the target), which columns hold the owning user id, which foreign keys may dangle and what to do about them, and its date column.
- `server/utils/data-management/user-data-transfer.ts` — the engine: pages through each table, remaps user ids, resolves references against this run *and* the target database, and inserts with `skipDuplicates`.
- `cli/users/data-transfer.ts` — the command.

## Behaviour

- `--sections`/`--skip`, `--since`/`--until`, `--replace`, `--dry-run`, `--list-sections`.
- `fitfiles` and `chat` are opt-in (size); everything else transfers by default.
- Re-running is safe — a second run copies only what is new.
- Skipping a section or narrowing the date range cannot break referential integrity: optional refs are nulled, required refs drop the row (reported in a `Dropped` column).

## Safety

- Never writes to the source; refuses to run if the target resolves to `DATABASE_URL_PROD` or equals the source URL.
- Only `host:port/database` is ever printed, never credentials.
- Not transferred: auth material, provider OAuth tokens, push tokens, billing rows, operational logs.
- Cleared on the way in: workout/planned-workout share tokens, training plan slugs (and plans arrive non-public).
- The profile section is an allowlist of training/preference columns — email, name, admin flag and subscription state on the target user are untouched.

## Verification

Ran against a scratch database created from `prisma migrate deploy`, with the real production database as source and a target user under a *different* id:

- `--dry-run --sections all`: 7,534 rows counted across 41 tables.
- Full run: 6,734 rows written, 0 failures; user ids remapped (0 rows left under the source id), chat `senderId` remapped for human messages only, share tokens and slugs cleared, 79 workout → planned-workout links and 83 `duplicateOf` self-references preserved.
- Re-run: 0 rows written (idempotent).
- `--replace --since 2026-06-01 --sections workouts,streams`: cleared and re-copied exactly the 29 workouts and 24 streams in range.
- `pnpm typecheck` and `eslint` clean.

Two production data issues surfaced and are handled: `WorkoutStreamV2` rows contain NULL elements inside `Int[]`/`Float[]` columns (Prisma refuses to decode them, so that table is copied with raw SQL), and the shared strength `Exercise` library is copied on demand when the target has never been seeded with it.