### PR TITLE
fix(worker): claim pending webhook logs atomically (CW-34)

### DIFF
--- a/cli/worker/start.ts
+++ b/cli/worker/start.ts
@@ -1,4 +1,4 @@
-import type { Job } from 'bullmq'
+import type { Job, Queue } from 'bullmq'
 import { Worker } from 'bullmq'
 import IORedis from 'ioredis'
 import chalk from 'chalk'
@@ -196,6 +196,44 @@ export function buildWebhookJob(log: ClaimedWebhookLog): {
   }
 
   return { queueJobName, jobData }
+}
+
+/**
+ * Enqueue an already-claimed batch of webhook logs.
+ *
+ * The claim flips the whole batch to QUEUED up front, so this function owns the
+ * invariant that every row it was handed either ends up with a job or goes back
+ * to PENDING. If an enqueue throws we abandon the batch (the caller treats it as
+ * a poll-level failure and may restart the worker), which means every row we
+ * have not enqueued yet must be released first — nothing re-picks a QUEUED row,
+ * since the claim query selects only PENDING and there is no reaper for stale
+ * QUEUED rows.
+ */
+export async function drainClaimedWebhookLogs(
+  client: WebhookClaimClient,
+  queue: Pick<Queue, 'add'>,
+  claimedLogs: ClaimedWebhookLog[]
+): Promise<void> {
+  for (let i = 0; i < claimedLogs.length; i++) {
+    const log = claimedLogs[i]!
+    const { queueJobName, jobData } = buildWebhookJob(log)
+
+    try {
+      await queue.add(queueJobName, jobData)
+    } catch (addErr) {
+      for (const stranded of claimedLogs.slice(i)) {
+        try {
+          await releaseClaimedWebhookLog(client, stranded.id)
+        } catch (releaseErr) {
+          console.error(
+            chalk.red(`[Poller] Failed to release webhook log ${stranded.id} back to PENDING:`),
+            releaseErr
+          )
+        }
+      }
+      throw addErr
+    }
+  }
 }
 
 export const startCommand = new Command('start')
@@ -869,25 +907,7 @@ export const startCommand = new Command('start')
             )
           }
 
-          for (const log of claimedLogs) {
-            const { queueJobName, jobData } = buildWebhookJob(log)
-
-            try {
-              await webhookQueue.add(queueJobName, jobData)
-            } catch (addErr) {
-              // The claim already marked the row QUEUED; hand it back so the
-              // webhook is retried on a later poll instead of being stranded.
-              try {
-                await releaseClaimedWebhookLog(prisma, log.id)
-              } catch (releaseErr) {
-                console.error(
-                  chalk.red(`[Poller] Failed to release webhook log ${log.id} back to PENDING:`),
-                  releaseErr
-                )
-              }
-              throw addErr
-            }
-          }
+          await drainClaimedWebhookLogs(prisma, webhookQueue, claimedLogs)
         }
       } catch (err) {
         console.error(chalk.red('[Poller] Error polling webhooks:'), err)

--- a/cli/worker/start.ts
+++ b/cli/worker/start.ts
@@ -12,6 +12,7 @@ import { OuraService } from '../../server/utils/services/ouraService'
 import { processStravaWebhookEvent } from '../../server/utils/services/stravaService'
 import { ResendService } from '../../server/utils/services/resendService'
 import { logWebhookRequest, updateWebhookStatus } from '../../server/utils/webhook-logger'
+import { Prisma } from '@prisma/client'
 import { prisma } from '../../server/utils/db'
 import { webhookQueue, pingQueue, streamsQueue, mainTaskQueue } from '../../server/utils/queue'
 import { executeRegisteredTask, getRegisteredTaskIds } from '../../server/utils/task-registry'
@@ -91,6 +92,110 @@ export async function registerScheduledTasks(
     )
   )
   return scheduledTasks.length
