### PR TITLE
fix(nutrition): bound metabolic wave range and daysAhead inputs (CW-73)

### DIFF
--- a/docs/issues/247-wave-endpoints-unbounded-range.md
+++ b/docs/issues/247-wave-endpoints-unbounded-range.md
@@ -3,7 +3,7 @@
 **Type:** Bug / Performance  
 **Priority:** Medium  
 **Area:** `nutrition` (API)  
-**Status:** Open
+**Status:** Fixed (CW-73)
 
 ## Description
 
@@ -30,3 +30,15 @@ Any authenticated user can tie up the server with a single request.
 - `daysAhead` clamped (e.g. 1–14); range endpoints validate dates and cap the span
   (e.g. ≤ 31 days), returning 400 otherwise.
 - `getWaveRange` itself refuses absurd spans as defense in depth.
+
+## Resolution (CW-73)
+
+- `extended-wave`: `daysAhead` defaults to 3 when absent, returns 400 when it is not an integer
+  (`abc`, `2.5`, repeated params), and clamps to 1–14 otherwise.
+- `metabolic-wave`: `startDate`/`endDate` are parsed and validated (400 on malformed dates and on
+  `endDate < startDate`), and the inclusive span is capped at **62 days**. The cap is 62 rather
+  than 31 because the activities calendar legitimately requests a month padded out to whole weeks —
+  up to 42 days — and a 31-day cap would have broken that view.
+- `metabolicService.getWaveRange` carries its own hard limit (`MAX_WAVE_RANGE_SPAN_DAYS = 92`) plus
+  invalid-date and inverted-range guards, so no caller (current or future) can get an unbounded
+  span past it. `generateExtendedWave` additionally rejects a non-finite/negative `daysAhead`.

--- a/server/api/nutrition/extended-wave.get.ts
+++ b/server/api/nutrition/extended-wave.get.ts
@@ -2,6 +2,34 @@ import { requireAuth } from '../../utils/auth-guard'
 import { metabolicService } from '../../utils/services/metabolicService'
 import { summariseIntakeConfidence } from '../../utils/nutrition/intake-confidence'
 
