### PR TITLE
fix(ai): add work-only interval aggregates to analysis payload (CW-381)

### DIFF
--- a/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
+++ b/server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap
@@ -127,6 +127,25 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 - Indoor Trainer: No
 - Avg Temperature: 21.0°C
 
+## Work vs Recovery Aggregates
+Duration-weighted averages over the resolved WORK and RECOVERY segments of the Interval Breakdown below (warmup and cooldown excluded). Any claim about interval, rep, or threshold execution MUST quote these figures, never the session averages above.
+
+### Work Intervals
+- Segments: 1
+- Total Time: 12m 0s
+- Average Segment Length: 12m 0s
+- Average Power (duration-weighted): 255W
+- Average HR (duration-weighted): 155 bpm
+- Average Cadence (duration-weighted): 90 rpm
+
+### Recovery Between Work
+- Segments: 1
+- Total Time: 5m 0s
+- Average Segment Length: 5m 0s
+- Average Power (duration-weighted): 120W
+- Average HR (duration-weighted): 128 bpm
+- Average Cadence (duration-weighted): 78 rpm
+
 ## Interval Breakdown
 Segmentation source: provider laps (labels re-derived). These are the same segments the Calculated Workout Facts v2 block above is computed over -- quote reps from this table only.
 
@@ -218,5 +237,7 @@ IMPORTANT:
 - Do not recommend purchasing new hardware or equipment from a single-workout analysis unless there is an explicit, repeated measurement limitation clearly stated in the facts.
 - Do not use ATL, CTL, or TSB alone as proof of technique breakdown; they are context only.
 - Prioritize metrics in this order: POWER > HR > PACE.
