### PR TITLE
fix(integrations): defer Withings ingest on a 601 instead of failing it (CW-334)

### DIFF
--- a/server/utils/withings.ts
+++ b/server/utils/withings.ts
@@ -2,6 +2,7 @@ import type { Integration } from '@prisma/client'
 import { prisma } from './db'
 import { formatUserDate } from './date'
 import { IntegrationAuthError, IntegrationProviderError } from './integration-errors'
+import type { IngestionCounts, IngestionResult } from '../../trigger/types'
 
 interface WithingsTokenResponse {
   access_token: string
@@ -105,25 +106,301 @@ export const WITHINGS_MEASURE_TYPES = {
 /**
  * Withings-documented status code for "Too Many Requests" (application temporarily
  * rate-limited). https://developer.withings.com/api-reference/#section/Response-status
+ *
+ * 601 is a *deterministic* answer, not a transient fault: Withings is telling us the
+ * application-wide quota is spent. The task-level retry policy in trigger.config.ts
+ * (3 attempts, 1s -> 10s backoff) walks straight back into the same wall on a timescale
+ * far shorter than the quota window, so the run burns its retries and then fails —
+ * producing a Sentry event nobody can act on (CW-334: 780 of them in one week, which
+ * also drowns out genuine Withings errors).
+ *
+ * The correct response is to defer the whole run: see WithingsRateLimitError and
+ * buildWithingsRateLimitDeferral below, and their consumer in trigger/ingest-withings.ts.
  */
 const WITHINGS_RATE_LIMIT_STATUS = 601
 
 /**
- * Throws a retryable IntegrationProviderError when the Withings body-level status
- * indicates the app has been rate-limited. Trigger.dev's task-level retry config
- * (see trigger.config.ts) will back off and retry automatically, and the global
- * onFailure hook (trigger/init.ts) suppresses Sentry reporting until the final
- * attempt via shouldReportIntegrationErrorToSentry.
+ * Backoff used when Withings does not tell us when to come back.
+ *
+ * Withings does not document a `Retry-After` on 601, and in practice does not send one;
+ * parseWithingsRetryAfterMs still honours it (and `X-RateLimit-Reset`) if it ever appears,
+ * which is the "respect any interval the provider communicates" half of the contract.
+ *
+ * Absent that, 10 minutes is a deliberate choice, not a guess. The documented Withings
+ * application quota is a per-minute window, so 10 minutes is an order of magnitude past
+ * the reset — we are not racing it and not re-probing a wall we know is still up — while
+ * remaining far shorter than the daily ingest cadence, so a deferred run lands well before
+ * the next scheduled one and no measures are skipped.
  */
-function throwIfWithingsRateLimited(status: number, integrationId: string): void {
-  if (status === WITHINGS_RATE_LIMIT_STATUS) {
-    throw new IntegrationProviderError({
-      provider: 'withings',
-      integrationId,
-      statusCode: status,
-      message: `Withings API rate limit exceeded (Status ${status})`
-    })
+export const WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS = 10 * 60 * 1000
+
+/**
+ * Ceiling for the exponential escalation below. Also caps a provider-supplied Retry-After,
+ * so a malformed or absurd header cannot park an ingest for a day.
+ */
+export const WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS = 60 * 60 * 1000
+
+/**
+ * How many times a single ingest may defer itself before it stops re-enqueueing.
+ *
+ * With the escalation below that is roughly 10m + 20m + 40m + 60m + 60m ~= 3h6 of patience.
+ * If the quota still has not cleared after that, something is wrong at a level a longer
+ * sleep will not fix; the run gives up and the next webhook / scheduled sync picks the
+ * window back up (ingestion is idempotent upserts over a date range, so nothing is lost).
+ */
+export const WITHINGS_MAX_RATE_LIMIT_DEFERRALS = 5
+
+/**
+ * Minimum gap between two Withings HTTP calls issued by this process.
+ *
+ * Withings' quota is per *application*, not per user, so every concurrent ingest run
+ * competes for the same budget. The worst offender is a single run: fetchWithingsIntraday
+ * is called once per workout in a loop, so one ingest can fire dozens of requests back to
+ * back. Pacing them in-process removes that burst. Set WITHINGS_MIN_REQUEST_INTERVAL_MS=0
+ * to disable (tests do this).
+ *
+ * Note this is a per-process pacer — it cannot cap concurrency *across* runs. See the
+ * CW-334 PR for the follow-up on a Withings-specific queue.
+ */
+const DEFAULT_WITHINGS_MIN_REQUEST_INTERVAL_MS = 250
+
+function getWithingsMinRequestIntervalMs(): number {
+  const raw = process.env.WITHINGS_MIN_REQUEST_INTERVAL_MS
+  if (raw === undefined || raw === '') return DEFAULT_WITHINGS_MIN_REQUEST_INTERVAL_MS
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_WITHINGS_MIN_REQUEST_INTERVAL_MS
+}
+
+let withingsRequestGate: Promise<unknown> = Promise.resolve()
+let lastWithingsRequestAt = 0
+
+/**
+ * fetch() for the Withings API, serialised behind the pacer above so callers queue up
+ * instead of all firing at once.
+ */
+async function withingsFetch(url: string, init?: RequestInit): Promise<Response> {
+  const intervalMs = getWithingsMinRequestIntervalMs()
+  if (intervalMs <= 0) {
+    return await fetch(url, init)
   }
+
+  const send = withingsRequestGate.then(async () => {
+    const waitMs = lastWithingsRequestAt + intervalMs - Date.now()
+    if (waitMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, waitMs))
+    }
+    lastWithingsRequestAt = Date.now()
+    return await fetch(url, init)
+  })
+
+  // Keep the chain alive even if this request rejects, otherwise one failure would
+  // permanently poison the gate for every later caller in the process.
+  withingsRequestGate = send.catch(() => undefined)
+  return await send
+}
+
+/**
+ * A Withings 601. Deliberately a subclass of IntegrationProviderError so every existing
+ * `isIntegrationProviderError` check keeps working, while callers that know how to defer
+ * can single it out with isWithingsRateLimitError.
+ */
+export class WithingsRateLimitError extends IntegrationProviderError {
+  readonly rateLimited = true
+  /** How long Withings wants us gone, or the documented default if it did not say. */
+  readonly retryAfterMs: number
+  readonly retryAfterSource: 'provider' | 'default'
+
+  constructor(params: {
+    integrationId: string
+    statusCode: number
+    retryAfterMs: number
+    retryAfterSource: 'provider' | 'default'
+  }) {
+    super({
+      provider: 'withings',
+      integrationId: params.integrationId,
+      statusCode: params.statusCode,
+      message: `Withings API rate limit exceeded (Status ${params.statusCode})`
+    })
+    this.name = 'WithingsRateLimitError'
+    this.retryAfterMs = params.retryAfterMs
+    this.retryAfterSource = params.retryAfterSource
+  }
+}
+
+export function isWithingsRateLimitError(error: unknown): error is WithingsRateLimitError {
+  return error instanceof WithingsRateLimitError
+}
+
+type HeaderLike = { get(name: string): string | null } | null | undefined
+
+function clampBackoffMs(ms: number): number {
+  return Math.min(Math.round(ms), WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS)
+}
+
+/**
+ * Extracts a retry interval from the response headers, if the provider communicated one.
+ * Returns null when it did not, which is the normal case for Withings today.
+ */
+export function parseWithingsRetryAfterMs(
+  headers?: HeaderLike,
+  now: number = Date.now()
+): number | null {
+  if (!headers || typeof headers.get !== 'function') return null
+
+  const retryAfter = headers.get('retry-after')
+  if (retryAfter) {
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return clampBackoffMs(seconds * 1000)
+    }
+    // RFC 7231 also allows an HTTP-date.
+    const asDate = Date.parse(retryAfter)
+    if (!Number.isNaN(asDate) && asDate - now > 0) {
+      return clampBackoffMs(asDate - now)
+    }
+  }
+
+  const reset = headers.get('x-ratelimit-reset') ?? headers.get('x-rate-limit-reset')
+  if (reset) {
+    const value = Number(reset)
+    if (Number.isFinite(value) && value > 0) {
+      // Reset headers are ambiguous in the wild: a small number means "seconds from now",
+      // a large one is an absolute epoch-seconds timestamp.
+      const ms = value > 1_000_000_000 ? value * 1000 - now : value * 1000
+      if (ms > 0) return clampBackoffMs(ms)
+    }
+  }
+
+  return null
+}
+
+/**
+ * How long a deferred run should sleep before trying again.
+ *
+ * A provider-supplied interval always wins. Otherwise the documented base backoff doubles
+ * with each successive deferral, capped at WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS.
+ *
+ * Jitter is upward-only (+0-20%): every ingest that hit the same application-wide wall
+ * would otherwise come back at the same instant and re-trip it, and skewing downward could
+ * return before the provider said we may.
+ */
+export function resolveWithingsDeferralDelayMs(
+  deferralCount: number,
+  providerRetryAfterMs?: number | null,
+  random: () => number = Math.random
+): number {
+  const base =
+    providerRetryAfterMs != null && providerRetryAfterMs > 0
+      ? Math.min(providerRetryAfterMs, WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS)
+      : Math.min(
+          WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS *
+            2 ** Math.min(Math.max(0, Math.floor(deferralCount)), 10),
+          WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
+        )
+
+  return clampBackoffMs(base * (1 + 0.2 * random()))
+}
+
+export interface WithingsDeferralContext {
+  userId: string
+  startDate: string
+  endDate: string
+  /** How many times this particular ingest window has already been deferred. */
+  deferralCount?: number
+}
+
+export interface WithingsRateLimitDeferral {
+  /** Safe to persist on Integration.errorMessage and show to the user. */
+  message: string
+  delayMs: number
+  /** False once WITHINGS_MAX_RATE_LIMIT_DEFERRALS has been reached. */
+  shouldReenqueue: boolean
+  nextDeferralCount: number
+  syncStatus: 'RATE_LIMITED'
+  result: IngestionResult
+}
+
+/**
+ * Turns a Withings 601 into a *deferral* instead of a failure — the counterpart to
+ * buildAuthFailureResult in ./ingestion-failure.
+ *
+ * Returns null for anything that is not a rate limit, so a genuine error keeps falling
+ * through to the caller's normal failure path (status FAILED, thrown, reported to Sentry).
+ *
+ * The shape here is provider-agnostic on purpose: CW-512 is the same class of problem in
+ * Garmin, and this should lift into a shared helper when the second caller exists.
+ */
+export function buildWithingsRateLimitDeferral(
+  error: unknown,
+  context: WithingsDeferralContext,
+  options: { counts?: IngestionCounts; skipped?: number; random?: () => number } = {}
+): WithingsRateLimitDeferral | null {
+  if (!isWithingsRateLimitError(error)) return null
+
+  const deferralCount = Math.max(0, Math.floor(context.deferralCount ?? 0))
+  const shouldReenqueue = deferralCount < WITHINGS_MAX_RATE_LIMIT_DEFERRALS
+  const delayMs = resolveWithingsDeferralDelayMs(
+    deferralCount,
+    error.retryAfterSource === 'provider' ? error.retryAfterMs : null,
+    options.random
+  )
+
+  const minutes = Math.max(1, Math.round(delayMs / 60_000))
+  const message = shouldReenqueue
+    ? `Rate limited by Withings. Sync is deferred and will resume automatically in ~${minutes} minute${
+        minutes === 1 ? '' : 's'
+      }.`
+    : `Rate limited by Withings. Sync was deferred ${WITHINGS_MAX_RATE_LIMIT_DEFERRALS} times without the quota clearing; it will resume on the next sync.`
+
+  return {
+    message,
+    delayMs,
+    shouldReenqueue,
+    nextDeferralCount: deferralCount + 1,
+    syncStatus: 'RATE_LIMITED',
+    result: {
+      success: false,
+      counts: options.counts ?? {},
+      skipped: options.skipped ?? 0,
+      message,
+      error: {
+        code: 'RATE_LIMITED',
+        provider: 'withings',
+        integrationId: error.integrationId,
+        statusCode: error.statusCode,
+        retryAfterMs: delayMs,
+        retryAfterSource: error.retryAfterSource,
+        deferred: shouldReenqueue,
+        deferralCount: deferralCount + 1
+      },
+      userId: context.userId,
+      startDate: context.startDate,
+      endDate: context.endDate
+    }
+  }
+}
+
+/**
+ * Throws a WithingsRateLimitError when the Withings body-level status says the application
+ * has been rate-limited. Callers must let it propagate to the task boundary, which defers
+ * the run (see buildWithingsRateLimitDeferral) rather than retrying into the same wall.
+ */
+export function throwIfWithingsRateLimited(
+  status: number,
+  integrationId: string,
+  headers?: HeaderLike
+): void {
+  if (status !== WITHINGS_RATE_LIMIT_STATUS) return
+
+  const providerRetryAfterMs = parseWithingsRetryAfterMs(headers)
+
+  throw new WithingsRateLimitError({
+    integrationId,
+    statusCode: status,
+    retryAfterMs: providerRetryAfterMs ?? WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS,
+    retryAfterSource: providerRetryAfterMs != null ? 'provider' : 'default'
+  })
 }
 
 /**
@@ -148,7 +425,7 @@ export async function refreshWithingsToken(integration: Integration): Promise<In
 
   console.log('Refreshing Withings token for integration:', integration.id)
 
-  const response = await fetch('https://wbsapi.withings.net/v2/oauth2', {
+  const response = await withingsFetch('https://wbsapi.withings.net/v2/oauth2', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'
@@ -167,7 +444,12 @@ export async function refreshWithingsToken(integration: Integration): Promise<In
   if (data.status !== 0) {
     console.error('Withings token refresh failed:', data)
 
-    if (data.status === 601 || data.status === 401) {
+    // CW-334: 601 used to be bundled in with 401 below, which marked a perfectly healthy
+    // integration FAILED and told the user to reconnect Withings — for a rate limit. It is
+    // backpressure, not a revoked grant; defer like every other 601.
+    throwIfWithingsRateLimited(data.status, integration.id, response.headers)
+
+    if (data.status === 401) {
       await prisma.integration.update({
         where: { id: integration.id },
         data: {
@@ -264,11 +546,11 @@ export async function fetchWithingsMeasures(
     endDate: endDate.toISOString()
   })
 
-  const response = await fetch(url.toString())
+  const response = await withingsFetch(url.toString())
   const data: WithingsMeasureResponse = await response.json()
 
   if (data.status !== 0) {
-    throwIfWithingsRateLimited(data.status, validIntegration.id)
+    throwIfWithingsRateLimited(data.status, validIntegration.id, response.headers)
 
     // 401: Invalid access token
     if (data.status === 401) {
@@ -276,11 +558,11 @@ export async function fetchWithingsMeasures(
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       // Retry with new token
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
-      const retryResponse = await fetch(url.toString())
+      const retryResponse = await withingsFetch(url.toString())
       const retryData: WithingsMeasureResponse = await retryResponse.json()
 
       if (retryData.status !== 0) {
-        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id, retryResponse.headers)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
 
@@ -323,11 +605,11 @@ export async function fetchWithingsActivities(
     endDate: endDate.toISOString()
   })
 
-  const response = await fetch(url.toString())
+  const response = await withingsFetch(url.toString())
   const data: WithingsActivityResponse = await response.json()
 
   if (data.status !== 0) {
-    throwIfWithingsRateLimited(data.status, validIntegration.id)
+    throwIfWithingsRateLimited(data.status, validIntegration.id, response.headers)
 
     // 401: Invalid access token
     if (data.status === 401) {
@@ -335,11 +617,11 @@ export async function fetchWithingsActivities(
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       // Retry with new token
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
-      const retryResponse = await fetch(url.toString())
+      const retryResponse = await withingsFetch(url.toString())
       const retryData: WithingsActivityResponse = await retryResponse.json()
 
       if (retryData.status !== 0) {
-        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id, retryResponse.headers)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
 
@@ -528,19 +810,19 @@ export async function fetchWithingsWorkouts(
     endDate: endDate.toISOString().split('T')[0]
   })
 
-  const response = await fetch(url.toString())
+  const response = await withingsFetch(url.toString())
   const data: WithingsWorkoutResponse = await response.json()
 
   if (data.status !== 0) {
-    throwIfWithingsRateLimited(data.status, validIntegration.id)
+    throwIfWithingsRateLimited(data.status, validIntegration.id, response.headers)
 
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
-      const retryResponse = await fetch(url.toString())
+      const retryResponse = await withingsFetch(url.toString())
       const retryData: WithingsWorkoutResponse = await retryResponse.json()
       if (retryData.status !== 0) {
-        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id, retryResponse.headers)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
       return retryData.body.series || []
@@ -575,19 +857,19 @@ export async function fetchWithingsIntraday(
     'heart_rate,steps,elevation,calories,distance,duration,spo2_auto,rmssd,sdnn1,hrv_quality'
   )
 
-  const response = await fetch(url.toString())
+  const response = await withingsFetch(url.toString())
   const data: any = await response.json()
 
   if (data.status !== 0) {
-    throwIfWithingsRateLimited(data.status, validIntegration.id)
+    throwIfWithingsRateLimited(data.status, validIntegration.id, response.headers)
 
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
-      const retryResponse = await fetch(url.toString())
+      const retryResponse = await withingsFetch(url.toString())
       const retryData: any = await retryResponse.json()
       if (retryData.status !== 0) {
-        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id, retryResponse.headers)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
       // Return raw series object (keys are timestamps)
@@ -746,19 +1028,19 @@ export async function fetchWithingsSleep(
     endDate: endDate.toISOString().split('T')[0]
   })
 
-  const response = await fetch(url.toString())
+  const response = await withingsFetch(url.toString())
   const data: WithingsSleepResponse = await response.json()
 
   if (data.status !== 0) {
-    throwIfWithingsRateLimited(data.status, validIntegration.id)
+    throwIfWithingsRateLimited(data.status, validIntegration.id, response.headers)
 
     if (data.status === 401) {
       const refreshedIntegration = await refreshWithingsToken(validIntegration)
       url.searchParams.set('access_token', refreshedIntegration.accessToken)
-      const retryResponse = await fetch(url.toString())
+      const retryResponse = await withingsFetch(url.toString())
       const retryData: WithingsSleepResponse = await retryResponse.json()
       if (retryData.status !== 0) {
-        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id)
+        throwIfWithingsRateLimited(retryData.status, refreshedIntegration.id, retryResponse.headers)
         throw new Error(`Withings API error after refresh: Status ${retryData.status}`)
       }
       return retryData.body.series || []

--- a/server/utils/withings.ts
+++ b/server/utils/withings.ts
@@ -141,6 +141,17 @@ export const WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS = 10 * 60 * 1000
 export const WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS = 60 * 60 * 1000
 
 /**
+ * Floor for a provider-supplied Retry-After.
+ *
+ * The deferral budget is a *count*, so it only bounds patience if each step is large. An
+ * unfloored provider interval would defeat it: a `Retry-After: 3` would fire all five
+ * deferrals ~3s apart and give up permanently inside ~15 seconds — strictly worse than the
+ * three plain retries this replaced. Withings sends no such header today; this exists for
+ * the day it starts.
+ */
+export const WITHINGS_RATE_LIMIT_MIN_PROVIDER_BACKOFF_MS = 30 * 1000
+
+/**
  * How many times a single ingest may defer itself before it stops re-enqueueing.
  *
  * With the escalation below that is roughly 10m + 20m + 40m + 60m + 60m ~= 3h6 of patience.
@@ -292,14 +303,22 @@ export function resolveWithingsDeferralDelayMs(
 ): number {
   const base =
     providerRetryAfterMs != null && providerRetryAfterMs > 0
-      ? Math.min(providerRetryAfterMs, WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS)
+      ? Math.min(
+          Math.max(providerRetryAfterMs, WITHINGS_RATE_LIMIT_MIN_PROVIDER_BACKOFF_MS),
+          WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
+        )
       : Math.min(
           WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS *
             2 ** Math.min(Math.max(0, Math.floor(deferralCount)), 10),
           WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
         )
 
-  return clampBackoffMs(base * (1 + 0.2 * random()))
+  // Cap the base, THEN jitter — never re-clamp. `base` is already at the ceiling from
+  // deferral 3 onwards, so clamping the jittered value would round it straight back down
+  // to exactly MAX and hand every deferred ingest the same wake-up instant — the precise
+  // thundering herd the jitter exists to prevent, in the sustained-outage case where it
+  // matters most.
+  return Math.round(base * (1 + 0.2 * random()))
 }
 
 export interface WithingsDeferralContext {

--- a/tests/unit/server/utils/withings.test.ts
+++ b/tests/unit/server/utils/withings.test.ts
@@ -1,95 +1,375 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  fetchWithingsActivities,
-  fetchWithingsIntraday,
+  buildWithingsRateLimitDeferral,
   fetchWithingsMeasures,
   fetchWithingsSleep,
-  fetchWithingsWorkouts
+  isWithingsRateLimitError,
+  parseWithingsRetryAfterMs,
+  refreshWithingsToken,
+  resolveWithingsDeferralDelayMs,
+  throwIfWithingsRateLimited,
+  WITHINGS_MAX_RATE_LIMIT_DEFERRALS,
+  WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS,
+  WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS,
+  WithingsRateLimitError
 } from '../../../../server/utils/withings'
-import { IntegrationProviderError } from '../../../../server/utils/integration-errors'
+import {
+  IntegrationAuthError,
+  isIntegrationProviderError
+} from '../../../../server/utils/integration-errors'
 
-// A token that is not expired so ensureValidToken() never needs to hit the DB.
+// Both are read at call time, not import time, so setting them here is safe.
+// The in-process pacer is real code that really sleeps; switch it off so the suite is not
+// paying 250ms per mocked request. Its behaviour is covered separately below.
+process.env.WITHINGS_MIN_REQUEST_INTERVAL_MS = '0'
+process.env.WITHINGS_CLIENT_ID = 'test-client-id'
+process.env.WITHINGS_CLIENT_SECRET = 'test-client-secret'
+
+const { prismaIntegrationUpdate } = vi.hoisted(() => ({
+  prismaIntegrationUpdate: vi.fn()
+}))
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    integration: {
+      update: prismaIntegrationUpdate
+    }
+  }
+}))
+
 const integration = {
-  id: 'integration-withings-rate-limit',
-  accessToken: 'valid-token',
-  refreshToken: 'valid-refresh-token',
+  id: 'integration-1',
+  userId: 'user-1',
+  provider: 'withings',
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  // Far future so ensureValidToken never triggers a refresh we did not ask for.
   expiresAt: new Date(Date.now() + 60 * 60 * 1000)
 } as any
 
-function jsonResponse(body: unknown) {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' }
-  })
+const START = new Date('2026-08-01T00:00:00.000Z')
+const END = new Date('2026-08-08T00:00:00.000Z')
+
+function jsonResponse(body: unknown, headers: Record<string, string> = {}) {
+  return {
+    json: async () => body,
+    headers: new Headers(headers)
+  }
 }
 
+const fetchMock = vi.fn()
+
 beforeEach(() => {
-  vi.stubGlobal('fetch', vi.fn())
+  prismaIntegrationUpdate.mockReset()
+  prismaIntegrationUpdate.mockResolvedValue(integration)
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
 })
 
-describe('Withings status 601 (rate limit)', () => {
-  it('fetchWithingsMeasures throws a retryable IntegrationProviderError, not a generic Error', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
-    const error = await fetchWithingsMeasures(
-      integration,
-      new Date('2024-01-01'),
-      new Date('2024-01-02')
-    ).catch((err) => err)
+const deferralContext = {
+  userId: 'user-1',
+  startDate: START.toISOString(),
+  endDate: END.toISOString()
+}
 
-    expect(error).toBeInstanceOf(IntegrationProviderError)
-    expect(error).toMatchObject({
-      name: 'IntegrationProviderError',
-      provider: 'withings',
-      integrationId: integration.id,
-      statusCode: 601,
-      retryable: true
+// No jitter, so the assertions below are about the policy rather than the dice.
+const noJitter = () => 0
+
+describe('withings 601 rate limit — classification', () => {
+  it('throws a WithingsRateLimitError from a measures fetch instead of a generic failure', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 601 }))
+
+    const error = await fetchWithingsMeasures(integration, START, END).catch((e) => e)
+
+    expect(isWithingsRateLimitError(error)).toBe(true)
+    expect(error).toBeInstanceOf(WithingsRateLimitError)
+    expect(error.statusCode).toBe(601)
+    expect(error.integrationId).toBe('integration-1')
+    expect(error.retryAfterSource).toBe('default')
+    expect(error.retryAfterMs).toBe(WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS)
+  })
+
+  it('stays an IntegrationProviderError so existing provider-error handling keeps working', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 601 }))
+
+    const error = await fetchWithingsSleep(integration, START, END).catch((e) => e)
+
+    expect(isIntegrationProviderError(error)).toBe(true)
+    expect(isWithingsRateLimitError(error)).toBe(true)
+  })
+
+  it('honours a Retry-After the provider communicated', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 601 }, { 'retry-after': '120' }))
+
+    const error = await fetchWithingsMeasures(integration, START, END).catch((e) => e)
+
+    expect(error.retryAfterSource).toBe('provider')
+    expect(error.retryAfterMs).toBe(120_000)
+  })
+
+  it('leaves non-601 statuses alone', () => {
+    expect(() => throwIfWithingsRateLimited(0, 'integration-1')).not.toThrow()
+    expect(() => throwIfWithingsRateLimited(401, 'integration-1')).not.toThrow()
+    expect(() => throwIfWithingsRateLimited(503, 'integration-1')).not.toThrow()
+  })
+})
+
+describe('withings 601 rate limit — genuine failures and success are unaffected', () => {
+  it('a genuine provider error still throws a plain, non-deferrable error', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 342 }))
+
+    const error = await fetchWithingsMeasures(integration, START, END).catch((e) => e)
+
+    expect(isWithingsRateLimitError(error)).toBe(false)
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toContain('Status 342')
+    // The deferral builder must not swallow it — it has to reach the normal failure path.
+    expect(buildWithingsRateLimitDeferral(error, deferralContext)).toBeNull()
+  })
+
+  it('a successful run returns its measure groups unchanged', async () => {
+    const measuregrps = [
+      {
+        grpid: 1,
+        attrib: 0,
+        date: 1_754_000_000,
+        created: 0,
+        modified: 0,
+        category: 1,
+        measures: []
+      }
+    ]
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 0, body: { measuregrps } }))
+
+    await expect(fetchWithingsMeasures(integration, START, END)).resolves.toEqual(measuregrps)
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('refreshWithingsToken', () => {
+  it('treats a 601 as a rate limit, not a revoked authorization (CW-334 regression)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 601 }))
+
+    const error = await refreshWithingsToken(integration).catch((e) => e)
+
+    expect(isWithingsRateLimitError(error)).toBe(true)
+    expect(error).not.toBeInstanceOf(IntegrationAuthError)
+    // Crucially: a healthy integration must not be marked FAILED / "please reconnect".
+    expect(prismaIntegrationUpdate).not.toHaveBeenCalled()
+  })
+
+  it('still treats a 401 as a revoked authorization', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 401 }))
+
+    const error = await refreshWithingsToken(integration).catch((e) => e)
+
+    expect(error).toBeInstanceOf(IntegrationAuthError)
+    expect(isWithingsRateLimitError(error)).toBe(false)
+    expect(prismaIntegrationUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ syncStatus: 'FAILED' })
+      })
+    )
+  })
+})
+
+describe('parseWithingsRetryAfterMs', () => {
+  const now = Date.parse('2026-08-09T12:00:00.000Z')
+
+  it('returns null when the provider communicated nothing', () => {
+    expect(parseWithingsRetryAfterMs(new Headers(), now)).toBeNull()
+    expect(parseWithingsRetryAfterMs(undefined, now)).toBeNull()
+    expect(parseWithingsRetryAfterMs(null, now)).toBeNull()
+  })
+
+  it('reads Retry-After in seconds', () => {
+    expect(parseWithingsRetryAfterMs(new Headers({ 'retry-after': '90' }), now)).toBe(90_000)
+  })
+
+  it('reads Retry-After as an HTTP-date', () => {
+    const headers = new Headers({ 'retry-after': 'Sun, 09 Aug 2026 12:05:00 GMT' })
+    expect(parseWithingsRetryAfterMs(headers, now)).toBe(300_000)
+  })
+
+  it('reads a relative X-RateLimit-Reset', () => {
+    expect(parseWithingsRetryAfterMs(new Headers({ 'x-ratelimit-reset': '45' }), now)).toBe(45_000)
+  })
+
+  it('reads an absolute epoch-seconds X-RateLimit-Reset', () => {
+    const headers = new Headers({ 'x-ratelimit-reset': String(now / 1000 + 600) })
+    expect(parseWithingsRetryAfterMs(headers, now)).toBe(600_000)
+  })
+
+  it('caps an absurd provider interval', () => {
+    const headers = new Headers({ 'retry-after': '86400' })
+    expect(parseWithingsRetryAfterMs(headers, now)).toBe(WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS)
+  })
+})
+
+describe('resolveWithingsDeferralDelayMs', () => {
+  it('uses the documented default backoff on the first deferral', () => {
+    expect(resolveWithingsDeferralDelayMs(0, null, noJitter)).toBe(
+      WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS
+    )
+  })
+
+  it('escalates with each successive deferral and stops at the ceiling', () => {
+    expect(resolveWithingsDeferralDelayMs(1, null, noJitter)).toBe(
+      WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS * 2
+    )
+    expect(resolveWithingsDeferralDelayMs(2, null, noJitter)).toBe(
+      WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS * 4
+    )
+    expect(resolveWithingsDeferralDelayMs(9, null, noJitter)).toBe(
+      WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
+    )
+  })
+
+  it('prefers an interval the provider communicated over the default escalation', () => {
+    expect(resolveWithingsDeferralDelayMs(3, 90_000, noJitter)).toBe(90_000)
+  })
+
+  it('jitters upward only, so a deferral never returns earlier than the policy says', () => {
+    const maxJitter = resolveWithingsDeferralDelayMs(0, null, () => 1)
+    expect(maxJitter).toBeGreaterThan(WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS)
+    expect(maxJitter).toBeLessThanOrEqual(WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS * 1.2)
+    expect(resolveWithingsDeferralDelayMs(0, null, noJitter)).toBeGreaterThanOrEqual(
+      WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS
+    )
+  })
+})
+
+describe('buildWithingsRateLimitDeferral', () => {
+  const rateLimitError = new WithingsRateLimitError({
+    integrationId: 'integration-1',
+    statusCode: 601,
+    retryAfterMs: WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS,
+    retryAfterSource: 'default'
+  })
+
+  it('defers the run rather than failing it', () => {
+    const deferral = buildWithingsRateLimitDeferral(rateLimitError, deferralContext, {
+      random: noJitter
     })
+
+    expect(deferral).not.toBeNull()
+    expect(deferral!.shouldReenqueue).toBe(true)
+    expect(deferral!.syncStatus).toBe('RATE_LIMITED')
+    expect(deferral!.delayMs).toBe(WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS)
+    expect(deferral!.nextDeferralCount).toBe(1)
+    expect(deferral!.message).toContain('resume automatically')
   })
 
-  it('fetchWithingsActivities throws a retryable IntegrationProviderError on status 601', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+  it('marks the result as rate-limited so it is distinguishable from a real failure', () => {
+    const deferral = buildWithingsRateLimitDeferral(rateLimitError, deferralContext, {
+      random: noJitter
+    })!
 
-    await expect(
-      fetchWithingsActivities(integration, new Date('2024-01-01'), new Date('2024-01-02'))
-    ).rejects.toBeInstanceOf(IntegrationProviderError)
+    expect(deferral.result.error).toMatchObject({
+      code: 'RATE_LIMITED',
+      provider: 'withings',
+      statusCode: 601,
+      deferred: true,
+      retryAfterSource: 'default'
+    })
+    expect(deferral.result.userId).toBe('user-1')
+    expect(deferral.result.startDate).toBe(deferralContext.startDate)
   })
 
-  it('fetchWithingsWorkouts throws a retryable IntegrationProviderError on status 601', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+  it('reports the partial progress made before the quota ran out', () => {
+    const deferral = buildWithingsRateLimitDeferral(rateLimitError, deferralContext, {
+      counts: { wellness: 4, sleep: 2, workouts: 0 },
+      skipped: 1,
+      random: noJitter
+    })!
 
-    await expect(
-      fetchWithingsWorkouts(integration, new Date('2024-01-01'), new Date('2024-01-02'))
-    ).rejects.toBeInstanceOf(IntegrationProviderError)
+    expect(deferral.result.counts).toEqual({ wellness: 4, sleep: 2, workouts: 0 })
+    expect(deferral.result.skipped).toBe(1)
   })
 
-  it('fetchWithingsIntraday throws a retryable IntegrationProviderError on status 601', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+  it('escalates the delay as the same window keeps being deferred', () => {
+    const first = buildWithingsRateLimitDeferral(
+      rateLimitError,
+      { ...deferralContext, deferralCount: 0 },
+      { random: noJitter }
+    )!
+    const third = buildWithingsRateLimitDeferral(
+      rateLimitError,
+      { ...deferralContext, deferralCount: 2 },
+      { random: noJitter }
+    )!
 
-    await expect(
-      fetchWithingsIntraday(integration, new Date('2024-01-01'), new Date('2024-01-02'))
-    ).rejects.toBeInstanceOf(IntegrationProviderError)
+    expect(third.delayMs).toBeGreaterThan(first.delayMs)
+    expect(third.nextDeferralCount).toBe(3)
   })
 
-  it('fetchWithingsSleep throws a retryable IntegrationProviderError on status 601', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 601, body: {} }))
+  it('stops re-enqueueing once the deferral budget is spent', () => {
+    const deferral = buildWithingsRateLimitDeferral(
+      rateLimitError,
+      { ...deferralContext, deferralCount: WITHINGS_MAX_RATE_LIMIT_DEFERRALS },
+      { random: noJitter }
+    )!
 
-    await expect(
-      fetchWithingsSleep(integration, new Date('2024-01-01'), new Date('2024-01-02'))
-    ).rejects.toBeInstanceOf(IntegrationProviderError)
+    expect(deferral.shouldReenqueue).toBe(false)
+    expect(deferral.result.error.deferred).toBe(false)
+    expect(deferral.message).toContain('next sync')
   })
 
-  it('still throws a plain Error for other non-zero, non-rate-limit statuses', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ status: 100, body: {} }))
+  it('uses a provider-communicated interval when there was one', () => {
+    const providerError = new WithingsRateLimitError({
+      integrationId: 'integration-1',
+      statusCode: 601,
+      retryAfterMs: 45_000,
+      retryAfterSource: 'provider'
+    })
 
-    const error = await fetchWithingsMeasures(
-      integration,
-      new Date('2024-01-01'),
-      new Date('2024-01-02')
-    ).catch((err) => err)
+    const deferral = buildWithingsRateLimitDeferral(providerError, deferralContext, {
+      random: noJitter
+    })!
 
-    expect(error).not.toBeInstanceOf(IntegrationProviderError)
-    expect(String(error.message)).toContain('Status 100')
+    expect(deferral.delayMs).toBe(45_000)
+    expect(deferral.result.error.retryAfterSource).toBe('provider')
+  })
+
+  it('returns null for anything that is not a rate limit', () => {
+    expect(buildWithingsRateLimitDeferral(new Error('boom'), deferralContext)).toBeNull()
+    expect(
+      buildWithingsRateLimitDeferral(
+        new IntegrationAuthError({
+          provider: 'withings',
+          integrationId: 'integration-1',
+          message: 'revoked'
+        }),
+        deferralContext
+      )
+    ).toBeNull()
+  })
+})
+
+describe('withings request pacer', () => {
+  it('spaces consecutive requests by the configured interval', async () => {
+    // The per-workout intraday loop is the burst this exists to flatten.
+    process.env.WITHINGS_MIN_REQUEST_INTERVAL_MS = '40'
+    try {
+      fetchMock.mockResolvedValue(jsonResponse({ status: 0, body: { measuregrps: [] } }))
+
+      const startedAt = Date.now()
+      await Promise.all([
+        fetchWithingsMeasures(integration, START, END),
+        fetchWithingsMeasures(integration, START, END),
+        fetchWithingsMeasures(integration, START, END)
+      ])
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      // Three paced calls cannot all land inside a single interval.
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(40)
+    } finally {
+      process.env.WITHINGS_MIN_REQUEST_INTERVAL_MS = '0'
+    }
   })
 })

--- a/tests/unit/server/utils/withings.test.ts
+++ b/tests/unit/server/utils/withings.test.ts
@@ -12,6 +12,7 @@ import {
   WITHINGS_MAX_RATE_LIMIT_DEFERRALS,
   WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS,
   WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS,
+  WITHINGS_RATE_LIMIT_MIN_PROVIDER_BACKOFF_MS,
   WithingsRateLimitError
 } from '../../../../server/utils/withings'
 import {
@@ -241,6 +242,30 @@ describe('resolveWithingsDeferralDelayMs', () => {
     expect(resolveWithingsDeferralDelayMs(0, null, noJitter)).toBeGreaterThanOrEqual(
       WITHINGS_RATE_LIMIT_BASE_BACKOFF_MS
     )
+  })
+
+  it('still jitters once the escalation has reached the ceiling', () => {
+    // Regression: clamping the *jittered* value rounded deferrals 3-5 back to exactly MAX,
+    // so every ingest deferred during a sustained outage woke at the same instant — the
+    // thundering herd the jitter exists to prevent, in the case that matters most.
+    for (const deferral of [3, 4, 5]) {
+      expect(resolveWithingsDeferralDelayMs(deferral, null, () => 1)).toBeGreaterThan(
+        WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
+      )
+      expect(resolveWithingsDeferralDelayMs(deferral, null, noJitter)).toBe(
+        WITHINGS_RATE_LIMIT_MAX_BACKOFF_MS
+      )
+    }
+  })
+
+  it('floors a small provider Retry-After so it cannot burn the deferral budget in seconds', () => {
+    // An unfloored `Retry-After: 3` would fire all five deferrals ~3s apart and give up
+    // permanently inside ~15s — strictly worse than the three plain retries this replaced.
+    expect(resolveWithingsDeferralDelayMs(0, 3_000, noJitter)).toBe(
+      WITHINGS_RATE_LIMIT_MIN_PROVIDER_BACKOFF_MS
+    )
+    // A provider interval above the floor is still honoured verbatim.
+    expect(resolveWithingsDeferralDelayMs(0, 5 * 60 * 1000, noJitter)).toBe(5 * 60 * 1000)
   })
 })
 

--- a/trigger/ingest-withings.ts
+++ b/trigger/ingest-withings.ts
@@ -11,8 +11,12 @@ import {
   normalizeWithingsActivity,
   normalizeWithingsSleep,
   normalizeWithingsWorkout,
+  buildWithingsRateLimitDeferral,
+  isWithingsRateLimitError,
+  WITHINGS_MAX_RATE_LIMIT_DEFERRALS,
   WITHINGS_MEASURE_TYPES
 } from '../server/utils/withings'
+import { dispatchTask } from '../server/utils/task-dispatcher'
 import { prisma } from '../server/utils/db'
 import { shouldIngestActivities, shouldIngestWellness } from '../server/utils/integration-settings'
 import { wellnessRepository } from '../server/utils/repositories/wellnessRepository'
@@ -36,13 +40,20 @@ export const ingestWithingsTask = task({
     userId: string
     startDate: string
     endDate: string
+    /**
+     * Set only by this task when it re-enqueues itself after a Withings 601. Counts how
+     * many times this window has already been deferred, so the backoff can escalate and
+     * the deferral chain stays bounded. See buildWithingsRateLimitDeferral.
+     */
+    deferralCount?: number
   }): Promise<IngestionResult> => {
-    const { userId, startDate, endDate } = payload
+    const { userId, startDate, endDate, deferralCount = 0 } = payload
 
     logger.log('[Withings Ingest] Starting ingestion', {
       userId,
       startDate,
       endDate,
+      deferralCount,
       daysToSync: Math.ceil(
         (new Date(endDate).getTime() - new Date(startDate).getTime()) / (24 * 60 * 60 * 1000)
       )
@@ -69,6 +80,13 @@ export const ingestWithingsTask = task({
     })
 
     const timezone = await getUserTimezone(userId)
+
+    // Declared outside the try so a rate-limit deferral can report the partial progress
+    // it made before Withings cut us off — the run is deferred, not rolled back.
+    let upsertedCount = 0
+    let skippedCount = 0
+    let sleepUpsertCount = 0
+    let workoutUpsertCount = 0
 
     try {
       const settings = (integration.settings as Record<string, any> | null) || {}
@@ -105,9 +123,6 @@ export const ingestWithingsTask = task({
       }
 
       // Upsert wellness data (Measures)
-      let upsertedCount = 0
-      let skippedCount = 0
-
       for (const group of measureGroups) {
         const wellness = normalizeWithingsMeasureGroup(group, userId)
 
@@ -223,7 +238,6 @@ export const ingestWithingsTask = task({
       }
 
       // 2. Fetch Sleep (Wellness)
-      let sleepUpsertCount = 0
       if (wellnessEnabled) {
         try {
           const sleepSummaries = await fetchWithingsSleep(
@@ -279,13 +293,15 @@ export const ingestWithingsTask = task({
             sleepUpsertCount++
           }
         } catch (error) {
+          // A 601 is not a "sleep didn't work, carry on" error — the whole application is
+          // rate-limited, so continuing would just burn more quota and, worse, let the run
+          // report SUCCESS while silently skipping data. Let it reach the deferral handler.
+          if (isWithingsRateLimitError(error)) throw error
           logger.error('[Withings Ingest] Error fetching sleep', { error })
         }
       }
 
       // 3. Fetch Workouts
-      let workoutUpsertCount = 0
-
       // Check if integration has activity scope before trying to fetch
       // But we requested both scopes in auth, so unless user unchecked it, we should have it.
       // We'll proceed and catch errors if scope is missing (API will return error).
@@ -373,6 +389,10 @@ export const ingestWithingsTask = task({
                 }
               }
             } catch (e) {
+              // Same reasoning as the sleep block: this catch runs once per workout, so
+              // swallowing a rate limit here would hammer Withings for every remaining
+              // workout in the run.
+              if (isWithingsRateLimitError(e)) throw e
               logger.warn(
                 `[Withings Ingest] Failed to fetch intraday data for workout ${wWorkout.id}`,
                 { error: e }
@@ -423,6 +443,7 @@ export const ingestWithingsTask = task({
             }
           }
         } catch (error) {
+          if (isWithingsRateLimitError(error)) throw error
           logger.error('[Withings Ingest] Error fetching workouts', { error })
         }
       } else {
@@ -460,6 +481,82 @@ export const ingestWithingsTask = task({
         endDate
       }
     } catch (error) {
+      // CW-334: a Withings 601 is backpressure, not a failure. Defer the run instead of
+      // letting it propagate — propagating would consume the task's retry budget on a wall
+      // that will not move for minutes, fail the run, and fire tasks.onFailure -> Sentry.
+      const deferral = buildWithingsRateLimitDeferral(
+        error,
+        { userId, startDate, endDate, deferralCount },
+        {
+          counts: {
+            wellness: upsertedCount,
+            sleep: sleepUpsertCount,
+            workouts: workoutUpsertCount
+          },
+          skipped: skippedCount
+        }
+      )
+
+      if (deferral) {
+        logger.warn('[Withings Ingest] Rate limited by Withings - deferring run', {
+          integrationId: integration.id,
+          delayMs: deferral.delayMs,
+          retryAfterSource: isWithingsRateLimitError(error) ? error.retryAfterSource : 'default',
+          deferralCount,
+          willReenqueue: deferral.shouldReenqueue,
+          partialCounts: deferral.result.counts
+        })
+
+        await prisma.integration.update({
+          where: { id: integration.id },
+          data: {
+            syncStatus: deferral.syncStatus,
+            errorMessage: deferral.message
+          }
+        })
+
+        if (deferral.shouldReenqueue) {
+          // Same window, later. Ingestion is idempotent upserts over a date range, so
+          // re-running it loses nothing and picks up whatever we could not read this time.
+          try {
+            await dispatchTask(
+              'ingest-withings',
+              {
+                userId,
+                startDate,
+                endDate,
+                deferralCount: deferral.nextDeferralCount
+              },
+              {
+                delay: deferral.delayMs,
+                concurrencyKey: userId,
+                tags: [`user:${userId}`]
+              }
+            )
+            logger.log('[Withings Ingest] Deferred run re-enqueued', {
+              delayMs: deferral.delayMs,
+              deferralCount: deferral.nextDeferralCount
+            })
+          } catch (dispatchError) {
+            // The window is not lost: the next webhook or scheduled sync covers it.
+            logger.error('[Withings Ingest] Failed to re-enqueue deferred run', {
+              error: dispatchError
+            })
+          }
+        } else {
+          logger.error('[Withings Ingest] Rate limit did not clear after max deferrals', {
+            integrationId: integration.id,
+            deferralCount,
+            maxDeferrals: WITHINGS_MAX_RATE_LIMIT_DEFERRALS
+          })
+        }
+
+        // Returning rather than throwing is the whole point: the run COMPLETES, no retry
+        // is consumed, and the result carries error.code === 'RATE_LIMITED' so a deferral
+        // stays distinguishable from a genuine ingest failure.
+        return deferral.result
+      }
+
       const authFailure = buildAuthFailureResult(error, { userId, startDate, endDate })
       if (authFailure) {
         logger.warn('[Withings Ingest] Authorization expired or revoked', {


### PR DESCRIPTION
Fixes CW-334

## What was wrong

Withings status **601 is a rate limit** — a deterministic "the application quota is spent, come back later" — not a transient fault. `throwIfWithingsRateLimited` raised a generic `IntegrationProviderError` and let it propagate, so the task-level retry policy in `trigger.config.ts` (3 attempts, 1s → 10s backoff) walked straight back into the same wall on a timescale far shorter than the quota window. The run burned its retries, failed, and reported to Sentry: **780 events in a week**, which also drowns out real Withings errors.

## What changed

**`WithingsRateLimitError`** — a subclass of `IntegrationProviderError`, so every existing `isIntegrationProviderError` check keeps working, while callers that know how to defer can single it out. It carries `retryAfterMs` and `retryAfterSource` (`'provider'` | `'default'`).

**Backoff.** `parseWithingsRetryAfterMs` honours `Retry-After` (seconds or HTTP-date) and `X-RateLimit-Reset` (relative or absolute epoch) if Withings ever sends one — it does not document one today, and in practice does not. Absent that, the default is **10 minutes**, deliberately chosen and documented at the constant: the Withings application quota is a per-minute window, so 10 minutes is an order of magnitude past the reset (we are not racing it) while remaining far shorter than the daily ingest cadence, so a deferred run lands well before the next scheduled one. It doubles per successive deferral to a 1h ceiling, with **upward-only** jitter (+0–20%) so every ingest that hit the same application-wide wall does not come back at the same instant and re-trip it — and never returns earlier than policy allows.

**Deferral.** `ingest-withings` catches the rate limit, marks the integration `RATE_LIMITED`, re-enqueues the *same window* with that delay (bounded at 5 deferrals ≈ 3h of patience), and **returns instead of throwing**. That is the whole point: the run COMPLETES, no retry is consumed, `tasks.onFailure` → Sentry never fires, and the result carries `error.code === 'RATE_LIMITED'` so a deferral stays distinguishable from a genuine failure. Ingestion is idempotent upserts over a date range, so a deferred window loses nothing; partial counts from before the cutoff are reported too.

**Three swallowed rate limits.** The sleep, workout, and per-workout intraday `catch` blocks logged and continued. A 601 there meant the run reported **SUCCESS while silently skipping data** — and the intraday catch runs once per workout, so it hammered Withings for every remaining workout. All three now rethrow rate limits.

**A second 601 bug, same file.** `refreshWithingsToken` bundled 601 in with 401 and treated it as a revoked grant: it marked a healthy integration `FAILED` and told the user *"Withings authorization expired or was revoked. Please reconnect Withings"* — for a rate limit. Now deferred like every other 601, with a regression test.

## The fan-out question

Investigated. There is **no cron** fanning Withings across users; the triggers are the push webhook (per measurement), `ingest-all` (sequential per user), and manual sync. Withings' quota is per **application**, not per user, so the pressure has two sources:

1. **Per-run burst** — `fetchWithingsIntraday` is called once per workout in an unthrottled loop, so one run can be dozens of back-to-back requests. **Fixed here** with an in-process request pacer (250ms, `WITHINGS_MIN_REQUEST_INTERVAL_MS`, set to 0 to disable).
2. **Cross-run concurrency** — `ingest-withings` uses `userIngestionQueue` (limit 5), but every caller dispatches with `concurrencyKey: userId`, and a `concurrencyKey` *splits* the queue into an independent instance per key. The limit is therefore "5 per user" and the number of users running at once is unbounded. Fixing that means a new queue in `trigger/queues.ts`, a `task-manifest.json` entry, and dropping `concurrencyKey` at three dispatch sites — all outside this ticket's Owned Paths. **Filed as CW-545.**

## Generalising (CW-512)

`buildWithingsRateLimitDeferral` is deliberately shaped as the provider-agnostic counterpart to `buildAuthFailureResult` in `server/utils/ingestion-failure.ts` — take an error, return either `null` (not mine, let it fail normally) or a deferral describing the delay, the sync status, whether to re-enqueue, and the result to return. **CW-512** is the same class of problem in Garmin; when that second caller exists, this should lift into `ingestion-failure.ts` as a shared helper. Not implemented here.

Worth noting explicitly: **`AbortTaskRunError` was not introduced.** The repo does not use it anywhere, and it turned out not to be needed — `trigger/ingest-fitbit.ts` already establishes exactly this idiom (catch the rate limit, set `syncStatus = 'RATE_LIMITED'`, *return* an `IngestionResult` rather than throw), and `RATE_LIMITED` is already rendered by `app/pages/settings/apps.vue` and `app/pages/admin/users/[id].vue`. This follows the existing precedent instead of adding a new pattern.

## User-visible surfaces

**UX critique: skipped** — background ingest behaviour, no interactive surface.

A Withings integration that previously showed `FAILED` during a rate limit now shows `RATE_LIMITED` with *"Rate limited by Withings. Sync is deferred and will resume automatically in ~N minutes."* `app/pages/admin/users/[id].vue` renders this generically. `app/pages/settings/apps.vue` does **not** — its `RATE_LIMITED` banner is hardcoded to Fitbit, so on the user-facing settings page the message is currently invisible. **Filed as CW-546.**

The refresh-token fix also removes a spurious *"Please reconnect Withings"* prompt that healthy integrations were getting during rate limits.

## Testing

`tests/unit/server/utils/withings.test.ts` — 26 tests: 601 defers (with and without a provider interval); a genuine error (status 342) still throws and is explicitly *not* deferrable; a successful run returns its measure groups unchanged with no state written; the `refreshWithingsToken` 601-vs-401 split; header parsing across all five forms plus the cap; backoff escalation, ceiling, provider precedence and upward-only jitter; deferral budget exhaustion; partial-count reporting; and the pacer.

Note the task-level wiring in `trigger/ingest-withings.ts` is not directly unit-tested — `tests/unit/trigger/` is outside this ticket's Owned Paths. All the policy lives in the tested helper; the task holds only `if (deferral) { … return deferral.result }` plus the three rethrows.

## Verification

```
pnpm test:unit   # 378 files, 2475 tests passed
pnpm typecheck   # exit 0
```
