### PR TITLE
fix(webhooks): write oauth webhook log atomically in one statement (CW-503)

### DIFF
--- a/server/api/webhooks/oauth/[clientId].post.ts
+++ b/server/api/webhooks/oauth/[clientId].post.ts
@@ -46,30 +46,36 @@ export default defineEventHandler(async (event) => {
   const providedSecret = (headers['x-webhook-secret'] as string) || (query.secret as string)
   const secretMatched = app.webhookSecret && providedSecret === app.webhookSecret
 
-  // 3. Log the request - set status to PENDING for the worker poller to pick up
-  const log = await logWebhookRequest({
+  // 3. Log the request - set status to PENDING for the worker poller to pick up.
+  //
+  // Both worker-facing fields MUST be written in this single `create`. The
+  // poller (`claimPendingWebhookLogs` in cli/worker/start.ts) atomically flips
+  // PENDING -> QUEUED, and `buildWebhookJob` derives the job's `appName` from
+  // `eventType` and `secretMatched` from `error`. A row created with placeholder
+  // values and corrected by a follow-up `update` can be claimed in between, and
+  // because the claim is atomic the wrong values are permanent - nothing
+  // re-reads the row afterwards. See CW-503.
+  //
+  // NOTE: `error` doubles as the secret-verification result here rather than
+  // carrying an actual error. That overloading is pre-existing and intentional
+  // for now (the worker reads `log.error === 'SECRET_MATCHED'`); giving the
+  // WebhookLog schema a dedicated column is tracked in CW-564.
+  const secretStatus = secretMatched
+    ? 'SECRET_MATCHED'
+    : providedSecret
+      ? 'SECRET_MISMATCH'
+      : 'NO_SECRET_PROVIDED'
+
+  await logWebhookRequest({
     provider: `oauth-generic`,
-    eventType: 'RAW_PUSH',
+    // Metadata for the generic worker - must be final at creation time.
+    eventType: `oauth:${app.name}`,
     payload: body,
     headers,
     query,
-    status: 'PENDING'
+    status: 'PENDING',
+    error: secretStatus
   })
-
-  if (log) {
-    await prisma.webhookLog.update({
-      where: { id: log.id },
-      data: {
-        error: secretMatched
-          ? 'SECRET_MATCHED'
-          : providedSecret
-            ? 'SECRET_MISMATCH'
-            : 'NO_SECRET_PROVIDED',
-        // Also store metadata for generic worker
-        eventType: `oauth:${app.name}`
-      }
-    })
-  }
 
   // Always return 200 OK as per requirement to be developer-friendly
   return {

--- a/tests/unit/server/api/webhooks/oauth-clientid.post.test.ts
+++ b/tests/unit/server/api/webhooks/oauth-clientid.post.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildWebhookJob, type ClaimedWebhookLog } from '../../../../../cli/worker/start'
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('defineRouteMeta', vi.fn())
+vi.stubGlobal('getRouterParam', (event: any, name: string) => event?.params?.[name])
+vi.stubGlobal('readBody', async (event: any) => event?.body)
+vi.stubGlobal('getRequestHeaders', (event: any) => event?.headers || {})
+vi.stubGlobal('getQuery', (event: any) => event?.query || {})
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  // @ts-expect-error test helper property
+  error.statusCode = err.statusCode
+  return error
+})
+
+const oAuthAppFindUnique = vi.fn()
+const webhookLogCreate = vi.fn()
+const webhookLogUpdate = vi.fn()
+
+vi.mock('../../../../../server/utils/db', () => ({
+  prisma: {
+    oAuthApp: {
+      findUnique: (...args: unknown[]) => oAuthAppFindUnique(...args)
+    },
+    webhookLog: {
+      create: (...args: unknown[]) => webhookLogCreate(...args),
+      update: (...args: unknown[]) => webhookLogUpdate(...args)
+    }
+  }
+}))
+
+const getHandler = async () => {
+  const mod = await import('../../../../../server/api/webhooks/oauth/[clientId].post')
+  return mod.default
+}
+
+/**
+ * Reproduce what the worker's atomic claim returns for the row the handler just
+ * persisted. `claimPendingWebhookLogs` flips PENDING -> QUEUED in one statement
+ * and RETURNs exactly these columns, so whatever the handler wrote in its
+ * *first* statement is all the worker will ever see.
+ */
+const claimRowFrom = (createArgs: any): ClaimedWebhookLog => ({
+  id: 'log-1',
+  provider: createArgs.data.provider,
+  eventType: createArgs.data.eventType ?? null,
+  payload: createArgs.data.payload ?? null,
+  headers: createArgs.data.headers ?? null,
+  query: createArgs.data.query ?? null,
+  error: createArgs.data.error ?? null
+})
+
+const buildEvent = (overrides: Record<string, any> = {}) => ({
+  params: { clientId: 'client-abc' },
+  body: { hello: 'world' },
+  headers: {},
+  query: {},
+  ...overrides
+})
+
+describe('POST /api/webhooks/oauth/[clientId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    webhookLogCreate.mockImplementation(async (args: any) => ({ id: 'log-1', ...args.data }))
+    oAuthAppFindUnique.mockResolvedValue({
+      id: 'app-1',
+      clientId: 'client-abc',
+      name: 'withings',
+      webhookSecret: 'super-secret'
+    })
+  })
+
+  it('404s when the application is unknown', async () => {
+    oAuthAppFindUnique.mockResolvedValue(null)
+    const handler = await getHandler()
+
+    await expect(handler(buildEvent() as any)).rejects.toMatchObject({
+      statusCode: 404
+    })
+    expect(webhookLogCreate).not.toHaveBeenCalled()
+  })
+
+  it('persists eventType and the secret result in a single statement (CW-503)', async () => {
+    const handler = await getHandler()
+
+    await handler(buildEvent({ headers: { 'x-webhook-secret': 'super-secret' } }) as any)
+
+    expect(webhookLogCreate).toHaveBeenCalledTimes(1)
+    // The corrective second write is what CW-503 removes - there must be no
+    // window in which a poll can observe the intermediate row.
+    expect(webhookLogUpdate).not.toHaveBeenCalled()
+
+    expect(webhookLogCreate.mock.calls[0]![0].data).toMatchObject({
+      provider: 'oauth-generic',
+      eventType: 'oauth:withings',
+      error: 'SECRET_MATCHED',
+      status: 'PENDING'
+    })
+  })
+
+  it('a row claimed with no follow-up write still yields the right appName and secretMatched', async () => {
+    const handler = await getHandler()
+
+    await handler(buildEvent({ headers: { 'x-webhook-secret': 'super-secret' } }) as any)
+
+    // Simulate the worker poller landing immediately after the create, i.e. the
+    // exact window that previously produced appName 'unknown' / secretMatched false.
+    const claimed = claimRowFrom(webhookLogCreate.mock.calls[0]![0])
+    const { queueJobName, jobData } = buildWebhookJob(claimed)
+
+    expect(queueJobName).toBe('oauth-webhook')
+    expect(jobData).toMatchObject({
+      provider: 'oauth-generic',
+      type: 'oauth:withings',
+      appName: 'withings',
+      secretMatched: true,
+      logId: 'log-1'
+    })
+  })
+
+  it('records a mismatched secret as SECRET_MISMATCH and claims as secretMatched false', async () => {
+    const handler = await getHandler()
+
+    const result = await handler(
+      buildEvent({ headers: { 'x-webhook-secret': 'wrong-secret' } }) as any
+    )
+
+    expect(webhookLogCreate.mock.calls[0]![0].data).toMatchObject({
+      eventType: 'oauth:withings',
+      error: 'SECRET_MISMATCH'
+    })
+    expect(webhookLogUpdate).not.toHaveBeenCalled()
+
+    const { jobData } = buildWebhookJob(claimRowFrom(webhookLogCreate.mock.calls[0]![0]))
+    expect(jobData).toMatchObject({ appName: 'withings', secretMatched: false })
+
+    // Accept/reject semantics are unchanged: still a 200 with the flag echoed back.
+    expect(result).toMatchObject({ status: 'success', secretMatched: false })
+  })
+
+  it('records a missing secret as NO_SECRET_PROVIDED', async () => {
+    const handler = await getHandler()
+
+    await handler(buildEvent() as any)
+
+    expect(webhookLogCreate.mock.calls[0]![0].data).toMatchObject({
+      eventType: 'oauth:withings',
+      error: 'NO_SECRET_PROVIDED'
+    })
+    expect(webhookLogUpdate).not.toHaveBeenCalled()
+  })
+
+  it('accepts the secret from the query string as well as the header', async () => {
+    const handler = await getHandler()
+
+    await handler(buildEvent({ query: { secret: 'super-secret' } }) as any)
+
+    expect(webhookLogCreate.mock.calls[0]![0].data).toMatchObject({
+      error: 'SECRET_MATCHED'
+    })
+  })
+
+  it('still returns 200 with the captured payload envelope', async () => {
+    const handler = await getHandler()
+
+    const result = await handler(
+      buildEvent({ headers: { 'x-webhook-secret': 'super-secret' } }) as any
+    )
+
+    expect(result).toMatchObject({ status: 'success', message: 'Data captured' })
+    expect(typeof (result as any).receivedAt).toBe('string')
+  })
+})


