### PR TITLE
fix(analysis): keep estimated-power rides in mixed analysis mode (CW-437)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2441,6 +2441,105 @@ describe('Strava estimated ride power provenance (CW-394)', () => {
   })
 })
 
+describe('analysis mode for estimated-power rides (CW-437)', () => {
+  // CW-394 started routing power-meter-less Strava rides through the 'estimated' branch of
+  // getAnalysisMode, which used to mean run/ski and therefore led on pace. Cycling speed is
+  // confounded by wind, gradient and drafting far more than running pace is, so an
+  // estimated-power ride must resolve to 'mixed' — no single metric leads. Every case here
+  // drops averageHr so hrUsable is false: that isolates the estimated branch from the
+  // `if (hrUsable) return 'mixed'` fallback further down, and makes 'mixed' load-bearing.
+  function modes(workout: Record<string, unknown>) {
+    return {
+      v1: buildWorkoutAnalysisFacts({ workout }).telemetry.analysisMode,
+      v2: buildWorkoutAnalysisFactsV2({ workout }).guardrails.analysisMode
+    }
+  }
+
+  function outdoorRide(overrides: Record<string, unknown> = {}) {
+    return makeWorkout({
+      type: 'Ride',
+      title: 'Outdoor Ride',
+      durationSec: 3600,
+      averageWatts: 198,
+      normalizedPower: 214,
+      averageHr: null,
+      averageSpeed: 8.1,
+      ...overrides
+    })
+  }
+
+  it('routes an estimated-power ride with a speed signal to mixed rather than pace', () => {
+    const workout = outdoorRide({ rawJson: { device_watts: false } })
+    const facts = buildWorkoutAnalysisFactsV2({ workout })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('estimated')
+    expect(facts.guardrails.telemetry.paceUsable).toBe(true)
+    expect(modes(workout)).toEqual({ v1: 'mixed', v2: 'mixed' })
+  })
+
+  it('routes an estimated-power ride carrying a velocity stream to mixed as well', () => {
+    const workout = outdoorRide({
+      averageSpeed: null,
+      rawJson: { device_watts: false },
+      streams: { velocity: [7.8, 8.2, 8.6, 9.1, 8.4, 7.9] }
+    })
+    const facts = buildWorkoutAnalysisFactsV2({ workout })
+
+    expect(facts.guardrails.telemetry.powerSourceType).toBe('estimated')
+    expect(facts.guardrails.telemetry.paceUsable).toBe(true)
+    expect(modes(workout)).toEqual({ v1: 'mixed', v2: 'mixed' })
+  })
+
+  it('leaves measured-power rides on their existing modes', () => {
+    const withoutHr = outdoorRide({ rawJson: { device_watts: true } })
+    const withHr = outdoorRide({ averageHr: 145, rawJson: { device_watts: true } })
+
+    expect(
+      buildWorkoutAnalysisFactsV2({ workout: withoutHr }).guardrails.telemetry.powerSourceType
+    ).toBe('measured')
+    expect(modes(withoutHr)).toEqual({ v1: 'power', v2: 'power' })
+    expect(modes(withHr)).toEqual({ v1: 'mixed', v2: 'mixed' })
+  })
+
+  it('leaves a run with pace on pace mode', () => {
+    const workout = makeWorkout({
+      type: 'Run',
+      durationSec: 3600,
+      averageWatts: 290,
+      averageHr: null,
+      averageSpeed: 3.3
+    })
+
+    expect(buildWorkoutAnalysisFactsV2({ workout }).guardrails.telemetry.powerSourceType).toBe(
+      'estimated'
+    )
+    expect(modes(workout)).toEqual({ v1: 'pace', v2: 'pace' })
+  })
+
+  it('leaves estimated-power ski sessions on pace mode', () => {
+    const withPace = makeWorkout({
+      type: 'NordicSki',
+      durationSec: 3600,
+      averageWatts: 180,
+      averageHr: null,
+      averageSpeed: 4.2
+    })
+    const withoutPace = makeWorkout({
+      type: 'NordicSki',
+      durationSec: 3600,
+      averageWatts: 180,
+      averageHr: null,
+      averageSpeed: null
+    })
+
+    expect(
+      buildWorkoutAnalysisFactsV2({ workout: withPace }).guardrails.telemetry.powerSourceType
+    ).toBe('estimated')
+    expect(modes(withPace)).toEqual({ v1: 'pace', v2: 'pace' })
+    expect(modes(withoutPace)).toEqual({ v1: 'mixed', v2: 'mixed' })
+  })
+})
+
 describe('heart-rate physiological plausibility (CW-395)', () => {
   // A clean stream reading `usable: true` is the primary acceptance criterion here:
   // falsely suppressing HR removes decoupling, zone times, EF and durability from the

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -619,7 +619,26 @@ function getAnalysisMode(params: {
 }) {
   if (params.family === 'run' && params.hasPace) return 'pace'
   if (params.powerSourceType === 'measured') return params.hrUsable ? 'mixed' : 'power'
-  if (params.powerSourceType === 'estimated') return params.hasPace ? 'pace' : 'mixed'
+  if (params.powerSourceType === 'estimated') {
+    /**
+     * Rides never lead on speed (CW-437).
+     *
+     * This branch predates CW-394, when `'estimated'` meant runs and ski — modalities
+     * where pace really is the primary effort metric. CW-394 made
+     * `inferPowerSourceType` classify a Strava ride whose `device_watts` is explicitly
+     * `false` as estimated, which routed real outdoor rides here for the first time.
+     *
+     * Cycling speed is a far weaker proxy for effort than running pace: wind, gradient
+     * and drafting move it independently of the work done, so the same 200 W produces
+     * wildly different speeds into a headwind and down a descent. Leading the analysis
+     * with speed would build pacing narratives on the wrong signal, so an
+     * estimated-power ride resolves to `'mixed'` — which already means "no single
+     * metric leads", the honest description of that session. Run and ski behaviour is
+     * deliberately untouched (runs are caught by the `family === 'run'` rule above).
+     */
+    if (params.family === 'ride') return 'mixed'
+    return params.hasPace ? 'pace' : 'mixed'
+  }
   if (params.hrUsable) return 'mixed'
   if (params.hasRpe) return 'rpe'
   return 'mixed'


### PR DESCRIPTION
Fixes CW-437

## What changed

`getAnalysisMode` (`server/utils/workout-analysis-facts.ts`) now keeps **estimated-power rides in `'mixed'`** instead of routing them to `'pace'`:

```ts
if (params.powerSourceType === 'estimated') {
  if (params.family === 'ride') return 'mixed'
  return params.hasPace ? 'pace' : 'mixed'
}
```

The `'estimated'` branch was written when `'estimated'` meant runs and ski, where pace genuinely is the primary metric. CW-394 changed the population: `inferPowerSourceType` now classifies a Strava ride whose `device_watts` is explicitly `false` as estimated, so real outdoor rides started reaching this branch and leading their analysis on speed. Cycling speed is confounded by wind, gradient and drafting to a degree running pace is not — the same 200 W gives wildly different speeds into a headwind and down a descent — so speed is the wrong leading signal for a ride.

Run and ski behaviour is deliberately untouched (runs never reach this branch anyway; the `family === 'run' && hasPace` rule catches them first). Measured-power rides are untouched. A comment on the branch records the decision and the reasoning for the next reader.

`getAnalysisMode` is called from both facts builders (V1 and V2), so the change lands once and applies to both. CW-438 (that duplication) is out of scope here and untouched.

## How the coach-facing narrative changes

For an outdoor ride with no power meter, the AI prompt previously declared **pace/speed as the leading metric** and the analysis would frame pacing, fade and execution in terms of speed. It now declares `'mixed'` — "no single metric leads" — so the model weighs estimated power, HR and speed together rather than building a pacing story on a signal that a headwind or a climb can move by 30% at constant effort. Nothing is removed from the prompt; only which metric is presented as primary changes. `powerAbsoluteUsable` stays `false` for these rides (CW-394 behaviour), so absolute-watts benchmarking remains suppressed as before.

## Verification

```
$ pnpm test:unit server/utils/workout-analysis-facts.test.ts
 Test Files  1 passed (1)
      Tests  89 passed (89)

$ pnpm typecheck
EXIT=0
```

**No existing expectation was changed.** The test-file diff is +99 / -0 — pure additions. CW-419's cadence tests are untouched.

New tests (`analysis mode for estimated-power rides (CW-437)`), each asserted against **both** builders:
- estimated-power ride with `averageSpeed` → `mixed`
- estimated-power ride with a `velocity` stream → `mixed`
- measured-power ride → unchanged (`power` without usable HR, `mixed` with)
- run with pace → unchanged (`pace`)
- estimated-power ski → unchanged (`pace` with speed, `mixed` without)

Every case drops `averageHr` so `hrUsable` is false — that isolates the `'estimated'` branch from the `if (hrUsable) return 'mixed'` fallback further down and makes the `'mixed'` assertions load-bearing rather than incidentally true.

## Risks

Low. Behaviour change is confined to one family/source-type combination. `analysisMode` feeds `classifyArchetype` and the `primaryMetric` consistency check downstream; the full existing suite (which covers both) stays green.

## UX critique

UX critique: skipped — analysis-mode selection feeding the AI prompt, no interactive surface.

## Files changed vs Owned Paths

Exactly the two owned paths, nothing else:
- `server/utils/workout-analysis-facts.ts`
- `server/utils/workout-analysis-facts.test.ts`