-- Use POWER as the primary evidence base whenever available."
+- Use POWER as the primary evidence base whenever available.
+- Every claim about interval, rep, or threshold execution must quote the figures from "## Work vs Recovery Aggregates" (or a specific row of "## Interval Breakdown"). The session averages under Power Metrics, Heart Rate & Cadence and Pace & Speed cover the whole file including warmup, recoveries and cooldown, so they must never be described as interval, rep or threshold values.
+- When a work-only figure and the session average disagree, that gap is the shape of the session, not an error to reconcile; judge the intervals on the work-only figure."
 `;

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -1348,3 +1348,216 @@ describe('report analysis schemas match the prompts they are handed with (CW-425
     ).not.toContain('avg_protein_g')
   })
 })
+
+/**
+ * CW-381: the payload carried per-lap rows and session means with nothing in
+ * between, so the model reached for the session mean whenever it wanted an
+ * interval number. A live 4x4min threshold run was told "your average cadence
+ * of 162 spm is somewhat low for threshold work" -- 162 being the whole-session
+ * mean, dragged down by warmup, recovery jogs and cooldown, while the four reps
+ * averaged 177 spm. The advice was inverted, not merely imprecise.
+ */
+describe('work-only interval aggregates', () => {
+  /** The reference session from the ticket, lapped the way Intervals.icu sends it. */
+  const THRESHOLD_RUN_LAPS = [
+    { seconds: 600, speed: 2.6, cadence: 76, hr: 130 },
+    { seconds: 240, speed: 4.1, cadence: 89, hr: 168 },
+    { seconds: 120, speed: 2.8, cadence: 78, hr: 140 },
+    { seconds: 240, speed: 4.1, cadence: 88, hr: 172 },
+    { seconds: 120, speed: 2.8, cadence: 78, hr: 142 },
+    { seconds: 240, speed: 4.0, cadence: 89, hr: 174 },
+    { seconds: 120, speed: 2.8, cadence: 77, hr: 143 },
+    { seconds: 240, speed: 4.0, cadence: 88, hr: 175 },
+    { seconds: 600, speed: 2.5, cadence: 74, hr: 128 }
+  ]
+
+  function buildThresholdRun(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'workout-fixture-cw381',
+      date: new Date('2026-03-22T06:00:00Z'),
+      title: '4 x 4min Threshold',
+      type: 'Run',
+      durationSec: 2520,
+      distanceMeters: 8000,
+      averageSpeed: 3.17,
+      averageHr: 149,
+      maxHr: 178,
+      // One-legged, as every provider stores run cadence: 81 doubles to the
+      // 162 spm the model quoted as if it were a threshold figure.
+      averageCadence: 81,
+      rawJson: {
+        // Every lap labelled WORK, exactly as the provider sends it. The
+        // aggregate must be built from the labels CW-376 re-derives, not these.
+        icu_intervals: THRESHOLD_RUN_LAPS.map((lap) => ({
+          type: 'WORK',
+          moving_time: lap.seconds,
+          average_speed: lap.speed,
+          average_cadence: lap.cadence,
+          average_heartrate: lap.hr
+        }))
+      },
+      ...overrides
+    }
+  }
+
+  it('puts a duration-weighted work-only aggregate in the payload', () => {
+    const data = buildWorkoutAnalysisData(buildThresholdRun())
+
+    // Four reps of 240s. Cadence is normalised here and only here: the weighted
+    // one-legged mean is 88.5, i.e. the 177 spm the athlete actually ran, and
+    // NOT the 162 spm session mean sitting in `avg_cadence`.
+    expect(data.avg_cadence).toBe(162)
+    expect(data.work_interval_summary).toMatchObject({
+      rep_count: 4,
+      total_duration_s: 960,
+      avg_duration_s: 240,
+      avg_cadence: 177
+    })
+    expect(Math.round(data.work_interval_summary.avg_hr)).toBe(172)
+
+    // Recovery jogs only -- warmup and cooldown are not recoveries between reps.
+    expect(data.recovery_interval_summary).toMatchObject({
+      rep_count: 3,
+      total_duration_s: 360
+    })
+    expect(Math.round(data.recovery_interval_summary.avg_cadence)).toBe(155)
+
+    // Nothing an aggregate emits may be NaN, whatever the metric coverage.
+    for (const summary of [data.work_interval_summary, data.recovery_interval_summary]) {
+      for (const value of Object.values(summary)) {
+        expect(Number.isNaN(value as number)).toBe(false)
+      }
+    }
+  })
+
+  it('prints the work-only figures in the prompt and forbids quoting the session means', () => {
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(buildThresholdRun()),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('## Work vs Recovery Aggregates')
+    expect(prompt).toContain('### Work Intervals')
+    expect(prompt).toContain('- Segments: 4')
+    expect(prompt).toContain('- Total Time: 16m 0s')
+    expect(prompt).toContain('- Average Segment Length: 4m 0s')
+    // The number the model should have quoted, in the same canonical unit as
+    // the session line and the per-rep rows (CW-387).
+    expect(prompt).toContain('- Average Cadence (duration-weighted): 177 spm')
+    expect(prompt).toContain('- Average HR (duration-weighted): 172 bpm')
+    // 4.05 m/s duration-weighted over the four reps is 247 s/km.
+    expect(prompt).toContain('- Average Pace (duration-weighted): 4:07/km')
+
+    // The session mean is still printed -- it is a true session fact -- but it
+    // is now unmistakably the session's, not the reps'.
+    expect(prompt).toContain('- Average Cadence: 162 spm')
+
+    expect(prompt).toContain('### Recovery Between Work')
+    expect(prompt).toContain('- Segments: 3')
+
+    // The instruction, both at the section and next to the hard rules.
+    expect(prompt).toContain(
+      'Any claim about interval, rep, or threshold execution MUST quote these figures, never the session averages above.'
+    )
+    expect(prompt).toContain('must never be described as interval, rep or threshold values')
+  })
+
+  it('does not derive the aggregate from lap_splits (CW-389)', () => {
+    // Automatic per-distance splits are present and deliberately disagree with
+    // the laps: they cut across warmup, reps, recoveries and cooldown, so an
+    // aggregate built from them would be another session-wide average wearing
+    // an interval label.
+    const data = buildWorkoutAnalysisData(
+      buildThresholdRun({
+        rawJson: {
+          icu_intervals: THRESHOLD_RUN_LAPS.map((lap) => ({
+            type: 'WORK',
+            moving_time: lap.seconds,
+            average_speed: lap.speed,
+            average_cadence: lap.cadence,
+            average_heartrate: lap.hr
+          })),
+          splits_metric: [
+            { distance: 1000, moving_time: 315, average_speed: 3.17, average_heartrate: 150 },
+            { distance: 1000, moving_time: 315, average_speed: 3.17, average_heartrate: 151 },
+            { distance: 1000, moving_time: 315, average_speed: 3.17, average_heartrate: 152 }
+          ]
+        }
+      })
+    )
+
+    expect(data.lap_splits).toHaveLength(3)
+    // Three splits, four reps: the aggregate followed the resolved laps.
+    expect(data.work_interval_summary.rep_count).toBe(4)
+    expect(data.work_interval_summary.total_duration_s).toBe(960)
+    expect(data.work_interval_summary.avg_cadence).toBe(177)
+  })
+
+  it('states the absence rather than printing a fabricated zero when a session has no reps', () => {
+    // A steady ride: one lap, no recoveries. `resolveProviderIntervalTypes`
+    // leaves a sub-3-lap session alone, so this is work-only by construction.
+    const data = buildWorkoutAnalysisData({
+      id: 'workout-fixture-cw381-steady',
+      date: new Date('2026-03-23T06:00:00Z'),
+      title: 'Endurance',
+      type: 'Ride',
+      durationSec: 3600,
+      averageWatts: 180,
+      averageCadence: 86,
+      rawJson: {
+        icu_intervals: [
+          {
+            type: 'WORK',
+            moving_time: 3600,
+            average_watts: 180,
+            average_cadence: 86,
+            average_heartrate: 132
+          }
+        ]
+      }
+    })
+
+    expect(data.work_interval_summary).toMatchObject({ rep_count: 1, avg_power: 180 })
+    expect(data.recovery_interval_summary).toBeUndefined()
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      data,
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('### Recovery Between Work')
+    expect(prompt).toContain('- None: no recovery segments between work')
+    expect(prompt).toContain('- Average Cadence (duration-weighted): 86 rpm')
+    expect(prompt).not.toContain('spm')
+  })
+
+  it('omits the section entirely for a session with no resolved intervals', () => {
+    const data = buildWorkoutAnalysisData({
+      id: 'workout-fixture-cw381-no-intervals',
+      date: new Date('2026-03-24T06:00:00Z'),
+      title: 'Easy spin',
+      type: 'Ride',
+      durationSec: 1800,
+      averageWatts: 140
+    })
+
+    expect(data.work_interval_summary).toBeUndefined()
+    expect(data.recovery_interval_summary).toBeUndefined()
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      data,
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'POWER' },
+      USER_PROFILE
+    )
+
+    expect(prompt).not.toContain('## Work vs Recovery Aggregates')
+  })
+})

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -24,11 +24,13 @@ import {
 } from '../../../trigger/utils/workout-metric-priority'
 import { formatStructuredPlanForPrompt } from '../../../trigger/utils/planned-workout-targets'
 import {
+  buildIntervalGroupSummaries,
   formatCadenceWithUnit,
   getActualIntervalsForAnalysis,
   getActualIntervalsSourceForAnalysis,
   isRunningCadenceFamily,
   toCanonicalCadence,
+  type IntervalGroupSummary,
   type WorkoutAnalysisFactsV2
 } from '../workout-analysis-facts'
 import { summarizePowerFromWatts } from '../power-metrics'
@@ -555,6 +557,40 @@ export function buildWorkoutAnalysisData(workout: any, options: WorkoutAnalysisD
       start_index: interval.startIndex,
       end_index: interval.endIndex
     }))
+
+    // Work-only and recovery-only aggregates over the SAME arbitrated set
+    // (CW-381).
+    //
+    // Without these the payload jumps straight from per-lap rows to session
+    // means, and the model reaches for the session mean when it wants an
+    // interval number: a 4x4min threshold run was told 162 spm was "somewhat
+    // low for threshold work" when 162 was the whole-session mean (warmup,
+    // recovery jogs and cooldown included) and the four reps themselves ran
+    // 177 spm.
+    //
+    // Grouped by the RESOLVED interval type, never by `lap_splits` -- those are
+    // automatic per-distance splits that cut across reps and recoveries
+    // (CW-389). Cadence is normalised here and only here, exactly like the
+    // session and per-interval values above.
+    const intervalGroups = buildIntervalGroupSummaries(actualIntervals)
+    const toSummaryPayload = (summary: IntervalGroupSummary | null) =>
+      summary
+        ? {
+            rep_count: summary.repCount,
+            total_duration_s: Math.round(summary.totalDurationSeconds),
+            avg_duration_s: Math.round(summary.avgDurationSeconds),
+            avg_power: summary.avgPower,
+            avg_hr: summary.avgHr,
+            avg_cadence: normalizeCadence(summary.avgCadence),
+            avg_speed_ms: summary.avgSpeed,
+            avg_pace_s_per_km: summary.avgPaceSecondsPerKm
+          }
+        : null
+
+    const workSummary = toSummaryPayload(intervalGroups.work)
+    const recoverySummary = toSummaryPayload(intervalGroups.recovery)
+    if (workSummary) data.work_interval_summary = workSummary
+    if (recoverySummary) data.recovery_interval_summary = recoverySummary
   }
 
   // Extract pacing splits from rawJson if available
@@ -1029,6 +1065,50 @@ export function formatIntervalDuration(durationSeconds: number): string {
  */
 export function formatIntervalIntensity(intensityFactor: number): string {
   return `${intensityFactor.toFixed(2)} IF (${Math.round(intensityFactor * 100)}% of threshold)`
+}
+
+/**
+ * Render one duration-weighted interval aggregate as prompt bullets (CW-381).
+ *
+ * Only metrics the group actually carried are printed: a missing value means
+ * "these segments had no such measurement", and printing a fabricated `0W`
+ * would hand the model a number to reason from. Values arrive already on the
+ * canonical scales `buildWorkoutAnalysisData` established (cadence normalised,
+ * speed in m/s, pace in seconds per kilometre); this renderer only labels them.
+ */
+export function formatIntervalGroupSummary(
+  summary: any,
+  options: {
+    workoutType: string
+    isCadenceRelevant: boolean
+    paceCapable: boolean
+    distanceUnits?: string | null
+  }
+): string {
+  if (!summary) return ''
+
+  let block = `- Segments: ${summary.rep_count}\n`
+  block += `- Total Time: ${formatIntervalDuration(summary.total_duration_s)}\n`
+  block += `- Average Segment Length: ${formatIntervalDuration(summary.avg_duration_s)}\n`
+  if (summary.avg_power != null) {
+    block += `- Average Power (duration-weighted): ${Math.round(summary.avg_power)}W\n`
+  }
+  if (summary.avg_hr != null) {
+    block += `- Average HR (duration-weighted): ${Math.round(summary.avg_hr)} bpm\n`
+  }
+  if (options.isCadenceRelevant && summary.avg_cadence != null) {
+    block += `- Average Cadence (duration-weighted): ${formatCadenceWithUnit(
+      Math.round(summary.avg_cadence),
+      options.workoutType
+    )}\n`
+  }
+  if (options.paceCapable && summary.avg_pace_s_per_km != null) {
+    block += `- Average Pace (duration-weighted): ${formatPromptPace(
+      summary.avg_pace_s_per_km,
+      options.distanceUnits
+    )}\n`
+  }
+  return block
 }
 
 /**
@@ -1588,6 +1668,47 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
     prompt += '\n'
   }
 
+  // Work-only and recovery-only aggregates (CW-381).
+  //
+  // Printed BEFORE the per-interval table and before the model is asked for
+  // anything, because these are the figures every interval-level claim has to
+  // be built from. The sections above this one are all session-wide -- a
+  // session mean over an intervalled workout is an average of warmup, reps,
+  // recoveries and cooldown, so quoting it as "your threshold cadence" or
+  // "your interval power" is not an approximation, it is a different number
+  // about a different thing (the 162-vs-177 spm inversion this ticket exists
+  // for).
+  const workIntervalSummary = workoutData.work_interval_summary
+  const recoveryIntervalSummary = workoutData.recovery_interval_summary
+  if (workIntervalSummary || recoveryIntervalSummary) {
+    const summaryOptions = {
+      workoutType,
+      isCadenceRelevant,
+      paceCapable: isRunningCadenceFamily(workoutType),
+      distanceUnits: userProfile?.distanceUnits
+    }
+
+    prompt += '\n## Work vs Recovery Aggregates\n'
+    prompt +=
+      'Duration-weighted averages over the resolved WORK and RECOVERY segments of the Interval Breakdown below (warmup and cooldown excluded). Any claim about interval, rep, or threshold execution MUST quote these figures, never the session averages above.\n'
+
+    if (workIntervalSummary) {
+      prompt += '\n### Work Intervals\n'
+      prompt += formatIntervalGroupSummary(workIntervalSummary, summaryOptions)
+    } else {
+      prompt +=
+        '\n### Work Intervals\n- None: this session has no segments resolved as work, so do not make rep-level or interval-level claims about it.\n'
+    }
+
+    if (recoveryIntervalSummary) {
+      prompt += '\n### Recovery Between Work\n'
+      prompt += formatIntervalGroupSummary(recoveryIntervalSummary, summaryOptions)
+    } else {
+      prompt +=
+        '\n### Recovery Between Work\n- None: no recovery segments between work, so do not characterise recovery quality.\n'
+    }
+  }
+
   // Add interval analysis if available.
   //
   // These rows ARE the arbitrated segmentation -- the same `ActualInterval[]`
@@ -1702,6 +1823,15 @@ ${buildAnalysisGuardrailInstructions(workoutType, analysisFactsV2)}
 ${buildAnalysisRequestMetricRules(metricPriorityContext)
   .map((rule) => `- ${rule}`)
   .join('\n')}`