+}
+
+export const WEBHOOK_POLL_BATCH_SIZE = 50
+
+export type ClaimedWebhookLog = {
+  id: string
+  provider: string
+  eventType: string | null
+  payload: unknown
+  headers: unknown
+  query: unknown
+  error: string | null
+}
+
+type WebhookClaimClient = {
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>
+  $executeRaw(query: Prisma.Sql): Promise<number>
+}
+
+/**
+ * Atomically claim a batch of PENDING webhook logs.
+ *
+ * Selection and the transition to QUEUED happen in a single statement, so two
+ * worker instances polling at the same time can never claim the same row:
+ * `FOR UPDATE SKIP LOCKED` makes the loser of the race skip the locked rows
+ * instead of waiting for them and re-reading a stale `PENDING` status.
+ */
+export async function claimPendingWebhookLogs(
+  client: WebhookClaimClient,
+  limit: number = WEBHOOK_POLL_BATCH_SIZE
+): Promise<ClaimedWebhookLog[]> {
+  const rows = await client.$queryRaw<ClaimedWebhookLog[]>(Prisma.sql`
+    UPDATE "WebhookLog"
+    SET "status" = 'QUEUED'
+    WHERE "id" IN (
+      SELECT "id"
+      FROM "WebhookLog"
+      WHERE "status" = 'PENDING'
+      ORDER BY "createdAt" ASC
+      LIMIT ${limit}
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING "id", "provider", "eventType", "payload", "headers", "query", "error"
+  `)
+  return rows ?? []
+}
+
+/**
+ * Hand a claimed webhook log back to the poller when the BullMQ enqueue failed,
+ * so the webhook is retried instead of being stranded in QUEUED with no job.
+ * Guarded on `status = 'QUEUED'` so it can never resurrect a row that another
+ * code path has already moved to a terminal status.
+ */
+export async function releaseClaimedWebhookLog(
+  client: WebhookClaimClient,
+  id: string
+): Promise<void> {
+  await client.$executeRaw(Prisma.sql`
+    UPDATE "WebhookLog"
+    SET "status" = 'PENDING'
+    WHERE "id" = ${id} AND "status" = 'QUEUED'
+  `)
+}
+
+/**
+ * Map a claimed webhook log onto the BullMQ job name + payload the webhook
+ * worker expects.
+ */
+export function buildWebhookJob(log: ClaimedWebhookLog): {
+  queueJobName: string
+  jobData: Record<string, unknown>
+} {
+  let queueJobName = `${log.provider}-webhook`
+  let provider = log.provider
+  let jobData: Record<string, unknown> = {
+    provider,
+    type: log.eventType,
+    payload: log.payload,
+    headers: log.headers,
+    query: log.query,
+    logId: log.id,
+    // Oauth specific fields if any were stored in error or similar
+    appName: log.eventType?.startsWith('oauth:') ? log.eventType.split(':')[1] : 'unknown',
+    secretMatched: log.error === 'SECRET_MATCHED'
+  }
+
+  if (provider === 'intervals-bulk' || provider === 'intervals') {
+    queueJobName = 'intervals-webhook-bulk'
+    provider = 'intervals-bulk' // Force bulk handler for both
+    jobData.provider = provider
+  } else if (provider === 'oauth-generic') {
+    queueJobName = 'oauth-webhook'
+  } else if (provider === 'resend') {
+    const payload = (log.payload || {}) as Record<string, any>
+    jobData = {
+      provider: 'resend',
+      type: payload.type || log.eventType,
+      data: payload.data,
+      createdAt: payload.created_at,
+      logId: log.id
+    }
+  }
+
+  return { queueJobName, jobData }
 }
 
 export const startCommand = new Command('start')