### PR DESCRIPTION
Fixes CW-503

## Problem

`server/api/webhooks/oauth/[clientId].post.ts` wrote the webhook log in **two** statements: `create` the row `PENDING` with `eventType: 'RAW_PUSH'` and no `error`, then `update` it to `eventType: 'oauth:<app>'` + `error: 'SECRET_MATCHED'`.

The worker's poller (`claimPendingWebhookLogs`) can land between them. `buildWebhookJob` derives `appName` from `eventType` and `secretMatched` from `error`, so a job enqueued in that window carried `appName: 'unknown'` and `secretMatched: false`.

The window pre-dates CW-34; what CW-34 changed is recovery. Previously the row stayed `PENDING` and a later poll picked it up with the corrected values. Now the atomic claim flips it to `QUEUED` immediately, so the wrong values are permanent.

## Fix

Compute the secret-verification result before persisting and write `eventType` and `error` in the **single** `logWebhookRequest`/`create`. The corrective `update` is removed, so there is no intermediate state a poll can observe.

`cli/worker/start.ts` is untouched.

## Blast radius of `secretMatched: false` — observability only, not a security issue

The only consumer is the `oauth-generic` branch of the worker (`cli/worker/start.ts:557-568`), which does exactly one thing with the flag: prints it in a console line. It then unconditionally calls `updateWebhookStatus(logId, 'PROCESSED', ...)` and returns `{ handled: true }`. There is **no** gate, rejection, downgrade, or differing code path on `secretMatched === false`. The HTTP endpoint likewise always returns 200 regardless of the secret.