+
+  // Restated at the point of use, next to the other hard rules: the section
+  // header alone lost to the session averages printed higher up, which is how
+  // a session mean ended up being quoted as an interval metric (CW-381).
+  if (workIntervalSummary || recoveryIntervalSummary) {
+    prompt += `
+- Every claim about interval, rep, or threshold execution must quote the figures from "## Work vs Recovery Aggregates" (or a specific row of "## Interval Breakdown"). The session averages under Power Metrics, Heart Rate & Cadence and Pace & Speed cover the whole file including warmup, recoveries and cooldown, so they must never be described as interval, rep or threshold values.
+- When a work-only figure and the session average disagree, that gap is the shape of the session, not an error to reconcile; judge the intervals on the work-only figure.`
+  }
 
   return prompt
 }

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   alignPlannedToActualIntervals,
+  buildIntervalGroupSummaries,
   buildWorkoutAnalysisFacts,
   buildWorkoutAnalysisFactsV2,
   formatActualIntervalsForPrompt,
@@ -3341,5 +3342,222 @@ describe('actual-interval source arbitration and hard-repeat scale (CW-408)', ()
           .every((interval) => (interval.avgPower ?? 0) >= ARBITRATION_FIXTURE_FTP * 0.95)
       ).toBe(true)
     })