@@ -753,57 +858,35 @@ export const startCommand = new Command('start')
     // This loop checks for PENDING webhooks in SQL and moves them to BullMQ
     const pollWebhooks = async () => {
       try {
-        const pendingLogs = await prisma.webhookLog.findMany({
-          where: { status: 'PENDING' },
-          orderBy: { createdAt: 'asc' },
-          take: 50
-        })
+        // Claim the batch atomically: the rows come back already flipped to
+        // QUEUED, so a second worker polling concurrently cannot pick them up.
+        const claimedLogs = await claimPendingWebhookLogs(prisma, WEBHOOK_POLL_BATCH_SIZE)
 
-        if (pendingLogs.length > 0) {
+        if (claimedLogs.length > 0) {
           if (verboseWorkerLogs) {
-            console.log(chalk.gray(`[Poller] Found ${pendingLogs.length} pending webhooks in SQL`))
+            console.log(
+              chalk.gray(`[Poller] Claimed ${claimedLogs.length} pending webhooks in SQL`)
+            )
           }
 
-          for (const log of pendingLogs) {
-            let queueJobName = `${log.provider}-webhook`
-            let provider = log.provider
-            let jobData: Record<string, unknown> = {
-              provider,
-              type: log.eventType,
-              payload: log.payload,
-              headers: log.headers,
-              query: log.query,
-              logId: log.id,
-              // Oauth specific fields if any were stored in error or similar
-              appName: log.eventType?.startsWith('oauth:')
-                ? log.eventType.split(':')[1]
-                : 'unknown',
-              secretMatched: log.error === 'SECRET_MATCHED'
-            }
+          for (const log of claimedLogs) {
+            const { queueJobName, jobData } = buildWebhookJob(log)
 
-            if (provider === 'intervals-bulk' || provider === 'intervals') {
-              queueJobName = 'intervals-webhook-bulk'
-              provider = 'intervals-bulk' // Force bulk handler for both
-              jobData.provider = provider
-            } else if (provider === 'oauth-generic') {
-              queueJobName = 'oauth-webhook'
-            } else if (provider === 'resend') {
-              const payload = (log.payload || {}) as Record<string, any>
-              jobData = {
-                provider: 'resend',
-                type: payload.type || log.eventType,
-                data: payload.data,
-                createdAt: payload.created_at,
-                logId: log.id
+            try {
+              await webhookQueue.add(queueJobName, jobData)
+            } catch (addErr) {
+              // The claim already marked the row QUEUED; hand it back so the
+              // webhook is retried on a later poll instead of being stranded.
+              try {
+                await releaseClaimedWebhookLog(prisma, log.id)
+              } catch (releaseErr) {
+                console.error(
+                  chalk.red(`[Poller] Failed to release webhook log ${log.id} back to PENDING:`),
+                  releaseErr
+                )
               }
+              throw addErr
             }
-
-            await webhookQueue.add(queueJobName, jobData)
-
-            await prisma.webhookLog.update({
-              where: { id: log.id },
-              data: { status: 'QUEUED' }
-            })
           }
         }
       } catch (err) {

--- a/tests/unit/cli/worker.test.ts
+++ b/tests/unit/cli/worker.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { registerScheduledTasks } from '../../../cli/worker/start'
+import type { Prisma } from '@prisma/client'
+import {
+  buildWebhookJob,
+  claimPendingWebhookLogs,
+  registerScheduledTasks,
+  releaseClaimedWebhookLog,
+  WEBHOOK_POLL_BATCH_SIZE,
+  type ClaimedWebhookLog
+} from '../../../cli/worker/start'
 import {
   ensureTaskHandlersRegistered,
   getLoadedTaskDefinitions,
@@ -127,5 +135,142 @@ describe('Worker schedule registration', () => {
 
     expect(count).toBe(scheduledDefinitions.length)
     expect(upserted).toEqual(scheduledDefinitions.map((d) => `task-schedule:${d.id}`))
+  })
+})
+
+describe('Webhook poller atomic claim', () => {
+  const makeClient = (rows: ClaimedWebhookLog[] = []) => {
+    const queries: Prisma.Sql[] = []
+    return {
+      queries,
+      client: {
+        $queryRaw: vi.fn(async (query: Prisma.Sql) => {
+          queries.push(query)
+          return rows as any
+        }),
+        $executeRaw: vi.fn(async (query: Prisma.Sql) => {
+          queries.push(query)
+          return 1
+        })
+      }
+    }
+  }
+
+  it('selects and marks PENDING rows QUEUED in a single locking statement', async () => {
+    const { client, queries } = makeClient([
+      {
+        id: 'log-1',
+        provider: 'strava',
+        eventType: 'activity',
+        payload: { a: 1 },
+        headers: null,
+        query: null,
+        error: null
+      }
+    ])
+
+    const claimed = await claimPendingWebhookLogs(client)
+
+    expect(claimed).toHaveLength(1)
+    expect(claimed[0]!.id).toBe('log-1')
+    expect(client.$queryRaw).toHaveBeenCalledTimes(1)
+
+    const sql = queries[0]!.sql.replace(/\s+/g, ' ')
+    // One statement does both the selection and the status transition, so a
+    // concurrently polling worker can never claim the same row twice.
+    expect(sql).toContain('UPDATE "WebhookLog"')
+    expect(sql).toContain(`SET "status" = 'QUEUED'`)
+    expect(sql).toContain(`WHERE "status" = 'PENDING'`)
+    expect(sql).toContain('ORDER BY "createdAt" ASC')
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED')
+    expect(sql).toContain('RETURNING')
+    expect(queries[0]!.values).toEqual([WEBHOOK_POLL_BATCH_SIZE])
+  })
+
+  it('returns an empty batch when nothing is pending', async () => {
+    const { client } = makeClient([])
+    await expect(claimPendingWebhookLogs(client, 10)).resolves.toEqual([])
+  })
+
+  it('releases a claimed row back to PENDING only while it is still QUEUED', async () => {
+    const { client, queries } = makeClient()
+
+    await releaseClaimedWebhookLog(client, 'log-9')
+
+    const sql = queries[0]!.sql.replace(/\s+/g, ' ')
+    expect(sql).toContain(`SET "status" = 'PENDING'`)
+    expect(sql).toContain(`"status" = 'QUEUED'`)
+    expect(queries[0]!.values).toEqual(['log-9'])
+  })
+
+  it('maps claimed logs onto the queue job name and payload', () => {
+    expect(
+      buildWebhookJob({
+        id: 'log-1',
+        provider: 'intervals',
+        eventType: 'wellness',
+        payload: { x: 1 },
+        headers: { h: 1 },
+        query: { q: 1 },
+        error: null
+      })
+    ).toEqual({
+      queueJobName: 'intervals-webhook-bulk',
+      jobData: {
+        provider: 'intervals-bulk',
+        type: 'wellness',
+        payload: { x: 1 },
+        headers: { h: 1 },
+        query: { q: 1 },
+        logId: 'log-1',
+        appName: 'unknown',
+        secretMatched: false
+      }
+    })
+
+    expect(
+      buildWebhookJob({
+        id: 'log-2',
+        provider: 'oauth-generic',
+        eventType: 'oauth:withings',
+        payload: null,
+        headers: null,
+        query: null,
+        error: 'SECRET_MATCHED'
+      })
+    ).toEqual({
+      queueJobName: 'oauth-webhook',
+      jobData: {
+        provider: 'oauth-generic',
+        type: 'oauth:withings',
+        payload: null,
+        headers: null,
+        query: null,
+        logId: 'log-2',
+        appName: 'withings',
+        secretMatched: true
+      }
+    })
+
+    expect(
+      buildWebhookJob({
+        id: 'log-3',
+        provider: 'resend',
+        eventType: null,
+        payload: { type: 'email.delivered', data: { id: 'e1' }, created_at: '2026-01-01' },
+        headers: null,
+        query: null,
+        error: null
+      })
+    ).toEqual({
+      queueJobName: 'resend-webhook',
+      jobData: {
+        provider: 'resend',
+        type: 'email.delivered',
+        data: { id: 'e1' },
+        createdAt: '2026-01-01',
+        logId: 'log-3'
+      }
+    })
   })
 })

--- a/tests/unit/cli/worker.test.ts
+++ b/tests/unit/cli/worker.test.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client'
 import {
   buildWebhookJob,
   claimPendingWebhookLogs,
+  drainClaimedWebhookLogs,
   registerScheduledTasks,
   releaseClaimedWebhookLog,
   WEBHOOK_POLL_BATCH_SIZE,
@@ -272,5 +273,84 @@ describe('Webhook poller atomic claim', () => {
         logId: 'log-3'
       }
     })
+  })
+})
+
+describe('Webhook poller batch drain', () => {
+  function makeLogs(n: number): ClaimedWebhookLog[] {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `log-${i}`,
+      provider: 'strava',
+      eventType: 'activity',
+      payload: { i },
+      headers: null,
+      query: null,
+      error: null
+    }))
+  }
+
+  function makeReleaseClient() {
+    const released: string[] = []
+    return {
+      released,
+      client: {
+        $queryRaw: vi.fn(async () => []),
+        $executeRaw: vi.fn(async (query: Prisma.Sql) => {
+          released.push(query.values[0] as string)
+          return 1
+        })
+      }
+    }
+  }
+
+  it('enqueues every claimed log when the queue is healthy', async () => {
+    const { client, released } = makeReleaseClient()
+    const queue = { add: vi.fn(async () => ({}) as never) }
+
+    await drainClaimedWebhookLogs(client, queue, makeLogs(3))
+
+    expect(queue.add).toHaveBeenCalledTimes(3)
+    expect(released).toEqual([])
+  })
+
+  it('releases the failing row AND the whole unenqueued remainder', async () => {
+    // Regression: the batch is already flipped to QUEUED by the claim, and we
+    // abandon the loop on error. Releasing only the row that threw stranded
+    // every later row in QUEUED with no job and no reaper to recover it.
+    const { client, released } = makeReleaseClient()
+    const queue = {
+      add: vi.fn(async () => {
+        if (queue.add.mock.calls.length === 3) throw new Error('redis down')
+        return {} as never
+      })
+    }
+
+    await expect(drainClaimedWebhookLogs(client, queue, makeLogs(6))).rejects.toThrow('redis down')
+
+    // log-0..log-1 enqueued; log-2 threw; log-2..log-5 all handed back.
+    expect(released).toEqual(['log-2', 'log-3', 'log-4', 'log-5'])
+  })
+
+  it('still releases the remainder when an individual release throws', async () => {
+    const released: string[] = []
+    const client = {
+      $queryRaw: vi.fn(async () => []),
+      $executeRaw: vi.fn(async (query: Prisma.Sql) => {
+        const id = query.values[0] as string
+        if (id === 'log-1') throw new Error('db blip')
+        released.push(id)
+        return 1
+      })
+    }
+    const queue = {
+      add: vi.fn(async () => {
+        throw new Error('redis down')
+      })
+    }
+
+    await expect(drainClaimedWebhookLogs(client, queue, makeLogs(3))).rejects.toThrow('redis down')
+
+    // log-1's release failed but must not abort the rest of the drain.
+    expect(released).toEqual(['log-0', 'log-2'])
   })
 })


