### PR TITLE
fix(analysis): scope cadence stability to work reps with an applicability gate (CW-427)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -1993,6 +1993,142 @@ describe('rep-scoped durability and stability signals', () => {
     expect(facts.performanceSignals.sportSpecific.cadenceDriftPct).toBeCloseTo(0, 5)
   })
 
+  it('scores cadence stability within the reps rather than across the whole session (CW-427)', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: buildThresholdWorkout(),
+      plannedWorkout: thresholdPlan,
+      sportSettings: { ftp: THRESHOLD_FIXTURE_FTP }
+    })
+
+    // Session-wide, this fixture's cadence CoV is 7.43% — the 85 rpm warmup,
+    // the 80 rpm jogs, the 88 rpm buffer and the 70 rpm cooldown all averaged
+    // together — and scored 62.9/100 as if the athlete's cadence had wandered.
+    // The reps themselves were all ridden at a flat 92 rpm.
+    expect(facts.performanceSignals.sportSpecific.cadenceStabilityScore).toBe(100)
+    expect(facts.performanceSignals.applicability.cadenceStability).toEqual({
+      applicable: true,
+      reason: null
+    })
+  })
+
+  it('withholds cadence stability with a reason when the reps cannot be scoped (CW-427)', () => {
+    // Same premise as the mixed-ride case below: an intervalled session whose
+    // work efforts are not repetitions of one another. A session-wide cadence
+    // CoV here would be presented as execution quality, which is the
+    // substitution CW-393 forbade and CW-427 extends to this signal.
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Unstructured Mixed Ride',
+        type: 'Ride',
+        durationSec: 2160,
+        averageWatts: 200,
+        variabilityIndex: 1.16,
+        rawJson: {
+          icu_intervals: [
+            {
+              type: 'WORK',
+              moving_time: 60,
+              average_watts: 350,
+              average_cadence: 95,
+              intensity: 1.25,
+              start_index: 0,
+              end_index: 59
+            },
+            {
+              type: 'REST',
+              moving_time: 300,
+              average_watts: 120,
+              average_cadence: 78,
+              intensity: 0.43,
+              start_index: 60,
+              end_index: 359
+            },
+            {
+              type: 'WORK',
+              moving_time: 300,
+              average_watts: 260,
+              average_cadence: 90,
+              intensity: 0.93,
+              start_index: 360,
+              end_index: 659
+            },
+            {
+              type: 'REST',
+              moving_time: 300,
+              average_watts: 120,
+              average_cadence: 78,
+              intensity: 0.43,
+              start_index: 660,
+              end_index: 959
+            },
+            {
+              type: 'WORK',
+              moving_time: 900,
+              average_watts: 205,
+              average_cadence: 86,
+              intensity: 0.73,
+              start_index: 960,
+              end_index: 1859
+            },
+            {
+              type: 'WORK',
+              moving_time: 300,
+              average_watts: 110,
+              average_cadence: 70,
+              intensity: 0.4,
+              start_index: 1860,
+              end_index: 2159
+            }
+          ]
+        },
+        streams: {
+          time: Array.from({ length: 2160 }, (_, index) => index),
+          watts: Array.from({ length: 2160 }, (_, index) =>
+            index < 60
+              ? 350
+              : index < 360
+                ? 120
+                : index < 660
+                  ? 260
+                  : index < 960
+                    ? 120
+                    : index < 1860
+                      ? 205
+                      : 110
+          ),
+          cadence: Array.from({ length: 2160 }, (_, index) => (index < 60 ? 95 : 86))
+        }
+      }),
+      sportSettings: { ftp: 280 }
+    })
+
+    expect(facts.guardrails.archetype.sessionSteadiness).toBe('intervalled')
+    // Withheld, not quietly replaced by the session-wide figure.
+    expect(facts.performanceSignals.sportSpecific.cadenceStabilityScore).toBeNull()
+    expect(facts.performanceSignals.applicability.cadenceStability.applicable).toBe(false)
+    expect(facts.performanceSignals.applicability.cadenceStability.reason).toContain(
+      'comparable work reps'
+    )
+  })
+
+  it('withholds cadence stability when an interval session carries no cadence (CW-427)', () => {
+    const workout = buildThresholdWorkout()
+    delete (workout as any).streams.cadence
+
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout,
+      plannedWorkout: thresholdPlan,
+      sportSettings: { ftp: THRESHOLD_FIXTURE_FTP }
+    })
+
+    expect(facts.guardrails.archetype.sessionSteadiness).toBe('intervalled')
+    expect(facts.performanceSignals.sportSpecific.cadenceStabilityScore).toBeNull()
+    expect(facts.performanceSignals.applicability.cadenceStability).toEqual({
+      applicable: false,
+      reason: 'Cadence stability is unavailable because cadence telemetry is missing or too sparse.'
+    })
+  })
+
   it('reads late-session fade as first rep versus last rep for an interval session', () => {
     const facts = buildWorkoutAnalysisFactsV2({
       workout: buildThresholdWorkout(),
@@ -2165,6 +2301,13 @@ describe('rep-scoped durability and stability signals', () => {
     // A steady ride has no repeated efforts, so repeatability stays withheld.
     expect(facts.performanceSignals.durability.repeatabilityScore).toBeNull()
     expect(facts.performanceSignals.applicability.repeatability.applicable).toBe(false)
+    // CW-427: no rep structure to scope to, so cadence stability keeps the
+    // session-wide CoV (1.61%) and the value it produced before the change.
+    expect(facts.performanceSignals.sportSpecific.cadenceStabilityScore).toBe(92)
+    expect(facts.performanceSignals.applicability.cadenceStability).toEqual({
+      applicable: true,
+      reason: null
+    })
   })
 })
 

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -180,6 +180,7 @@ export interface WorkoutAnalysisFactsV2 {
       executionStability: SignalApplicability
       repeatability: SignalApplicability
       cadenceDrift: SignalApplicability
+      cadenceStability: SignalApplicability
       pacingDrift: SignalApplicability
     }
     decoupling: {
@@ -3441,6 +3442,11 @@ type DurabilityGates = {
   repeatability: SignalGate
 }
 
+type SportSpecificGates = {
+  cadenceDrift: SignalGate
+  cadenceStability: SignalGate
+}
+
 function deriveDurabilitySignals(params: {
   workout: any
   family: ReturnType<typeof getWorkoutFamily>
@@ -3603,7 +3609,7 @@ function deriveSportSpecificSignals(params: {
   repScope: RepScope
 }): {
   sportSpecific: WorkoutAnalysisFactsV2['performanceSignals']['sportSpecific']
-  gates: { cadenceDrift: SignalGate }
+  gates: SportSpecificGates
 } {
   const { workout, family, archetype, motionPattern, repScope } = params
   const cadence = asNumberArray(workout?.streams?.cadence)
@@ -3612,6 +3618,7 @@ function deriveSportSpecificSignals(params: {
   let cadenceStabilityScore: number | null = null
   let pacingDriftPct: number | null = null
   let cadenceDriftGate: SignalGate = OPEN_GATE
+  let cadenceStabilityGate: SignalGate = OPEN_GATE
   let torqueProfile: WorkoutAnalysisFactsV2['performanceSignals']['sportSpecific']['torqueProfile'] =
     'unknown'
 
@@ -3638,9 +3645,27 @@ function deriveSportSpecificSignals(params: {
     if (first && last && first > 0) cadenceDriftPct = round(((first - last) / first) * 100, 1)
   }
 
-  // Session-wide cadence stability is untouched by CW-393: it has no
-  // applicability gate and is out of that ticket's scope.
-  if (cadence.length >= 120) {
+  // Cadence stability follows the same rule as every other structure-scoped
+  // signal (CW-427): when the session has a comparable rep set, the CoV is
+  // measured WITHIN each work rep. Session-wide, the number is dominated by the
+  // gap between rep cadence and recovery-jog cadence — which is the prescribed
+  // shape of the session, not a flaw in how it was ridden. A steady session has
+  // no rep structure to scope to, so it keeps the session-wide CoV.
+  if (repScope.active) {
+    const repCoV = cadence.length >= 120 ? repScopedStabilityCoV(repScope.reps, cadence) : null
+    if (repCoV !== null) {
+      cadenceStabilityScore = round(clamp(100 - repCoV * 5, 0, 100), 1)
+    } else {
+      cadenceStabilityGate = {
+        applicable: false,
+        reason:
+          cadence.length < 120
+            ? 'Cadence stability is unavailable because cadence telemetry is missing or too sparse.'
+            : (repScope.reason ??
+              'Cadence stability is measured within each work rep for this session shape, and the rep boundaries could not be located in the cadence stream.')
+      }
+    }
+  } else if (cadence.length >= 120) {
     const stability = calculateStabilityMetrics(cadence, [])
     if (stability) cadenceStabilityScore = round(clamp(100 - stability.overallCoV * 5, 0, 100), 1)
   }
@@ -3677,7 +3702,7 @@ function deriveSportSpecificSignals(params: {
       torqueProfile,
       pacingDriftPct
     },
-    gates: { cadenceDrift: cadenceDriftGate }
+    gates: { cadenceDrift: cadenceDriftGate, cadenceStability: cadenceStabilityGate }
   }
 }
 
@@ -3688,7 +3713,7 @@ function deriveSignalApplicability(params: {
   motionPattern: MotionPattern
   durability: WorkoutAnalysisFactsV2['performanceSignals']['durability']
   sportSpecific: WorkoutAnalysisFactsV2['performanceSignals']['sportSpecific']
-  gates: DurabilityGates & { cadenceDrift: SignalGate }
+  gates: DurabilityGates & SportSpecificGates
 }): WorkoutAnalysisFactsV2['performanceSignals']['applicability'] {
   const { workout, family, archetype, motionPattern, durability, sportSpecific, gates } = params
   const durationSec = Number(workout?.durationSec || 0)
@@ -3739,6 +3764,11 @@ function deriveSignalApplicability(params: {
       gates.cadenceDrift,
       sportSpecific.cadenceDriftPct,
       'Cadence drift is unavailable because cadence telemetry is missing or too sparse.'
+    ),
+    cadenceStability: resolve(
+      gates.cadenceStability,
+      sportSpecific.cadenceStabilityScore,
+      'Cadence stability is unavailable because cadence telemetry is missing or too sparse.'
     ),
     pacingDrift:
       sportSpecific.pacingDriftPct !== null
@@ -4258,6 +4288,17 @@ function buildPromptDecisionsV2(facts: WorkoutAnalysisFactsV2): Record<string, P
     !facts.performanceSignals.applicability.cadenceDrift.applicable &&
       Boolean(facts.performanceSignals.applicability.cadenceDrift.reason),
     'A reason is useful when cadence drift is unavailable or inapplicable.'
+  )
+  set(
+    'performanceSignals.applicability.cadenceStability.applicable',
+    !facts.performanceSignals.applicability.cadenceStability.applicable,
+    'Show non-applicability when cadence stability cannot be trusted.'
+  )
+  set(
+    'performanceSignals.applicability.cadenceStability.reason',
+    !facts.performanceSignals.applicability.cadenceStability.applicable &&
+      Boolean(facts.performanceSignals.applicability.cadenceStability.reason),
+    'A reason is useful when cadence stability is unavailable or inapplicable.'
   )
   set(
     'performanceSignals.applicability.pacingDrift.applicable',


### PR DESCRIPTION
Fixes CW-427

## What

`cadenceStabilityScore` was the fifth signal computing a session-scoped statistic to answer a structure-scoped question. It called `calculateStabilityMetrics(cadence, [])` — no intervals at all — so `overallCoV` spanned warmup, reps, recovery jogs and cooldown together, and was handed to the model as if it described execution quality. It had no entry in `deriveSignalApplicability`, so unlike the five signals CW-393 gated it was never withheld.

This applies the CW-393 rule to it, reusing the machinery that ticket built:

- When `repScope.active`, cadence stability is measured **within each work rep** via the existing `repScopedStabilityCoV` helper — which is `calculateStabilityMetrics(stream, reps)` with the reps bounded and mapped to the `StabilityInterval` shape CW-428 typed. The `* 5` weight and the `clamp(0, 100)` are unchanged.
- When the rep-scoped value cannot be computed, the signal is **withheld with a reason** rather than falling back to the session-wide number. Sparse/absent cadence gets its own reason; otherwise `repScope.reason` (the one that names the actual session shape) wins, mirroring `executionStability` exactly.
- `deriveSportSpecificSignals` now returns `gates: { cadenceDrift, cadenceStability }` (extracted as `SportSpecificGates`), and `deriveSignalApplicability` resolves `cadenceStability` with the same `gate && value` `resolve` as the other five.
- `cadenceStability` added to the `applicability` type and to `buildPromptDecisionsV2` alongside the `cadenceDrift` rows.
- Steady (non-`repScope.active`) sessions take the unchanged session-wide branch.
- The CW-393 deferral comment is replaced with a description of the new rule.

## Coach-facing narrative change

For an intervalled session the number changes materially and in the athlete's favour. On the `4x4 Threshold` fixture (reps ridden at a flat 92 rpm, with an 85 rpm warmup, 80 rpm jogs, an 88 rpm buffer block and a 70 rpm cooldown), the session-wide cadence CoV is 7.43% and scored **62.9/100** — "cadence wandered" for a session pedalled perfectly. Rep-scoped it is **100/100**. Where the reps cannot be scoped, the model now receives an explicit not-applicable reason instead of a misleading score.

Note the reason string reaches the model today only through the generic "Do not base recommendations on inapplicable signals" rule, because the prompt renderer's applicability row list lives outside this ticket's Owned Paths. Filed as **CW-532** (same class as CW-520).

## Verification

```
$ pnpm test:unit server/utils/workout-analysis-facts.test.ts
 Test Files  1 passed (1)
      Tests  92 passed (92)

$ pnpm typecheck
exit 0

$ pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts   # knock-on check
 Test Files  1 passed (1)
      Tests  47 passed (47)
```

**No existing expectations were changed.** 89 -> 92 tests: three new cases only, plus two additional assertions appended to the existing steady-ride test. CW-419's cadence-adherence tests and CW-437's analysis-mode tests were not touched.

New coverage:
- intervalled session with reps -> rep-scoped value (100) and `applicable: true`
- intervalled session whose work efforts are not comparable reps -> `cadenceStabilityScore` null, `applicable: false`, reason naming the missing comparable rep set
- intervalled session with no cadence stream -> withheld with the sparse-telemetry reason
- steady endurance ride -> unchanged 92.0 and `applicable: true`

## UX critique

**Skipped** — this is an analysis-facts signal feeding the AI prompt. No interactive surface, no user-completable flow, nothing to drive in a running app.

## Files changed vs Owned Paths

Exactly the two owned files: `server/utils/workout-analysis-facts.ts`, `server/utils/workout-analysis-facts.test.ts`.

## Risks

- `performanceSignals.applicability` gains a key. The only external consumer that enumerates it (`workout-analysis-prompt.ts` line ~992) iterates `Object.entries` generically, so it picks the new key up without change; its explicit row list ignores unknown keys. Prompt tests confirm no knock-on.
- Intervalled sessions will report a different (higher) cadence stability score than before. That is the point of the ticket, but it is a visible change in emitted facts for any already-analysed interval workout.
