### PR TITLE
fix(integrations): let a reconnect retry a failed Garmin backfill (CW-513)

### DIFF
--- a/server/api/integrations/garmin/callback.get.ts
+++ b/server/api/integrations/garmin/callback.get.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'crypto'
+import { createHash, timingSafeEqual } from 'crypto'
 import { dispatchTask } from '../../../utils/task-dispatcher'
 import { getServerSession } from '../../../utils/session'
 import { prisma } from '../../../utils/db'
@@ -196,6 +196,31 @@ export default defineEventHandler(async (event) => {
   // Best-effort: merge export permissions (HEALTH_EXPORT, WORKOUT_IMPORT, …) into scope.
   await refreshGarminIntegrationPermissions(integration)
 
+  // CW-513: scope the backfill's idempotency key to *this* connect, not to the user.
+  //
+  // The key is there to stop a single connect from queueing several expensive
+  // backfills when the callback is delivered more than once (double submit, two
+  // tabs, a proxy/browser retry). Keyed on the user alone with a 1h TTL it also
+  // swallowed the *next* connect: since CW-95 this task can end FAILED, and
+  // neither Trigger.dev nor the BullMQ `deduplication` fallback in
+  // server/utils/task-dispatcher.ts releases a key early when the run behind it
+  // fails. A user whose backfill failed was therefore deduplicated against that
+  // dead run for the rest of the hour - and disconnect/reconnect, the one remedy
+  // available to them, is exactly what the key suppressed.
+  //
+  // The OAuth authorization code is the right discriminator: every trip through
+  // /authorize mints a fresh one, while a re-delivery of a single connect carries
+  // the code we already exchanged. So any deliberate reconnect (with or without a
+  // disconnect first, and regardless of whether the Integration row is recreated)
+  // gets a new key and a new run, while duplicate deliveries of one connect still
+  // collapse into one run. It is hashed rather than embedded verbatim because the
+  // code is a single-use credential and idempotency keys are persisted and shown
+  // by the task backend.
+  const connectFingerprint = createHash('sha256')
+    .update(code as string)
+    .digest('hex')
+    .slice(0, 16)
+
   // Start historical backfill after a short delay via Trigger.dev
   // We use a delay to ensure Garmin's Push API registration is fully propagated
   // to avoid "User not registered with consumer" (403) errors.
@@ -206,11 +231,13 @@ export default defineEventHandler(async (event) => {
       {
         concurrencyKey: session.user.id,
         tags: [`user:${session.user.id}`],
-        idempotencyKey: `garmin-backfill:${session.user.id}`,
+        idempotencyKey: `garmin-backfill:${session.user.id}:${connectFingerprint}`,
         idempotencyKeyTTL: '1h'
       }
     )
-    console.log(`[GarminCallback] Queued garmin-backfill for user ${session.user.id}`)
+    console.log(
+      `[GarminCallback] Queued garmin-backfill for user ${session.user.id} (connect ${connectFingerprint})`
+    )
   } catch (e) {
     console.error('[GarminCallback] Failed to trigger backfill task', e)
   }


### PR DESCRIPTION
Fixes CW-513

## Problem

The Garmin backfill was dispatched from the OAuth callback with `idempotencyKey: garmin-backfill:${userId}` and `idempotencyKeyTTL: '1h'`. Since CW-95 the backfill task can end **failed**, and neither dispatch backend releases an idempotency key early when the run behind it fails:

- Trigger.dev holds the key for the full TTL regardless of run outcome.
- The BullMQ fallback in `server/utils/task-dispatcher.ts` maps `idempotencyKeyTTL` onto `deduplication: { id, ttl }`, which behaves the same.

So a user whose backfill failed was deduplicated against that dead run for the rest of the hour — and the obvious remedy (disconnect and reconnect) is exactly what the user-scoped key suppressed.

## Fix — key composition (one file changed)

`server/api/integrations/garmin/callback.get.ts`:

```
garmin-backfill:${userId}
→ garmin-backfill:${userId}:${sha256(authorization code).slice(0, 16)}
```

The OAuth authorization code is the discriminator between "a new connect" and "the same connect delivered twice":

- **Every trip through `/api/integrations/garmin/authorize` mints a new code.** Any deliberate reconnect therefore produces a new key and a fresh backfill run — whether or not the user disconnected first, and regardless of whether the `Integration` row was recreated or updated in place.
- **A re-delivery of one connect carries the code we already exchanged** (double submit, two tabs on the same callback URL, a proxy/browser retry). Same code → same key → still collapses into one run. The key's original purpose is intact; it is not deleted or weakened for the normal path.

The code is hashed rather than embedded verbatim: it is a single-use credential, and idempotency keys are persisted and displayed by the task backend. The truncated digest is also logged next to the queue line so a run can be correlated back to a specific connect.

`idempotencyKeyTTL` stays at `1h`. With the key now per-connect, the TTL only bounds how long a re-delivery of *the same* callback is suppressed, so a long TTL is free and no longer blocks recovery. Shortening it would have weakened duplicate protection without fixing anything.

## Alternatives considered and rejected

- **Shorten the TTL only.** Narrows the dead window but never removes it — a user who retries inside the shorter window is still deduplicated against a failed run.
- **Key on the integration's `createdAt` / `id`.** `disconnect.delete.ts` does delete the row, so this covers disconnect → reconnect. But a plain re-authorize while still connected takes the upsert **update** path and keeps the same `id`/`createdAt`, leaving that path broken. `updatedAt` changes on every duplicate callback too, which would defeat deduplication entirely.
- **Scope the key to exclude failed runs.** Requires reading back the prior run's status, but the run id is not persisted, and the logic would have to hold for all three dispatch drivers (Trigger.dev, BullMQ, inline). Too much machinery for the benefit.

## Verification

- `pnpm typecheck` — clean, exit 0.
- `npx eslint server/api/integrations/garmin/callback.get.ts` — clean.

**What could not be verified automatically:** the ticket's gate is typecheck-only — this OAuth callback has no test harness, and a test would require a new file outside the ticket's Owned Paths. Specifically unverified end-to-end:

- That a real reconnect produces a fresh run — driving it needs live Garmin credentials and a genuine failed backfill.
- Garmin's actual behaviour on authorization-code reuse. The reasoning does not depend on it: if Garmin rejects a reused code the duplicate callback never reaches the dispatch (it redirects at token exchange), and if Garmin accepts it the identical code yields the identical key and is deduplicated. Both branches are safe.
- Deduplication behaviour on the BullMQ driver was reasoned from the dispatcher code, not exercised against a live Redis.

The one behavioural trade-off, stated explicitly: a user who reconnects while a previous backfill is still queued or running now gets a second run queued rather than suppressed, and **those two runs can overlap**. `concurrencyKey: userId` does not serialise them — it *partitions* a queue's concurrency limit per key, and `garmin-backfill` declares `queue: { name: "user-ingestion", concurrencyLimit: 5 }` in `server/utils/task-manifest.json`, so up to 5 same-user runs may execute concurrently (in practice capped by the worker's `CW_WORKER_QUEUE_TASK_CONCURRENCY`, default 3, with no cross-process guarantee if more than one worker runs). Trigger.dev partitions the same way.

That is acceptable because duplicate backfill requests are idempotent at Garmin's end: `requestGarminBackfill` treats HTTP 409 "already requested" as success (`server/utils/garmin.ts:598`), so the cost of a duplicate run is roughly six requests that Garmin answers 409. Honouring a deliberate reconnect is the point of the ticket, and this is the intended consequence.

**UX critique: skipped** — backend OAuth callback logic, no UI surface; effect not drivable without live Garmin credentials.
