### PR TITLE
fix(workouts): reject flattened repeat sets missing recovery (CW-583)

### DIFF
--- a/server/utils/structured-workout-validation.ts
+++ b/server/utils/structured-workout-validation.ts
@@ -13,11 +13,101 @@ function hasRenderableStrengthBlocks(blocks: unknown): boolean {
   )
 }
 
+const RECOVERY_TYPES = new Set(['rest', 'cooldown'])
+const RECOVERY_INTENTS = new Set(['recovery', 'rest', 'easy'])
+const NON_WORK_TYPES = new Set(['rest', 'cooldown', 'warmup'])
+
+function isRecoveryStep(step: any): boolean {
+  if (!step || typeof step !== 'object') return false
+  const type = String(step.type || '').toLowerCase()
+  const intent = String(step.intent || '').toLowerCase()
+  if (RECOVERY_TYPES.has(type) || RECOVERY_INTENTS.has(intent)) return true
+  return (Number(step.restSeconds) || 0) > 0
+}
+
+/**
+ * A leaf work step: an effort the athlete actually performs, not a rest,
+ * cooldown, warmup, or a repeat/container block.
+ */
+function isLeafWorkStep(step: any): boolean {
+  if (!step || typeof step !== 'object') return false
+  if (Array.isArray(step.steps) && step.steps.length > 0) return false
+  if (Number(step.reps ?? step.repeat ?? step.intervals ?? 1) > 1) return false
+  if (isRecoveryStep(step)) return false
+  return !NON_WORK_TYPES.has(String(step.type || '').toLowerCase())
+}
+
+/**
+ * Canonical description of a work step's prescription. Two steps sharing this
+ * key are the same effort repeated, not a progression or an over-under.
+ */
+function workStepSignature(step: any): string {
+  const duration = Number(step.durationSeconds) || Number(step.duration) || 0
+  const distance = Number(step.distanceMeters) || Number(step.distance) || 0
+  const power = step.power
+  let powerKey = 'none'
+  if (power && typeof power === 'object') {
+    powerKey = power.range ? `r:${power.range.start}-${power.range.end}` : `v:${power.value ?? ''}`
+  } else if (power != null) {
+    powerKey = `v:${power}`
+  }
+  return `${duration}|${distance}|${powerKey}`
+}
+
+/**
+ * Catches repeat sets the model emitted *flattened* — e.g. "3 x 8min at
+ * threshold" written as three consecutive identical Active steps with no
+ * recovery between them, and no repeat wrapper.
+ *
+ * `hasValidRepeatBlockRecovery` only inspects steps with `reps > 1`, so a
+ * flattened set has no step it examines and passes untouched. The athlete then
+ * receives what is effectively one continuous 24-minute threshold block.
+ *
+ * Only *identical* consecutive efforts are rejected: differing power or
+ * duration means a progression, ramp, or over-under, which is legitimately
+ * continuous.
+ */
+function findFlattenedRepeatWithoutRecovery(steps: any[]): string | null {
+  let runSignature: string | null = null
+  let runLength = 0
+  let runName = 'Interval'
+
+  const violation = () =>
+    `${runLength} consecutive "${runName}" work steps appear with no recovery between them (flattened repeat set)`
+
+  for (const step of steps) {
+    const signature = isLeafWorkStep(step) ? workStepSignature(step) : null
+
+    // A step with neither duration nor distance carries no prescription to
+    // compare, so it breaks the run rather than matching everything.
+    if (!signature || signature.startsWith('0|0|')) {
+      if (runLength > 1) return violation()
+      runSignature = null
+      runLength = 0
+      continue
+    }
+
+    if (signature === runSignature) {
+      runLength += 1
+    } else {
+      if (runLength > 1) return violation()
+      runSignature = signature
+      runLength = 1
+      runName = step.name || step.text || 'Interval'
+    }
+  }
+
+  return runLength > 1 ? violation() : null
+}
+
 export function hasValidRepeatBlockRecovery(steps: unknown): {
   valid: boolean
   reason: string | null
 } {
   if (!Array.isArray(steps)) return { valid: true, reason: null }
+
+  const flattened = findFlattenedRepeatWithoutRecovery(steps)
+  if (flattened) return { valid: false, reason: flattened }
 
   for (const step of steps) {
     if (!step || typeof step !== 'object') continue

--- a/tests/unit/trigger/generate-structured-workout.test.ts
+++ b/tests/unit/trigger/generate-structured-workout.test.ts
@@ -126,6 +126,121 @@ describe('Structured Workout Generator - Repeat Block Recovery Validation', () =
     })
   })
 
