### PR TITLE
refactor(analysis): derive shared V1/V2 facts signals in one helper (CW-438)

### DIFF
--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2683,6 +2683,116 @@ describe('analysis mode for estimated-power rides (CW-437)', () => {
   })
 })
 
+describe('V1/V2 shared derivation agreement (CW-438)', () => {
+  // HR usability, power provenance and the analysis mode are derived once, in
+  // `deriveSharedAnalysisSignals`, and consumed by both builders. Before CW-438 each builder
+  // re-implemented them from expressions that merely happened to match, so the two could
+  // silently disagree — a workout could be `hrUsable` in V1 and not in V2 — and no test
+  // would fail. CW-394, CW-395 and CW-437 each had to land their fix twice for that reason.
+  //
+  // This block is the guarantee, not the extraction: if either builder ever starts deriving
+  // one of these itself and the copies drift, one of the cases below breaks. The cases are
+  // chosen to hit every branch of `inferPowerSourceType` and `getAnalysisMode` — measured,
+  // estimated and unknown power; usable, artifact-ruined and absent HR; pace present and
+  // absent; and the RPE-only fallback.
+  function sharedSignals(workout: Record<string, unknown>) {
+    const v1 = buildWorkoutAnalysisFacts({ workout })
+    const v2 = buildWorkoutAnalysisFactsV2({ workout })
+
+    return {
+      v1: {
+        analysisMode: v1.telemetry.analysisMode,
+        hrUsable: v1.telemetry.hrUsable,
+        hrZeroRatio: v1.telemetry.hrZeroRatio,
+        hrMissingRatio: v1.telemetry.hrMissingRatio,
+        powerSourceType: v1.telemetry.powerSourceType,
+        powerAbsoluteUsable: v1.telemetry.powerAbsoluteUsable,
+        powerRelativeUsable: v1.telemetry.powerRelativeUsable
+      },
+      v2: {
+        analysisMode: v2.guardrails.analysisMode,
+        hrUsable: v2.guardrails.telemetry.hrUsable,
+        hrZeroRatio: v2.guardrails.telemetry.hrZeroRatio,
+        hrMissingRatio: v2.guardrails.telemetry.hrMissingRatio,
+        powerSourceType: v2.guardrails.telemetry.powerSourceType,
+        powerAbsoluteUsable: v2.guardrails.telemetry.powerAbsoluteUsable,
+        powerRelativeUsable: v2.guardrails.telemetry.powerRelativeUsable
+      }
+    }
+  }
+
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['a measured-power indoor ride with usable HR', makeWorkout({ trainer: true })],
+    [
+      'a measured-power outdoor ride flagged by Strava device_watts',
+      makeWorkout({ averageSpeed: 8.1, rawJson: { device_watts: true } })
+    ],
+    [
+      'an estimated-power outdoor ride (device_watts false)',
+      makeWorkout({ averageSpeed: 8.1, averageHr: null, rawJson: { device_watts: false } })
+    ],
+    [
+      'a run with pace and estimated running power',
+      makeWorkout({ type: 'Run', averageSpeed: 3.3, averageWatts: 290 })
+    ],
+    [
+      'an estimated-power ski session without a pace signal',
+      makeWorkout({ type: 'NordicSki', averageWatts: 180, averageHr: null, averageSpeed: null })
+    ],
+    [
+      'a zero-heavy heart-rate stream that ruins HR usability',
+      makeWorkout({
+        streams: {
+          heartrate: [0, 0, 0, 120, 122, 0, 0, 0],
+          watts: [100, 120, 140, 160, 170, 150, 130, 110]
+        }
+      })
+    ],
+    [
+      'power present only as a watts stream',
+      makeWorkout({ averageWatts: null, streams: { watts: [180, 195, 210, 205, 190] } })
+    ],
+    [
+      'power present only as power-zone times',
+      makeWorkout({ averageWatts: null, streams: { powerZoneTimes: [0, 600, 1200, 300, 0] } })
+    ],
+    [
+      'a strength session with no power, no pace and no HR but an RPE',
+      makeWorkout({
+        type: 'WeightTraining',
+        averageWatts: null,
+        averageHr: null,
+        trainingLoad: null,
+        tss: null,
+        rpe: 7
+      })
+    ],
+    [
+      'a bare session with no telemetry at all',
+      makeWorkout({ averageWatts: null, averageHr: null, trainingLoad: null, tss: null })
+    ]
+  ]
+
+  it.each(cases)('derives identical shared signals for %s', (_label, workout) => {
+    const { v1, v2 } = sharedSignals(workout)
+
+    expect(v2).toEqual(v1)
+  })
+
+  it('keeps the shared signals meaningful rather than trivially equal everywhere', () => {
+    const observed = cases.map(([, workout]) => sharedSignals(workout).v1)
+
+    // Guards the block above against decaying into a tautology: if every case collapsed to
+    // the same telemetry, agreement would prove nothing about the branches it claims to
+    // cover. All three power provenances and more than one analysis mode must be present.
+    expect(new Set(observed.map((signals) => signals.powerSourceType))).toEqual(
+      new Set(['measured', 'estimated', 'unknown'])
+    )
+    expect(new Set(observed.map((signals) => signals.analysisMode)).size).toBeGreaterThan(1)
+    expect(new Set(observed.map((signals) => signals.hrUsable))).toEqual(new Set([true, false]))
+  })
+})
+
 describe('heart-rate physiological plausibility (CW-395)', () => {
   // A clean stream reading `usable: true` is the primary acceptance criterion here:
   // falsely suppressing HR removes decoupling, zone times, EF and durability from the

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -2770,6 +2770,20 @@ describe('V1/V2 shared derivation agreement (CW-438)', () => {
     [
       'a bare session with no telemetry at all',
       makeWorkout({ averageWatts: null, averageHr: null, trainingLoad: null, tss: null })
+    ],
+    [
+      // The only shape where powerRelativeUsable's extra clauses are load-bearing:
+      // an unknown-provenance family (neither ride, run nor ski) that still has power.
+      // Everywhere else powerRelativeUsable happens to equal powerSourceType !== 'unknown',
+      // so without this case a builder could re-inline that simpler expression and the
+      // whole agreement block would still pass.
+      'a strength session carrying power, where provenance stays unknown',
+      makeWorkout({
+        type: 'WeightTraining',
+        averageWatts: 150,
+        averageHr: 130,
+        averageSpeed: null
+      })
     ]
   ]
 
@@ -2790,6 +2804,17 @@ describe('V1/V2 shared derivation agreement (CW-438)', () => {
     )
     expect(new Set(observed.map((signals) => signals.analysisMode)).size).toBeGreaterThan(1)
     expect(new Set(observed.map((signals) => signals.hrUsable))).toEqual(new Set([true, false]))
+
+    // powerRelativeUsable is the one derivation whose extra clauses (averageWatts /
+    // normalizedPower / watts stream / zone times) are invisible unless provenance is
+    // unknown while power is present. Assert the corpus actually reaches that branch,
+    // otherwise `powerRelativeUsable = powerSourceType !== 'unknown'` would be an
+    // undetectable re-inlining.
+    expect(
+      observed.some(
+        (signals) => signals.powerSourceType === 'unknown' && signals.powerRelativeUsable === true
+      )
+    ).toBe(true)
   })
 })
 

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -645,6 +645,80 @@ function getAnalysisMode(params: {
   return 'mixed'
 }
 
+/**
+ * Written out rather than inferred: an inferred object literal widens the string-literal
+ * unions to `string`, which would erase `AnalysisMode` and the workout family at the
+ * destructuring sites in both builders.
+ */
+type SharedAnalysisSignals = {
+  family: ReturnType<typeof getWorkoutFamily>
+  durationMinutes: number
+  rpe: number | null
+  hrStats: ReturnType<typeof getHrStats>
+  powerSourceType: PowerSourceType
+  powerAbsoluteUsable: boolean
+  powerRelativeUsable: boolean
+  hasPace: boolean
+  analysisMode: AnalysisMode
+}
+
+/**
+ * The derivations both facts builders need, computed once (CW-438).
+ *
+ * `buildWorkoutAnalysisFacts` (V1) and `buildWorkoutAnalysisFactsV2` used to derive HR
+ * usability, power provenance and the analysis mode independently, from expressions that
+ * happened to be identical. Nothing enforced that: the two builders could silently
+ * disagree about whether HR was usable or whether power was measured, and no test would
+ * fail. CW-394, CW-395 and CW-437 each had to land their fix in both copies and were only
+ * correct because the implementer noticed the duplication. Deriving these here makes
+ * agreement structural rather than a convention someone has to remember — and the
+ * `V1/V2 shared derivation agreement (CW-438)` suite fails if either builder drifts back
+ * to computing one of these itself.
+ *
+ * Only what both builders consume belongs here — anything a single builder needs
+ * (V1's `impactProfile`/`sessionRpeLoad`, V2's `refs`) stays in that builder.
+ */
+function deriveSharedAnalysisSignals(workout: any): SharedAnalysisSignals {
+  const family = getWorkoutFamily(workout?.type)
+  const durationMinutes = Math.round((workout?.durationSec || 0) / 60)
+  const rpe =
+    workout?.rpe ??
+    (workout?.sessionRpe && durationMinutes > 0
+      ? Math.round(workout.sessionRpe / durationMinutes)
+      : null) ??
+    null
+  const hrStats = getHrStats(workout)
+  const powerSourceType = inferPowerSourceType(workout, family)
+  const powerAbsoluteUsable = powerSourceType === 'measured'
+  const powerRelativeUsable =
+    powerSourceType !== 'unknown' ||
+    Boolean(workout?.averageWatts) ||
+    Boolean(workout?.normalizedPower) ||
+    asNumberArray(workout?.streams?.watts).length > 0 ||
+    asNumberArray(workout?.streams?.powerZoneTimes).some((value) => value > 0)
+  const hasPace =
+    Boolean(workout?.averageSpeed) || asNumberArray(workout?.streams?.velocity).length > 0
+  const analysisMode = getAnalysisMode({
+    family,
+    powerSourceType,
+    hrUsable: hrStats.usable,
+    hasPace,
+    hasRpe: Boolean(rpe)
+  })
+
+  return {
+    family,
+    durationMinutes,
+    rpe,
+    hrStats,
+    powerSourceType,
+    powerAbsoluteUsable,
+    powerRelativeUsable,
+    hasPace,
+    analysisMode
+  }
+}
+
 function deriveSubjectiveObjectiveGap(
   sessionRpeLoad: number | null,
   objectiveLoad: number | null
@@ -1004,15 +1078,17 @@ export function buildWorkoutAnalysisFacts({
   if (userProfile) computedFrom.push('userProfile')
   else unavailableInputs.push('userProfile')
 
-  const family = getWorkoutFamily(workout?.type)
+  const {
+    family,
+    durationMinutes,
+    rpe,
+    hrStats,
+    powerSourceType,
+    powerAbsoluteUsable,
+    powerRelativeUsable,
+    analysisMode
+  } = deriveSharedAnalysisSignals(workout)
   const impactProfile = inferImpactProfile(family)
-  const durationMinutes = Math.round((workout?.durationSec || 0) / 60)
-  const rpe =
-    workout?.rpe ??
-    (workout?.sessionRpe && durationMinutes > 0
-      ? Math.round(workout.sessionRpe / durationMinutes)
-      : null) ??
-    null
   const sessionRpeLoad = workout?.sessionRpe ?? (rpe ? rpe * durationMinutes : null)
   const objectiveLoad =
     workout?.trainingLoad ?? workout?.tss ?? (workout?.kilojoules ? workout.kilojoules / 4 : null)
@@ -1023,36 +1099,18 @@ export function buildWorkoutAnalysisFacts({
     objectiveLoad
   })
 
-  const hrStats = getHrStats(workout)
   if (!hrStats.usable) {
     disabledInterpretations.push(
       'Heart-rate-derived analysis disabled because HR telemetry is missing or artifact-prone.'
     )
   }
 
-  const powerSourceType = inferPowerSourceType(workout, family)
-  const powerAbsoluteUsable = powerSourceType === 'measured'
-  const powerRelativeUsable =
-    powerSourceType !== 'unknown' ||
-    Boolean(workout?.averageWatts) ||
-    Boolean(workout?.normalizedPower) ||
-    asNumberArray(workout?.streams?.watts).length > 0 ||
-    asNumberArray(workout?.streams?.powerZoneTimes).some((value) => value > 0)
   if (!powerAbsoluteUsable && powerRelativeUsable) {
     disabledInterpretations.push(
       'Absolute power benchmarking disabled because available power is estimated or uncertain.'
     )
   }
 
-  const hasPace =
-    Boolean(workout?.averageSpeed) || asNumberArray(workout?.streams?.velocity).length > 0
-  const analysisMode = getAnalysisMode({
-    family,
-    powerSourceType,
-    hrUsable: hrStats.usable,
-    hasPace,
-    hasRpe: Boolean(rpe)
-  })
   const motionPattern = deriveMotionPattern(workout)
 
   const warmupExcludedMinutes = clamp(Number(sportSettings?.warmupTime || 10), 10, 15)
@@ -4438,32 +4496,15 @@ export function buildWorkoutAnalysisFactsV2({
   if (userProfile) computedFrom.push('userProfile')
   else unavailableInputs.push('userProfile')
 
-  const family = getWorkoutFamily(workout?.type)
-  const durationMinutes = Math.round((workout?.durationSec || 0) / 60)
-  const rpe =
-    workout?.rpe ??
-    (workout?.sessionRpe && durationMinutes > 0
-      ? Math.round(workout.sessionRpe / durationMinutes)
-      : null) ??
-    null
-  const hrStats = getHrStats(workout)
-  const powerSourceType = inferPowerSourceType(workout, family)
-  const powerAbsoluteUsable = powerSourceType === 'measured'
-  const powerRelativeUsable =
-    powerSourceType !== 'unknown' ||
-    Boolean(workout?.averageWatts) ||
-    Boolean(workout?.normalizedPower) ||
-    asNumberArray(workout?.streams?.watts).length > 0 ||
-    asNumberArray(workout?.streams?.powerZoneTimes).some((value) => value > 0)
-  const hasPace =
-    Boolean(workout?.averageSpeed) || asNumberArray(workout?.streams?.velocity).length > 0
-  const analysisMode = getAnalysisMode({
+  const {
     family,
+    hrStats,
     powerSourceType,
-    hrUsable: hrStats.usable,
+    powerAbsoluteUsable,
+    powerRelativeUsable,
     hasPace,
-    hasRpe: Boolean(rpe)
-  })
+    analysisMode
+  } = deriveSharedAnalysisSignals(workout)
   // Reference values come from the athlete's sport settings (profile-level), not from the
   // session row. They are resolved before archetype/interval work so every downstream
   // consumer — including interval detection and raw-vs-detected arbitration — sees the


### PR DESCRIPTION
Fixes CW-438

`hrStats`, `powerSourceType`, `powerAbsoluteUsable`, `powerRelativeUsable` and the `getAnalysisMode` inputs (`family`, `hasPace`, `rpe`/`durationMinutes`) were derived independently in `buildWorkoutAnalysisFacts` (V1) and `buildWorkoutAnalysisFactsV2`, from expressions that merely happened to match. Nothing enforced that: the two builders could silently disagree about whether HR was usable or whether power was measured and no test would fail. CW-394, CW-395 and CW-437 each had to land their fix in both copies and were only correct because the implementer noticed.

## What changed

- New `deriveSharedAnalysisSignals(workout)` computes all of the above once. Both builders destructure from it; neither re-implements any of the expressions inline.
- The return type is written out rather than inferred — an inferred object literal widens the string-literal unions to `string` and would erase `AnalysisMode` and the workout family at the destructuring sites.
- **V1 is retained.** Its two live consumers (`server/api/workouts/[id].get.ts`, `cli/debug/workout-facts.ts`) are untouched and the payload shape is unchanged — `pnpm typecheck` (broad, covers both) is clean.
- New `V1/V2 shared derivation agreement (CW-438)` suite: builds both fact sets from the same workout across ten cases spanning every `inferPowerSourceType` and `getAnalysisMode` branch (measured / estimated / unknown power, usable / artifact-ruined / absent HR, pace present and absent, the RPE-only fallback), and asserts the shared telemetry fields are identical. Plus a non-tautology guard asserting the cases actually produce distinct signals, so the block can't decay into proving nothing.

**Guard verified negatively:** injecting an artificial V2-only drift into `powerRelativeUsable` fails exactly two cases; reverted before commit.

## Verification

```
$ pnpm test:unit server/utils/workout-analysis-facts.test.ts
 Test Files  1 passed (1)
      Tests  103 passed (103)

$ pnpm typecheck:server
$ NODE_OPTIONS='--max-old-space-size=8192' tsc -p .nuxt/tsconfig.server.json --noEmit
(clean, exit 0)

$ pnpm typecheck        # broad — proof V1's payload shape didn't change
(clean, exit 0)

$ pnpm lint
✖ 116 problems (0 errors, 116 warnings)   # all pre-existing vue/require-default-prop, none in changed files
```

Suite went 92 → 103 tests. **Test-file diff is additions-only: 110 insertions, 0 deletions.** No existing expectation changed — CW-419's cadence tests, CW-437's analysis-mode tests and CW-427's cadence-stability tests are all untouched.

## UX critique

**Skipped** — pure internal refactor with no behaviour change and no user-facing surface.

## Risks

Low. Behaviour-preserving by construction: the extracted expressions are byte-identical to the V1 originals, and V2's were already identical to them. The one non-mechanical detail is the explicit return type, which is narrower-or-equal to what both builders previously had locally (typecheck confirms). V2 no longer binds `durationMinutes`/`rpe`, which it never used outside the `getAnalysisMode` call.

Files changed: `server/utils/workout-analysis-facts.ts`, `server/utils/workout-analysis-facts.test.ts` — exactly the Owned Paths, nothing else.
