### PR TITLE
fix(analysis): exclude unmeasurable cadence steps from cadenceHitRate (CW-419)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -1646,6 +1646,132 @@ describe('planned-to-actual alignment (CW-386)', () => {
     expect(facts.adherence.executionClassification).toBe('as_prescribed')
   })
 
+  describe('cadence hit-rate denominator (CW-419)', () => {
+    // A four-step cadence-targeted plan: two reps at 95 rpm with 85 rpm
+    // recoveries. Every variation below only changes what the executed laps
+    // recorded, so the denominator behaviour is the only moving part.
+    const cadencePlan = {
+      durationSec: 1200,
+      structuredWorkout: {
+        steps: [
+          {
+            type: 'Interval',
+            durationSeconds: 300,
+            power: { value: 100, units: '%' },
+            cadence: 95
+          },
+          { type: 'Rest', durationSeconds: 300, power: { value: 50, units: '%' }, cadence: 85 },
+          {
+            type: 'Interval',
+            durationSeconds: 300,
+            power: { value: 100, units: '%' },
+            cadence: 95
+          },
+          { type: 'Rest', durationSeconds: 300, power: { value: 50, units: '%' }, cadence: 85 }
+        ]
+      }
+    }
+
+    const factsFor = (icuIntervals: Record<string, unknown>[]) =>
+      buildWorkoutAnalysisFactsV2({
+        workout: makeWorkout({
+          title: 'Cadence Denominator Session',
+          type: 'Ride',
+          durationSec: 1200,
+          rawJson: { icu_intervals: icuIntervals }
+        }),
+        sportSettings: { ftp: 250 },
+        plannedWorkout: cadencePlan
+      })
+
+    it('excludes aligned steps whose segment carries no cadence measurement', () => {
+      // Every planned step is paired, the reps were executed on target power,
+      // but the head unit had no cadence sensor. Before CW-419 this reported
+      // `cadenceHitRate: 0` with `cadenceAssessable: true` — an explicit
+      // "assessable" hard zero the AI could only read as total non-compliance.
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 },
+        { type: 'WORK', moving_time: 300, average_watts: 250, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceHitRate).toBeNull()
+      expect(facts.adherence.cadenceAssessable).toBe(false)
+    })
+
+    it('treats a zero cadence average as unmeasured rather than a miss', () => {
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 0, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 0, intensity: 50 },
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 0, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 0, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceHitRate).toBeNull()
+      expect(facts.adherence.cadenceAssessable).toBe(false)
+    })
+
+    it('still counts a planned cadence step with no aligned segment as a miss', () => {
+      // Only the first rep and its recovery were executed. The two unpaired
+      // planned steps are execution evidence, not missing measurement, so they
+      // stay in the denominator (CW-386).
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 95, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 85, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceAssessable).toBe(true)
+      expect(facts.adherence.cadenceHitRate).toBe(50)
+    })
+
+    it('reports a real miss rate when cadence was recorded and missed', () => {
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 70, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 70, intensity: 50 },
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 70, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 70, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceAssessable).toBe(true)
+      expect(facts.adherence.cadenceHitRate).toBe(0)
+    })
+
+    it('scores only the measured steps when cadence coverage is partial', () => {
+      // Rep 1 recorded cadence and hit it; rep 2's lap has no cadence at all.
+      // Denominator drops to the two measured steps rather than diluting the
+      // athlete's real compliance with unmeasurable ones.
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, average_cadence: 95, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, average_cadence: 85, intensity: 50 },
+        { type: 'WORK', moving_time: 300, average_watts: 250, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceAssessable).toBe(true)
+      expect(facts.adherence.cadenceHitRate).toBe(100)
+    })
+
+    it('always surfaces the cadence assessability flag to the prompt', () => {
+      // The narrative must be able to say "cadence was not assessable"; gating
+      // the flag on its own truth value hid exactly the case that matters.
+      const facts = factsFor([
+        { type: 'WORK', moving_time: 300, average_watts: 250, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 },
+        { type: 'WORK', moving_time: 300, average_watts: 250, intensity: 100 },
+        { type: 'REST', moving_time: 300, average_watts: 125, intensity: 50 }
+      ])
+
+      expect(facts.adherence.cadenceAssessable).toBe(false)
+      expect(
+        facts.confidence.debugMeta.promptDecisions['adherence.cadenceAssessable']!.include
+      ).toBe(true)
+      expect(facts.confidence.debugMeta.promptDecisions['adherence.cadenceHitRate']!.include).toBe(
+        false
+      )
+    })
+  })
+
   it('does not let a mid-session stub lap consume a planned rep', () => {
     const facts = buildWorkoutAnalysisFactsV2({
       workout: makeWorkout({

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -3903,6 +3903,24 @@ function deriveAdherence(params: {
   ) => actual !== null && planned.metric === 'rpe' && !result.comparable
 
   /**
+   * The same rule for cadence targets (CW-419). A cadence-prescribed step can
+   * only be scored when its aligned segment actually carries a cadence
+   * measurement: riding a cadence-targeted plan on a bike with no cadence
+   * sensor says nothing about whether the athlete respected the prescription.
+   * Those steps leave the denominator instead of scoring as misses, so a
+   * session with no cadence stream reports `cadenceHitRate: null` /
+   * `cadenceAssessable: false` rather than a hard zero the AI would read as
+   * total non-compliance.
+   *
+   * `actual !== null` is load-bearing: a planned step the alignment could not
+   * pair at all is execution evidence (see the note below) and keeps counting
+   * as a miss, exactly as CW-386 established.
+   */
+  const isUnmeasurableCadenceStep = (actual: ActualInterval | null) =>
+    actual !== null &&
+    (actual.avgCadence === null || !Number.isFinite(actual.avgCadence) || actual.avgCadence <= 0)
+
+  /**
    * A planned step the alignment could not pair at all is a different case from
    * CW-385's unmeasurable RPE step, and is treated differently on purpose.
    *
@@ -3920,10 +3938,12 @@ function deriveAdherence(params: {
   let workHits = 0
   let recoveryHits = 0
   let cadenceHits = 0
-  // Denominators start at every planned step and shrink only when an RPE step
-  // turns out to be unmeasurable (see `isUnmeasurableRpeStep`).
+  // Denominators start at every planned step and shrink only when the step
+  // turns out to be unmeasurable (see `isUnmeasurableRpeStep` /
+  // `isUnmeasurableCadenceStep`).
   let scorableWorkSteps = plannedWork.length
   let scorableRecoverySteps = plannedRecovery.length
+  let scorableCadenceSteps = cadencePlanned.length
   const overshoots: number[] = []
   const undershoots: number[] = []
 
@@ -3955,9 +3975,16 @@ function deriveAdherence(params: {
   // athlete's warmup lap (CW-386).
   for (const { planned, actual } of alignment.pairs) {
     if (planned.cadence === null) continue
-    if (!actual || actual.avgCadence === null || actual.avgCadence <= 0) continue
+    if (isUnmeasurableCadenceStep(actual)) {
+      scorableCadenceSteps--
+      continue
+    }
+    const measuredCadence = actual?.avgCadence ?? null
+    // No aligned segment at all: the work was not executed, so this stays in
+    // the denominator as a miss (CW-386).
+    if (measuredCadence === null) continue
     const tolerance = planned.ramp ? 8 : 5
-    if (Math.abs(actual.avgCadence - planned.cadence) <= tolerance) cadenceHits++
+    if (Math.abs(measuredCadence - planned.cadence) <= tolerance) cadenceHits++
   }
 
   const workIntervalHitRate =
@@ -3965,7 +3992,7 @@ function deriveAdherence(params: {
   const recoveryHitRate =
     scorableRecoverySteps > 0 ? round((recoveryHits / scorableRecoverySteps) * 100, 1) : null
   const cadenceHitRate =
-    cadencePlanned.length > 0 ? round((cadenceHits / cadencePlanned.length) * 100, 1) : null
+    scorableCadenceSteps > 0 ? round((cadenceHits / scorableCadenceSteps) * 100, 1) : null
   const structureMatched =
     plannedWork.length > 0 &&
     actualWork.length > 0 &&
@@ -3996,7 +4023,9 @@ function deriveAdherence(params: {
     workIntervalHitRate,
     recoveryHitRate,
     cadenceHitRate,
-    cadenceAssessable: cadencePlanned.length > 0,
+    // Assessable means cadence was prescribed AND at least one prescribed step
+    // could actually be measured — not merely that cadence was planned (CW-419).
+    cadenceAssessable: scorableCadenceSteps > 0,
     targetOvershootPct,
     targetUndershootPct,
     structureMatched,
@@ -4134,8 +4163,12 @@ function buildPromptDecisionsV2(facts: WorkoutAnalysisFactsV2): Record<string, P
   )
   set(
     'adherence.cadenceAssessable',
-    facts.adherence.cadenceAssessable,
-    'The model should know whether cadence prescriptions were present and assessable.'
+    true,
+    // Always surfaced, including when false: a cadence-targeted plan ridden
+    // without a cadence sensor now yields `cadenceHitRate: null`, and the
+    // narrative must be able to say "cadence was not assessable" instead of
+    // silently dropping cadence or implying zero compliance (CW-419).
+    'The model must know whether cadence prescriptions could be assessed at all; false means cadence was not prescribed or not measured, never that the athlete ignored it.'
   )
   set(
     'adherence.targetOvershootPct',


### PR DESCRIPTION
Fixes CW-419

## Problem

`deriveAdherence` scored cadence off `alignment.pairs` (CW-386) but kept the *planned* count as the denominator. An aligned segment carrying no cadence measurement `continue`d past the hit check and stayed in `cadencePlanned.length`, so a cadence-targeted plan ridden on a device with no cadence sensor produced `cadenceHitRate: 0` together with `cadenceAssessable: true` — a hard zero explicitly flagged as assessable.

## Change

Mirrors what CW-385 did for RPE-planned steps:

- New `isUnmeasurableCadenceStep(actual)` — true only when a segment **exists** but carries no usable cadence (`null`, non-finite, or `<= 0`).
- New `scorableCadenceSteps` denominator, seeded from `cadencePlanned.length` and decremented per unmeasurable step, exactly like `scorableWorkSteps` / `scorableRecoverySteps`.
- `cadenceHitRate` divides by `scorableCadenceSteps`; `cadenceAssessable` is now `scorableCadenceSteps > 0`, i.e. cadence was prescribed **and** at least one prescribed step was measurable.
- CW-386's execution-evidence rule is preserved deliberately: a planned cadence step with **no** aligned segment is still a miss and stays in the denominator (`actual !== null` in the helper is load-bearing).
- Prompt decision `adherence.cadenceAssessable` is now always included (previously gated on its own truth value), so the narrative can state "cadence was not assessable" instead of the flag silently vanishing in exactly the case it was added for.

## Effect on the coach-facing AI narrative

Before, a sensorless ride against a cadence-prescribed plan handed the model `cadenceHitRate: 0` + `cadenceAssessable: true` — it could only conclude the athlete ignored every cadence instruction. Now that session yields `cadenceHitRate: null` + `cadenceAssessable: false`, so the model has no compliance number to misread and an explicit "not measurable" signal. Sessions where cadence *was* recorded are unaffected: partial coverage now scores only the measured steps instead of diluting real compliance with unmeasurable ones, and a genuine cadence miss still reports a real non-null rate.

## Tests

Six new cases under `cadence hit-rate denominator (CW-419)`: aligned-but-unmeasured, zero-cadence-average, unaligned-still-a-miss, measured-and-missed, partial coverage, and the always-surfaced prompt decision. **No existing expectation was changed.**

## Verification

```
$ pnpm test:unit server/utils/workout-analysis-facts.test.ts
 Test Files  1 passed (1)
      Tests  84 passed (84)

$ pnpm typecheck
exit=0
```

## Scope

Files changed match Owned Paths exactly: `server/utils/workout-analysis-facts.ts`, `server/utils/workout-analysis-facts.test.ts`. Untouched: CW-427 (`cadenceStabilityScore`), CW-433 (arbitration delta), CW-437 (`getAnalysisMode`), CW-438 (V1/V2 duplication).

UX critique: skipped — analysis-facts derivation feeding the AI prompt, no interactive surface.

## Follow-up filed

CW-520 — `adherence.cadenceHitRate` / `adherence.cadenceAssessable` prompt decisions are computed but the prompt renderer (`workout-analysis-prompt.ts`, not an Owned Path here) never lists those paths, so cadence adherence reaches no prompt today. Filed to Triage.

## Risks

Low. Only the cadence denominator and one prompt-decision flag move. The one behavioural regression risk is a session where cadence coverage is partial: its hit rate now reflects only the measured steps, which will read higher than before — that is the intended correction.