+  // CW-583: repeat sets emitted flattened (no repeat wrapper) have no step with
+  // reps > 1, so the original check never inspected them and an athlete received
+  // e.g. 3x8min threshold as one continuous 24min block.
+  describe('hasValidRepeatBlockRecovery - flattened repeat sets', () => {
+    const warmup = { type: 'Warmup', name: 'Warm Up', durationSeconds: 600 }
+    const cooldown = { type: 'Cooldown', name: 'Cool Down', durationSeconds: 300 }
+    const threshold = (name = '8min Threshold') => ({
+      type: 'Active',
+      name,
+      durationSeconds: 480,
+      power: { value: 0.95 }
+    })
+
+    it('rejects 3x8min emitted as three identical Active steps with no recovery', () => {
+      const result = hasValidRepeatBlockRecovery([
+        warmup,
+        threshold(),
+        threshold(),
+        threshold(),
+        cooldown
+      ])
+
+      expect(result.valid).toBe(false)
+      expect(result.reason).toContain('no recovery between them')
+      expect(result.reason).toContain('3 consecutive')
+    })
+
+    it('rejects a flattened 2x20 pair', () => {
+      const twenty = { type: 'Active', name: '20min SST', durationSeconds: 1200 }
+
+      const result = hasValidRepeatBlockRecovery([warmup, twenty, twenty, cooldown])
+
+      expect(result.valid).toBe(false)
+      expect(result.reason).toContain('2 consecutive')
+    })
+
+    it('accepts the same reps when recovery separates them', () => {
+      const recovery = { type: 'Rest', name: '2min Easy', durationSeconds: 120 }
+
+      const result = hasValidRepeatBlockRecovery([
+        warmup,
+        threshold(),
+        recovery,
+        threshold(),
+        recovery,
+        threshold(),
+        cooldown
+      ])
+
+      expect(result.valid).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('accepts a single steady-state effort', () => {
+      const result = hasValidRepeatBlockRecovery([
+        warmup,
+        { type: 'Active', name: 'Steady Z2', durationSeconds: 2400 },
+        cooldown
+      ])
+
+      expect(result.valid).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('accepts over-unders, which are legitimately continuous', () => {
+      const over = { type: 'Active', name: 'Over', durationSeconds: 120, power: { value: 1.05 } }
+      const under = { type: 'Active', name: 'Under', durationSeconds: 120, power: { value: 0.95 } }
+
+      const result = hasValidRepeatBlockRecovery([warmup, over, under, over, under, cooldown])
+
+      expect(result.valid).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('accepts a progressive ramp of differing efforts', () => {
+      const result = hasValidRepeatBlockRecovery([
+        warmup,
+        { type: 'Active', name: 'Step 1', durationSeconds: 300, power: { value: 0.8 } },
+        { type: 'Active', name: 'Step 2', durationSeconds: 300, power: { value: 0.9 } },
+        { type: 'Active', name: 'Step 3', durationSeconds: 300, power: { value: 1.0 } },
+        cooldown
+      ])
+
+      expect(result.valid).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('accepts identical efforts separated by an intent-based recovery step', () => {
+      const spin = {
+        type: 'Active',
+        intent: 'recovery',
+        name: 'Easy Spin',
+        durationSeconds: 180
+      }
+
+      const result = hasValidRepeatBlockRecovery([threshold(), spin, threshold()])
+
+      expect(result.valid).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('detects a flattened set nested inside a container step', () => {
+      const result = hasValidRepeatBlockRecovery([
+        {
+          type: 'Active',
+          name: 'Main Block',
+          steps: [threshold(), threshold(), threshold()]
+        }
+      ])
+
+      expect(result.valid).toBe(false)
+      expect(result.reason).toContain('no recovery between them')
+    })
+  })
+
   describe('Prompt instructions for repeat block recovery', () => {
     it('buildDraftOutputRules includes mandatory recovery rules for repeat blocks', () => {
       const rules = buildDraftOutputRules({ preserveExistingStructure: false })


### PR DESCRIPTION
Fixes CW-583

## Problem

Two athletes independently reported generated interval sessions arriving with **no recovery between reps** — a `3 x 8min` threshold session delivered as one continuous 24-minute block, and `Threshold 4x8min` / `VO2 Max 5x3min` as unbroken efforts. Neither chat nor refresh could repair the workout.

A guard already existed (`hasValidRepeatBlockRecovery`), but it only inspects steps with `reps > 1`. When the model emits a repeat set **flattened** — N consecutive identical `Active` steps with no repeat wrapper — there is no step with `reps > 1`, so the validator examined nothing and the structure passed untouched.

This is a correctness defect, not a cosmetic one: the prescribed session is materially harder than intended and not trainable as written.

## Fix

Added run detection over sibling leaf work steps. Two or more consecutive efforts sharing duration, distance and power target, with no recovery between them, are rejected as a flattened repeat set.

Only *identical* consecutive efforts match, so shapes that are legitimately continuous still pass:

- progressions and ramps (differing power)
- over-unders (alternating power)
- a single steady-state block
- identical reps genuinely separated by a `Rest` step or an `intent: recovery` step

Because the check runs at the top of `hasValidRepeatBlockRecovery`, it applies to nested step lists through the existing recursion, and every current caller inherits it with no call-site change.

## Verification

```
pnpm test:unit tests/unit/trigger/generate-structured-workout.test.ts   # 18 passed
pnpm test:unit tests/unit/trigger                                        # 133 passed
pnpm typecheck                                                           # exit 0
```

8 new tests cover the flattened `3x8` and `2x20` shapes, the nested case, and the four false-positive shapes above.

## Follow-up not in this PR

The two support tickets' affected workouts still need regenerating once this ships (support tickets `dfb44aa1-…` and `c79a0020-…`, both replied to and set to IN_PROGRESS).