### PR TITLE
fix(tests): correct wellness-analysis prisma db mock path depth (CW-259)

### DIFF
--- a/tests/unit/server/utils/services/wellness-analysis.test.ts
+++ b/tests/unit/server/utils/services/wellness-analysis.test.ts
@@ -14,7 +14,7 @@ const {
   generateStructuredAnalysisMock: vi.fn()
 }))
 
-vi.mock('../../../../../../server/utils/db', () => ({
+vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
     wellness: {
       findUnique: prismaWellnessFindUnique,


### PR DESCRIPTION
Fixes CW-259

## What changed

One line. The `vi.mock()` specifier for `server/utils/db` in `tests/unit/server/utils/services/wellness-analysis.test.ts` used six `../` segments; from `tests/unit/server/utils/services/` five reach the repo root, which is what every other mock in the same file uses.

```diff
-vi.mock('../../../../../../server/utils/db', () => ({
+vi.mock('../../../../../server/utils/db', () => ({
```

No change to the mock's *shape* was needed — see below.

## Important: the reported symptom does not reproduce

The ticket describes 5 failing tests. **They were already passing on `develop` before this change.** Verified before touching anything:

- Target file, pre-fix: `Test Files 1 passed (1)` / `Tests 5 passed (5)`
- Full suite, pre-fix: `Test Files 378 passed (378)` / `Tests 2426 passed (2426)`

I mapped the behaviour by varying the depth on the pre-fix content:

| `../` depth | result |
|---|---|
| 4 | 5 failed — `Cannot read properties of undefined (reading 'findUnique')` |
| 5 (this PR) | 5 passed |
| 6 (previous) | 5 passed |
| 7 | 5 failed — the exact error the ticket reports |

Depth 6 resolves outside the repo root but is still rescued by a Vite resolver fallback, so the mock *did* apply and the assertions that depend on it (`prismaWellnessUpdate` called with `aiAnalysisStatus: 'QUOTA_EXCEEDED'`) genuinely passed. Depth 7 is past what the fallback covers.

I could not reproduce the failure under any configuration I tried: same result in the main checkout at a different filesystem depth (ruling out worktree nesting), and under `--environment happy-dom` (ruling out the `environment: 'node'` switch from CW-260, whose branch is already merged into `develop`).

So: the ticket's diagnosis of the **defect** is correct — the path is wrong and works only by accident — but the claimed **symptom** is not present on `develop`. This lands as correctness/robustness, not as a red-to-green fix. Because the mock was in fact being exercised all along, its shape was already correct and **nothing had to be added to it**.

## Acceptance criteria

- [x] Path corrected to `../../../../../server/utils/db`
- [x] All 5 tests in the file pass (`analyzeWellness quota enforcement` 3, `analyzeWellness skin temperature formatting` 2)
- [x] No other test file in `tests/unit/` has the same defect — verified by resolving *every* relative `vi.mock`/`vi.importActual`/`import` specifier across all 378 unit test files against the filesystem, not by grep. Pre-fix that check reported exactly one unresolvable specifier (this line); post-fix it reports clean. The other files matching a 6-`../` grep live at `tests/unit/server/api/<x>/<y>/`, where six segments is correct — a plain grep would have produced false positives.

## Verification

```
pnpm vitest run tests/unit/server/utils/services/wellness-analysis.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

pnpm test:unit
 Test Files  378 passed (378)
      Tests  2426 passed (2426)
```

Before: 5 passed / 2426 passed. After: 5 passed / 2426 passed. No neighbouring suite perturbed.

UX critique: skipped — test-only change, no runtime or user-facing surface.

## Files changed vs Owned Paths

`tests/unit/server/utils/services/wellness-analysis.test.ts` — the only Owned Path, the only file touched.

## Risks

Effectively none: a single specifier in one test file, with the full suite green before and after.
