### PR TITLE
fix(garmin): prune revoked user permissions on live refresh (CW-94)

### DIFF
--- a/server/api/workouts/planned/[id]/publish-garmin.post.ts
+++ b/server/api/workouts/planned/[id]/publish-garmin.post.ts
@@ -13,8 +13,9 @@ import {
 import {
   fetchGarminUserPermissions,
   hasGarminPermission,
-  mergeGarminScopes,
-  parseGarminScope
+  parseGarminScope,
+  reconcileGarminScopes,
+  serializeGarminScopes
 } from '../../../../utils/garmin'
 import { plannedWorkoutPublishRepository } from '../../../../utils/repositories/plannedWorkoutPublishRepository'
 import { serializeCanonicalForGarmin } from '../../../../utils/canonical-workout-serializer'
@@ -99,18 +100,17 @@ export default defineEventHandler(async (event) => {
 
   if (!hasGarminPermission(scopes, requiredPermission)) {
     try {
+      // Only a successful permissions response drives this: on failure the catch below leaves the
+      // stored scope untouched rather than pruning it.
       const permissions = await fetchGarminUserPermissions(integration as any)
-      const mergedScopes = mergeGarminScopes(scopes, permissions)
-      if (mergedScopes.size > 0) {
-        scopes = mergedScopes
-        await prisma.integration.update({
-          where: { id: integration.id },
-          data: {
-            scope: Array.from(mergedScopes).join(' '),
-            errorMessage: null
-          }
-        })
-      }
+      scopes = reconcileGarminScopes(scopes, permissions)
+      await prisma.integration.update({
+        where: { id: integration.id },
+        data: {
+          scope: serializeGarminScopes(scopes),
+          errorMessage: null
+        }
+      })
     } catch (error) {
       console.warn('[GarminPublish] Failed to fetch permissions from Garmin API', error)
     }

--- a/server/utils/garmin.ts
+++ b/server/utils/garmin.ts
@@ -707,6 +707,21 @@ export async function deRegisterGarminUser(integration: Integration) {
 }
 
 /**
+ * Narrow a permissions array to the strings we understand.
+ *
+ * Throws if the array had entries but none of them were strings: that is a payload shape we do
+ * not recognize, and returning the empty result would be indistinguishable from a genuine
+ * "user granted nothing" — which prunes every user permission for every user.
+ */
+function filterGarminPermissionStrings(values: unknown[]): string[] {
+  const strings = values.filter((value): value is string => typeof value === 'string')
+  if (values.length > 0 && strings.length === 0) {
+    throw new Error('Garmin permissions API returned an unrecognized payload')
+  }
+  return strings
+}
+
+/**
  * Fetch current user permissions granted to this app.
  *
  * Resolves only for a successful, well-formed response — an empty array then genuinely means
@@ -727,13 +742,17 @@ export async function fetchGarminUserPermissions(integration: Integration): Prom
 
     if (response.ok) {
       const data = await response.json().catch(() => undefined)
+      // A 200 we cannot parse is not evidence that every permission was
+      // revoked. That includes an array we *can* iterate but whose entries are
+      // not strings (e.g. a future `[{ permission: 'HEALTH_EXPORT' }]` shape):
+      // filtering it to strings would yield [], which reconcileGarminScopes
+      // would faithfully apply as a full revoke for every user.
       if (Array.isArray(data)) {
-        return data.filter((x) => typeof x === 'string')
+        return filterGarminPermissionStrings(data)
       }
       if (Array.isArray(data?.permissions)) {
-        return data.permissions.filter((x: unknown) => typeof x === 'string')
+        return filterGarminPermissionStrings(data.permissions)
       }
-      // A 200 we cannot parse is not evidence that every permission was revoked.
       throw new Error('Garmin permissions API returned an unrecognized payload')
     }
 

--- a/server/utils/garmin.ts
+++ b/server/utils/garmin.ts
@@ -17,6 +17,25 @@ interface GarminApiErrorPayload {
 
 const GARMIN_WRITE_SCOPE = 'PARTNER_WRITE'
 const GARMIN_IMPORT_PERMISSIONS = new Set(['WORKOUT_IMPORT', 'COURSE_IMPORT'])
+
+/**
+ * User-level grants that `GET /wellness-api/rest/user/permissions` is authoritative for.
+ * A successful live response therefore *replaces* this subset of `Integration.scope`:
+ * anything here that the response omits has been revoked in Garmin Connect.
+ *
+ * - `ACTIVITY_EXPORT` / `HEALTH_EXPORT` — wellness + activity export consents, toggled per user.
+ * - `WORKOUT_IMPORT` / `COURSE_IMPORT`  — Training/Courses push consents, toggled per user.
+ *
+ * Everything else stored in `Integration.scope` (notably `PARTNER_WRITE` and any OAuth/API scope
+ * returned by the token endpoint at connect time) is *not* reported by that endpoint and must be
+ * preserved untouched — pruning it would silently break publishing for correctly connected users.
+ */
+export const GARMIN_USER_PERMISSIONS = new Set([
+  'ACTIVITY_EXPORT',
+  'HEALTH_EXPORT',
+  'WORKOUT_IMPORT',
+  'COURSE_IMPORT'
+])
 const GARMIN_TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000
 const GARMIN_TOKEN_REQUEST_TIMEOUT_MS = 10_000
 const GARMIN_TOKEN_TRANSACTION_TIMEOUT_MS = 20_000
@@ -69,6 +88,58 @@ export function mergeGarminScopes(
   }
 
   return merged
+}
+
+/**
+ * Reconcile stored `Integration.scope` against a *successful* live Garmin user-permissions
+ * response.
+ *
+ * Unlike {@link mergeGarminScopes} (a pure union, still correct for merging OAuth scopes at
+ * connect time), this applies replacement semantics to the subset the permissions endpoint owns:
+ *
+ * - values in {@link GARMIN_USER_PERMISSIONS} are kept only when the live response still lists them
+ *   (so a revoked grant is dropped instead of surviving forever),
+ * - every other stored value (OAuth/API scopes such as `PARTNER_WRITE`) is preserved as-is,
+ * - anything the live response reports is added, including permissions we do not yet know about.
+ *
+ * Only call this with a parsed response from a successful request — an API failure must never be
+ * treated as "zero permissions", or a transient blip would revoke the user's integration.
+ */
+export function reconcileGarminScopes(
+  storedScope: string | string[] | Set<string> | null | undefined,
+  livePermissions: string[] | Set<string> | null | undefined
+): Set<string> {
+  const stored = mergeGarminScopes(storedScope)
+  const live = mergeGarminScopes(livePermissions)
+
+  const reconciled = new Set<string>()
+
+  for (const value of stored) {
+    // Dynamic user permissions are authoritative in the live response; keep the rest untouched.
+    if (GARMIN_USER_PERMISSIONS.has(value)) continue
+    reconciled.add(value)
+  }
+
+  for (const value of live) reconciled.add(value)
+
+  return reconciled
+}
+
+/**
+ * Serialize a scope set for storage. An empty set is stored as `null` rather than an empty string
+ * so "no permissions" reads the same as a never-populated scope column.
+ */
+export function serializeGarminScopes(scopes: Set<string> | string[]): string | null {
+  const values = Array.from(scopes)
+  return values.length > 0 ? values.join(' ') : null
+}
+
+function garminScopeSetsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const value of a) {
+    if (!b.has(value)) return false
+  }
+  return true
 }
 
 export function hasGarminPermission(
@@ -637,6 +708,10 @@ export async function deRegisterGarminUser(integration: Integration) {
 
 /**
  * Fetch current user permissions granted to this app.
+ *
+ * Resolves only for a successful, well-formed response — an empty array then genuinely means
+ * "the user granted nothing". Request failures and unrecognized payloads throw, so callers can
+ * never mistake a broken request for a full revocation.
  */
 export async function fetchGarminUserPermissions(integration: Integration): Promise<string[]> {
   const url = 'https://apis.garmin.com/wellness-api/rest/user/permissions'
@@ -651,14 +726,15 @@ export async function fetchGarminUserPermissions(integration: Integration): Prom
     })
 
     if (response.ok) {
-      const data = await response.json()
+      const data = await response.json().catch(() => undefined)
       if (Array.isArray(data)) {
         return data.filter((x) => typeof x === 'string')
       }
       if (Array.isArray(data?.permissions)) {
         return data.permissions.filter((x: unknown) => typeof x === 'string')
       }
-      return []
+      // A 200 we cannot parse is not evidence that every permission was revoked.
+      throw new Error('Garmin permissions API returned an unrecognized payload')
     }
 
     const errorBody = await response.json().catch(() => ({}))
@@ -676,26 +752,38 @@ export async function fetchGarminUserPermissions(integration: Integration): Prom
 }
 
 /**
- * Best-effort merge of live Garmin export permissions into Integration.scope.
- * Never throws — ingest/callback must keep working if permissions are unreachable.
+ * Best-effort reconciliation of live Garmin export permissions into Integration.scope.
+ *
+ * Grants are added and revoked permissions are pruned (see {@link reconcileGarminScopes}), while
+ * OAuth/API scopes are preserved. Never throws — ingest/callback must keep working if permissions
+ * are unreachable, and in that case the stored scope is left exactly as it was.
  */
 export async function refreshGarminIntegrationPermissions(
   integration: Integration
 ): Promise<Integration> {
+  let permissions: string[]
+
   try {
-    const permissions = await fetchGarminUserPermissions(integration)
-    const merged = mergeGarminScopes(integration.scope, permissions)
-    if (merged.size === 0) return integration
+    permissions = await fetchGarminUserPermissions(integration)
+  } catch (error) {
+    // Network failure, 5xx, auth failure, unparseable body: not a revocation. Leave scope alone.
+    console.warn('[Garmin] Failed to refresh user permissions', {
+      integrationId: integration.id,
+      error
+    })
+    return integration
+  }
 
-    const scope = Array.from(merged).join(' ')
-    if (scope === (integration.scope || '').trim()) return integration
+  const reconciled = reconcileGarminScopes(integration.scope, permissions)
+  if (garminScopeSetsEqual(reconciled, parseGarminScope(integration.scope))) return integration
 
+  try {
     return await prisma.integration.update({
       where: { id: integration.id },
-      data: { scope }
+      data: { scope: serializeGarminScopes(reconciled) }
     })
   } catch (error) {
-    console.warn('[Garmin] Failed to refresh user permissions', {
+    console.warn('[Garmin] Failed to persist refreshed user permissions', {
       integrationId: integration.id,
       error
     })

--- a/tests/unit/server/utils/garmin.test.ts
+++ b/tests/unit/server/utils/garmin.test.ts
@@ -145,6 +145,85 @@ describe('Garmin permission helpers', () => {
     )
   })
 
+  it('throws rather than pruning when a 200 array holds non-string entries', async () => {
+    // A future shape like [{ permission: 'HEALTH_EXPORT' }] passes Array.isArray
+    // but filters to [], which reconcileGarminScopes would faithfully apply as a
+    // full revoke for every user.
+    const { fetchGarminUserPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-shape',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT'
+    } as any
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [{ permission: 'HEALTH_EXPORT' }, { permission: 'ACTIVITY_EXPORT' }],
+        headers: new Headers()
+      }) as any
+    )
+
+    await expect(fetchGarminUserPermissions(integration)).rejects.toThrow(/unrecognized payload/i)
+  })
+
+  it('throws when a 200 permissions object holds non-string entries', async () => {
+    const { fetchGarminUserPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-shape-2',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT'
+    } as any
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ permissions: [{ permission: 'HEALTH_EXPORT' }] }),
+        headers: new Headers()
+      }) as any
+    )
+
+    await expect(fetchGarminUserPermissions(integration)).rejects.toThrow(/unrecognized payload/i)
+  })
+
+  it('leaves the stored scope untouched when the payload shape is unrecognized', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-shape-3',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT ACTIVITY_EXPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => [{ permission: 'HEALTH_EXPORT' }],
+        headers: new Headers()
+      }) as any
+    )
+
+    const result = await refreshGarminIntegrationPermissions(integration)
+
+    expect(result.scope).toBe('PARTNER_WRITE HEALTH_EXPORT ACTIVITY_EXPORT')
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
   it('keeps unknown permissions reported by Garmin', () => {
     expect(reconcileGarminScopes('PARTNER_WRITE', ['MCT_EXPORT'])).toEqual(
       new Set(['PARTNER_WRITE', 'MCT_EXPORT'])

--- a/tests/unit/server/utils/garmin.test.ts
+++ b/tests/unit/server/utils/garmin.test.ts
@@ -11,7 +11,9 @@ import {
   isGarminDownloadTokenError,
   mergeGarminScopes,
   parseGarminScope,
-  refreshGarminToken
+  reconcileGarminScopes,
+  refreshGarminToken,
+  serializeGarminScopes
 } from '../../../../server/utils/garmin'
 
 const { prismaIntegrationFindUnique, prismaIntegrationUpdate, prismaQueryRaw, prismaTransaction } =
@@ -121,6 +123,195 @@ describe('Garmin permission helpers', () => {
         scope: expect.stringContaining('HEALTH_EXPORT')
       }
     })
+  })
+
+  it('adds newly granted user permissions while keeping OAuth scopes', () => {
+    expect(reconcileGarminScopes('PARTNER_WRITE CONNECT_READ', ['health_export'])).toEqual(
+      new Set(['PARTNER_WRITE', 'CONNECT_READ', 'HEALTH_EXPORT'])
+    )
+  })
+
+  it('prunes user permissions absent from the live response but keeps OAuth scopes', () => {
+    expect(
+      reconcileGarminScopes('PARTNER_WRITE CONNECT_READ HEALTH_EXPORT ACTIVITY_EXPORT', [
+        'ACTIVITY_EXPORT'
+      ])
+    ).toEqual(new Set(['PARTNER_WRITE', 'CONNECT_READ', 'ACTIVITY_EXPORT']))
+  })
+
+  it('drops every user permission when the live response is empty', () => {
+    expect(reconcileGarminScopes('PARTNER_WRITE HEALTH_EXPORT WORKOUT_IMPORT', [])).toEqual(
+      new Set(['PARTNER_WRITE'])
+    )
+  })
+
+  it('keeps unknown permissions reported by Garmin', () => {
+    expect(reconcileGarminScopes('PARTNER_WRITE', ['MCT_EXPORT'])).toEqual(
+      new Set(['PARTNER_WRITE', 'MCT_EXPORT'])
+    )
+  })
+
+  it('serializes an empty scope set as null', () => {
+    expect(serializeGarminScopes(new Set())).toBeNull()
+    expect(serializeGarminScopes(new Set(['PARTNER_WRITE']))).toBe('PARTNER_WRITE')
+  })
+
+  it('refreshGarminIntegrationPermissions prunes a partially revoked permission', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-partial-revoke',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT ACTIVITY_EXPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    prismaIntegrationUpdate.mockImplementation(async ({ data }: any) => ({
+      ...integration,
+      ...data
+    }))
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ['ACTIVITY_EXPORT'],
+        headers: new Headers()
+      }) as any
+    )
+
+    const updated = await refreshGarminIntegrationPermissions(integration)
+
+    expect(prismaIntegrationUpdate).toHaveBeenCalledWith({
+      where: { id: 'integration-partial-revoke' },
+      data: { scope: 'PARTNER_WRITE ACTIVITY_EXPORT' }
+    })
+    expect(updated.scope).toBe('PARTNER_WRITE ACTIVITY_EXPORT')
+    expect(hasGarminPermission(updated.scope, 'HEALTH_EXPORT')).toBe(false)
+  })
+
+  it('refreshGarminIntegrationPermissions clears every user permission on a full revoke', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-full-revoke',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'HEALTH_EXPORT ACTIVITY_EXPORT WORKOUT_IMPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+    prismaIntegrationUpdate.mockImplementation(async ({ data }: any) => ({
+      ...integration,
+      ...data
+    }))
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+        headers: new Headers()
+      }) as any
+    )
+
+    const updated = await refreshGarminIntegrationPermissions(integration)
+
+    expect(prismaIntegrationUpdate).toHaveBeenCalledWith({
+      where: { id: 'integration-full-revoke' },
+      data: { scope: null }
+    })
+    expect(updated.scope).toBeNull()
+  })
+
+  it('refreshGarminIntegrationPermissions skips the write when nothing changed', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-unchanged',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ['HEALTH_EXPORT'],
+        headers: new Headers()
+      }) as any
+    )
+
+    const result = await refreshGarminIntegrationPermissions(integration)
+
+    expect(result).toBe(integration)
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refreshGarminIntegrationPermissions keeps stored permissions when the network fails', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-network-error',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT WORKOUT_IMPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')) as any)
+
+    // The permissions fetch retries with exponential backoff; drive its timers instead of waiting.
+    vi.useFakeTimers()
+    let result: any
+    try {
+      const pending = refreshGarminIntegrationPermissions(integration)
+      await vi.runAllTimersAsync()
+      result = await pending
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(result).toBe(integration)
+    expect(result.scope).toBe('PARTNER_WRITE HEALTH_EXPORT WORKOUT_IMPORT')
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refreshGarminIntegrationPermissions does not prune on an unrecognized 200 payload', async () => {
+    const { refreshGarminIntegrationPermissions } = await import('../../../../server/utils/garmin')
+
+    const integration = {
+      id: 'integration-bad-payload',
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      expiresAt: new Date(Date.now() + 3600_000),
+      scope: 'PARTNER_WRITE HEALTH_EXPORT'
+    } as any
+
+    prismaIntegrationFindUnique.mockResolvedValue(integration)
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ unexpected: true }),
+        headers: new Headers()
+      }) as any
+    )
+
+    const result = await refreshGarminIntegrationPermissions(integration)
+
+    expect(result).toBe(integration)
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
   })
 
   it('refreshGarminIntegrationPermissions returns the original integration on API failure', async () => {


### PR DESCRIPTION
Fixes CW-94

## Problem

`refreshGarminIntegrationPermissions` unioned the live `GET /wellness-api/rest/user/permissions` response into `Integration.scope` via `mergeGarminScopes` (a pure union). A permission the user revoked in Garmin Connect was never removed from the stored set, so the app kept reporting a revoked grant as active — a correctness/privacy-adjacent bug. The same union pattern existed in the Garmin publish endpoint.

## Fix

`Integration.scope` deliberately holds a *mixture*: OAuth/API scopes granted at connect time (e.g. `PARTNER_WRITE`, never reported by the permissions endpoint) and dynamic user grants that endpoint *is* authoritative for. So a naive "replace scope with the response" would wipe the OAuth scopes.

- New exported `GARMIN_USER_PERMISSIONS` set — `ACTIVITY_EXPORT`, `HEALTH_EXPORT`, `WORKOUT_IMPORT`, `COURSE_IMPORT` — documented member-by-member as the grants `/user/permissions` owns.
- New pure `reconcileGarminScopes(storedScope, livePermissions)`: prunes stored values **only** inside that set when the live response omits them, preserves every other stored value untouched, and adds everything the response reports (including permissions we don't know about yet).
- `mergeGarminScopes` is unchanged and still used for its correct union case.
- Error/empty distinction: `fetchGarminUserPermissions` resolves only on a successful, well-formed body — an empty array genuinely means "granted nothing". Request failures **and** an unrecognized 200 payload now throw instead of degrading to `[]`, so a network blip or a shape change can never be read as a full revocation. `refreshGarminIntegrationPermissions` narrows its `try` to the fetch alone and returns the integration untouched on failure; the persist step has its own guarded `try`.
- `serializeGarminScopes` stores an empty set as `null` rather than `''`; the write is skipped entirely when the reconciled set is unchanged (set comparison, not string comparison, so scope ordering no longer causes spurious writes).
- `server/api/workouts/planned/[id]/publish-garmin.post.ts` now uses the same reconcile + serialize path.

## Verification

```
$ pnpm test tests/unit/server/utils/garmin.test.ts

 RUN  v4.1.10 /Users/hdkiller/Develop/.worktrees/coach-wattz/CW-94

 Test Files  1 passed (1)
      Tests  25 passed (25)
   Duration  380ms
```

Also green (no changes needed): `pnpm typecheck`, and the neighbouring Garmin suites — `garminService`, `garmin-oauth-state`, `ingest-garmin`, `garmin-push` (5 files / 93 tests passed).

New tests cover grant, partial revoke, full revoke, no-op, network error (fake timers so the retry backoff doesn't cost 14s of wall clock), unrecognized 200 payload, and API 5xx failure.

## UX critique

UX critique: skipped — backend integration state correctness, no interactive flow change.

**Where the behaviour change lands (read-only grep of `app/`):** `Integration.scope` for Garmin is **not** rendered anywhere in `app/`. The "Permissions:" list in `app/pages/settings/apps.vue` is OAuth *consent* scopes for MCP apps (`app.consent.scopes`), a different field, and `server/api/integrations/status.get.ts` does not return the Garmin integration's `scope` to the client. The only user-visible consequence is server-side gating: a user who revoked `WORKOUT_IMPORT` / `COURSE_IMPORT` in Garmin Connect will now correctly get `400 "Garmin WORKOUT_IMPORT permission is required. Reconnect Garmin and grant permission."` from the publish endpoint instead of a stale pass-through. That is the intended fix.

## Risks / notes

- **`PARTNER_WRITE` still implies import permissions.** `hasGarminPermission` treats `PARTNER_WRITE` as sufficient for `WORKOUT_IMPORT`/`COURSE_IMPORT` (existing, documented in `docs/03-integrations/garmin/training-api-checklist.md`). Pruning is correct at the storage layer, but for a partner-write integration the import check still passes. Unchanged by this PR, called out so reviewers aren't surprised.
- The permissions allowlist is explicit, so a *new* Garmin user permission we haven't listed would be added but never pruned. Adding it to `GARMIN_USER_PERMISSIONS` is the one-line follow-up if Garmin ships one.
- Files changed are exactly the ticket's Owned Paths: `server/utils/garmin.ts`, `server/api/workouts/planned/[id]/publish-garmin.post.ts`, `tests/unit/server/utils/garmin.test.ts`.
