### PR TITLE
fix(garmin): report real backfill status instead of blanket success (CW-95)

### DIFF
--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -321,6 +321,28 @@ export function extractGarminBodyBatteryScore(record: Record<string, unknown> | 
   return readinessFallback !== null ? clampPercentage(readinessFallback) : null
 }
 
+/**
+ * Outcome of a `startBackfill` run (CW-95).
+ * - `no-integration`: the user has no Garmin integration, nothing was requested.
+ * - `failed`: every backfill request failed.
+ * - `partial`: at least one type succeeded and at least one failed.
+ * - `success`: every type was accepted by Garmin.
+ */
+export type GarminBackfillStatus = 'success' | 'partial' | 'failed' | 'no-integration'
+
+export interface GarminBackfillTypeFailure {
+  type: GarminBackfillType
+  error: string
+}
+
+export interface GarminBackfillResult {
+  status: GarminBackfillStatus
+  /** Types Garmin accepted a backfill request for (409 "already requested" counts as accepted). */
+  requested: GarminBackfillType[]
+  /** Types whose backfill request failed, with the error message per type. */
+  failed: GarminBackfillTypeFailure[]
+}
+
 export const GarminService = {
   /**
    * Process a single webhook payload (Push API).
@@ -511,14 +533,23 @@ export const GarminService = {
   },
 
   /**
-   * Start historical backfill for a user
+   * Start historical backfill for a user.
+   *
+   * Returns a machine-readable summary instead of throwing (CW-95): the caller decides
+   * what an incomplete backfill means. `runIngestGarmin`'s InvalidPullTokenException
+   * fallback below treats any outcome as best-effort, while the `garmin-backfill`
+   * Trigger task fails the run on `no-integration` / `failed` so an incomplete backfill
+   * can no longer be reported to the platform as a success.
    */
-  async startBackfill(userId: string) {
+  async startBackfill(userId: string): Promise<GarminBackfillResult> {
     const integration = await prisma.integration.findUnique({
       where: { userId_provider: { userId, provider: 'garmin' } }
     })
 
-    if (!integration) return
+    if (!integration) {
+      console.error(`[GarminService] Backfill skipped: no Garmin integration for user ${userId}`)
+      return { status: 'no-integration', requested: [], failed: [] }
+    }
 
     const now = Math.floor(Date.now() / 1000) - 60
     const thirtyDaysAgo = now - 30 * 24 * 60 * 60
@@ -534,14 +565,24 @@ export const GarminService = {
       'userMetrics'
     ]
 
+    const requested: GarminBackfillType[] = []
+    const failed: GarminBackfillTypeFailure[] = []
+
     for (const type of types) {
       try {
         await requestGarminBackfill(integration, type, thirtyDaysAgo, now)
+        requested.push(type)
         console.log(`[GarminService] Backfill requested for ${type}`)
       } catch (error) {
+        failed.push({ type, error: error instanceof Error ? error.message : String(error) })
         console.error(`[GarminService] Backfill failed for ${type}:`, error)
       }
     }
+
+    const status: GarminBackfillStatus =
+      failed.length === 0 ? 'success' : requested.length === 0 ? 'failed' : 'partial'
+
+    return { status, requested, failed }
   },
 
   /**

--- a/tests/unit/server/utils/services/garminService.test.ts
+++ b/tests/unit/server/utils/services/garminService.test.ts
@@ -27,6 +27,17 @@ vi.mock('../../../../../server/utils/db', () => ({
   prisma: prismaMock
 }))
 
+// CW-95: keep every real SDK export, but make `task()` hand back the raw run function so the
+// garmin-backfill task's status handling can be exercised directly.
+vi.mock('@trigger.dev/sdk/v3', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    task: (config: any) => ({ id: config.id, run: config.run }),
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }
+  }
+})
+
 describe('GarminService.extractPullToken', () => {
   it('prefers the webhook query token', () => {
     const token = GarminService.extractPullToken(
@@ -570,7 +581,11 @@ describe('GarminService.runIngestGarmin', () => {
     })
     prismaMock.integration.update.mockResolvedValue({})
 
-    const startBackfillSpy = vi.spyOn(GarminService, 'startBackfill').mockResolvedValue(undefined)
+    const startBackfillSpy = vi.spyOn(GarminService, 'startBackfill').mockResolvedValue({
+      status: 'success',
+      requested: ['activities', 'dailies', 'sleeps', 'hrv', 'bodyComps', 'userMetrics'],
+      failed: []
+    })
 
     const fetchers = await import('../../../../../server/utils/garmin')
     vi.spyOn(fetchers, 'refreshGarminIntegrationPermissions').mockImplementation(
@@ -1009,5 +1024,171 @@ describe('CW-99: concurrent Garmin OAuth callback race', () => {
     await expect(runGarminCallbackUpsert('user-c', 'garmin-ext-2')).rejects.toThrow(
       'connection reset'
     )
+  })
+})
+
+describe('CW-95: GarminService.startBackfill result reporting', () => {
+  const BACKFILL_TYPES = [
+    'activities',
+    'dailies',
+    'sleeps',
+    'hrv',
+    'bodyComps',
+    'userMetrics'
+  ] as const
+
+  async function garminModule() {
+    return await import('../../../../../server/utils/garmin')
+  }
+
+  it('reports a missing integration instead of silently returning success', async () => {
+    prismaMock.integration.findUnique.mockResolvedValue(null)
+    const fetchers = await garminModule()
+    const backfillSpy = vi.spyOn(fetchers, 'requestGarminBackfill')
+
+    const result = await GarminService.startBackfill('user-without-garmin')
+
+    expect(result).toEqual({ status: 'no-integration', requested: [], failed: [] })
+    expect(backfillSpy).not.toHaveBeenCalled()
+
+    vi.restoreAllMocks()
+  })
+
+  it('reports total failure when every backfill request is rejected', async () => {
+    prismaMock.integration.findUnique.mockResolvedValue({
+      id: 'int-1',
+      userId: 'user-1',
+      provider: 'garmin'
+    })
+    const fetchers = await garminModule()
+    vi.spyOn(fetchers, 'requestGarminBackfill').mockRejectedValue(
+      new Error('Garmin Backfill API error (403): User not registered with consumer')
+    )
+
+    const result = await GarminService.startBackfill('user-1')
+
+    expect(result.status).toBe('failed')
+    expect(result.requested).toEqual([])
+    expect(result.failed.map((f) => f.type)).toEqual([...BACKFILL_TYPES])
+    expect(result.failed[0]?.error).toContain('User not registered with consumer')
+
+    vi.restoreAllMocks()
+  })
+
+  it('reports partial success with the exact types that succeeded and failed', async () => {
+    prismaMock.integration.findUnique.mockResolvedValue({
+      id: 'int-1',
+      userId: 'user-1',
+      provider: 'garmin'
+    })
+    const fetchers = await garminModule()
+    vi.spyOn(fetchers, 'requestGarminBackfill').mockImplementation(async (_int, type) => {
+      if (type === 'hrv' || type === 'bodyComps') {
+        throw new Error(`Garmin Backfill API error (400): ${type} not permitted`)
+      }
+      return { success: true }
+    })
+
+    const result = await GarminService.startBackfill('user-1')
+
+    expect(result.status).toBe('partial')
+    expect(result.requested).toEqual(['activities', 'dailies', 'sleeps', 'userMetrics'])
+    expect(result.failed).toEqual([
+      { type: 'hrv', error: 'Garmin Backfill API error (400): hrv not permitted' },
+      { type: 'bodyComps', error: 'Garmin Backfill API error (400): bodyComps not permitted' }
+    ])
+
+    vi.restoreAllMocks()
+  })
+
+  it('reports full success for every requested type', async () => {
+    prismaMock.integration.findUnique.mockResolvedValue({
+      id: 'int-1',
+      userId: 'user-1',
+      provider: 'garmin'
+    })
+    const fetchers = await garminModule()
+    const backfillSpy = vi
+      .spyOn(fetchers, 'requestGarminBackfill')
+      .mockResolvedValue({ success: true })
+
+    const result = await GarminService.startBackfill('user-1')
+
+    expect(result).toEqual({ status: 'success', requested: [...BACKFILL_TYPES], failed: [] })
+    expect(backfillSpy).toHaveBeenCalledTimes(BACKFILL_TYPES.length)
+
+    vi.restoreAllMocks()
+  })
+})
+
+describe('CW-95: garmin-backfill task surfaces backfill status to the platform', () => {
+  async function runBackfillTask(userId: string) {
+    const { garminBackfillTask } = await import('../../../../../trigger/garmin-backfill')
+    return await (garminBackfillTask as any).run({ userId, delaySeconds: 0 })
+  }
+
+  it('fails the task when the user has no Garmin integration', async () => {
+    vi.spyOn(GarminService, 'startBackfill').mockResolvedValue({
+      status: 'no-integration',
+      requested: [],
+      failed: []
+    })
+
+    await expect(runBackfillTask('user-without-garmin')).rejects.toThrow(
+      /no Garmin integration found for user user-without-garmin/
+    )
+
+    vi.restoreAllMocks()
+  })
+
+  it('fails the task when every backfill request fails', async () => {
+    vi.spyOn(GarminService, 'startBackfill').mockResolvedValue({
+      status: 'failed',
+      requested: [],
+      failed: [
+        { type: 'activities', error: 'boom-activities' },
+        { type: 'dailies', error: 'boom-dailies' }
+      ]
+    })
+
+    await expect(runBackfillTask('user-1')).rejects.toThrow(
+      /all 2 backfill requests were rejected .*boom-activities.*boom-dailies/s
+    )
+
+    vi.restoreAllMocks()
+  })
+
+  it('succeeds with an explicit summary when only some types fail', async () => {
+    vi.spyOn(GarminService, 'startBackfill').mockResolvedValue({
+      status: 'partial',
+      requested: ['activities', 'dailies'],
+      failed: [{ type: 'hrv', error: 'hrv not permitted' }]
+    })
+
+    const result = await runBackfillTask('user-1')
+
+    expect(result).toEqual({
+      success: true,
+      status: 'partial',
+      requested: ['activities', 'dailies'],
+      failed: [{ type: 'hrv', error: 'hrv not permitted' }]
+    })
+
+    vi.restoreAllMocks()
+  })
+
+  it('keeps reporting success for a fully successful backfill', async () => {
+    vi.spyOn(GarminService, 'startBackfill').mockResolvedValue({
+      status: 'success',
+      requested: ['activities', 'dailies', 'sleeps', 'hrv', 'bodyComps', 'userMetrics'],
+      failed: []
+    })
+
+    const result = await runBackfillTask('user-1')
+
+    expect(result).toMatchObject({ success: true, status: 'success', failed: [] })
+    expect(result.requested).toHaveLength(6)
+
+    vi.restoreAllMocks()
   })
 })

--- a/trigger/garmin-backfill.ts
+++ b/trigger/garmin-backfill.ts
@@ -18,9 +18,50 @@ export const garminBackfillTask = task({
     logger.log(`Starting sequential Garmin backfill for user ${userId}`)
 
     try {
-      await GarminService.startBackfill(userId)
-      logger.log(`Garmin backfill requests completed for user ${userId}`)
-      return { success: true }
+      const result = await GarminService.startBackfill(userId)
+
+      // CW-95: an incomplete backfill must not look like a complete one.
+      //
+      // Hard failures (throw, so the run is marked failed and retried):
+      //  - `no-integration`: nothing was requested at all; the run did no work.
+      //  - `failed`: every backfill request was rejected — almost always a token/registration
+      //    problem that a retry can genuinely resolve.
+      //
+      // Partial failure succeeds *with a summary* rather than throwing, deliberately:
+      // each type is an independent Garmin request, so throwing would retry the whole run and
+      // re-request the types that already succeeded, and per-type failures are usually a
+      // permission/scope limitation for that user that no number of retries will fix. Failing
+      // the run would also hide "5 of 6 succeeded" behind a generic task failure. The returned
+      // `failed[]` carries the per-type error so an operator can see exactly which types are
+      // missing from the run output.
+      if (result.status === 'no-integration') {
+        throw new Error(`Garmin backfill aborted: no Garmin integration found for user ${userId}`)
+      }
+
+      if (result.status === 'failed') {
+        const detail = result.failed.map((f) => `${f.type}: ${f.error}`).join('; ')
+        throw new Error(
+          `Garmin backfill failed for user ${userId}: all ${result.failed.length} backfill requests were rejected (${detail})`
+        )
+      }
+
+      if (result.status === 'partial') {
+        logger.warn(`Garmin backfill partially completed for user ${userId}`, {
+          requested: result.requested,
+          failed: result.failed
+        })
+      } else {
+        logger.log(`Garmin backfill requests completed for user ${userId}`, {
+          requested: result.requested
+        })
+      }
+
+      return {
+        success: true,
+        status: result.status,
+        requested: result.requested,
+        failed: result.failed
+      }
     } catch (error) {
       logger.error(`Garmin backfill task failed for user ${userId}`, { error })
       throw error


### PR DESCRIPTION
Fixes CW-95

## Problem

`GarminService.startBackfill` returned `void`. It silently returned when the user had no Garmin integration, and it caught every per-type error without rethrowing or aggregating. `trigger/garmin-backfill.ts` therefore returned `{ success: true }` for "backfilled 6/6", "backfilled 0/6" and "there was nothing to back fill" alike — the platform and operators could not tell them apart.

## Change

- `startBackfill` now returns a machine-readable `GarminBackfillResult`:
  `{ status: 'success' | 'partial' | 'failed' | 'no-integration', requested: GarminBackfillType[], failed: Array<{ type, error }> }`.
- It stays **non-throwing** on purpose. The other caller is the `InvalidPullTokenException` fallback inside `runIngestGarmin` (`garminService.ts`), which treats the backfill as best-effort and must keep returning `success: true`; making the service throw would have turned that graceful fallback into an ingest error. The task, not the service, decides what an incomplete backfill means.
- `garmin-backfill` task now:
  - **throws** on `no-integration` (nothing was requested; the run did no work),
  - **throws** on `failed` (every request rejected — usually a token/registration problem a retry can genuinely fix),
  - **succeeds with a summary** on `partial`, and returns `{ success, status, requested, failed }` in all non-throwing cases.

### Why partial success does not fail the task (deliberate decision)

Each type is an independent Garmin request. Throwing on partial would retry the whole run and re-request the types that already succeeded, and per-type failures are typically a permission/scope limitation for that user that no number of retries resolves. Failing the run would also hide "5 of 6 succeeded" behind a generic task failure. Instead the run succeeds and carries `failed[{ type, error }]` in its output, so an operator can see exactly which types are missing. The reasoning is also recorded as a comment in `trigger/garmin-backfill.ts`.

The fully-successful path keeps `success: true` and only gains extra fields, so nothing downstream breaks. `server/api/integrations/garmin/callback.get.ts` dispatches the task fire-and-forget and does not read its return value.

## Tests

Eight new cases in `tests/unit/server/utils/services/garminService.test.ts`:
- service: missing integration, total failure, partial success (asserts the exact succeeded/failed type lists), full success;
- task: fails on missing integration, fails on total failure, succeeds-with-summary on partial, still reports success on full success.

## Verification

```
$ pnpm test tests/unit/server/utils/services/garminService.test.ts
 Test Files  1 passed (1)
      Tests  55 passed (55)
```

Also green: `pnpm typecheck`, `npx prettier --check` + `npx eslint` on the changed files, and the wider `pnpm vitest run tests/unit/trigger/ tests/unit/server/utils/` (195 files / 1377 tests passed) to confirm no regression in the ingest paths.

## User-visible surface

UX critique: skipped — backend task status correctness, no user-facing flow change.

No UI surfaces Garmin backfill status: `grep -ri backfill app/` only hits an unrelated TrendChart comment about synthetic data and an admin-issues prompt string. The behaviour change lands entirely in Trigger.dev run status/output — runs that previously showed green with an incomplete or impossible backfill will now show as failed. That is the intended change, and it may make previously-invisible Garmin registration failures start appearing in the Trigger dashboard.

## Files changed vs Owned Paths

All three changed files are exactly the ticket's Owned Paths:
- `server/utils/services/garminService.ts`
- `trigger/garmin-backfill.ts`
- `tests/unit/server/utils/services/garminService.test.ts`

## Risks

- Trigger.dev will now retry `garmin-backfill` runs that used to pass silently (missing integration / total failure). For a user who disconnects Garmin between the OAuth callback and the 30s-delayed task, the run will fail rather than no-op — that is the intended signal, but it will show up as new red runs in the dashboard.
- `startBackfill`'s return type changed from `void`; the only in-repo consumers are the two call sites above, both updated/verified.
- Not touched here: `processUserPermissionChanges` scope overwrite (CW-500), per instruction.
