### PR TITLE
fix(worker): demote orphaned-webhook warnings to debug logging (CW-313)

### DIFF
--- a/cli/worker/start.ts
+++ b/cli/worker/start.ts
@@ -435,6 +435,7 @@ export const startCommand = new Command('start')
             )?.id
 
           let queuedCount = 0
+          let orphanedCount = 0
           try {
             for (const intervalEvent of events) {
               const { athlete_id, type: eventType } = intervalEvent
@@ -448,9 +449,17 @@ export const startCommand = new Command('start')
               })
 
               if (!integration) {
-                console.warn(
-                  `[BulkJob ${job.id}] No integration found for athlete_id: ${athlete_id}`
-                )
+                // Routine: the athlete deleted their account or unlinked Intervals.icu
+                // and the provider is still sending events. Not a failure — keep it out
+                // of the default log stream; the count is persisted on the parent log.
+                orphanedCount++
+                if (verboseWorkerLogs) {
+                  console.debug(
+                    chalk.gray(
+                      `[BulkJob ${job.id}] Skipping orphaned event, no integration for athlete_id: ${athlete_id}`
+                    )
+                  )
+                }
                 continue
               }
 
@@ -476,7 +485,9 @@ export const startCommand = new Command('start')
               await updateWebhookStatus(
                 parentLogId,
                 queuedCount > 0 ? 'PROCESSED' : 'IGNORED',
-                `Dispatched ${queuedCount} child events`
+                orphanedCount > 0
+                  ? `Dispatched ${queuedCount} child events (${orphanedCount} orphaned, no integration)`
+                  : `Dispatched ${queuedCount} child events`
               )
             }
             return { queuedCount }
@@ -768,7 +779,14 @@ export const startCommand = new Command('start')
           }
 
           if (!userId) {
-            console.warn(`[StravaJob ${job.id}] No user found for strava payload`)
+            // Routine: Strava keeps delivering events for athletes who deleted their
+            // account or revoked the connection. Not a failure — the IGNORED webhook
+            // log below is the durable record, so keep it out of the default stream.
+            if (verboseWorkerLogs) {
+              console.debug(
+                chalk.gray(`[StravaJob ${job.id}] Skipping orphaned event, no user for payload`)
+              )
+            }
             if (logId) await updateWebhookStatus(logId, 'IGNORED', 'User not found')
             return { handled: false, message: 'User not found' }
           }

--- a/server/utils/services/garminService.ts
+++ b/server/utils/services/garminService.ts
@@ -35,6 +35,10 @@ import { normalizeReadinessScore, normalizeStressScoreForStorage } from '../well
 import { parseCalendarDate } from '../date'
 import crypto from 'crypto'
 
+// `processWebhookEvent` only ever runs inside the BullMQ webhook worker, so it
+// shares the worker's verbosity knob rather than introducing a second one.
+const verboseWorkerLogs = process.env.CW_VERBOSE_WORKER_LOGS === '1'
+
 function normalizeDeviceName(name: unknown): string | null {
   if (typeof name !== 'string') return null
   const trimmed = name.trim()
@@ -442,7 +446,16 @@ export const GarminService = {
 
     const integration = integrations[0]
     if (!integration) {
-      console.warn('[GarminService] No integration found for externalUserId', { externalUserId })
+      // Routine: the athlete deleted their account or unlinked Garmin and Garmin is
+      // still delivering events. Not a failure — keep it out of the default log stream.
+      if (verboseWorkerLogs) {
+        console.debug(
+          '[GarminService] Skipping orphaned event, no integration for externalUserId',
+          {
+            externalUserId
+          }
+        )
+      }
       return
     }
 


### PR DESCRIPTION
Fixes CW-313

## What changed

Provider webhooks arriving for deleted/unlinked athletes are a routine condition, not a failure. All three `console.warn` sites for "integration not found" are demoted to `console.debug`, gated behind the **existing** `CW_VERBOSE_WORKER_LOGS` flag (`process.env.CW_VERBOSE_WORKER_LOGS === '1'`).

**On "debug level":** the repo has no logger abstraction — the established idiom is a module-level `const verboseXLogs = process.env.CW_VERBOSE_*_LOGS === '1'` gate (already used in `cli/worker/start.ts`, `calculate-workout-stress.ts`, `workout-insight-email.ts`). Per the ticket, gating behind the existing verbose flag is the accepted reading of "equivalent low-noise logging". No new dependency, no new env var: `garminService.processWebhookEvent` is only ever invoked from the webhook worker, so it reuses the same `CW_VERBOSE_WORKER_LOGS` knob.

| Site | Provider | Before | After |
|---|---|---|---|
| `cli/worker/start.ts` (bulk fan-out) | Intervals.icu | `console.warn` per orphaned event | `console.debug` behind verbose flag |
| `cli/worker/start.ts` (Strava job) | Strava | `console.warn` | `console.debug` behind verbose flag |
| `server/utils/services/garminService.ts` | Garmin | `console.warn` | `console.debug` behind verbose flag |

## Skip/metrics accounting preserved

- **Intervals bulk:** `queuedCount` is unchanged (orphans still `continue` without incrementing it). Added an `orphanedCount` and surfaced it on the parent webhook log message — `Dispatched N child events (M orphaned, no integration)` — so the signal survives the log demotion in a durable place instead of only in stdout. Falls back to the original message when `orphanedCount === 0`.
- **Strava:** still writes `updateWebhookStatus(logId, 'IGNORED', 'User not found')` and returns `{ handled: false }`.
- **Garmin:** unchanged control flow (early `return`).

## Not changed

Only the "integration not found" branch in each spot. Malformed-payload handling, the `console.error` for duplicate Garmin `externalUserId` mappings, and every `catch`/`FAILED` path are untouched.

Note: the Garmin branch is defensive — the reachable no-integration path is the earlier `integrations.length === 0` return, which never logged. The demoted line covers the TS-narrowing `integrations[0]` case.

## Verification

```
pnpm test:unit   →  Test Files 378 passed (378) | Tests 2426 passed (2426)
pnpm typecheck   →  exit 0
```

`tests/unit/cli/worker.test.ts` including the `Webhook poller batch drain` suite from CW-34 passes.

UX critique: skipped — worker log levels, no user-facing surface.

## Risks

Low. If an operator was relying on these warnings appearing in default worker output, they now need `CW_VERBOSE_WORKER_LOGS=1`; the persisted webhook-log rows (`IGNORED` status, orphan count on the bulk parent) remain the durable record either way.