### PR DESCRIPTION
Fixes CW-34

## Problem

`pollWebhooks` in `cli/worker/start.ts` did `findMany({ status: 'PENDING' })`, enqueued each row, then updated it to `QUEUED` — a classic select-then-update race. Two worker instances polling within the same window both read the same `PENDING` rows and enqueued them twice.

## Fix

Selection and the `PENDING -> QUEUED` transition are now a single statement:

```sql
UPDATE "WebhookLog" SET "status" = 'QUEUED'
WHERE "id" IN (
  SELECT "id" FROM "WebhookLog" WHERE "status" = 'PENDING'
  ORDER BY "createdAt" ASC LIMIT $1 FOR UPDATE SKIP LOCKED
)
RETURNING ...
```

- `claimPendingWebhookLogs(client, limit)` — the atomic claim. `FOR UPDATE SKIP LOCKED` makes a concurrent poller skip rows another transaction has locked rather than block and then act on a stale `PENDING` read, so each row is claimed by exactly one worker.
- `buildWebhookJob(log)` — the existing job-name/payload mapping, extracted verbatim (intervals/intervals-bulk, oauth-generic, resend branches unchanged).
- `releaseClaimedWebhookLog(client, id)` — if `webhookQueue.add()` throws, the claimed row goes back to `PENDING` (guarded on `status = 'QUEUED'`) so a failed enqueue is retried rather than stranded. The original error is still rethrown into the existing poller catch, which keeps the Redis-connectivity restart path intact.

