### PR TITLE
fix(scripts): seed the dev bypass user with consent so pages stop 302ing to /onboarding (CW-548)

### DIFF
--- a/scripts/seed-dev-user.ts
+++ b/scripts/seed-dev-user.ts
@@ -2,15 +2,68 @@ import 'dotenv/config'
 import { PrismaClient } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 import pg from 'pg'
+import { PRIVACY_POLICY_VERSION, TERMS_OF_SERVICE_VERSION } from '../shared/policy-versions'
 
 const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
 const prisma = new PrismaClient({ adapter: new PrismaPg(pool) })
 
+// The auth bypass (server/plugins/auth-bypass.ts) makes this user genuinely
+// authenticated, but app/middleware/onboarding.global.ts is a *global* middleware
+// that redirects every authenticated page to /onboarding while termsAcceptedAt is
+// null. A dev user seeded without consent therefore cannot reach a single page, and
+// the redirect reads like an auth-bypass failure rather than a consent gate (CW-548).
+// So the seeded user is consented by default, exactly as server/api/user/consent.post.ts
+// would leave them (terms + health consent, both versions) — a half-consented user
+// would clear the middleware but still report incomplete consent from
+// server/utils/onboarding-status.ts.
+//
+// SEED_SKIP_CONSENT=1 does the opposite on purpose: it puts the dev user back at the
+// consent gate so the real /onboarding flow can be exercised end to end without
+// hand-editing the database. (Two other escape hatches already exist and are
+// unaffected by consent: /onboarding?testing=1 and /onboarding/restart.)
+const skipConsent = process.env.SEED_SKIP_CONSENT === '1'
+
 async function main() {
   const email = process.env.AUTH_BYPASS_USER || 'dev@coachwatts.test'
+  const now = new Date()
+
+  const consent = {
+    termsAcceptedAt: now,
+    termsVersion: TERMS_OF_SERVICE_VERSION,
+    healthConsentAcceptedAt: now,
+    privacyPolicyVersion: PRIVACY_POLICY_VERSION
+  }
+
+  const clearedConsent = {
+    termsAcceptedAt: null,
+    termsVersion: null,
+    healthConsentAcceptedAt: null,
+    privacyPolicyVersion: null
+  }
+
+  const existing = await prisma.user.findUnique({
+    where: { email },
+    select: { termsAcceptedAt: true, healthConsentAcceptedAt: true }
+  })
+
+  // Backfill, never clobber. Re-running the seed has to repair a worktree that was
+  // seeded before this fix (otherwise the fix only helps brand-new worktrees), but it
+  // must not stomp consent timestamps the user actually produced by walking the flow.
+  // Only null fields are filled in.
+  const update = skipConsent
+    ? clearedConsent
+    : {
+        ...(existing?.termsAcceptedAt
+          ? {}
+          : { termsAcceptedAt: now, termsVersion: TERMS_OF_SERVICE_VERSION }),
+        ...(existing?.healthConsentAcceptedAt
+          ? {}
+          : { healthConsentAcceptedAt: now, privacyPolicyVersion: PRIVACY_POLICY_VERSION })
+      }
+
   const user = await prisma.user.upsert({
     where: { email },
-    update: {},
+    update,
     create: {
       email,
       name: process.env.AUTH_BYPASS_NAME || 'Dev Athlete',
@@ -20,10 +73,22 @@ async function main() {
       maxHr: 190,
       weight: 72,
       uiLanguage: 'en',
-      timezone: 'UTC'
+      timezone: 'UTC',
+      ...(skipConsent ? {} : consent)
     }
   })
-  console.log('Seeded dev user:', { id: user.id, email: user.email, isAdmin: user.isAdmin })
+
+  console.log('Seeded dev user:', {
+    id: user.id,
+    email: user.email,
+    isAdmin: user.isAdmin,
+    termsAcceptedAt: user.termsAcceptedAt
+  })
+  if (skipConsent) {
+    console.log(
+      'SEED_SKIP_CONSENT=1 — consent cleared; every authenticated page will redirect to /onboarding.'
+    )
+  }
 }
 
 main()


### PR DESCRIPTION
Fixes CW-548

## Problem

`server/plugins/auth-bypass.ts` makes the seeded dev user genuinely authenticated, but `app/middleware/onboarding.global.ts` is a **global** middleware that redirects every authenticated page to `/onboarding` while `termsAcceptedAt` is null. `scripts/seed-dev-user.ts` never set it, so every fresh worktree could not load a single page — and because the session is real, the redirect reads as an auth-bypass failure rather than a consent gate.

## Change (one file, `scripts/seed-dev-user.ts`)

- **create**: seeds `termsAcceptedAt`, `healthConsentAcceptedAt`, `termsVersion`, `privacyPolicyVersion` from `shared/policy-versions.ts` — the same four fields `server/api/user/consent.post.ts` writes, and the same set `e2e/seed.ts` already uses for its fixtures. Terms alone would clear the middleware but leave `resolveOnboardingStatus()` (`server/utils/onboarding-status.ts:168` needs both) reporting incomplete consent, i.e. a half-consented user.
- **update**: **backfills null consent fields only.** Chosen over `update: {}` because leaving existing users alone would mean the fix helps brand-new worktrees only — an already-provisioned worktree would stay broken with no obvious remedy. Chosen over an unconditional write so re-seeding can never stomp timestamps a user produced by actually walking the flow.
- **`SEED_SKIP_CONSENT=1`**: seeds (or resets an existing user to) the unconsented state on purpose. Read only inside this file — no diff widening.

## Onboarding testability — checked, nothing depended on the seeded user being unconsented

- **E2E cannot see this user.** `nuxt.config.ts:297-300` forces `authBypassEnabled: false` under `E2E_MODE=true`, and `docker-compose.e2e.yml:75-76` blanks `AUTH_BYPASS_USER`. The e2e stack uses `e2e/seed.ts`, whose fixtures already set `termsAcceptedAt`. No e2e spec exercises `/onboarding`.
- **Unit tests mock the session** (`tests/unit/app/middleware/onboarding.global.test.ts`) and never touch the DB.
- **Two escape hatches already exist and are unaffected by consent**: the middleware explicitly lets `/onboarding?testing=1` through for a consented user (line 47, documented in `docs/issues/295-...md`) and `/onboarding/restart` through unconditionally (line 52). `SEED_SKIP_CONSENT=1` adds a third for the true unconsented gate.

## Verification (port 3348, `bin/worktree-dev.sh`)

| Path | Before | After |
|---|---|---|
| `/dashboard` | **302 → `/onboarding?redirect=/dashboard`** | **200** (`<title>Dashboard - Coach Watts</title>`, 104 KB) |
| `/settings` | **302 → `/onboarding?redirect=/settings`** | 302 → `/settings/apps` (normal index redirect) |
| `/calendar`, `/nutrition` | — | 200 |
| `/onboarding?testing=1` | 200 | **200** |
| `/onboarding/restart` | 200 | **200** |
| `/onboarding` | 200 | 302 → `/dashboard` (designed behaviour for any consented user, middleware line 47-51) |

Both write paths exercised against `watts_wt_cw_548` only:
- **create** — deleted the seeded user, re-ran the seed: new row, `termsAcceptedAt` set, all pages above 200.
- **update/backfill** — re-ran against the pre-existing broken row: filled in, `/dashboard` 200.
- **`SEED_SKIP_CONSENT=1`** — `termsAcceptedAt: null`, `/dashboard` back to 302 → `/onboarding`, `/onboarding` 200. Gate reproducible on demand.

`pnpm typecheck` exit 0. `prettier --check` and `eslint` clean on the changed file.

**UX critique: skipped** — dev-fixture script, no production surface. The before/after walkthrough above replaces it.

Follow-up worth noting but not done here (would widen the diff outside Owned Paths): `AGENTS.md:94` documents the seed command and could mention `SEED_SKIP_CONSENT=1`.