+  })
+})
+
+/**
+ * CW-381: duration-weighted work-only / recovery-only aggregates.
+ *
+ * The payload used to hand the model per-lap rows and session means with
+ * nothing in between, so interval-level claims were made from the session mean.
+ * These cover the aggregate helper directly: the grouping (resolved type, never
+ * `lap_splits`), the weighting (duration, not lap count), and the three shapes
+ * a session can take -- all work, no work, mixed.
+ */
+describe('buildIntervalGroupSummaries', () => {
+  function makeInterval(
+    overrides: Partial<ActualIntervalForAnalysis> = {}
+  ): ActualIntervalForAnalysis {
+    const type = String(overrides.type ?? 'WORK')
+    const lower = type.toLowerCase()
+    const classification =
+      lower.includes('rest') ||
+      lower.includes('recovery') ||
+      lower.includes('warm') ||
+      lower.includes('cool')
+        ? ('recovery' as const)
+        : ('work' as const)
+
+    return {
+      type,
+      durationSeconds: 240,
+      avgPower: null,
+      avgHr: null,
+      avgSpeed: null,
+      avgCadence: null,
+      intensity: null,
+      matchScore: null,
+      confidence: null,
+      ambiguityNote: null,
+      classification,
+      startIndex: null,
+      endIndex: null,
+      ...overrides
+    }
+  }
+
+  /** Nothing an aggregate emits may ever be NaN — the model would quote it. */
+  function expectNoNaN(summary: Record<string, unknown> | null) {
+    expect(summary).not.toBeNull()
+    for (const [key, value] of Object.entries(summary || {})) {
+      if (typeof value === 'number') {
+        expect(Number.isNaN(value), `${key} is NaN`).toBe(false)
+      }
+    }
+  }
+
+  it('weights by duration, not by lap count', () => {
+    // A 6-minute rep at 90 and a 2-minute rep at 60. The mean-of-lap-means is
+    // 75; the duration-weighted mean is 82.5, because the athlete spent three
+    // times as long at 90. This gap is exactly the 162-vs-177 spm inversion the
+    // ticket is about, in miniature.
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ durationSeconds: 360, avgCadence: 90, avgPower: 300 }),
+      makeInterval({ durationSeconds: 120, avgCadence: 60, avgPower: 180 })
+    ])
+
+    expect(summaries.work?.avgCadence).toBe(82.5)
+    expect(summaries.work?.avgPower).toBe(270)
+    expect(summaries.work?.repCount).toBe(2)
+    expect(summaries.work?.totalDurationSeconds).toBe(480)
+    expect(summaries.work?.avgDurationSeconds).toBe(240)
+    expectNoNaN(summaries.work)
+  })
+
+  it('summarises a session where every lap is work and there are no recoveries', () => {
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ durationSeconds: 600, avgPower: 200, avgHr: 140, avgCadence: 88 }),
+      makeInterval({ durationSeconds: 600, avgPower: 220, avgHr: 150, avgCadence: 90 })
+    ])
+
+    expect(summaries.work?.repCount).toBe(2)
+    expect(summaries.work?.avgPower).toBe(210)
+    expect(summaries.work?.avgHr).toBe(145)
+    expect(summaries.work?.avgCadence).toBe(89)
+    expectNoNaN(summaries.work)
+
+    // No recoveries is not "recoveries averaging zero": the aggregate is absent
+    // so the prompt can say there were none instead of printing a fabricated 0.
+    expect(summaries.recovery).toBeNull()
+  })
+
+  it('returns no work aggregate at all for a session with no work laps', () => {
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ type: 'WARMUP', durationSeconds: 600, avgHr: 120 }),
+      makeInterval({ type: 'RECOVERY', durationSeconds: 300, avgHr: 128 }),
+      makeInterval({ type: 'COOLDOWN', durationSeconds: 600, avgHr: 115 })
+    ])
+
+    expect(summaries.work).toBeNull()
+
+    // Warmup and cooldown are classified `recovery` but are not the recoveries
+    // between reps; only the genuine RECOVERY lap is aggregated.
+    expect(summaries.recovery?.repCount).toBe(1)
+    expect(summaries.recovery?.totalDurationSeconds).toBe(300)
+    expect(summaries.recovery?.avgHr).toBe(128)
+    expectNoNaN(summaries.recovery)
+  })
+
+  it('splits a mixed session into work and recovery without letting either leak', () => {
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ type: 'WARMUP', durationSeconds: 600, avgCadence: 76, avgHr: 130 }),
+      makeInterval({ type: 'WORK', durationSeconds: 240, avgCadence: 89, avgHr: 168 }),
+      makeInterval({ type: 'RECOVERY', durationSeconds: 120, avgCadence: 78, avgHr: 140 }),
+      makeInterval({ type: 'WORK', durationSeconds: 240, avgCadence: 88, avgHr: 172 }),
+      makeInterval({ type: 'RECOVERY', durationSeconds: 120, avgCadence: 78, avgHr: 142 }),
+      makeInterval({ type: 'COOLDOWN', durationSeconds: 600, avgCadence: 74, avgHr: 128 })
+    ])
+
+    expect(summaries.work?.repCount).toBe(2)
+    expect(summaries.work?.totalDurationSeconds).toBe(480)
+    expect(summaries.work?.avgCadence).toBe(88.5)
+    expect(summaries.work?.avgHr).toBe(170)
+
+    expect(summaries.recovery?.repCount).toBe(2)
+    expect(summaries.recovery?.totalDurationSeconds).toBe(240)
+    expect(summaries.recovery?.avgCadence).toBe(78)
+    expect(summaries.recovery?.avgHr).toBe(141)
+
+    expectNoNaN(summaries.work)
+    expectNoNaN(summaries.recovery)
+  })
+
+  it('skips laps missing a metric rather than counting them as zero', () => {
+    // A rep with no power meter must not halve the work power average.
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ durationSeconds: 240, avgPower: 300, avgHr: 170 }),
+      makeInterval({ durationSeconds: 240, avgPower: null, avgHr: 172 })
+    ])
+
+    expect(summaries.work?.avgPower).toBe(300)
+    expect(summaries.work?.avgHr).toBe(171)
+    // Nothing carried cadence or speed, so those stay absent instead of 0.
+    expect(summaries.work?.avgCadence).toBeNull()
+    expect(summaries.work?.avgSpeed).toBeNull()
+    expect(summaries.work?.avgPaceSecondsPerKm).toBeNull()
+    expectNoNaN(summaries.work)
+  })
+
+  it('falls back to an unweighted mean instead of NaN when no lap carries a duration', () => {
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ durationSeconds: 0, avgHr: 160 }),
+      makeInterval({ durationSeconds: 0, avgHr: 170 })
+    ])
+
+    expect(summaries.work?.avgHr).toBe(165)
+    expect(summaries.work?.totalDurationSeconds).toBe(0)
+    expect(summaries.work?.avgDurationSeconds).toBe(0)
+    expectNoNaN(summaries.work)
+  })
+
+  it('returns both aggregates as null for an empty interval list', () => {
+    expect(buildIntervalGroupSummaries([])).toEqual({ work: null, recovery: null })
+  })
+
+  it('derives pace from total distance over total time, not from a mean of lap paces', () => {
+    // 4.0 m/s for 300s (1200 m) and 2.0 m/s for 100s (200 m): 1400 m in 400 s
+    // is 3.5 m/s, i.e. 285.7 s/km. Averaging the two lap paces would say 375.
+    const summaries = buildIntervalGroupSummaries([
+      makeInterval({ durationSeconds: 300, avgSpeed: 4 }),
+      makeInterval({ durationSeconds: 100, avgSpeed: 2 })
+    ])
+
+    expect(summaries.work?.avgSpeed).toBe(3.5)
+    expect(summaries.work?.avgPaceSecondsPerKm).toBeCloseTo(285.71, 2)
+  })
+
+  it('groups by the RE-DERIVED provider labels, not the ones the provider sent (CW-376)', () => {
+    // Intervals.icu marks nearly every lap WORK. Straight off the provider this
+    // would be nine work laps averaging the whole session; after CW-376's
+    // re-derivation only the four reps are work.
+    const laps = [
+      { seconds: 600, speed: 2.6, cadence: 76, hr: 130 },
+      { seconds: 240, speed: 4.1, cadence: 89, hr: 168 },
+      { seconds: 120, speed: 2.8, cadence: 78, hr: 140 },
+      { seconds: 240, speed: 4.1, cadence: 88, hr: 172 },
+      { seconds: 120, speed: 2.8, cadence: 78, hr: 142 },
+      { seconds: 240, speed: 4.0, cadence: 89, hr: 174 },
+      { seconds: 120, speed: 2.8, cadence: 77, hr: 143 },
+      { seconds: 240, speed: 4.0, cadence: 88, hr: 175 },
+      { seconds: 600, speed: 2.5, cadence: 74, hr: 128 }
+    ]
+
+    const intervals = getActualIntervalsForAnalysis({
+      id: 'cw-381-fixture',
+      type: 'Run',
+      durationSec: 2520,
+      rawJson: {
+        icu_intervals: laps.map((lap) => ({
+          type: 'WORK',
+          moving_time: lap.seconds,
+          average_speed: lap.speed,
+          average_cadence: lap.cadence,
+          average_heartrate: lap.hr
+        }))
+      }
+    })
+
+    const summaries = buildIntervalGroupSummaries(intervals)
+
+    expect(summaries.work?.repCount).toBe(4)
+    expect(summaries.work?.totalDurationSeconds).toBe(960)
+    // Still one-legged here: the facts module never re-scales running cadence
+    // (`buildWorkoutAnalysisData` is the single conversion point), so 88.5 is
+    // the 177 spm the athlete actually ran.
+    expect(summaries.work?.avgCadence).toBe(88.5)
+    expect(summaries.recovery?.repCount).toBe(3)
+    expect(summaries.recovery?.totalDurationSeconds).toBe(360)
+    expectNoNaN(summaries.work)
+    expectNoNaN(summaries.recovery)
   })
 })

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -2732,6 +2732,156 @@ export function formatActualIntervalsForPrompt(
     .join('\n      ')
 }
 