## Verification

`pnpm typecheck` — exit 0, no errors.

`pnpm vitest run tests/unit/cli/worker.test.ts`:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Four new cases in the existing `tests/unit/cli/worker.test.ts` (which already covers `cli/worker/start.ts` exports): the claim statement's shape (single locking UPDATE, ordering, `SKIP LOCKED`, parameterised limit), empty batch, the guarded release, and the job mapping for all three provider branches.

The claim SQL was additionally validated against a real Postgres schema with `EXPLAIN` (non-executing) — plan uses `WebhookLog_status_idx` + `LockRows`.

`npx eslint` clean on both changed files.

UX critique: skipped — backend queue logic, no user-facing surface.

## Files changed vs Owned Paths

- `cli/worker/start.ts` — Owned Path.
- `tests/unit/cli/worker.test.ts` — outside the literal Owned Paths list, added per the ticket's test note: this file already imports from `cli/worker/start` and is that module's existing unit-test surface.

## Risks

- **Failure window moved, not eliminated.** A worker crash between the claim and `webhookQueue.add()` now leaves a row in `QUEUED` with no job (previously a crash in the mirror position caused double processing). This is the intended direction given the AC, but there is no reaper for stale `QUEUED` rows — filed as follow-up CW-499.
- **Isolation level:** correctness relies only on row locks, not on isolation level; it is safe under the default `READ COMMITTED`. No explicit transaction is opened — the single statement is its own transaction.
- **Connection pooling:** works with the repo's `pg` pool and would also work through a transaction-pooling proxy, since the claim is one statement with no cross-statement session state.
- `WebhookLog` has an index on `status`, so the claim's subquery is index-backed at the current batch size of 50.