So a raced production event was still fully captured and processed. What was lost is the operator-visible signal: `appName: 'unknown'`, `Secret Matched: NO` in the worker log, and `Captured data for unknown` written into the row.

Historical rows cannot be audited for the race either way — `updateWebhookStatus` overwrites `error` with `Captured data for <appName>` on completion, destroying the `SECRET_MATCHED` marker for *every* oauth event, raced or not.

## Tests

New `tests/unit/server/api/webhooks/oauth-clientid.post.test.ts` (7 tests). The key one builds the row exactly as the handler persists it, feeds it straight through the real `buildWebhookJob` — simulating the poller claiming with **no** second write having landed — and asserts `appName: 'withings'` / `secretMatched: true`. Others assert `webhookLog.update` is never called, cover all three secret outcomes, header vs query secret, and that the 200 response envelope is unchanged.

Confirmed the suite fails 5/7 against the pre-fix handler and passes against the fix.

## Follow-ups filed

- **CW-564** — `WebhookLog.error` is overloaded as the secret-verification result and is clobbered on completion; wants a dedicated column. (Schema change was out of scope here; noted in a code comment.)
- **CW-565** — `clientId` is destructured from `job.data` in the oauth worker branch but `buildWebhookJob` never sets it, so the log line always reads `(undefined)`.

Both touch `cli/worker/start.ts`, which is read-only for this ticket.

## Verification

```
pnpm test:unit   # 379 files, 2496 tests passed
pnpm typecheck   # exit 0
```