+const DEFAULT_DAYS_AHEAD = 3
+const MIN_DAYS_AHEAD = 1
+/**
+ * The wave simulation costs ~97 timeline points plus per-day work for every day in the range, so an
+ * unbounded `daysAhead` lets one request cost thousands of times the intended budget (CW-73). Two
+ * weeks is well past anything the UI asks for (the nutrition page requests 3).
+ */
+const MAX_DAYS_AHEAD = 14
+
+/**
+ * Missing/empty -> default. Unparseable -> 400, because `daysAhead=abc` is a caller bug worth
+ * surfacing rather than silently answering with the default. In-range-but-out-of-bounds numbers are
+ * clamped, so an over-eager client still gets a useful (bounded) answer instead of an error.
+ */
+function resolveDaysAhead(raw: unknown) {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_DAYS_AHEAD
+
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed)) {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid daysAhead: ${String(raw)}. Expected an integer between ${MIN_DAYS_AHEAD} and ${MAX_DAYS_AHEAD}.`
+    })
+  }
+
+  return Math.min(MAX_DAYS_AHEAD, Math.max(MIN_DAYS_AHEAD, parsed))
+}
+
 defineRouteMeta({
   openAPI: {
     tags: ['Nutrition'],
@@ -11,7 +39,9 @@ defineRouteMeta({
       {
         name: 'daysAhead',
         in: 'query',
-        schema: { type: 'integer', default: 3 }
+        description:
+          'Number of future days to project. Values outside the range are clamped; non-integer values are rejected.',
+        schema: { type: 'integer', default: 3, minimum: 1, maximum: 14 }
       }
     ],
     responses: {
@@ -44,6 +74,7 @@ defineRouteMeta({
           }
         }
       },
+      400: { description: 'Invalid daysAhead' },
       401: { description: 'Unauthorized' }
     }
   }
@@ -53,7 +84,7 @@ export default defineEventHandler(async (event) => {
   const authUser = await requireAuth(event, ['nutrition:read'])
   const userId = authUser.id
   const query = getQuery(event)
-  const daysAhead = query.daysAhead ? parseInt(query.daysAhead as string) : 3
+  const daysAhead = resolveDaysAhead(query.daysAhead)
 
   try {
     const { points, journeyEvents } = await metabolicService.generateExtendedWave(userId, daysAhead)
@@ -65,6 +96,10 @@ export default defineEventHandler(async (event) => {
       intakeConfidence: summariseIntakeConfidence(points as any)
     }
   } catch (error: any) {
+    // Don't bury a client error (e.g. the service's own range guards) under a 500.
+    if (error?.statusCode && error.statusCode >= 400 && error.statusCode < 500) {
+      throw error
+    }
     console.error('Error generating extended wave:', error)
     throw createError({
       statusCode: 500,

--- a/server/api/nutrition/metabolic-wave.get.ts
+++ b/server/api/nutrition/metabolic-wave.get.ts
@@ -3,6 +3,26 @@ import { metabolicService } from '../../utils/services/metabolicService'
 import { isNutritionTrackingEnabled } from '../../utils/nutrition/feature'
 import { summariseIntakeConfidence } from '../../utils/nutrition/intake-confidence'
 
+/**
+ * Maximum inclusive span, in days, this endpoint will simulate (CW-73).
+ *
+ * The wave costs ~97 timeline points plus per-day work for every day in the range, so an unbounded
+ * range lets a single request cost thousands of times the intended budget. 62 days comfortably
+ * covers the widest legitimate caller — the activities calendar, which requests a padded month grid
+ * of up to 42 days — while keeping the worst case bounded. The service enforces its own, looser
+ * hard limit underneath this one.
+ */
+const MAX_WAVE_RANGE_DAYS = 62
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function parseDateOnlyUtc(value: string, field: string) {
+  const parsed = new Date(`${value.slice(0, 10)}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) {
+    throw createError({ statusCode: 400, message: `Invalid ${field}: ${value}` })
+  }
+  return parsed
+}
+
 defineRouteMeta({
   openAPI: {
     tags: ['Nutrition'],
@@ -24,6 +44,7 @@ defineRouteMeta({
     ],
     responses: {
       200: { description: 'Success' },
+      400: { description: 'Missing, malformed, inverted, or too wide a date range (max 62 days)' },
       401: { description: 'Unauthorized' }
     }
   }
@@ -51,8 +72,20 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Start and End date required' })
   }
 
-  const startDate = new Date(`${startStr}T00:00:00Z`)
-  const endDate = new Date(`${endStr}T00:00:00Z`)
+  const startDate = parseDateOnlyUtc(String(startStr), 'startDate')
+  const endDate = parseDateOnlyUtc(String(endStr), 'endDate')
+
+  if (endDate.getTime() < startDate.getTime()) {
+    throw createError({ statusCode: 400, message: 'endDate must not be before startDate' })
+  }
+
+  const spanDays = Math.floor((endDate.getTime() - startDate.getTime()) / MS_PER_DAY) + 1
+  if (spanDays > MAX_WAVE_RANGE_DAYS) {
+    throw createError({
+      statusCode: 400,
+      message: `Requested range of ${spanDays} days exceeds the maximum of ${MAX_WAVE_RANGE_DAYS} days`
+    })
+  }
 
   const { points, journeyEvents } = await metabolicService.getWaveRange(userId, startDate, endDate)
 

--- a/server/utils/services/metabolicService.ts
+++ b/server/utils/services/metabolicService.ts
@@ -1,3 +1,4 @@
+import { createError } from 'h3'
 import { dailyBaseWindowKey } from '../../../shared/window-keys'
 import { prisma } from '../db'
 import { nutritionRepository } from '../repositories/nutritionRepository'
@@ -64,6 +65,29 @@ interface NutritionPlanSummary {
     fat: number
     calories: number
   }
+}
+
+/**
+ * Hard ceiling on the span `getWaveRange` will simulate, in days (inclusive of both ends).
+ *
+ * The wave simulation produces ~97 timeline points per day and issues per-day work, so the cost of
+ * a call is linear in the span. Without a bound, a single request asking for years of wave burns
+ * thousands of times the intended CPU/DB budget (CW-73).
+ *
+ * This is the *defensive* limit — the last line of defence for any caller, including ones that
+ * forget to validate. HTTP handlers apply their own, stricter limits (see
+ * `MAX_WAVE_RANGE_DAYS` in `server/api/nutrition/metabolic-wave.get.ts` and the `daysAhead`
+ * clamp in `extended-wave.get.ts`); this one only exists so that no caller can ever get past it.
+ */
+export const MAX_WAVE_RANGE_SPAN_DAYS = 92
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Inclusive span of a date range in whole days (same day => 1).
+ */
+export function waveRangeSpanDays(startDate: Date, endDate: Date) {
+  return Math.floor((endDate.getTime() - startDate.getTime()) / MS_PER_DAY) + 1
 }
 
 export const metabolicService = {
@@ -933,6 +957,15 @@ export const metabolicService = {
    * Generates a multi-day predictive wave (historical + current + future).
    */
   async generateExtendedWave(userId: string, daysAhead: number = 3) {
+    // Defensive (CW-73): a non-finite daysAhead would silently produce an Invalid Date end bound.
+    // The span itself is bounded by getWaveRange below.
+    if (!Number.isFinite(daysAhead) || daysAhead < 0) {
+      throw createError({
+        statusCode: 400,
+        message: 'daysAhead must be a non-negative number'
+      })
+    }
+
     const timezone = await getUserTimezone(userId)
     const today = getUserLocalDate(timezone)
     const startDate = new Date(today)
@@ -949,6 +982,35 @@ export const metabolicService = {
    * This is the single computation path for activity sparkline and extended wave charts.
    */
   async getWaveRange(userId: string, startDate: Date, endDate: Date) {
+    // Defensive bounds (CW-73). Every caller is expected to validate its own input, but this is the
+    // one place all wave computation funnels through, so an unbounded range must never get past it.
+    if (
+      !(startDate instanceof Date) ||
+      !(endDate instanceof Date) ||
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime())
+    ) {
+      throw createError({
+        statusCode: 400,
+        message: 'getWaveRange requires valid start and end dates'
+      })
+    }
+
+    if (endDate.getTime() < startDate.getTime()) {
+      throw createError({
+        statusCode: 400,
+        message: 'getWaveRange requires endDate to be on or after startDate'
+      })
+    }
+
+    const spanDays = waveRangeSpanDays(startDate, endDate)
+    if (spanDays > MAX_WAVE_RANGE_SPAN_DAYS) {
+      throw createError({
+        statusCode: 400,
+        message: `Requested wave range of ${spanDays} days exceeds the maximum of ${MAX_WAVE_RANGE_SPAN_DAYS} days`
+      })
+    }
+
     const startTime = Date.now()
     const timezone = await getUserTimezone(userId)
     const settings = await getUserNutritionSettings(userId)

--- a/tests/unit/server/api/nutrition/extended-wave.get.test.ts
+++ b/tests/unit/server/api/nutrition/extended-wave.get.test.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requireAuth } from '../../../../../server/utils/auth-guard'
+import { metabolicService } from '../../../../../server/utils/services/metabolicService'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('createError', (error: any) => {
+  const err = new Error(error.message) as any
+  err.statusCode = error.statusCode
+  return err
+})
+
+let query: any = {}
+vi.stubGlobal('getQuery', () => query)
+
+vi.mock('../../../../../server/utils/auth-guard', () => ({ requireAuth: vi.fn() }))
+vi.mock('../../../../../server/utils/services/metabolicService', () => ({
+  metabolicService: { generateExtendedWave: vi.fn() }
+}))
+vi.mock('../../../../../server/utils/nutrition/intake-confidence', () => ({
+  summariseIntakeConfidence: vi.fn(() => null)
+}))
+
+async function get(params: Record<string, unknown>) {
+  query = params
+  const handler = (await import('../../../../../server/api/nutrition/extended-wave.get')).default
+  return handler({} as any)
+}
+
+function daysAheadArg() {
+  return (vi.mocked(metabolicService.generateExtendedWave).mock.calls[0] as any)?.[1]
+}
+
+// CW-73: daysAhead fed getWaveRange unvalidated, so `daysAhead=3650` simulated a decade of wave
+// (~97 timeline points per day) in one request.
+describe('GET /api/nutrition/extended-wave daysAhead bounds (CW-73)', () => {
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(requireAuth).mockResolvedValue({ id: 'user-1' } as any)
+    vi.mocked(metabolicService.generateExtendedWave).mockResolvedValue({
+      points: [],
+      journeyEvents: []
+    } as any)
+  })
+
+  it('defaults to 3 days when the parameter is absent', async () => {
+    const result: any = await get({})
+
+    expect(result.success).toBe(true)
+    expect(daysAheadArg()).toBe(3)
+  })
+
+  it('passes an in-range value through untouched', async () => {
+    await get({ daysAhead: '7' })
+
+    expect(daysAheadArg()).toBe(7)
+  })
+
+  it('clamps an absurd range instead of simulating a decade of wave', async () => {
+    await get({ daysAhead: '3650' })
+
+    expect(daysAheadArg()).toBe(14)
+  })
+
+  it('clamps zero and negative values up to the minimum', async () => {
+    await get({ daysAhead: '0' })
+    expect(daysAheadArg()).toBe(1)
+
+    vi.mocked(metabolicService.generateExtendedWave).mockClear()
+    await get({ daysAhead: '-5' })
+    expect(daysAheadArg()).toBe(1)
+  })
+
+  it('rejects non-numeric input rather than silently defaulting', async () => {
+    await expect(get({ daysAhead: 'abc' })).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.generateExtendedWave).not.toHaveBeenCalled()
+  })
+
+  it('rejects a fractional value', async () => {
+    await expect(get({ daysAhead: '2.5' })).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.generateExtendedWave).not.toHaveBeenCalled()
+  })
+
+  it('rejects a repeated query parameter', async () => {
+    await expect(get({ daysAhead: ['1', '9999'] })).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.generateExtendedWave).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a service 400 instead of masking it as a 500', async () => {
+    const serviceError = Object.assign(new Error('range too wide'), { statusCode: 400 })
+    vi.mocked(metabolicService.generateExtendedWave).mockRejectedValue(serviceError)
+
+    await expect(get({ daysAhead: '3' })).rejects.toMatchObject({ statusCode: 400 })
+  })
+})

