### PR TITLE
docs(cli): document testing database access for users data transfer (CW-456)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 DATABASE_URL="postgresql://username:password@localhost:5439/dbname?connection_limit=20&pool_timeout=10&connect_timeout=10"
 # E2E tests use a dedicated stack (Postgres + Redis + app) — see .env.e2e.example, docs/04-guides/e2e-testing.md, and `pnpm e2e:setup`
 DATABASE_URL_PROD="postgresql://username:password@localhost:5439/dbname"
-# Testing instance database — target of `pnpm cw:cli users data transfer` (see docs/04-guides/user-data-transfer.md)
-DATABASE_URL_TESTING="postgresql://username:password@localhost:5439/dbname"
+# Testing instance database — target of `pnpm cw:cli users data transfer`.
+# Not directly reachable: point this at the local end of a forward into the deployment's
+# private network. See docs/04-guides/data-management.md ("Reaching the testing database").
+DATABASE_URL_TESTING="postgresql://username:password@127.0.0.1:15432/dbname"
 
 # PostgreSQL Connection (for scripts/tools)
 POSTGRES_HOST=localhost

--- a/docs/04-guides/data-management.md
+++ b/docs/04-guides/data-management.md
@@ -69,13 +69,30 @@ The export/import pair above always creates a **new** user from a file. To load 
 
 ### 1. Prerequisites
 
-- Network access to both databases.
+- Network access to both databases — see [Reaching the testing database](#reaching-the-testing-database) below, which is not as simple as it sounds.
 - `DATABASE_URL_PROD` and `DATABASE_URL_TESTING` in `.env` (either option also accepts a literal `postgresql://…` URL).
 - The target user must already exist on the target instance. Sign in there once, then look up the id:
 
 ```bash
 pnpm cw:cli users search you@example.com
 ```
+
+#### Reaching the testing database
+
+The testing instance's database runs inside the deployment's private container network and **publishes no host port**, so its connection string cannot be used from a workstation as-is. Reaching it needs a forward from your machine to that network — typically a short-lived proxy container on the deployment host plus an SSH local forward.
+
+`DATABASE_URL_TESTING` should therefore point at the **local end** of that forward, not at the internal hostname:
+
+```bash
+DATABASE_URL_TESTING="postgresql://<user>:<password>@127.0.0.1:15432/<database>"
+```
+
+The forward has to be up before the command runs; without it you get a connection refused on `127.0.0.1:15432`.
+
+> [!NOTE]
+> The host-specific recipe — stack and container names, host address, and the exact proxy/tunnel commands — lives in the private infrastructure runbook (`hdkiller/docs/applications/coach-watts.md`, "Testing instance database access"), not in this repository. Credentials come from the deployed stack; they are not stored in the repo or in `.env.example`.
+
+Tear the forward down when you are done, and keep the credentials out of anything tracked by git — `.env` is git-ignored, command lines and shell history are not, which is why `--to` also accepts an env var name rather than a literal URL.
 
 ### 2. See what would move
 


### PR DESCRIPTION
Fixes CW-456

## What

CW-452 shipped `cw:cli users data transfer`, which defaults its target to `DATABASE_URL_TESTING`, but never documented how to get that value — the testing instance's database publishes no host port, so it isn't reachable the way `DATABASE_URL_PROD` is.

## Changes

- `docs/04-guides/data-management.md` — new "Reaching the testing database" subsection under the transfer prerequisites: explains the constraint, the expected `DATABASE_URL_TESTING` shape (local tunnel address, not the internal one), and links to the private infra runbook for the host-specific steps (kept out of this public repo).
- `.env.example` — fixed a broken doc reference left over from CW-452 (pointed at a non-existent `user-data-transfer.md`) and switched the example URL to the tunnel's loopback address so it matches the documented flow.

Host-specific detail — stack/container names, the proxy + SSH-forward recipe — went into the private infra repo (`hdkiller/docs/applications/coach-watts.md`, new "Testing instance (coach-dev)" section), not here, per this repo's public/private split.