+/**
+ * A duration-weighted aggregate over ONE group of resolved intervals.
+ *
+ * Every average is weighted by each segment's duration, not by segment count:
+ * a mean-of-lap-means lets a 30-second stub count as much as a 4-minute rep,
+ * which is the same class of error as quoting the session mean for an interval
+ * metric. Cadence stays on whatever scale the caller's intervals carry (the
+ * facts module never re-scales running cadence; `buildWorkoutAnalysisData` is
+ * the single conversion point) — the weighting is linear, so normalising before
+ * or after aggregation gives the same number.
+ */
+export type IntervalGroupSummary = {
+  /** How many segments went into this aggregate. Never zero — the summary is `null` instead. */
+  repCount: number
+  totalDurationSeconds: number
+  /** Mean segment length, i.e. `totalDurationSeconds / repCount`. */
+  avgDurationSeconds: number
+  avgPower: number | null
+  avgHr: number | null
+  avgCadence: number | null
+  /** Duration-weighted mean speed in m/s, which is total distance over total time. */
+  avgSpeed: number | null
+  /** `1000 / avgSpeed`, i.e. seconds per kilometre; `null` when there is no usable speed. */
+  avgPaceSecondsPerKm: number | null
+}
+
+export type IntervalGroupSummaries = {
+  work: IntervalGroupSummary | null
+  recovery: IntervalGroupSummary | null
+}
+
+/**
+ * Warmup/cooldown markers, in the same languages `mapIntervalsToActual`
+ * recognises when it splits `classification` into work/recovery.
+ *
+ * These segments are classified `recovery`, but they are not the *recoveries*
+ * between reps: a warmup jog and a cooldown spin say nothing about how well the
+ * athlete recovered mid-session, and folding them in is precisely what drags a
+ * "recovery" figure toward the session mean. They are therefore excluded from
+ * the recovery aggregate and, being non-work, never reach the work aggregate.
+ */
+const WARMUP_COOLDOWN_TOKENS = ['warm', 'cool', 'calentamiento', 'enfriamiento']
+
+function isWarmupOrCooldownInterval(interval: ActualInterval): boolean {
+  const lower = String(interval.type || '').toLowerCase()
+  return WARMUP_COOLDOWN_TOKENS.some((token) => lower.includes(token))
+}
+
+/**
+ * Duration-weighted mean of one metric over `intervals`.
+ *
+ * Segments whose metric is absent are skipped entirely rather than counted as
+ * zero — a rep with no cadence sensor must not pull the cadence average down.
+ * When every contributing segment has a non-positive duration (fixtures, or a
+ * source that carries no timing at all) the weights are all zero, so the
+ * function falls back to the unweighted mean rather than dividing by zero and
+ * returning `NaN`.
+ */
+function durationWeightedMean(
+  intervals: ActualInterval[],
+  pick: (interval: ActualInterval) => number | null
+): number | null {
+  let weightedSum = 0
+  let weight = 0
+  let plainSum = 0
+  let count = 0
+
+  for (const interval of intervals) {
+    const value = pick(interval)
+    if (value === null || !Number.isFinite(value)) continue
+    const duration = Number(interval.durationSeconds)
+    plainSum += value
+    count += 1
+    if (Number.isFinite(duration) && duration > 0) {
+      weightedSum += value * duration
+      weight += duration
+    }
+  }
+
+  if (count === 0) return null
+  if (weight > 0) return weightedSum / weight
+  return plainSum / count
+}
+
+/**
+ * Aggregate one already-selected group of intervals.
+ *
+ * Returns `null` for an empty group rather than a zero-filled record: "there
+ * were no work intervals" and "the work intervals averaged nothing" are
+ * different statements, and only the first one is true of, say, a steady
+ * endurance ride. Every metric is independently `null` when no segment in the
+ * group carried it, so a run without a power meter reports no work power
+ * instead of `0W`.
+ */
+export function summarizeIntervalGroup(intervals: ActualInterval[]): IntervalGroupSummary | null {
+  if (!Array.isArray(intervals) || intervals.length === 0) return null
+
+  const totalDurationSeconds = intervals.reduce((sum, interval) => {
+    const duration = Number(interval.durationSeconds)
+    return sum + (Number.isFinite(duration) && duration > 0 ? duration : 0)
+  }, 0)
+
+  const avgSpeed = durationWeightedMean(intervals, (interval) =>
+    interval.avgSpeed !== null && Number(interval.avgSpeed) > 0 ? Number(interval.avgSpeed) : null
+  )
+
+  return {
+    repCount: intervals.length,
+    totalDurationSeconds,
+    avgDurationSeconds: totalDurationSeconds / intervals.length,
+    avgPower: durationWeightedMean(intervals, (interval) => interval.avgPower),
+    avgHr: durationWeightedMean(intervals, (interval) => interval.avgHr),
+    avgCadence: durationWeightedMean(intervals, (interval) => interval.avgCadence),
+    avgSpeed,
+    avgPaceSecondsPerKm: avgSpeed !== null && avgSpeed > 0 ? 1000 / avgSpeed : null
+  }
+}
+
+/**
+ * Split the arbitrated interval set into work-only and recovery-only aggregates
+ * (CW-381).
+ *
+ * The grouping reads the RESOLVED interval type — `classification`, which
+ * `mapIntervalsToActual` derives from the label `resolveProviderIntervalTypes`
+ * re-derived (CW-376) — and never `lap_splits`, which are the provider's
+ * automatic per-distance splits and straddle warmup, reps, recoveries and
+ * cooldown arbitrarily (CW-389).
+ *
+ * Why this exists: the payload gave the model per-lap rows plus session means
+ * and nothing in between, so interval-level claims were made from the session
+ * mean. A 4x4min threshold run was told its "average cadence of 162 spm is
+ * somewhat low for threshold work" — 162 spm being the whole-session mean,
+ * dragged down by warmup, recovery jogs and cooldown, while the four reps
+ * themselves averaged 177 spm. The advice was inverted, not merely imprecise.
+ */
+export function buildIntervalGroupSummaries(
+  intervals: ActualIntervalForAnalysis[]
+): IntervalGroupSummaries {
+  const all = Array.isArray(intervals) ? intervals : []
+  const work = all.filter((interval) => interval.classification === 'work')
+  const recovery = all.filter(
+    (interval) => interval.classification === 'recovery' && !isWarmupOrCooldownInterval(interval)
+  )
+
+  return {
+    work: summarizeIntervalGroup(work),
+    recovery: summarizeIntervalGroup(recovery)
+  }
+}
+
 function rateConfidence(score: number): FactConfidence {
   if (score >= 0.75) return 'high'
   if (score >= 0.4) return 'medium'


### PR DESCRIPTION
Fixes CW-381

## Problem

The analysis payload gave the LLM per-lap rows plus session-level averages and nothing in between, so interval-level claims were built from the session mean. A live 4x4min threshold run got "your average cadence of 162 spm is somewhat low for threshold work" — 162 spm is the whole-session mean (dragged down by warmup, recovery jogs, cooldown); the four threshold reps averaged 177 spm. The advice was inverted, not merely imprecise.

## Change

Duration-weighted work-only and recovery-only aggregates over the **same arbitrated segmentation** the Interval Breakdown and the v2 facts block already use, grouped by the interval types CW-376 re-derives — never by `lap_splits` (provider per-distance splits that cut across reps and recoveries, CW-389).

- `server/utils/workout-analysis-facts.ts`: new `summarizeIntervalGroup` / `buildIntervalGroupSummaries` + `IntervalGroupSummary` type. Duration-weighted, not mean-of-lap-means — that distinction is exactly the 162-vs-177 gap. Absent metrics are skipped rather than counted as zero; an empty group returns `null` rather than a zero-filled record; an all-zero-duration group falls back to an unweighted mean instead of dividing by zero.
- `server/utils/services/workout-analysis-prompt.ts`: `work_interval_summary` / `recovery_interval_summary` on the payload (cadence normalised at the single existing conversion point), a `## Work vs Recovery Aggregates` section printed before the per-interval table, and a hard rule next to the other guardrails — any interval/rep/threshold claim must quote these figures, never the session means.

Warmup and cooldown are excluded from both aggregates: they are classified `recovery` but say nothing about how well the athlete recovered between reps, and folding them in is what drags a "recovery" figure back toward the session mean.

## Verification

```
pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts server/utils/workout-analysis-facts.test.ts
  Test Files  2 passed (2)
       Tests  168 passed (168)

pnpm typecheck  # exit 0
```

Unit coverage for the aggregate helper includes all-work (no recoveries), no-work-laps, and mixed sessions, plus duration-weighting, missing-metric, empty-list and zero-duration cases — all asserted free of `NaN`/fabricated `0`. Prompt-level coverage reproduces the ticket's 4x4min run end to end (session 162 spm vs work-only 177 spm) and pins that the aggregate follows the resolved laps, not `lap_splits`.

The pinned prompt snapshot (`server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap`) is updated: it gains exactly the new section and the two guardrail rules.

UX critique: skipped — backend/prompt-only change, no UI surface.