### PR TITLE
fix(cli): drop dead ./deduplicate import from the gemini command (CW-531)

### DIFF
--- a/cli/gemini/index.ts
+++ b/cli/gemini/index.ts
@@ -1,13 +1,10 @@
 import { Command } from 'commander'
 import { modelsCommand } from './models'
 import { pricingCommand } from './pricing'
-import deduplicateCommand from './deduplicate'
 
 const geminiCommand = new Command('gemini').description('Gemini AI model and pricing management')
 
 geminiCommand.addCommand(modelsCommand)
 geminiCommand.addCommand(pricingCommand)
-// Accidentally put it here in thought process, but better to make a new top-level 'workouts' command or add to 'debug'.
-// 'debug' seems appropriate for now given the context.
 
 export default geminiCommand


### PR DESCRIPTION
Fixes CW-531

`cli/gemini/index.ts` imported `deduplicateCommand from './deduplicate'` — a file that does not exist under `cli/gemini/`.

## Does it break at runtime? No — but only by luck

`pnpm cli --help` and `pnpm cli gemini --help` both worked on the unmodified tree. The binding was imported but **never** passed to `addCommand`, and esbuild (used by `tsx`) elides unused import bindings in TS files, so Node never resolved the specifier:

```
$ npx esbuild --format=esm --loader=ts < cli/gemini/index.ts
import { Command } from "commander";
import { modelsCommand } from "./models";
import { pricingCommand } from "./pricing";      # ./deduplicate is gone
```

That is a landmine, not a safety net: `cli/index.ts` imports `./gemini` eagerly, so the moment anyone referenced the binding, **every** CLI command would die at startup.

## Drop, not repoint

The real command is `cli/debug/deduplicate.ts` and it is **already registered** on `debug` (`cli/debug/index.ts:23` and `:77`) — which is exactly what the stale comment concluded ("'debug' seems appropriate for now"). Registering it on `gemini` would be a duplicate registration of a workout-deduplication command under a namespace described as "Gemini AI model and pricing management". So the import and the stale comment are removed; nothing is repointed and no command is lost.

## Why typecheck missed it — `cli/**` is in no tsconfig project

Root `tsconfig.json` has `"files": []` and four project references, whose `include` globs cover `app/**`, `server/**`, `shared/**`, `modules/*`, `layers/*`, `tests/nuxt/**`, `nuxt.config.*` — and nothing else. `./tsconfig.json` is the only tsconfig in the repo. So `cli/` (201 TS files), `scripts/` (113) and `trigger/` (78) are typechecked by **nothing**. ESLint does lint `cli/`, but no rule in the config resolves import specifiers, so it missed it too.

Same root cause as CW-523 (`tests/unit/**`), in three more directories. Filed as **CW-560** — deliberately not fixed here, since it touches build config well outside this ticket's single Owned Path.

Repo-wide sweep for unresolvable relative import specifiers: `cli/gemini/index.ts -> ./deduplicate` was the only hit.

## Verification

- `pnpm typecheck` — exit 0 (proves nothing about this bug; that is the ticket's point)
- `npx eslint cli/gemini/index.ts` — clean
- `pnpm cli gemini --help` after the change — byte-identical to before (`models`, `pricing`)
- `pnpm cli debug --help` — `deduplicate` still present and unaffected
