### PR TITLE
refactor(workouts): type calculateStabilityMetrics intervals param (CW-428)

### DIFF
--- a/server/utils/performance-metrics.ts
+++ b/server/utils/performance-metrics.ts
@@ -91,12 +91,28 @@ export function calculateFatigueSensitivity(
 }
 
 /**
+ * Minimal structural shape `calculateStabilityMetrics` needs from an interval.
+ *
+ * Deliberately NOT the full `Interval` from `./interval-detection`: callers pass
+ * a mix of detected `Interval` objects and ad-hoc rep bounds built inline (see
+ * `repScopedStabilityCoV` in `workout-analysis-facts.ts`), whose `type` widens to
+ * `string`. Keeping this a structural subset means every existing caller
+ * type-checks unchanged while a missing `start_index` / `end_index` — the fields
+ * actually read below — becomes a compile error instead of a silent `NaN`.
+ */
+export interface StabilityInterval {
+  type?: string
+  start_index: number
+  end_index: number
+}
+
+/**
  * Calculate Stability Metrics (Consistency)
  * Uses Coefficient of Variation (StdDev / Mean)
  */
 export function calculateStabilityMetrics(
   stream: number[],
-  intervals: any[] = []
+  intervals: StabilityInterval[] = []
 ): StabilityMetrics | null {
   if (!stream || stream.length === 0) return null
 

--- a/tests/unit/server/utils/performance-metrics.test.ts
+++ b/tests/unit/server/utils/performance-metrics.test.ts
@@ -4,14 +4,22 @@ import {
   calculateStabilityMetrics,
   calculateWPrimeBalance,
   calculateEfficiencyFactorDecay,
-  calculateQuadrantAnalysis
+  calculateQuadrantAnalysis,
+  type StabilityInterval
 } from '../../../../server/utils/performance-metrics'
+import type { Interval } from '../../../../server/utils/interval-detection'
 
 describe('Performance Metrics Utils', () => {
   describe('calculateFatigueSensitivity', () => {
     it('should return null if streams mismatch or too short', () => {
       expect(calculateFatigueSensitivity([], [], [])).toBeNull()
-      expect(calculateFatigueSensitivity(new Array(500).fill(100), new Array(500).fill(100), new Array(500).fill(1))).toBeNull()
+      expect(
+        calculateFatigueSensitivity(
+          new Array(500).fill(100),
+          new Array(500).fill(100),
+          new Array(500).fill(1)
+        )
+      ).toBeNull()
     })
 
     it('should calculate decay correctly', () => {
@@ -69,6 +77,68 @@ describe('Performance Metrics Utils', () => {
       expect(result!.intervalStability).toHaveLength(1)
       expect(result!.intervalStability[0].cov).toBe(0)
     })
+
+    it('should select exactly the WORK and STEADY segments and skip everything else', () => {
+      // Index:      0    1    2  |  3   4  |   5    6   7  |   8    9
+      // Type:      <---WORK--->  | RECOV.  | <--STEADY-->  | <-COOLDOWN->
+      const stream = [100, 100, 100, 50, 50, 100, 110, 90, 300, 300]
+
+      const intervals: StabilityInterval[] = [
+        { type: 'WORK', start_index: 0, end_index: 2 },
+        { type: 'RECOVERY', start_index: 3, end_index: 4 },
+        { type: 'STEADY', start_index: 5, end_index: 7 },
+        { type: 'COOLDOWN', start_index: 8, end_index: 9 }
+      ]
+
+      const result = calculateStabilityMetrics(stream, intervals)
+
+      // Only WORK + STEADY survive the filter, and they are re-indexed from 0.
+      expect(result!.intervalStability).toEqual([
+        { index: 0, cov: 0, label: 'Interval 1' },
+        { index: 1, cov: expect.closeTo(8.16, 2), label: 'Interval 2' }
+      ])
+    })
+
+    it('should skip WARMUP, REST and untyped entries', () => {
+      const stream = [100, 110, 90, 100, 110, 90, 100, 110, 90]
+
+      const intervals: StabilityInterval[] = [
+        { type: 'WARMUP', start_index: 0, end_index: 2 },
+        { type: 'REST', start_index: 3, end_index: 5 },
+        // No `type` at all — `type` is optional on StabilityInterval, and an
+        // entry without one is not WORK/STEADY, so it must not be measured.
+        { start_index: 6, end_index: 8 }
+      ]
+
+      expect(calculateStabilityMetrics(stream, intervals)!.intervalStability).toEqual([])
+    })
+
+    it('should accept a full detected Interval without widening the parameter type', () => {
+      // Structural compatibility check: the real `Interval` shape from
+      // `interval-detection.ts` carries many more fields, and its `type` is a
+      // string union. It must still satisfy `StabilityInterval` so the eight
+      // existing call sites compile untouched.
+      const detected: Interval = {
+        type: 'WORK',
+        start_index: 0,
+        end_index: 2,
+        start_time: 0,
+        end_time: 2,
+        duration: 3,
+        avg_power: 100
+      }
+
+      const result = calculateStabilityMetrics([100, 100, 100], [detected])
+      expect(result!.intervalStability).toHaveLength(1)
+      expect(result!.intervalStability[0].cov).toBe(0)
+    })
+
+    // Compile-time contract (documentation — `tests/` is not part of the
+    // `tsconfig.server.json` project, so this is not enforced by
+    // `pnpm typecheck:server`; the enforcement lives in the type itself):
+    //
+    //   // @ts-expect-error — start_index is required
+    //   const bad: StabilityInterval = { type: 'WORK', end_index: 2 }
   })
 
   describe('calculateWPrimeBalance', () => {
@@ -155,13 +225,13 @@ describe('Performance Metrics Utils', () => {
         300, // Q1 (High P, High C)
         300, // Q2 (High P, Low C)
         100, // Q3 (Low P, Low C)
-        100  // Q4 (Low P, High C)
+        100 // Q4 (Low P, High C)
       ]
       const cadence = [
         100, // Q1
-        80,  // Q2
-        80,  // Q3
-        100  // Q4
+        80, // Q2
+        80, // Q3
+        100 // Q4
       ]
 
       const result = calculateQuadrantAnalysis(power, cadence, ftp, targetCadence)


### PR DESCRIPTION
Fixes CW-428

## What

`calculateStabilityMetrics(stream, intervals: any[])` read `type`, `start_index` and `end_index` off untyped objects. CW-393 started passing real interval objects into it for the first time, and `any[]` would not have caught a shape mismatch — the per-rep CoV would simply have come back as `NaN` with no type error.

Replaced `any[]` with an exported minimal structural interface:

```ts
export interface StabilityInterval {
  type?: string
  start_index: number
  end_index: number
}
```

Deliberately structural rather than importing `Interval` from `interval-detection.ts` wholesale, so that **no caller needed editing**: the eight call sites pass a mix of detected `Interval[]`, inline rep bounds whose `type` widens to `string` (`repScopedStabilityCoV`), and plain `[]` defaults. All compile untouched.

## Runtime behaviour

Identical — type-only change. No logic lines were modified.

## Verification

```
$ pnpm test:unit tests/unit/server/utils/performance-metrics.test.ts && pnpm typecheck:server

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Duration  420ms

$ NODE_OPTIONS='--max-old-space-size=8192' tsc -p .nuxt/tsconfig.server.json --noEmit
(clean, no output)
```

`typecheck:server` passing is the proof that all eight callers compile with no source changes. No caller was edited.

### Compile-error criterion

`tests/` is not part of any tsconfig project, so a `@ts-expect-error` there would not be enforced. Proved instead with a throwaway probe file under `server/utils/` (since deleted, not committed):

```
error TS2741: Property 'end_index' is missing in type '{ type: string; start_index: number; }' but required in type 'StabilityInterval'.
error TS2741: Property 'start_index' is missing in type '{ type: string; end_index: number; }' but required in type 'StabilityInterval'.
error TS2322: Type 'string' is not assignable to type 'number'.  (x2)
```

## Tests added

- `should select exactly the WORK and STEADY segments and skip everything else` — pins the filter against a stream with WORK / RECOVERY / STEADY / COOLDOWN blocks and asserts the exact selected segments, their re-indexing, and their CoVs.
- `should skip WARMUP, REST and untyped entries`.
- `should accept a full detected Interval without widening the parameter type` — structural compatibility with the real `Interval` shape.

No existing expectations were changed. (lint-staged reformatted some pre-existing lines in the test file via prettier.)

## UX critique

UX critique: skipped — type-only change, runtime behaviour identical.

## Files changed vs Owned Paths

Exactly the two owned paths, nothing else:

- `server/utils/performance-metrics.ts`
- `tests/unit/server/utils/performance-metrics.test.ts`

`server/utils/workout-analysis-facts.ts` (owned by CW-419 in flight) was **not** touched.

## Risks

Minimal. Type-only; the sole behavioural surface is that future callers must supply `start_index`/`end_index`, which is the point.