### PR TITLE
fix(worker): escalate a permanently-failing webhook claim query (CW-502)

### DIFF
--- a/cli/worker/start.ts
+++ b/cli/worker/start.ts
@@ -140,6 +140,57 @@ export async function claimPendingWebhookLogs(
 }
 
 /**
+ * Number of consecutive claim-query failures before the poller escalates.
+ *
+ * The poller runs every 5s, so this is ~15s of a fully halted webhook pipeline
+ * before we alert — long enough to ride out a single connection blip, short
+ * enough that a genuinely broken claim query is not silent.
+ */
+export const WEBHOOK_CLAIM_ESCALATION_THRESHOLD = 3
+
+/**
+ * Tracks consecutive failures of the webhook *claim* query specifically.
+ *
+ * A claim that fails permanently (a malformed statement, a dropped column, a
+ * bind parameter Postgres will not accept) halts all webhook processing while
+ * producing nothing louder than a `console.error` every 5 seconds — the poller's
+ * only escalation path is `isRedisConnectionError`, which such a failure is not.
+ * This distinguishes "transient blip" from "the claim query itself is broken"
+ * and escalates once per failure streak.
+ */
+export function createWebhookClaimFailureTracker(options: {
+  threshold?: number
+  onEscalate: (error: unknown, consecutiveFailures: number) => void
+}) {
+  const threshold = options.threshold ?? WEBHOOK_CLAIM_ESCALATION_THRESHOLD
+  let consecutiveFailures = 0
+  let escalated = false
+
+  return {
+    /** A successful claim ends the streak and re-arms escalation. */
+    recordSuccess(): void {
+      consecutiveFailures = 0
+      escalated = false
+    },
+    /** Returns the current streak length. Escalates once when it crosses the threshold. */
+    recordFailure(error: unknown): number {
+      consecutiveFailures++
+      if (consecutiveFailures >= threshold && !escalated) {
+        escalated = true
+        options.onEscalate(error, consecutiveFailures)
+      }
+      return consecutiveFailures
+    },
+    get consecutiveFailures(): number {
+      return consecutiveFailures
+    },
+    get hasEscalated(): boolean {
+      return escalated
+    }
+  }
+}
+
+/**
  * Hand a claimed webhook log back to the poller when the BullMQ enqueue failed,
  * so the webhook is retried instead of being stranded in QUEUED with no job.
  * Guarded on `status = 'QUEUED'` so it can never resurrect a row that another
@@ -911,24 +962,62 @@ export const startCommand = new Command('start')
     })
 
     // --- Webhook Log Poller ---
-    // This loop checks for PENDING webhooks in SQL and moves them to BullMQ
-    const pollWebhooks = async () => {
-      try {
-        // Claim the batch atomically: the rows come back already flipped to
-        // QUEUED, so a second worker polling concurrently cannot pick them up.
-        const claimedLogs = await claimPendingWebhookLogs(prisma, WEBHOOK_POLL_BATCH_SIZE)
-
-        if (claimedLogs.length > 0) {
-          if (verboseWorkerLogs) {
-            console.log(
-              chalk.gray(`[Poller] Claimed ${claimedLogs.length} pending webhooks in SQL`)
-            )
-          }
-
-          await drainClaimedWebhookLogs(prisma, webhookQueue, claimedLogs)
+    // This loop checks for PENDING webhooks in SQL and moves them to BullMQ.
+    //
+    // A claim query that is broken rather than merely unlucky halts every
+    // webhook in the system. Escalate it loudly instead of letting it scroll
+    // past as a console.error once every 5 seconds.
+    const claimFailures = createWebhookClaimFailureTracker({
+      onEscalate: (error, consecutiveFailures) => {
+        const detail = formatErrorMessage(error)
+        console.error(
+          chalk.red.bold(
+            `[Poller] WEBHOOK INGESTION HALTED — the claim query has failed ${consecutiveFailures} consecutive times. ` +
+              `No webhook has been queued since the streak began. This is not a transient error; ` +
+              `the claim statement itself is likely broken. Last error: ${detail}`
+          )
+        )
+        if (process.env.SENTRY_DSN) {
+          Sentry.captureException(error, {
+            level: 'fatal',
+            tags: { worker: 'webhookPoller', failure: 'claim-query' },
+            extra: { consecutiveFailures, batchSize: WEBHOOK_POLL_BATCH_SIZE }
+          })
         }
+      }
+    })
+
+    const pollWebhooks = async () => {
+      // Claim the batch atomically: the rows come back already flipped to
+      // QUEUED, so a second worker polling concurrently cannot pick them up.
+      let claimedLogs: ClaimedWebhookLog[]
+      try {
+        claimedLogs = await claimPendingWebhookLogs(prisma, WEBHOOK_POLL_BATCH_SIZE)
+        claimFailures.recordSuccess()
       } catch (err) {
-        console.error(chalk.red('[Poller] Error polling webhooks:'), err)
+        const streak = claimFailures.recordFailure(err)
+        console.error(
+          chalk.red(`[Poller] Claim query failed (consecutive failures: ${streak}):`),
+          err
+        )
+        if (isRedisConnectionError(err)) {
+          requestRestart('sql-to-queue poller lost redis connectivity', err)
+        }
+        return
+      }
+
+      if (claimedLogs.length === 0) return
+
+      if (verboseWorkerLogs) {
+        console.log(chalk.gray(`[Poller] Claimed ${claimedLogs.length} pending webhooks in SQL`))
+      }
+
+      try {
+        await drainClaimedWebhookLogs(prisma, webhookQueue, claimedLogs)
+      } catch (err) {
+        // Drain failures are already self-healing: drainClaimedWebhookLogs hands
+        // every un-enqueued row back to PENDING before rethrowing.
+        console.error(chalk.red('[Poller] Error draining claimed webhooks:'), err)
         if (isRedisConnectionError(err)) {
           requestRestart('sql-to-queue poller lost redis connectivity', err)
         }

--- a/tests/unit/cli/worker.test.ts
+++ b/tests/unit/cli/worker.test.ts
@@ -3,9 +3,11 @@ import type { Prisma } from '@prisma/client'
 import {
   buildWebhookJob,
   claimPendingWebhookLogs,
+  createWebhookClaimFailureTracker,
   drainClaimedWebhookLogs,
   registerScheduledTasks,
   releaseClaimedWebhookLog,
+  WEBHOOK_CLAIM_ESCALATION_THRESHOLD,
   WEBHOOK_POLL_BATCH_SIZE,
   type ClaimedWebhookLog
 } from '../../../cli/worker/start'
@@ -188,6 +190,28 @@ describe('Webhook poller atomic claim', () => {
     expect(queries[0]!.values).toEqual([WEBHOOK_POLL_BATCH_SIZE])
   })
 
+  // CW-502: the batch size reaches Postgres as `LIMIT $1`. Postgres rejects a
+  // non-integer there, and a rejected claim halts webhook ingestion entirely.
+  // Verified against real Postgres (Prisma 7.8.0 / @prisma/adapter-pg 7.8.0):
+  // the driver wire-encodes a JS integer as pg `integer`, so the query is fine.
+  // This guards the remaining way to break it — feeding LIMIT a non-integer.
+  it('binds LIMIT as an integer, never a float or string', async () => {
+    for (const limit of [WEBHOOK_POLL_BATCH_SIZE, 1, 2, 250]) {
+      const { client, queries } = makeClient([])
+      await claimPendingWebhookLogs(client, limit)
+
+      const bound = queries[0]!.values[0]
+      expect(typeof bound).toBe('number')
+      expect(Number.isInteger(bound)).toBe(true)
+      expect(bound as number).toBeGreaterThan(0)
+    }
+  })
+
+  it('declares a batch size that is itself a positive integer', () => {
+    expect(Number.isInteger(WEBHOOK_POLL_BATCH_SIZE)).toBe(true)
+    expect(WEBHOOK_POLL_BATCH_SIZE).toBeGreaterThan(0)
+  })
+
   it('returns an empty batch when nothing is pending', async () => {
     const { client } = makeClient([])
     await expect(claimPendingWebhookLogs(client, 10)).resolves.toEqual([])
@@ -273,6 +297,73 @@ describe('Webhook poller atomic claim', () => {
         logId: 'log-3'
       }
     })
+  })
+})
+
+describe('Webhook claim failure escalation', () => {
+  // CW-502: a permanently broken claim query halts every webhook while the
+  // poller's only escalation path (isRedisConnectionError) stays silent about
+  // it. A failure streak must become loud instead of looping on console.error.
+  it('does not escalate a transient failure that recovers', () => {
+    const onEscalate = vi.fn()
+    const tracker = createWebhookClaimFailureTracker({ onEscalate })
+
+    tracker.recordFailure(new Error('blip'))
+    tracker.recordSuccess()
+    tracker.recordFailure(new Error('blip'))
+    tracker.recordSuccess()
+
+    expect(onEscalate).not.toHaveBeenCalled()
+    expect(tracker.consecutiveFailures).toBe(0)
+    expect(tracker.hasEscalated).toBe(false)
+  })
+
+  it('escalates once the failure streak reaches the threshold', () => {
+    const onEscalate = vi.fn()
+    const tracker = createWebhookClaimFailureTracker({ onEscalate })
+    const err = new Error('could not determine data type of parameter $1')
+
+    for (let i = 1; i < WEBHOOK_CLAIM_ESCALATION_THRESHOLD; i++) {
+      expect(tracker.recordFailure(err)).toBe(i)
+      expect(onEscalate).not.toHaveBeenCalled()
+    }
+
+    expect(tracker.recordFailure(err)).toBe(WEBHOOK_CLAIM_ESCALATION_THRESHOLD)
+    expect(onEscalate).toHaveBeenCalledTimes(1)
+    expect(onEscalate).toHaveBeenCalledWith(err, WEBHOOK_CLAIM_ESCALATION_THRESHOLD)
+    expect(tracker.hasEscalated).toBe(true)
+  })
+
+  it('escalates only once per streak, so a permanent failure does not spam', () => {
+    const onEscalate = vi.fn()
+    const tracker = createWebhookClaimFailureTracker({ onEscalate, threshold: 2 })
+
+    // Simulate the 5s poll loop failing for a long time.
+    for (let i = 0; i < 100; i++) tracker.recordFailure(new Error('broken'))
+
+    expect(onEscalate).toHaveBeenCalledTimes(1)
+    expect(tracker.consecutiveFailures).toBe(100)
+  })
+
+  it('re-arms after a recovery so a second outage escalates again', () => {
+    const onEscalate = vi.fn()
+    const tracker = createWebhookClaimFailureTracker({ onEscalate, threshold: 2 })
+
+    tracker.recordFailure(new Error('a'))
+    tracker.recordFailure(new Error('a'))
+    expect(onEscalate).toHaveBeenCalledTimes(1)
+
+    tracker.recordSuccess()
+    expect(tracker.hasEscalated).toBe(false)
+
+    tracker.recordFailure(new Error('b'))
+    tracker.recordFailure(new Error('b'))
+    expect(onEscalate).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses a threshold that keeps the halt window short', () => {
+    expect(WEBHOOK_CLAIM_ESCALATION_THRESHOLD).toBeGreaterThan(1)
+    expect(WEBHOOK_CLAIM_ESCALATION_THRESHOLD).toBeLessThanOrEqual(5)
   })
 })
 


### PR DESCRIPTION
Fixes CW-502

## Verdict: the LIMIT bind-param bug is **not** real

`claimPendingWebhookLogs` was executed against a real Postgres (`watts_wt_cw_502`, 227 migrations applied) through the actual Prisma 7.8.0 + `@prisma/adapter-pg` 7.8.0 code path — the real `PrismaClient` from `server/utils/db.ts`, not a mock and not `psql`, so the driver's parameter serialisation was genuinely exercised.

```
--- claim with default WEBHOOK_POLL_BATCH_SIZE = 50 ---
claimed rows: 5
statuses after claim: [{"_count":{"_all":5},"status":"QUEUED"}]

--- claim with limit = 2 (LIMIT must actually truncate) ---
claimed rows: 2 (expected 2)
statuses: [{"_count":{"_all":3},"status":"PENDING"},{"_count":{"_all":2},"status":"QUEUED"}]

--- how does the driver wire-encode a JS number bind param? ---
bind param 50 arrives as: {"t":"integer","v":"50"}

--- claim on empty set ---
claim on empty table: []

OK — no error thrown.
```

`adapter-pg` sends the JS integer as pg `integer`. The claim executes, `LIMIT` truncates correctly, rows flip to `QUEUED`, and all seven projected columns come back intact. **No change was made to the query.**

## But the failure mode it implied is real, so this PR fixes that

Forcing the suspected failure (a float `LIMIT`) confirms the concern was well founded — it simply never triggers:

```
broken claim threw: Raw query failed. Code: `22P02`. Message: `invalid input syntax for type bigint: "50.5"`
isRedisConnectionError(err) = false
  ^ false means the OLD code would have logged and looped silently forever
NEW code escalations after 10 consecutive failures: [ 3 ]
```

Postgres parses `LIMIT $1` as **bigint**, a non-integer there is fatal, and such an error is **not** an `isRedisConnectionError` — the poller's only escalation path. A permanently broken claim would therefore have halted all webhook ingestion behind a `console.error` every 5 seconds, forever, with no alert. That is acceptance criterion 3, which stands regardless of the LIMIT outcome.

## Changes

`cli/worker/start.ts`
- New exported `createWebhookClaimFailureTracker` + `WEBHOOK_CLAIM_ESCALATION_THRESHOLD = 3` (~15s of halted ingestion — long enough to ride out a blip, short enough not to be silent). Counts *consecutive* claim failures, fires `onEscalate` exactly once per streak, re-arms on success.
- `pollWebhooks` splits its single `try` into a **claim** path and a **drain** path. These have different recovery semantics: `drainClaimedWebhookLogs` already hands un-enqueued rows back to `PENDING` before rethrowing, whereas a broken claim never self-heals.
- Escalation emits a prominent `WEBHOOK INGESTION HALTED` log plus `Sentry.captureException(..., { level: 'fatal', tags: { worker: 'webhookPoller', failure: 'claim-query' } })`.
- Escalation deliberately does **not** `requestRestart`. A restart cannot repair a broken SQL statement and would crash-loop the ping, streams and mainTask workers that are still healthy. Sentry is the alerting channel this worker already uses.

`tests/unit/cli/worker.test.ts` (+8 tests, 16 passing)
- Regression guard on the bind parameter: `LIMIT` is always bound as a positive **integer** across several batch sizes, and `WEBHOOK_POLL_BATCH_SIZE` is itself a positive integer. In the mocked tier this is the one remaining way to reintroduce the bug.
- Escalation semantics: transient failures that recover never escalate; the streak escalates exactly at the threshold; 100 consecutive failures escalate only once (no alert spam); a recovery re-arms so a second outage alerts again.

## Verification

```
pnpm test:unit tests/unit/cli/worker.test.ts   # 16 passed
pnpm typecheck                                  # exit 0
```
ESLint and Prettier clean.

## Notes

- The manual harnesses were scratch scripts and are not committed, per the ticket. A DB-backed test tier that could run this claim in CI is **CW-501** and is deliberately not folded in here.
- **CW-499** (stale `QUEUED` reaper) also touches this area and is separately queued.