### PR TITLE
perf(streams): answer presence-only stream reads in SQL (CW-296)

### DIFF
--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client'
 import { prisma } from '../db'
 import { toPrismaInputJsonValue } from '../prisma-json'
 
@@ -168,10 +169,18 @@ export interface FindManyByWorkoutIdsOptions {
    * behavior and should be kept for callers that need full-fidelity stream
    * data (e.g. the GDPR/migration data export in data-management/collector.ts).
    *
-   * When provided (including an empty array), only the mandatory baseline
-   * fields plus whatever is listed here are fetched, which is dramatically
-   * cheaper for hot paths that read a handful of scalar fields (or none) off
-   * potentially hundreds of workouts' streams at once.
+   * When provided with at least one field, the mandatory baseline
+   * (REQUIRED_V2_SELECT/REQUIRED_V1_SELECT) plus whatever is listed here is
+   * fetched, which is dramatically cheaper for hot paths that read a handful
+   * of scalar fields off potentially hundreds of workouts' streams at once.
+   *
+   * An **empty array** means "presence only": the caller never reads a stream
+   * field and only tests whether a workout has usable stream data at all. That
+   * takes a separate, much cheaper code path -- see
+   * findStreamPresenceByWorkoutIds() -- which transfers no series data
+   * whatsoever. Streams returned that way have every series/metadata field set
+   * to null; only id/workoutId/createdAt/updatedAt are populated. Do not pass
+   * `fields: []` if you intend to read anything off the returned stream.
    */
   fields?: readonly WorkoutStreamOptionalField[]
 }
@@ -251,6 +260,161 @@ function chunkArray<T>(items: readonly T[], size: number): T[][] {
   return chunks
 }
 
