### PR TITLE
fix(coaching): surface invite/request fetch failures instead of empty state (CW-154)

### DIFF
--- a/app/pages/coaching/athletes/index.vue
+++ b/app/pages/coaching/athletes/index.vue
@@ -45,17 +45,12 @@
           </p>
         </div>
 
-        <CoachingGroupManager
-          v-if="athletes.length > 0 || groups.length > 0"
-          v-model:active-group-id="activeGroupId"
-          :groups="groups"
-          :athletes="athletes"
-          :teams="teams"
-          @refresh="fetchGroups"
-        />
-
-        <div v-if="requestsError" class="px-4 sm:px-0">
+        <!-- Load failures for the requests/invites sub-requests, grouped at the top of the page so
+             a coach scanning for "anything wrong" cannot scroll past one. A failure must never be
+             rendered as an empty list — missing a real connection request costs a client. -->
+        <div v-if="requestsError || invitesError" class="px-4 sm:px-0 space-y-3">
           <UAlert
+            v-if="requestsError"
             color="error"
             variant="soft"
             icon="i-heroicons-exclamation-triangle"
@@ -84,7 +79,47 @@
               />
             </template>
           </UAlert>
+
+          <UAlert
+            v-if="invitesError"
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            :title="tr('athletes_invites_error_title', 'Could not load pending invitations')"
+            :description="
+              tr(
+                'athletes_invites_error_desc',
+                'We could not reach the server, so your pending invites and share links are not shown. This is a loading error — any existing invites are still active.'
+              )
+            "
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                :loading="retryingInvites"
+                :label="tr('athletes_invites_error_retry', 'Retry')"
+                @click="
+                  () => {
+                    void retryPendingInvites()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
         </div>
+
+        <CoachingGroupManager
+          v-if="athletes.length > 0 || groups.length > 0"
+          v-model:active-group-id="activeGroupId"
+          :groups="groups"
+          :athletes="athletes"
+          :teams="teams"
+          @refresh="fetchGroups"
+        />
 
         <UCard v-if="pendingRequests.length > 0" :ui="{ ...mobileListCardUi, body: 'p-4 sm:p-6' }">
           <div class="flex items-center justify-between gap-4 mb-4">
@@ -352,38 +387,6 @@
             </div>
           </div>
         </UCard>
-
-        <div v-if="invitesError" class="px-4 sm:px-0">
-          <UAlert
-            color="error"
-            variant="soft"
-            icon="i-heroicons-exclamation-triangle"
-            :title="tr('athletes_invites_error_title', 'Could not load pending invitations')"
-            :description="
-              tr(
-                'athletes_invites_error_desc',
-                'We could not reach the server, so your pending invites and share links are not shown. This is a loading error — any existing invites are still active.'
-              )
-            "
-          >
-            <template #actions>
-              <UButton
-                color="error"
-                variant="outline"
-                size="xs"
-                icon="i-heroicons-arrow-path"
-                class="font-bold"
-                :loading="retryingInvites"
-                :label="tr('athletes_invites_error_retry', 'Retry')"
-                @click="
-                  () => {
-                    void retryPendingInvites()
-                  }
-                "
-              />
-            </template>
-          </UAlert>
-        </div>
 
         <UCard v-if="pendingInvites.length > 0" :ui="{ ...mobileListCardUi, body: 'p-4 sm:p-6' }">
           <div class="flex items-center justify-between gap-4 mb-4">

--- a/app/pages/coaching/athletes/index.vue
+++ b/app/pages/coaching/athletes/index.vue
@@ -54,6 +54,38 @@
           @refresh="fetchGroups"
         />
 
+        <div v-if="requestsError" class="px-4 sm:px-0">
+          <UAlert
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            :title="tr('athletes_requests_error_title', 'Could not load coaching requests')"
+            :description="
+              tr(
+                'athletes_requests_error_desc',
+                'We could not reach the server, so pending requests from your start page are not shown. This is a loading error — you may still have requests waiting.'
+              )
+            "
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                :loading="retryingRequests"
+                :label="tr('athletes_requests_error_retry', 'Retry')"
+                @click="
+                  () => {
+                    void retryPendingRequests()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
+        </div>
+
         <UCard v-if="pendingRequests.length > 0" :ui="{ ...mobileListCardUi, body: 'p-4 sm:p-6' }">
           <div class="flex items-center justify-between gap-4 mb-4">
             <div>
@@ -320,6 +352,38 @@
             </div>
           </div>
         </UCard>
+
+        <div v-if="invitesError" class="px-4 sm:px-0">
+          <UAlert
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            :title="tr('athletes_invites_error_title', 'Could not load pending invitations')"
+            :description="
+              tr(
+                'athletes_invites_error_desc',
+                'We could not reach the server, so your pending invites and share links are not shown. This is a loading error — any existing invites are still active.'
+              )
+            "
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                :loading="retryingInvites"
+                :label="tr('athletes_invites_error_retry', 'Retry')"
+                @click="
+                  () => {
+                    void retryPendingInvites()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
+        </div>
 
         <UCard v-if="pendingInvites.length > 0" :ui="{ ...mobileListCardUi, body: 'p-4 sm:p-6' }">
           <div class="flex items-center justify-between gap-4 mb-4">
@@ -602,6 +666,10 @@
   const inviteEmail = ref('')
   const pendingInvites = ref<any[]>([])
   const pendingRequests = ref<any[]>([])
+  const invitesError = ref(false)
+  const requestsError = ref(false)
+  const retryingInvites = ref(false)
+  const retryingRequests = ref(false)
   const revokingInviteId = ref<string | null>(null)
   const reviewingRequestId = ref<string | null>(null)
   const reviewingAction = ref<'approve' | 'decline' | null>(null)
@@ -638,21 +706,80 @@
     return athletes.value.filter((rel) => memberIds.includes(rel.athlete.id))
   })
 
+  // Loads pending invites on its own so a transient failure does not take the whole page
+  // down — but it never masquerades as an empty list: `invitesError` drives an explicit
+  // error state with a retry, while a successful empty response clears it.
+  async function loadPendingInvites() {
+    try {
+      const data = await $fetch<any, string & {}>('/api/coaching/athletes/invites')
+      pendingInvites.value = (data as any[]) || []
+      invitesError.value = false
+      return true
+    } catch (e) {
+      console.error(e)
+      pendingInvites.value = []
+      invitesError.value = true
+      return false
+    }
+  }
+
+  async function loadPendingRequests() {
+    try {
+      const data = await $fetch<any, string & {}>('/api/coaching/athletes/requests')
+      pendingRequests.value = (data as any[]) || []
+      requestsError.value = false
+      return true
+    } catch (e) {
+      console.error(e)
+      pendingRequests.value = []
+      requestsError.value = true
+      return false
+    }
+  }
+
+  async function retryPendingInvites() {
+    retryingInvites.value = true
+    try {
+      const ok = await loadPendingInvites()
+      if (!ok) {
+        toast.add({
+          title: tr('athletes_invites_error_toast', 'Still unable to load pending invitations'),
+          color: 'error'
+        })
+      }
+    } finally {
+      retryingInvites.value = false
+    }
+  }
+
+  async function retryPendingRequests() {
+    retryingRequests.value = true
+    try {
+      const ok = await loadPendingRequests()
+      if (!ok) {
+        toast.add({
+          title: tr('athletes_requests_error_toast', 'Still unable to load coaching requests'),
+          color: 'error'
+        })
+      }
+    } finally {
+      retryingRequests.value = false
+    }
+  }
+
   async function fetchData() {
     loading.value = true
     try {
-      const [athletesData, groupsData, teamsData, invitesData, requestsData] = await Promise.all([
+      const [athletesData, groupsData, teamsData] = await Promise.all([
         $fetch<any, string & {}>('/api/coaching/athletes'),
         $fetch<any, string & {}>('/api/coaching/groups'),
         $fetch<any, string & {}>('/api/coaching/teams'),
-        $fetch<any, string & {}>('/api/coaching/athletes/invites').catch(() => []),
-        $fetch<any, string & {}>('/api/coaching/athletes/requests').catch(() => [])
+        loadPendingInvites(),
+        loadPendingRequests()
       ])
       athletes.value = athletesData as any[]
       groups.value = groupsData as any[]
       teams.value = teamsData as any[]
-      pendingInvites.value = invitesData as any[]
-      pendingRequests.value = requestsData as any[]
     } catch (e) {
       console.error(e)
       toast.add({ title: 'Failed to load coaching data', color: 'error' })

--- a/app/pages/coaching/teams/[id].vue
+++ b/app/pages/coaching/teams/[id].vue
@@ -132,29 +132,15 @@
                 />
               </div>
 
+              <!-- On a roster load failure the alert above the tabs owns the message and the
+                   retry; this empty state must stay hidden so it cannot be read as "no athletes". -->
               <div
                 v-if="rosterError"
                 class="text-center py-12 bg-neutral-50 dark:bg-neutral-800/20 rounded-xl border-2 border-dashed border-gray-200 dark:border-gray-800"
               >
-                <UIcon
-                  name="i-heroicons-exclamation-triangle"
-                  class="w-12 h-12 text-error-400 mb-2"
-                />
-                <p class="text-neutral-500">The roster could not be loaded.</p>
-                <UButton
-                  color="error"
-                  variant="outline"
-                  size="xs"
-                  icon="i-heroicons-arrow-path"
-                  class="font-bold mt-4"
-                  label="Retry"
-                  :loading="retryingRoster"
-                  @click="
-                    () => {
-                      void retryRoster()
-                    }
-                  "
-                />
+                <p class="text-sm text-neutral-500 italic font-medium">
+                  Roster unavailable — see the error above.
+                </p>
               </div>
               <div
                 v-else-if="roster.length === 0"
@@ -419,25 +405,15 @@
                   />
                 </div>
 
+                <!-- Same rule as the roster: the alert above the tabs owns the message and the
+                     retry, so "No active invites." can never stand in for a failed load. -->
                 <div
                   v-if="invitesError"
                   class="text-center py-8 border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-lg"
                 >
-                  <p class="text-sm text-neutral-500">Pending invitations could not be loaded.</p>
-                  <UButton
-                    color="error"
-                    variant="outline"
-                    size="xs"
-                    icon="i-heroicons-arrow-path"
-                    class="font-bold mt-3"
-                    label="Retry"
-                    :loading="retryingInvites"
-                    @click="
-                      () => {
-                        void retryInvites()
-                      }
-                    "
-                  />
+                  <p class="text-sm text-neutral-500 italic font-medium">
+                    Invitations unavailable — see the error above.
+                  </p>
                 </div>
                 <div
                   v-else-if="invites.length === 0"

--- a/app/pages/coaching/teams/[id].vue
+++ b/app/pages/coaching/teams/[id].vue
@@ -52,6 +52,63 @@
           </p>
         </div>
 
+        <!-- Load failures for the roster/invites sub-requests. These must never be rendered as
+             an empty roster or an empty invite list — a coach has to be able to tell "nothing
+             pending" apart from "we could not load it". -->
+        <div v-if="rosterError || invitesError" class="px-4 sm:px-0 space-y-3">
+          <UAlert
+            v-if="rosterError"
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            title="Could not load the team roster"
+            description="We could not reach the server, so this team's athletes are not shown. This is a loading error — the roster itself is unchanged."
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                label="Retry"
+                :loading="retryingRoster"
+                @click="
+                  () => {
+                    void retryRoster()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
+
+          <UAlert
+            v-if="invitesError"
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            title="Could not load pending invitations"
+            description="We could not reach the server, so this team's invite codes and share links are not shown. This is a loading error — any existing invites are still active."
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                label="Retry"
+                :loading="retryingInvites"
+                @click="
+                  () => {
+                    void retryInvites()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
+        </div>
+
         <!-- Dashboard Content -->
         <UTabs :items="tabs" class="w-full">
           <!-- Roster Tab -->
@@ -76,7 +133,31 @@
               </div>
 
               <div
-                v-if="roster.length === 0"
+                v-if="rosterError"
+                class="text-center py-12 bg-neutral-50 dark:bg-neutral-800/20 rounded-xl border-2 border-dashed border-gray-200 dark:border-gray-800"
+              >
+                <UIcon
+                  name="i-heroicons-exclamation-triangle"
+                  class="w-12 h-12 text-error-400 mb-2"
+                />
+                <p class="text-neutral-500">The roster could not be loaded.</p>
+                <UButton
+                  color="error"
+                  variant="outline"
+                  size="xs"
+                  icon="i-heroicons-arrow-path"
+                  class="font-bold mt-4"
+                  label="Retry"
+                  :loading="retryingRoster"
+                  @click="
+                    () => {
+                      void retryRoster()
+                    }
+                  "
+                />
+              </div>
+              <div
+                v-else-if="roster.length === 0"
                 class="text-center py-12 bg-neutral-50 dark:bg-neutral-800/20 rounded-xl border-2 border-dashed border-gray-200 dark:border-gray-800"
               >
                 <UIcon name="i-heroicons-users" class="w-12 h-12 text-neutral-300 mb-2" />
@@ -339,7 +420,27 @@
                 </div>
 
                 <div
-                  v-if="invites.length === 0"
+                  v-if="invitesError"
+                  class="text-center py-8 border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-lg"
+                >
+                  <p class="text-sm text-neutral-500">Pending invitations could not be loaded.</p>
+                  <UButton
+                    color="error"
+                    variant="outline"
+                    size="xs"
+                    icon="i-heroicons-arrow-path"
+                    class="font-bold mt-3"
+                    label="Retry"
+                    :loading="retryingInvites"
+                    @click="
+                      () => {
+                        void retryInvites()
+                      }
+                    "
+                  />
+                </div>
+                <div
+                  v-else-if="invites.length === 0"
                   class="text-center py-8 border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-lg"
                 >
                   <p class="text-sm text-neutral-500">No active invites.</p>
@@ -679,6 +780,10 @@
   const team = ref<any>(null)
   const roster = ref<any[]>([])
   const invites = ref<any[]>([])
+  const rosterError = ref(false)
+  const invitesError = ref(false)
+  const retryingRoster = ref(false)
+  const retryingInvites = ref(false)
   const myCoachedAthletes = ref<any[]>([])
   const loading = ref(true)
   const creatingInvite = ref(false)
@@ -844,18 +949,69 @@
     }
   }
 
+  // Roster and invites load independently so one transient failure does not blank the whole
+  // page — but a failure is never rendered as "nothing here": the *Error flags drive an
+  // explicit error state with a retry, and a successful empty response clears them.
+  async function loadRoster() {
+    const teamId = route.params.id as string
+    try {
+      const data = await $fetch<any, string & {}>(`/api/coaching/teams/${teamId}/roster`)
+      roster.value = (data as any[]) || []
+      rosterError.value = false
+      return true
+    } catch (e) {
+      console.error(e)
+      roster.value = []
+      rosterError.value = true
+      return false
+    }
+  }
+
+  async function loadInvites() {
+    const teamId = route.params.id as string
+    try {
+      const data = await $fetch<any, string & {}>(`/api/coaching/teams/${teamId}/invites`)
+      invites.value = (data as any[]) || []
+      invitesError.value = false
+      return true
+    } catch (e) {
+      console.error(e)
+      invites.value = []
+      invitesError.value = true
+      return false
+    }
+  }
+
+  async function retryRoster() {
+    retryingRoster.value = true
+    try {
+      const ok = await loadRoster()
+      if (!ok) {
+        toast.add({ title: 'Still unable to load the team roster', color: 'error' })
+      }
+    } finally {
+      retryingRoster.value = false
+    }
+  }
+
+  async function retryInvites() {
+    retryingInvites.value = true
+    try {
+      const ok = await loadInvites()
+      if (!ok) {
+        toast.add({ title: 'Still unable to load pending invitations', color: 'error' })
+      }
+    } finally {
+      retryingInvites.value = false
+    }
+  }
+
   async function refreshTeam() {
     const teamId = route.params.id as string
     try {
       team.value = await $fetch<any, string & {}>(`/api/coaching/teams/${teamId}`)
 
-      const [rosterData, invitesData] = await Promise.all([
-        $fetch<any, string & {}>(`/api/coaching/teams/${teamId}/roster`).catch(() => []),
-        $fetch<any, string & {}>(`/api/coaching/teams/${teamId}/invites`).catch(() => [])
-      ])
-
-      roster.value = rosterData as any[]
-      invites.value = invitesData as any[]
+      await Promise.all([loadRoster(), loadInvites()])
     } catch (e) {
       console.error(e)
       toast.add({ title: 'Failed to load team data', color: 'error' })


### PR DESCRIPTION
Fixes CW-154

## Problem

`fetchData` (coaching athletes) and `refreshTeam` (team detail) fetched their invite/request/roster sub-requests with `.catch(() => [])` inside `Promise.all`. A transient network or server failure therefore rendered **exactly like "nothing pending"** — no error, no retry. A coach could open the page, see no pending coaching requests, and never learn that the check had failed. Since those requests come from the public Start page, a missed one is a lost client.

## Change

Each affected sub-request now has its own loader that records whether it failed:

- `app/pages/coaching/athletes/index.vue` — `loadPendingInvites()` / `loadPendingRequests()` set `invitesError` / `requestsError`.
- `app/pages/coaching/teams/[id].vue` — `loadRoster()` / `loadInvites()` set `rosterError` / `invitesError`.

On failure the page shows a red `UAlert` explaining that this is a *loading* error (not an empty inbox) with a **Retry** button that refetches only that section; a retry that fails again also raises an error toast. On success the flag is cleared, so a genuinely empty response still renders the normal empty UI — which is the whole point of the ticket: `[]` because the server said "none" must not look like `[]` because the request failed.

The failure stays non-fatal for the rest of the page (athletes, groups and teams still render) — it just no longer masquerades as "nothing pending". On the team page the misleading "No athletes in this team roster yet." / "No active invites." empty states are suppressed on error and replaced by a muted pointer line, so there is exactly one error message and one Retry per failed sub-request.

## Verification

`pnpm typecheck` — exit 0, no diagnostics:

```
$ NODE_OPTIONS='--max-old-space-size=8192' nuxt typecheck --checker=vue-tsc
[sidebase-auth] ℹ nuxt-auth setup starting
[sidebase-auth] ✔ nuxt-auth setup done
ℹ Nuxt Icon server bundle mode is set to local
[nuxt:icon] ✔ Nuxt Icon discovered local-installed 6 collections: heroicons, lucide, material-symbols, ph, simple-icons, tabler
EXIT: 0
```

`pnpm lint` — `✖ 116 problems (0 errors, 116 warnings)`, all pre-existing and none in the changed files. `prettier --check` on both files clean.

## UX critique: required

Ran with the `factory-ux-critic` agent against the running app, forcing partial sub-request failures via request blocking, on desktop and at 375px.

- **Round 1 → FIX-FIRST.** Two in-scope findings: the team page rendered two error messages and two Retry buttons for a single failure (banner + inline block, differently worded), with inconsistent icon treatment between the two inline styles. A third finding — one athletes-page alert rendering below a large green onboarding CTA where it could be scrolled past — was filed as follow-up but fixed here too.
- **Round 2 → SHIP.** All three confirmed resolved: one message + one Retry per failure, both alerts grouped at the top of the athletes page, and recovery (unblock + Retry) restores the correct genuine empty states with no page reload. No new findings.

Screenshots on CW-154.

## Risks

Low, and UI-only. Behaviour on the success path is unchanged. The one deliberate behavioural change is that a failed sub-request no longer silently degrades to an empty list — which is the fix. No API, schema or server-side changes.