--- a/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
+++ b/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getServerSession } from '../../../../../server/utils/session'
+import { isNutritionTrackingEnabled } from '../../../../../server/utils/nutrition/feature'
+import { metabolicService } from '../../../../../server/utils/services/metabolicService'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', () => {})
+vi.stubGlobal('createError', (error: any) => {
+  const err = new Error(error.message) as any
+  err.statusCode = error.statusCode
+  return err
+})
+
+let query: any = {}
+vi.stubGlobal('getQuery', () => query)
+
+vi.mock('../../../../../server/utils/session', () => ({ getServerSession: vi.fn() }))
+vi.mock('../../../../../server/utils/nutrition/feature', () => ({
+  isNutritionTrackingEnabled: vi.fn()
+}))
+vi.mock('../../../../../server/utils/services/metabolicService', () => ({
+  metabolicService: { getWaveRange: vi.fn() }
+}))
+vi.mock('../../../../../server/utils/nutrition/intake-confidence', () => ({
+  summariseIntakeConfidence: vi.fn(() => null)
+}))
+
+async function get(params: Record<string, unknown>) {
+  query = params
+  const handler = (await import('../../../../../server/api/nutrition/metabolic-wave.get')).default
+  return handler({} as any)
+}
+
+// CW-73: startDate/endDate went straight from the query string into getWaveRange, so
+// `endDate=2100-01-01` ran decades of day simulations in a single request.
+describe('GET /api/nutrition/metabolic-wave range bounds (CW-73)', () => {
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(isNutritionTrackingEnabled).mockResolvedValue(true)
+    vi.mocked(metabolicService.getWaveRange).mockResolvedValue({
+      points: [],
+      journeyEvents: []
+    } as any)
+  })
+
+  it('accepts a normal range', async () => {
+    const result: any = await get({ startDate: '2026-02-01', endDate: '2026-02-10' })
+
+    expect(result.success).toBe(true)
+    const [, start, end] = vi.mocked(metabolicService.getWaveRange).mock.calls[0] as any
+    expect(start.toISOString()).toBe('2026-02-01T00:00:00.000Z')
+    expect(end.toISOString()).toBe('2026-02-10T00:00:00.000Z')
+  })
+
+  it('accepts the widest padded month grid the activities calendar can request (42 days)', async () => {
+    // The calendar pads a month out to whole weeks, so the real-world worst case is 6 weeks.
+    await get({ startDate: '2026-02-23', endDate: '2026-04-05' })
+
+    expect(metabolicService.getWaveRange).toHaveBeenCalled()
+  })
+
+  it('still requires both dates', async () => {
+    await expect(get({ startDate: '2026-02-01' })).rejects.toMatchObject({ statusCode: 400 })
+    await expect(get({ endDate: '2026-02-01' })).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed date instead of passing an Invalid Date to the simulation', async () => {
+    await expect(get({ startDate: '2026-02-01', endDate: 'not-a-date' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: 'nonsense', endDate: '2026-02-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects an inverted range', async () => {
+    await expect(get({ startDate: '2026-02-10', endDate: '2026-02-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a range wider than the cap rather than simulating it', async () => {
+    await expect(get({ startDate: '2026-01-01', endDate: '2027-01-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2026-01-01', endDate: '2100-01-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('accepts exactly the maximum span and rejects one day more', async () => {
+    // 62-day inclusive span.
+    await get({ startDate: '2026-01-01', endDate: '2026-03-03' })
+    expect(metabolicService.getWaveRange).toHaveBeenCalledTimes(1)
+
+    await expect(get({ startDate: '2026-01-01', endDate: '2026-03-04' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects unauthenticated requests before any parsing', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null as any)
+
+    await expect(get({ startDate: '2026-01-01', endDate: '2026-01-02' })).rejects.toMatchObject({
+      statusCode: 401
+    })
+  })
+})

--- a/tests/unit/server/utils/services/metabolicService.test.ts
+++ b/tests/unit/server/utils/services/metabolicService.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { metabolicService } from '../../../../../server/utils/services/metabolicService'
+import {
+  MAX_WAVE_RANGE_SPAN_DAYS,
+  metabolicService,
+  waveRangeSpanDays
+} from '../../../../../server/utils/services/metabolicService'
 import { prisma } from '../../../../../server/utils/db'
 import { nutritionRepository } from '../../../../../server/utils/repositories/nutritionRepository'
 import { workoutRepository } from '../../../../../server/utils/repositories/workoutRepository'
@@ -778,6 +782,66 @@ describe('metabolicService smoke coverage', () => {
       // Today is not past, so getDailyTimeline still merges in planned-but-uncompleted workouts -
       // only the finalized-past-day behavior changed.
       expect(plannedWorkoutRepository.list).toHaveBeenCalled()
+    })
+  })
+})
+
+// CW-73: getWaveRange is the single computation path for every wave caller and costs ~97 timeline
+// points plus per-day work for each day of the span, so it carries its own bounds rather than
+// trusting callers to have validated. These assert the guard fires before any DB work happens.
+describe('getWaveRange defensive range bounds (CW-73)', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    // An earlier suite in this file spies on getWaveRange without restoring it, and clearAllMocks
+    // only resets calls - restore so these exercise the real implementation's guards.
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('computes an inclusive day span', () => {
+    expect(
+      waveRangeSpanDays(new Date('2026-02-13T00:00:00Z'), new Date('2026-02-13T00:00:00Z'))
+    ).toBe(1)
+    expect(
+      waveRangeSpanDays(new Date('2026-02-13T00:00:00Z'), new Date('2026-02-14T00:00:00Z'))
+    ).toBe(2)
+  })
+
+  it('rejects a span wider than the hard limit before touching the database', async () => {
+    const start = new Date('2026-01-01T00:00:00Z')
+    const end = new Date(start.getTime() + (MAX_WAVE_RANGE_SPAN_DAYS + 1) * 24 * 60 * 60 * 1000)
+
+    await expect(metabolicService.getWaveRange(userId, start, end)).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('rejects an end date before the start date', async () => {
+    await expect(
+      metabolicService.getWaveRange(
+        userId,
+        new Date('2026-02-13T00:00:00Z'),
+        new Date('2026-02-11T00:00:00Z')
+      )
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid dates', async () => {
+    await expect(
+      metabolicService.getWaveRange(userId, new Date('nonsense'), new Date('2026-02-13T00:00:00Z'))
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(prisma.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-finite daysAhead in generateExtendedWave instead of building an Invalid Date', async () => {
+    await expect(metabolicService.generateExtendedWave(userId, Number.NaN)).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(metabolicService.generateExtendedWave(userId, -1)).rejects.toMatchObject({
+      statusCode: 400
     })
   })
 })


### PR DESCRIPTION
Fixes CW-73

## Problem

`GET /api/nutrition/extended-wave` and `GET /api/nutrition/metabolic-wave` passed unvalidated, user-controlled ranges into `metabolicService.getWaveRange`, which simulates ~97 timeline points plus per-day fetches for every day in the span. `daysAhead=3650` or `endDate=2100-01-01` let one authenticated request cost thousands of times the intended CPU/DB budget. `parseInt` also meant `daysAhead=abc` produced `NaN`, and malformed dates reached the simulator as `Invalid Date`.

## Changes

**`server/api/nutrition/extended-wave.get.ts`**
- `daysAhead`: absent/empty → default 3 (unchanged behaviour); non-integer (`abc`, `2.5`, repeated query params) → **400**; otherwise **clamped to 1–14**.
- The `catch` no longer masks a 4xx from the service as a 500.
- OpenAPI meta updated (min/max, 400 response).

**`server/api/nutrition/metabolic-wave.get.ts`**
- Dates parsed via the same `parseDateOnlyUtc` shape already used by `grocery.get.ts`; malformed dates → **400** instead of an `Invalid Date`.
- `endDate < startDate` → **400**.
- Inclusive span capped at **62 days** → **400**.

**`server/utils/services/metabolicService.ts`**
- `getWaveRange` gained its own defensive guards that run before any DB work: invalid dates, inverted range, and a hard `MAX_WAVE_RANGE_SPAN_DAYS = 92` ceiling. This is deliberately looser than the endpoint cap so it never fires for a legitimate caller, but no caller — current or future — can get an unbounded span past it.
- `generateExtendedWave` rejects a non-finite/negative `daysAhead` (which would otherwise silently build an `Invalid Date` end bound).
- Exports `MAX_WAVE_RANGE_SPAN_DAYS` and `waveRangeSpanDays`.

### Deviations from the acceptance criteria (documented as requested)

- **Span cap is 62 days, not 31.** A 31-day cap would have broken a real caller: `app/pages/activities.vue` requests the metabolic wave for the calendar grid, which pads a month out to whole weeks — **up to 42 days**. 62 keeps the worst case bounded (~6k points) while leaving headroom above the widest legitimate request. Verified by test.
- **`daysAhead` clamps range violations but 400s on unparseable input.** Clamping is what the criteria ask for and keeps an over-eager client working; `abc` / `2.5` is a caller bug that deserves a clear error rather than a silent default.
- **Two-tier limit.** Endpoint 62 days / service 92 days, so the defensive layer is a true backstop rather than a duplicate of the endpoint rule.

## Existing callers checked (none broken)

| Caller | Request | Under new limits? |
| --- | --- | --- |
| `app/pages/nutrition/index.vue:888` | `extended-wave?daysAhead=3` | ✅ |
| `app/pages/activities.vue:1485` | `metabolic-wave` padded month grid, ≤ 42 days | ✅ (cap 62) |
| `server/api/nutrition/strategy.get.ts:96` | `getWaveRange` today−3 → today | ✅ |
| `server/utils/ai-tools/nutrition.ts:957` | `getWaveRange` today−3 → today | ✅ |
| `metabolicService.getUpcomingFuelingWindows` | `getWaveRange` 24h probe | ✅ |
| `e2e/tests/nutrition-fueling.spec.ts:534` | 2-day range | ✅ |

No frontend caller passes anything the new limits would reject.

## Verification

```
$ pnpm typecheck
→ exit 0 (no errors)

$ npx vitest run tests/unit/server/api/nutrition tests/unit/server/utils/services \
    tests/unit/server/utils/nutrition-timezone.test.ts tests/unit/server/utils/nutrition-tools.test.ts
→ Test Files  33 passed (33)
   Tests  314 passed (314)

$ npx eslint <changed files>
→ exit 0
```

## Files changed vs Owned Paths

Owned Paths (all three touched):
- `server/api/nutrition/extended-wave.get.ts`
- `server/api/nutrition/metabolic-wave.get.ts`
- `server/utils/services/metabolicService.ts`

Narrow, justified deviations:
- `tests/unit/server/api/nutrition/extended-wave.get.test.ts` (new) and `tests/unit/server/api/nutrition/metabolic-wave.get.test.ts` (new) — test coverage for a security fix. Follow the existing `grocery.get.test.ts` handler-test pattern; no new test infrastructure. The test file the ticket named (`index.post.test.ts`) covers an unrelated endpoint, so extending it would have been wrong.
- `tests/unit/server/utils/services/metabolicService.test.ts` — added a describe block for the `getWaveRange` guards. Note: an earlier suite in that file `vi.spyOn`s `getWaveRange` without restoring, so the new block calls `vi.restoreAllMocks()` in its `beforeEach`.
- `docs/issues/247-wave-endpoints-unbounded-range.md` — the repo's local mirror of this issue; flipped `Open` → `Fixed (CW-73)` per the convention used by the other 200+ docs in that directory, with a short resolution note.

## Risks

- Any *undiscovered* client requesting a metabolic-wave span > 62 days would now get a 400 instead of a slow 200. Every caller in this repo was enumerated above and all are well under the cap; if a mobile client in another repo requests a wider window it would need checking, but the widest in-repo pattern (padded month grid) has explicit test coverage at 42 days.
- Behaviour change for `daysAhead=abc`: previously `NaN` (which produced an Invalid Date range and unpredictable output), now an explicit 400.

UX critique: skipped — server-side input validation, no user-facing flow change.