+/** Row returned by the presence probe: identity columns plus the usability flag. */
+type StreamPresenceRow = {
+  id: string
+  workoutId: string
+  createdAt: Date
+  updatedAt: Date
+  hasData: boolean | null
+}
+
+/**
+ * SQL equivalent of hasUsableStreamData() for WorkoutStreamV2, evaluated in
+ * Postgres so the series themselves never cross the wire. `lat` stands in for
+ * `latlng` (normalizeV2 derives latlng from lat/lng). Each disjunct is written
+ * so it can only be TRUE/FALSE per column -- the outer COALESCE then turns the
+ * all-NULL case (row exists, every probed column NULL) into FALSE.
+ */
+const V2_HAS_DATA_SQL = Prisma.sql`COALESCE(
+  COALESCE(array_length("time", 1), 0) > 0
+  OR COALESCE(array_length("heartrate", 1), 0) > 0
+  OR COALESCE(array_length("watts", 1), 0) > 0
+  OR COALESCE(array_length("velocity", 1), 0) > 0
+  OR COALESCE(array_length("lat", 1), 0) > 0
+  OR ("hrZoneTimes" IS NOT NULL AND jsonb_typeof("hrZoneTimes") <> 'null')
+  OR ("powerZoneTimes" IS NOT NULL AND jsonb_typeof("powerZoneTimes") <> 'null'),
+  false
+)`
+
+/**
+ * Same probe for the legacy V1 table, whose series are JSONB arrays rather
+ * than Postgres arrays. `jsonb_typeof(col) = 'array'` mirrors the
+ * Array.isArray() guard in hasUsableStreamData(), and comparing against
+ * '[]'::jsonb mirrors its `.length > 0` check without calling
+ * jsonb_array_length() on a value that might not be an array.
+ */
+const V1_HAS_DATA_SQL = Prisma.sql`COALESCE(
+  (jsonb_typeof("time") = 'array' AND "time" <> '[]'::jsonb)
+  OR (jsonb_typeof("heartrate") = 'array' AND "heartrate" <> '[]'::jsonb)
+  OR (jsonb_typeof("watts") = 'array' AND "watts" <> '[]'::jsonb)
+  OR (jsonb_typeof("velocity") = 'array' AND "velocity" <> '[]'::jsonb)
+  OR (jsonb_typeof("latlng") = 'array' AND "latlng" <> '[]'::jsonb)
+  OR ("hrZoneTimes" IS NOT NULL AND jsonb_typeof("hrZoneTimes") <> 'null')
+  OR ("powerZoneTimes" IS NOT NULL AND jsonb_typeof("powerZoneTimes") <> 'null'),
+  false
+)`
+
+/**
+ * A NormalizedStream carrying no payload -- every series, JSON blob and scalar
+ * is null. Returned by the presence-only path so `streams` stays a truthy
+ * object for consumers that merely test existence, without fetching megabytes
+ * of per-second arrays to produce a boolean.
+ */
+function toPresenceStream(row: StreamPresenceRow): NormalizedStream {
+  return {
+    id: row.id,
+    workoutId: row.workoutId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    time: null,
+    distance: null,
+    velocity: null,
+    heartrate: null,
+    cadence: null,
+    watts: null,
+    altitude: null,
+    latlng: null,
+    grade: null,
+    moving: null,
+    temp: null,
+    torque: null,
+    leftRightBalance: null,
+    hrv: null,
+    respiration: null,
+    targetPower: null,
+    avgPacePerKm: null,
+    paceVariability: null,
+    lapSplits: null,
+    paceZones: null,
+    pacingStrategy: null,
+    surges: null,
+    hrZoneTimes: null,
+    powerZoneTimes: null,
+    extrasMeta: null
+  }
+}
+
+/**
+ * Presence-only bulk read (`findManyByWorkoutIds(ids, { fields: [] })`).
+ *
+ * The mandatory baseline exists solely so hasUsableStreamData() can decide
+ * V2-vs-V1 in JS, which means six large array columns per workout even for
+ * callers that never look at a series. The deduplication paths ask this
+ * question for a user's entire workout history at once, which is the
+ * CW-296 slow query (`IN ($1..$71)` over time/heartrate/watts/velocity/
+ * lat/lng). Evaluating the same predicate in Postgres reduces each row to a
+ * few dozen bytes while keeping the V2 -> V1 fallback semantics identical.
+ *
+ * It also sidesteps CW-453: no numeric array is decoded, so rows with NULL
+ * elements can't fail Prisma's decoder and blank out a whole batch.
+ */
+async function findStreamPresenceByWorkoutIds(
+  workoutIds: string[]
+): Promise<Map<string, NormalizedStream>> {
+  const result = new Map<string, NormalizedStream>()
+
+  const v2Chunks = await Promise.all(
+    chunkArray(workoutIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+      prisma
+        .$queryRaw<StreamPresenceRow[]>(
+          Prisma.sql`
+            SELECT "id", "workoutId", "createdAt", "updatedAt", ${V2_HAS_DATA_SQL} AS "hasData"
+            FROM "WorkoutStreamV2"
+            WHERE "workoutId" IN (${Prisma.join(chunk)})
+          `
+        )
+        .catch(() => [] as StreamPresenceRow[])
+    )
+  )
+
+  const missingIds: string[] = []
+  const coveredIds = new Set<string>()
+  for (const row of v2Chunks.flat()) {
+    coveredIds.add(row.workoutId)
+    if (row.hasData) {
+      result.set(row.workoutId, toPresenceStream(row))
+    } else {
+      missingIds.push(row.workoutId)
+    }
+  }
+  for (const id of workoutIds) {
+    if (!coveredIds.has(id)) missingIds.push(id)
+  }
+
+  if (missingIds.length === 0) return result
+
+  const v1Chunks = await Promise.all(
+    chunkArray(missingIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+      prisma
+        .$queryRaw<StreamPresenceRow[]>(
+          Prisma.sql`
+            SELECT "id", "workoutId", "createdAt", "updatedAt", ${V1_HAS_DATA_SQL} AS "hasData"
+            FROM "WorkoutStream"
+            WHERE "workoutId" IN (${Prisma.join(chunk)})
+          `
+        )
+        .catch(() => [] as StreamPresenceRow[])
+    )
+  )
+
+  for (const row of v1Chunks.flat()) {
+    if (row.hasData) result.set(row.workoutId, toPresenceStream(row))
+  }
+
+  return result
+}
+
 export const workoutStreamRepository = {
   async findByWorkoutId(workoutId: string): Promise<NormalizedStream | null> {
     const v2 = await (prisma as any).workoutStreamV2
@@ -280,6 +444,14 @@ export const workoutStreamRepository = {
     if (workoutIds.length === 0) return result
 
     const fields = options?.fields
+
+    // `fields: []` == "does this workout have usable streams at all?". Answer
+    // it in SQL instead of hauling six per-second arrays per workout across
+    // the wire (CW-296).
+    if (fields !== undefined && fields.length === 0) {
+      return findStreamPresenceByWorkoutIds(workoutIds)
+    }
+
     const v2Select = buildV2Select(fields)
 
     const v2Chunks = await Promise.all(

--- a/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/tests/unit/server/utils/repositories/workoutStreamRepository.test.ts
@@ -20,11 +20,26 @@ vi.mock('../../../../../server/utils/db', () => ({
       findMany: vi.fn(),
       update: vi.fn()
     },
+    $queryRaw: vi.fn(),
     get workoutStreamV2() {
       return workoutStreamV2
     }
   }
 }))
+
+/** Flattened SQL text of the Nth prisma.$queryRaw call. */
+function rawSqlOf(callIndex: number): string {
+  const arg = vi.mocked(prisma.$queryRaw).mock.calls[callIndex]![0] as unknown as { sql: string }
+  return arg.sql
+}
+
+/** Bind parameters of the Nth prisma.$queryRaw call. */
+function rawValuesOf(callIndex: number): unknown[] {
+  const arg = vi.mocked(prisma.$queryRaw).mock.calls[callIndex]![0] as unknown as {
+    values: unknown[]
+  }
+  return arg.values
+}
 
 describe('workoutStreamRepository', () => {
   beforeEach(() => {
@@ -199,31 +214,6 @@ describe('workoutStreamRepository', () => {
       expect(call.select.extrasMeta).toBeUndefined()
     })
 
-    it('still fetches the mandatory baseline when `fields` is an empty array (existence-only callers)', async () => {
-      workoutStreamV2.findMany.mockResolvedValue([
-        { workoutId: 'workout-1', time: [0, 1], watts: [50], lat: [], lng: [] }
-      ])
-
-      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-1'], {
-        fields: []
-      })
-
-      const call = workoutStreamV2.findMany.mock.calls[0]![0]
-      expect(call.select).toEqual(
-        expect.objectContaining({
-          time: true,
-          heartrate: true,
-          watts: true,
-          velocity: true,
-          lat: true,
-          lng: true,
-          hrZoneTimes: true,
-          powerZoneTimes: true
-        })
-      )
-      expect(streams.get('workout-1')).toBeTruthy()
-    })
-
     it('splits a large IN(...) clause into chunks of at most 200 IDs', async () => {
       const workoutIds = Array.from({ length: 450 }, (_, i) => `workout-${i}`)
 
@@ -262,6 +252,130 @@ describe('workoutStreamRepository', () => {
         })
       )
       expect(streams.get('workout-legacy')).toBeTruthy()
+    })
+  })
+
+  // CW-296: `fields: []` means "does this workout have usable streams at all?".
+  // Callers: trigger/deduplicate-workouts.ts and intervalsService.deleteActivity,
+  // both of which only test `workout.streams` for truthiness.
+  describe('findManyByWorkoutIds (presence-only, `fields: []`)', () => {
+    beforeEach(() => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([] as any)
+    })
+
+    it('never selects a series column: it probes usability in SQL instead', async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([
+        {
+          id: 'stream-1',
+          workoutId: 'workout-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          hasData: true
+        }
+      ] as any)
+
+      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-1'], {
+        fields: []
+      })
+
+      // The wide findMany that produced the Sentry slow query is gone.
+      expect(workoutStreamV2.findMany).not.toHaveBeenCalled()
+      expect(prisma.workoutStream.findMany).not.toHaveBeenCalled()
+
+      const sql = rawSqlOf(0)
+      expect(sql).toContain('"WorkoutStreamV2"')
+      expect(sql).toContain('array_length("time", 1)')
+      expect(sql).toContain('AS "hasData"')
+      expect(rawValuesOf(0)).toEqual(['workout-1'])
+
+      const stream = streams.get('workout-1')
+      expect(stream).toBeTruthy()
+      expect(stream!.workoutId).toBe('workout-1')
+      // Presence-only streams carry no payload by design.
+      expect(stream!.time).toBeNull()
+      expect(stream!.watts).toBeNull()
+      expect(stream!.latlng).toBeNull()
+      expect(stream!.hrZoneTimes).toBeNull()
+    })
+
+    it('omits workouts whose V2 row exists but holds no usable data', async () => {
+      vi.mocked(prisma.$queryRaw)
+        .mockResolvedValueOnce([
+          {
+            id: 'stream-empty',
+            workoutId: 'workout-empty',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            hasData: false
+          }
+        ] as any)
+        .mockResolvedValueOnce([] as any)
+
+      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-empty'], {
+        fields: []
+      })
+
+      expect(streams.size).toBe(0)
+    })
+
+    it('falls back to the legacy V1 table for workouts with no usable V2 row', async () => {
+      vi.mocked(prisma.$queryRaw)
+        .mockResolvedValueOnce([] as any)
+        .mockResolvedValueOnce([
+          {
+            id: 'v1-stream',
+            workoutId: 'workout-legacy',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            hasData: true
+          }
+        ] as any)
+
+      const streams = await workoutStreamRepository.findManyByWorkoutIds(['workout-legacy'], {
+        fields: []
+      })
+
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(2)
+      const v1Sql = rawSqlOf(1)
+      expect(v1Sql).toContain('"WorkoutStream"')
+      expect(v1Sql).toContain(`jsonb_typeof("time") = 'array'`)
+      expect(rawValuesOf(1)).toEqual(['workout-legacy'])
+      expect(streams.get('workout-legacy')).toBeTruthy()
+    })
+
+    it('skips the V1 probe entirely when every workout has usable V2 data', async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([
+        {
+          id: 'stream-1',
+          workoutId: 'workout-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          hasData: true
+        }
+      ] as any)
+
+      await workoutStreamRepository.findManyByWorkoutIds(['workout-1'], { fields: [] })
+
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(1)
+    })
+
+    it('chunks the presence probe at 200 IDs per query', async () => {
+      const workoutIds = Array.from({ length: 450 }, (_, i) => `workout-${i}`)
+
+      await workoutStreamRepository.findManyByWorkoutIds(workoutIds, { fields: [] })
+
+      // 3 V2 probes; every ID is unresolved so 3 more V1 probes follow.
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(6)
+      expect(rawValuesOf(0)).toHaveLength(200)
+      expect(rawValuesOf(1)).toHaveLength(200)
+      expect(rawValuesOf(2)).toHaveLength(50)
+    })
+
+    it('returns an empty map without querying for an empty ID list', async () => {
+      const streams = await workoutStreamRepository.findManyByWorkoutIds([], { fields: [] })
+
+      expect(streams.size).toBe(0)
+      expect(prisma.$queryRaw).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Fixes CW-296

## The call site

The Sentry query is **not** a "select every column" query — its 12 columns are exactly `REQUIRED_V2_SELECT` in `workoutStreamRepository.ts`. The caller already opts into the lean `fields` path; it passes `fields: []`. What costs money is the *mandatory baseline* itself, which fetches `time`/`heartrate`/`watts`/`velocity`/`lat`/`lng` for one reason only: so `hasUsableStreamData()` can decide V2-vs-V1 fallback in JS.

Two call sites pass `fields: []`:

| Call site | Batch size | What it consumes |
| --- | --- | --- |
| `trigger/deduplicate-workouts.ts:72` | a user's **entire** workout history (71 IDs = a 71-workout user) | truthiness of `streams` only |
| `server/utils/services/intervalsService.ts:1412` (`deleteActivity`) | a workout's duplicates (small N) | truthiness of `streams` only |

The dedup trigger runs on every sync, which matches the 5,988 events / 9 days.

Ruled out by column shape, not assumption:
- `server/api/scores/athlete-profile.get.ts:50` — `fields: ['distance']`, so 13 columns, and it genuinely reads `time`/`watts` via `pbDetectionService`. Filed as **CW-544** (payload-size follow-up, one-shot per user).
- `server/api/workouts/streams.post.ts:121` and `server/api/analytics/workout-comparison/streams.post.ts:103` — no `fields`, so ~29 columns. Neither matches the captured 12.
- `server/utils/report-engine.ts:93` and `server/utils/data-management/collector.ts:100` — full fetch, already documented in-code as deliberate (report templates are user-editable DB content; the collector is the GDPR export). Left alone per the "document why rather than forcing a change" criterion.

## The change

`fields: []` now means *presence only* and takes a separate path (`findStreamPresenceByWorkoutIds`) that evaluates the usability predicate in Postgres and returns identity columns plus a `hasData` flag — no series data crosses the wire.

The SQL is a literal translation of `hasUsableStreamData()`: `array_length(col, 1) > 0` for the V2 Postgres arrays (`lat` standing in for `latlng`, which `normalizeV2` derives from `lat`/`lng`), `jsonb_typeof(col) = 'array' AND col <> '[]'::jsonb` for the legacy V1 JSONB columns, and `IS NOT NULL AND jsonb_typeof(col) <> 'null'` for the zone-time blobs (matching Prisma's decode of a stored JSON `null` to JS `null`). Every disjunct is TRUE/FALSE-only, and the whole expression is wrapped in `COALESCE(..., false)`. V2 → V1 fallback, chunking at 200 IDs, and the swallow-on-error behaviour are all preserved.

Non-empty `fields` is untouched — it still gets the baseline plus requested columns, so `athlete-profile.get.ts` keeps the `time`/`watts` it reads.

## No behaviour change

Verified by reading each consumer, not by assuming:
- `deduplicationService.calculateCompletenessScore()` line 314 — `workout.streams && (Array.isArray(...) ? length > 0 : true)`, a truthiness test. A presence stream is a non-array object, so it scores identically.
- `deduplicationService.findDuplicateGroups()` — never touches a stream field.
- `deduplicationService.mergeDuplicateGroup()` — re-queries the DB itself (`select: { streams: { select: { id: true } } }`), doesn't use the attached object.
- `findMatchingPlannedWorkoutForWorkout()` (via `findProposedLink`) — no stream reads.
- `intervalsService.deleteActivity` — `calculateCompletenessScore` only.

Presence streams deliberately carry `null` in every series/JSON/scalar field. That's documented on `FindManyByWorkoutIdsOptions.fields`, on the function, and asserted in tests, so a future caller that passes `fields: []` and then reads `streams.watts` fails loudly in review rather than silently rendering an empty chart.

## Interaction with CW-453

Positive, no conflict. CW-453 is about NULL elements in the numeric arrays breaking Prisma's decoder, which `.catch(() => [])` currently swallows so one bad row blanks a whole batch. The presence path never decodes an array, so it is structurally immune. CW-453 remains free to change the `fields`-bearing and full-fetch branches; this PR doesn't touch their decode behaviour.

## Tests

Six new cases in `tests/unit/server/utils/repositories/workoutStreamRepository.test.ts`: the probe replaces the wide `findMany` entirely; unusable V2 rows are omitted; V1 fallback fires with the JSONB predicate; the V1 probe is skipped when V2 covers everything; the probe chunks at 200 IDs; an empty ID list issues no query. The old "still fetches the mandatory baseline when `fields` is an empty array" test is replaced, since that assertion *was* the bug.

`pnpm test:unit` — 2460 passed (378 files). `pnpm typecheck` — exit 0.

## UX critique

Skipped: server-side query shaping with no user-facing surface. For a reviewer wondering where a regression would show, the changed call sites serve **workout deduplication** — the dedup review screen driven by `trigger/deduplicate-workouts.ts` (dry-run duplicate groups and their completeness ranking), and Intervals.icu activity deletion, where the best duplicate gets promoted to canonical. A regression would look like a duplicate group ranking the wrong workout as "best", not like a broken chart.
