### PR TITLE
fix(workouts): tolerate NULL stream array elements in WorkoutStreamV2 decode (CW-453)

### DIFF
--- a/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/server/utils/repositories/workoutStreamRepository.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { prisma } from '../db'
+import {
+  enforceNoNullStreamElements,
+  extractDecodeColumn,
+  workoutStreamRepository
+} from './workoutStreamRepository'
+
+vi.mock('../db', () => ({
+  prisma: {
+    workoutStreamV2: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      upsert: vi.fn()
+    },
+    workoutStream: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn()
+    },
+    $queryRaw: vi.fn()
+  }
+}))
+
+const db = prisma as unknown as {
+  workoutStreamV2: {
+    findUnique: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+    upsert: ReturnType<typeof vi.fn>
+  }
+  workoutStream: {
+    findUnique: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+  }
+  $queryRaw: ReturnType<typeof vi.fn>
+}
+
+/**
+ * The exact shape of the Prisma client failure this ticket is about: Postgres
+ * allows a NULL element inside an `integer[]`, the client's decoder does not.
+ */
+function decodeError(column: string): Error {
+  return new Error(`Expected an integer in column '${column}', got object: null`)
+}
+
+/** A WorkoutStreamV2 row as the DB returns it once NULL elements are repaired. */
+function repairedRow(workoutId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `stream-${workoutId}`,
+    workoutId,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    time: [0, 1, 2],
+    heartrate: [120, 121, 122],
+    watts: [200, 0, 210],
+    velocity: [5.1, 5.2, 5.3],
+    cadence: [90, 0, 91],
+    lat: [47.5, 47.5, 47.5],
+    lng: [19.0, 19.0, 19.0],
+    hrZoneTimes: null,
+    powerZoneTimes: null,
+    ...overrides
+  }
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  // V1 is empty in production; individual tests override where it matters.
+  db.workoutStream.findUnique.mockResolvedValue(null)
+  db.workoutStream.findMany.mockResolvedValue([])
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('extractDecodeColumn', () => {
+  it('pulls the offending column out of a Prisma decode error', () => {
+    expect(extractDecodeColumn(decodeError('cadence[593]'))).toBe('cadence[593]')
+  })
+
+  it('returns null for an error that names no column', () => {
+    expect(extractDecodeColumn(new Error('connection reset'))).toBeNull()
+  })
+})
+
+describe('findByWorkoutId', () => {
+  it('returns usable stream data for a row whose arrays contain NULL elements', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
+    db.$queryRaw.mockResolvedValue([repairedRow('workout-1')])
+
+    const stream = await workoutStreamRepository.findByWorkoutId('workout-1')
+
+    expect(stream).not.toBeNull()
+    expect(stream?.workoutId).toBe('workout-1')
+    // NULL elements are coerced to 0 rather than dropped, so every series stays
+    // index-aligned with `time`.
+    expect(stream?.cadence).toEqual([90, 0, 91])
+    expect(stream?.time).toEqual([0, 1, 2])
+    expect(stream?.latlng).toEqual([
+      [47.5, 19.0],
+      [47.5, 19.0],
+      [47.5, 19.0]
+    ])
+    // The undecodable row must not fall through to the (production-empty) V1 table.
+    expect(db.workoutStream.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('logs the workout id and the offending column instead of swallowing the error', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
+    db.$queryRaw.mockResolvedValue([repairedRow('workout-1')])
+
+    await workoutStreamRepository.findByWorkoutId('workout-1')
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[workoutStreamRepository] stream read failed',
+      expect.objectContaining({
+        operation: 'findByWorkoutId',
+        table: 'WorkoutStreamV2',
+        column: 'cadence[593]',
+        workoutIds: ['workout-1']
+      })
+    )
+  })
+
+  it('logs when the legacy V1 fallback read fails', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([])
+    db.workoutStream.findUnique.mockRejectedValue(new Error('connection reset'))
+
+    await expect(workoutStreamRepository.findByWorkoutId('workout-1')).resolves.toBeNull()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[workoutStreamRepository] stream read failed',
+      expect.objectContaining({ operation: 'findByWorkoutId', table: 'WorkoutStream' })
+    )
+  })
+})
+
+describe('findManyByWorkoutIds', () => {
+  it('repairs the whole batch in SQL when one row cannot be decoded', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('watts[12]'))
+    db.$queryRaw.mockResolvedValue([
+      repairedRow('good-1'),
+      repairedRow('bad-1'),
+      repairedRow('good-2')
+    ])
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds([
+      'good-1',
+      'bad-1',
+      'good-2'
+    ])
+
+    expect([...streams.keys()].sort()).toEqual(['bad-1', 'good-1', 'good-2'])
+    expect(streams.get('bad-1')?.watts).toEqual([200, 0, 210])
+  })
+
+  it('returns every row it can decode and omits only the undecodable one', async () => {
+    // Both the typed read and the SQL repair fail, forcing the per-row path.
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
+    db.$queryRaw.mockRejectedValue(new Error('relation "WorkoutStreamV2" is not available'))
+    db.workoutStreamV2.findUnique.mockImplementation(async ({ where }: any) => {
+      if (where.workoutId === 'bad-1') throw decodeError('cadence[593]')
+      return repairedRow(where.workoutId)
+    })
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds([
+      'good-1',
+      'bad-1',
+      'good-2'
+    ])
+
+    expect([...streams.keys()].sort()).toEqual(['good-1', 'good-2'])
+    expect(streams.has('bad-1')).toBe(false)
+    expect(streams.get('good-1')?.time).toEqual([0, 1, 2])
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[workoutStreamRepository] stream read failed',
+      expect.objectContaining({
+        operation: 'findManyByWorkoutIds:per-row',
+        workoutIds: ['bad-1']
+      })
+    )
+  })
+
+  it('leaves the clean path untouched', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([repairedRow('good-1')])
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['good-1'])
+
+    expect(streams.get('good-1')?.watts).toEqual([200, 0, 210])
+    expect(db.$queryRaw).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('findWattsByWorkoutIds', () => {
+  it('recovers watts from a row with NULL elements', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('watts[41]'))
+    db.$queryRaw.mockResolvedValue([{ workoutId: 'workout-1', watts: [250, 0, 260] }])
+
+    const watts = await workoutStreamRepository.findWattsByWorkoutIds(['workout-1'])
+
+    expect(watts.get('workout-1')).toEqual([250, 0, 260])
+  })
+})
+
+describe('upsert write guard', () => {
+  it('never writes a NULL element into a numeric or boolean array', async () => {
+    db.workoutStreamV2.upsert.mockResolvedValue({ id: 'stream-1' })
+
+    await workoutStreamRepository.upsert('workout-1', {
+      time: [0, null as any, 2],
+      cadence: [90, null as any, 91],
+      watts: [200, undefined as any, 210],
+      altitude: [100.5, null as any, 101.5],
+      moving: [true, null as any, false],
+      latlng: [
+        [47.5, 19.0],
+        [null as any, 19.1],
+        [47.6, 19.2]
+      ]
+    })
+
+    const payload = db.workoutStreamV2.upsert.mock.calls[0]?.[0].update
+    for (const column of ['time', 'cadence', 'watts', 'altitude', 'moving', 'lat', 'lng']) {
+      expect(payload[column].some((value: unknown) => value == null)).toBe(false)
+    }
+    expect(payload.time).toEqual([0, 0, 2])
+    expect(payload.cadence).toEqual([90, 0, 91])
+    expect(payload.watts).toEqual([200, 0, 210])
+    expect(payload.moving).toEqual([true, false, false])
+    // The invalid GPS point is skipped, so lat/lng stay pairwise consistent.
+    expect(payload.lat).toHaveLength(2)
+    expect(payload.lng).toHaveLength(2)
+  })
+
+  it('logs loudly if a NULL element ever reaches the final guard', () => {
+    const writeData: Record<string, unknown> = { cadence: [90, null, 91], lapSplits: [null] }
+
+    enforceNoNullStreamElements(writeData, 'workout-1')
+
+    expect(writeData.cadence).toEqual([90, 0, 91])
+    // JSON metadata may legitimately contain nulls and must not be rewritten.
+    expect(writeData.lapSplits).toEqual([null])
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[workoutStreamRepository] blocked NULL element in stream write',
+      expect.objectContaining({ workoutId: 'workout-1', column: 'cadence', index: 1 })
+    )
+  })
+})

--- a/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/server/utils/repositories/workoutStreamRepository.test.ts
@@ -160,9 +160,10 @@ describe('findManyByWorkoutIds', () => {
   })
 
   it('returns every row it can decode and omits only the undecodable one', async () => {
-    // Both the typed read and the SQL repair fail, forcing the per-row path.
+    // Both the typed read and the SQL repair hit a decode error (a column the
+    // repair does not cover), which is the only thing that earns the per-row path.
     db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
-    db.$queryRaw.mockRejectedValue(new Error('relation "WorkoutStreamV2" is not available'))
+    db.$queryRaw.mockRejectedValue(decodeError('cadence[593]'))
     db.workoutStreamV2.findUnique.mockImplementation(async ({ where }: any) => {
       if (where.workoutId === 'bad-1') throw decodeError('cadence[593]')
       return repairedRow(where.workoutId)
@@ -184,6 +185,34 @@ describe('findManyByWorkoutIds', () => {
         workoutIds: ['bad-1']
       })
     )
+  })
+
+  it('does not escalate an infrastructure failure into a per-row fan-out', async () => {
+    // A pool/statement timeout is not a decode error: there is nothing for the
+    // repair read to fix, and answering an unhealthy database with one query
+    // per id (200 per chunk, and chunks run concurrently) is the worst possible
+    // response. It must degrade immediately, as it did before CW-453.
+    db.workoutStreamV2.findMany.mockRejectedValue(
+      new Error('Timed out fetching a new connection from the connection pool')
+    )
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['a', 'b', 'c'])
+
+    expect(streams.size).toBe(0)
+    expect(db.$queryRaw).not.toHaveBeenCalled()
+    expect(db.workoutStreamV2.findUnique).not.toHaveBeenCalled()
+    // One log line for the chunk, not one per id.
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fan out per row when the repair read itself fails on infrastructure', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
+    db.$queryRaw.mockRejectedValue(new Error('canceling statement due to statement timeout'))
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['a', 'b', 'c'])
+
+    expect(streams.size).toBe(0)
+    expect(db.workoutStreamV2.findUnique).not.toHaveBeenCalled()
   })
 
   it('leaves the clean path untouched', async () => {

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -116,6 +116,72 @@ export function splitLatlngPoints(latlng: readonly unknown[] | null | undefined)
   return { lat, lng }
 }
 
+/**
+ * Every array column written to WorkoutStreamV2, mapped to the sanitizer that
+ * makes it safe for Prisma to read back (CW-453 write-path guard).
+ *
+ * Building the upsert payload by iterating this table instead of listing the
+ * columns inline keeps "which columns are series" defined exactly once -- the
+ * same list the invariant check below walks, so a column can't be sanitized on
+ * write and then skipped by the guard (or vice versa).
+ */
+const V2_ARRAY_WRITE_SANITIZERS: Record<string, (values: any) => Array<number | boolean>> = {
+  lat: sanitizeFloatStreamArray,
+  lng: sanitizeFloatStreamArray,
+  time: sanitizeIntStreamArray,
+  distance: sanitizeFloatStreamArray,
+  velocity: sanitizeFloatStreamArray,
+  heartrate: sanitizeIntStreamArray,
+  cadence: sanitizeIntStreamArray,
+  watts: sanitizeIntStreamArray,
+  altitude: sanitizeFloatStreamArray,
+  grade: sanitizeFloatStreamArray,
+  moving: sanitizeBooleanStreamArray,
+  temp: sanitizeIntStreamArray,
+  torque: sanitizeIntStreamArray,
+  leftRightBalance: sanitizeIntStreamArray,
+  hrv: sanitizeFloatStreamArray,
+  respiration: sanitizeFloatStreamArray,
+  targetPower: sanitizeIntStreamArray
+}
+
+const BOOLEAN_WRITE_COLUMNS: ReadonlySet<string> = new Set(['moving'])
+
+function isUnwritableStreamElement(value: unknown): boolean {
+  return value == null || (typeof value === 'number' && !Number.isFinite(value))
+}
+
+/**
+ * Last line of defence before `upsert()`: no numeric/boolean series may contain
+ * a NULL (or non-finite) element, because Postgres accepts it happily and the
+ * Prisma client then cannot read the row back at all (CW-453).
+ *
+ * The sanitizers above already guarantee this, so a repair here means one of
+ * them regressed or a series bypassed them -- which is logged loudly rather
+ * than corrected in silence. Only the known series columns are inspected: JSON
+ * metadata such as `lapSplits` may legitimately contain nulls and is untouched.
+ */
+export function enforceNoNullStreamElements(
+  writeData: Record<string, unknown>,
+  workoutId: string
+): void {
+  for (const column of Object.keys(V2_ARRAY_WRITE_SANITIZERS)) {
+    const values = writeData[column]
+    if (!Array.isArray(values)) continue
+    const index = values.findIndex(isUnwritableStreamElement)
+    if (index === -1) continue
+
+    console.error('[workoutStreamRepository] blocked NULL element in stream write', {
+      operation: 'upsert',
+      workoutId,
+      column,
+      index
+    })
+    const fallback: number | boolean = BOOLEAN_WRITE_COLUMNS.has(column) ? false : 0
+    writeData[column] = values.map((value) => (isUnwritableStreamElement(value) ? fallback : value))
+  }
+}
+
 export async function attachStreamToWorkout<T extends { id: string }>(
   workout: T
 ): Promise<T & { streams: NormalizedStream | null }> {
@@ -241,6 +307,205 @@ function buildV1Select(
   const select: Record<string, true> = { ...REQUIRED_V1_SELECT }
   for (const field of fields) select[field] = true
   return select
+}
+
+/**
+ * CW-453: Postgres permits NULL *elements* inside `integer[]` / `double
+ * precision[]`, the Prisma client does not. Reading such a row throws
+ * `Expected an integer in column 'cadence[593]', got object: null` and used to
+ * be swallowed by a bare `.catch()`, so ~24% of production streams rendered as
+ * "no stream data at all".
+ *
+ * The columns below drive a raw-SQL fallback read that repairs those rows on
+ * the way out with `array_replace(col, NULL, 0)`.
+ *
+ * **NULL element -> 0, never dropped.** Every series in a WorkoutStreamV2 row
+ * is index-aligned with `time`; `array_remove()` would shorten one series and
+ * silently shift every later sample against the clock, corrupting the chart
+ * rather than patching it. Coercing to 0 keeps the alignment and matches what
+ * the write path already does (see sanitizeIntStreamArray/
+ * sanitizeFloatStreamArray), so a row read back after a repair looks exactly
+ * like a row written today. For `moving`, the boolean analogue is `false`.
+ */
+const V2_INT_ARRAY_COLUMNS = [
+  'time',
+  'heartrate',
+  'cadence',
+  'watts',
+  'temp',
+  'torque',
+  'leftRightBalance',
+  'targetPower'
+] as const
+
+const V2_FLOAT_ARRAY_COLUMNS = [
+  'distance',
+  'velocity',
+  'altitude',
+  'lat',
+  'lng',
+  'grade',
+  'hrv',
+  'respiration'
+] as const
+
+const V2_BOOLEAN_ARRAY_COLUMNS = ['moving'] as const
+
+/** Columns with no array elements to repair -- selected verbatim. */
+const V2_PLAIN_COLUMNS = [
+  'id',
+  'workoutId',
+  'avgPacePerKm',
+  'paceVariability',
+  'lapSplits',
+  'paceZones',
+  'pacingStrategy',
+  'surges',
+  'hrZoneTimes',
+  'powerZoneTimes',
+  'extrasMeta',
+  'createdAt',
+  'updatedAt'
+] as const
+
+const V2_INT_ARRAY_COLUMN_SET: ReadonlySet<string> = new Set(V2_INT_ARRAY_COLUMNS)
+const V2_FLOAT_ARRAY_COLUMN_SET: ReadonlySet<string> = new Set(V2_FLOAT_ARRAY_COLUMNS)
+const V2_BOOLEAN_ARRAY_COLUMN_SET: ReadonlySet<string> = new Set(V2_BOOLEAN_ARRAY_COLUMNS)
+
+const ALL_V2_COLUMNS: readonly string[] = [
+  ...V2_PLAIN_COLUMNS,
+  ...V2_INT_ARRAY_COLUMNS,
+  ...V2_FLOAT_ARRAY_COLUMNS,
+  ...V2_BOOLEAN_ARRAY_COLUMNS
+]
+
+const V2_COLUMN_SET: ReadonlySet<string> = new Set(ALL_V2_COLUMNS)
+
+/**
+ * Select expression for one WorkoutStreamV2 column in the repair read.
+ *
+ * `column` is only ever interpolated raw after being checked against
+ * V2_COLUMN_SET, so no caller-controlled string can reach the SQL text.
+ */
+function v2RepairColumnSql(column: string): Prisma.Sql {
+  if (!V2_COLUMN_SET.has(column)) {
+    throw new Error(`[workoutStreamRepository] unknown WorkoutStreamV2 column: ${column}`)
+  }
+  const ref = Prisma.raw(`"${column}"`)
+  if (V2_INT_ARRAY_COLUMN_SET.has(column)) {
+    return Prisma.sql`array_replace(${ref}, NULL::integer, 0) AS ${ref}`
+  }
+  if (V2_FLOAT_ARRAY_COLUMN_SET.has(column)) {
+    return Prisma.sql`array_replace(${ref}, NULL::double precision, 0::double precision) AS ${ref}`
+  }
+  if (V2_BOOLEAN_ARRAY_COLUMN_SET.has(column)) {
+    return Prisma.sql`array_replace(${ref}, NULL::boolean, false) AS ${ref}`
+  }
+  return Prisma.sql`${ref}`
+}
+
+/** `Expected an integer in column 'cadence[593]', got object: null` -> `cadence[593]`. */
+export function extractDecodeColumn(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : String(error)
+  return /column '([^']+)'/.exec(message)?.[1] ?? null
+}
+
+/**
+ * Stream reads are best-effort by design -- a workout still renders without its
+ * series -- but they must never fail *silently*: a swallowed decode error is
+ * exactly how CW-453 stayed invisible for 90k rows. Every remaining `.catch()`
+ * in this file routes here.
+ */
+function logStreamReadFailure(
+  operation: string,
+  table: 'WorkoutStreamV2' | 'WorkoutStream',
+  workoutIds: readonly string[],
+  error: unknown
+): void {
+  console.error('[workoutStreamRepository] stream read failed', {
+    operation,
+    table,
+    column: extractDecodeColumn(error),
+    workoutIdCount: workoutIds.length,
+    // Bounded so a 200-id chunk can't blow up a log line; the column plus a
+    // handful of ids is enough to locate the offending rows.
+    workoutIds: workoutIds.slice(0, 10),
+    error: error instanceof Error ? error.message : String(error)
+  })
+}
+
+/**
+ * Raw read of WorkoutStreamV2 that repairs NULL array elements in Postgres, so
+ * the result can't trip the Prisma client's array decoder (CW-453).
+ *
+ * Only used as a fallback: the typed client path stays the hot path for the
+ * ~76% of rows that are clean, and this pays the extra round trip only for
+ * batches that actually contain a damaged row.
+ */
+async function readV2WithNullRepair(
+  workoutIds: readonly string[],
+  columns: readonly string[]
+): Promise<any[]> {
+  if (workoutIds.length === 0) return []
+  const selection = Prisma.join(
+    columns.map((column) => v2RepairColumnSql(column)),
+    ', '
+  )
+  return prisma.$queryRaw<any[]>(
+    Prisma.sql`
+      SELECT ${selection}
+      FROM "WorkoutStreamV2"
+      WHERE "workoutId" IN (${Prisma.join(workoutIds as string[])})
+    `
+  )
+}
+
+/**
+ * Read a chunk of WorkoutStreamV2 rows, degrading instead of returning nothing:
+ *
+ * 1. typed Prisma client (fast path, unchanged for clean rows);
+ * 2. on a decode error, the raw repair read for the whole chunk;
+ * 3. if even that fails, one typed read per id, so the batch loses only the
+ *    rows that genuinely cannot be decoded rather than all of them.
+ */
+async function readV2Chunk(
+  workoutIds: readonly string[],
+  select: Record<string, true> | undefined,
+  operation: string
+): Promise<any[]> {
+  if (workoutIds.length === 0) return []
+  const findManyArgs = {
+    where: { workoutId: { in: workoutIds as string[] } },
+    ...(select ? { select } : {})
+  }
+
+  try {
+    return await (prisma as any).workoutStreamV2.findMany(findManyArgs)
+  } catch (error) {
+    logStreamReadFailure(operation, 'WorkoutStreamV2', workoutIds, error)
+  }
+
+  const columns = select ? Object.keys(select) : ALL_V2_COLUMNS
+  try {
+    return await readV2WithNullRepair(workoutIds, columns)
+  } catch (error) {
+    logStreamReadFailure(`${operation}:null-repair`, 'WorkoutStreamV2', workoutIds, error)
+  }
+
+  const rows = await Promise.all(
+    workoutIds.map(async (workoutId) => {
+      try {
+        return await (prisma as any).workoutStreamV2.findUnique({
+          where: { workoutId },
+          ...(select ? { select } : {})
+        })
+      } catch (error) {
+        logStreamReadFailure(`${operation}:per-row`, 'WorkoutStreamV2', [workoutId], error)
+        return null
+      }
+    })
+  )
+  return rows.filter((row) => row != null)
 }
 
 /**
@@ -374,7 +639,10 @@ async function findStreamPresenceByWorkoutIds(
             WHERE "workoutId" IN (${Prisma.join(chunk)})
           `
         )
-        .catch(() => [] as StreamPresenceRow[])
+        .catch((error) => {
+          logStreamReadFailure('findStreamPresenceByWorkoutIds', 'WorkoutStreamV2', chunk, error)
+          return [] as StreamPresenceRow[]
+        })
     )
   )
 
@@ -404,7 +672,10 @@ async function findStreamPresenceByWorkoutIds(
             WHERE "workoutId" IN (${Prisma.join(chunk)})
           `
         )
-        .catch(() => [] as StreamPresenceRow[])
+        .catch((error) => {
+          logStreamReadFailure('findStreamPresenceByWorkoutIds', 'WorkoutStream', chunk, error)
+          return [] as StreamPresenceRow[]
+        })
     )
   )
 
@@ -417,15 +688,19 @@ async function findStreamPresenceByWorkoutIds(
 
 export const workoutStreamRepository = {
   async findByWorkoutId(workoutId: string): Promise<NormalizedStream | null> {
-    const v2 = await (prisma as any).workoutStreamV2
-      .findUnique({ where: { workoutId } })
-      .catch(() => null)
+    // readV2Chunk() falls back to the NULL-repairing raw read, so a row with
+    // NULL array elements yields usable series instead of dropping through to
+    // the (production-empty) V1 table and returning null. CW-453.
+    const [v2] = await readV2Chunk([workoutId], undefined, 'findByWorkoutId')
     if (v2) {
       const normalized = normalizeV2(v2)
       if (hasUsableStreamData(normalized)) return normalized
     }
 
-    const v1 = await prisma.workoutStream.findUnique({ where: { workoutId } }).catch(() => null)
+    const v1 = await prisma.workoutStream.findUnique({ where: { workoutId } }).catch((error) => {
+      logStreamReadFailure('findByWorkoutId', 'WorkoutStream', [workoutId], error)
+      return null
+    })
     if (!v1) return null
     const normalized = toNormalizedFromV1(v1)
     return hasUsableStreamData(normalized) ? normalized : null
@@ -456,12 +731,7 @@ export const workoutStreamRepository = {
 
     const v2Chunks = await Promise.all(
       chunkArray(workoutIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
-        (prisma as any).workoutStreamV2
-          .findMany({
-            where: { workoutId: { in: chunk } },
-            ...(v2Select ? { select: v2Select } : {})
-          })
-          .catch(() => [])
+        readV2Chunk(chunk, v2Select, 'findManyByWorkoutIds')
       )
     )
     const v2Records: any[] = v2Chunks.flat()
@@ -490,7 +760,10 @@ export const workoutStreamRepository = {
               where: { workoutId: { in: chunk } },
               ...(v1Select ? { select: v1Select } : {})
             })
-            .catch(() => [])
+            .catch((error) => {
+              logStreamReadFailure('findManyByWorkoutIds', 'WorkoutStream', chunk, error)
+              return []
+            })
         )
       )
       const v1Records = v1Chunks.flat()
@@ -525,12 +798,7 @@ export const workoutStreamRepository = {
 
     const v2Chunks = await Promise.all(
       chunks.map((chunk) =>
-        (prisma as any).workoutStreamV2
-          .findMany({
-            where: { workoutId: { in: chunk } },
-            select: { workoutId: true, watts: true }
-          })
-          .catch(() => [])
+        readV2Chunk(chunk, { workoutId: true, watts: true }, 'findWattsByWorkoutIds')
       )
     )
 
@@ -550,7 +818,10 @@ export const workoutStreamRepository = {
             where: { workoutId: { in: chunk } },
             select: { workoutId: true, watts: true }
           })
-          .catch(() => [])
+          .catch((error) => {
+            logStreamReadFailure('findWattsByWorkoutIds', 'WorkoutStream', chunk, error)
+            return []
+          })
       )
     )
 
@@ -567,9 +838,15 @@ export const workoutStreamRepository = {
     workoutId: string,
     data: { hrZoneTimes?: unknown; powerZoneTimes?: unknown }
   ): Promise<void> {
+    // `select: { id: true }` decodes no arrays, so this can only fail for
+    // infrastructure reasons -- but failing quietly here silently redirects the
+    // metadata write to the legacy V1 row, so it must be logged.
     const v2 = await (prisma as any).workoutStreamV2
       .findUnique({ where: { workoutId }, select: { id: true } })
-      .catch(() => null)
+      .catch((error: unknown) => {
+        logStreamReadFailure('updateMetadata', 'WorkoutStreamV2', [workoutId], error)
+        return null
+      })
 
     if (v2) {
       await (prisma as any).workoutStreamV2.update({
@@ -653,26 +930,33 @@ export const workoutStreamRepository = {
     } = data
     const { lat, lng } = splitLatlngPoints(latlng)
 
-    const writeData: any = {
-      ...meta,
-      lat: sanitizeFloatStreamArray(lat),
-      lng: sanitizeFloatStreamArray(lng),
-      time: sanitizeIntStreamArray(time),
-      distance: sanitizeFloatStreamArray(distance),
-      velocity: sanitizeFloatStreamArray(velocity),
-      heartrate: sanitizeIntStreamArray(heartrate),
-      cadence: sanitizeIntStreamArray(cadence),
-      watts: sanitizeIntStreamArray(watts),
-      altitude: sanitizeFloatStreamArray(altitude),
-      grade: sanitizeFloatStreamArray(grade),
-      moving: sanitizeBooleanStreamArray(moving),
-      temp: sanitizeIntStreamArray(temp),
-      torque: sanitizeIntStreamArray(torque),
-      leftRightBalance: sanitizeIntStreamArray(leftRightBalance),
-      hrv: sanitizeFloatStreamArray(hrv),
-      respiration: sanitizeFloatStreamArray(respiration),
-      targetPower: sanitizeIntStreamArray(targetPower)
+    const rawSeries: Record<string, unknown> = {
+      lat,
+      lng,
+      time,
+      distance,
+      velocity,
+      heartrate,
+      cadence,
+      watts,
+      altitude,
+      grade,
+      moving,
+      temp,
+      torque,
+      leftRightBalance,
+      hrv,
+      respiration,
+      targetPower
     }
+
+    const writeData: any = { ...meta }
+    for (const [column, sanitize] of Object.entries(V2_ARRAY_WRITE_SANITIZERS)) {
+      writeData[column] = sanitize(rawSeries[column])
+    }
+    // CW-453: nothing may reach Postgres with a NULL element in a numeric or
+    // boolean array -- that is what made 24% of stream rows unreadable.
+    enforceNoNullStreamElements(writeData, workoutId)
 
     return (prisma as any).workoutStreamV2.upsert({
       where: { workoutId },

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -322,10 +322,14 @@ function buildV1Select(
  * **NULL element -> 0, never dropped.** Every series in a WorkoutStreamV2 row
  * is index-aligned with `time`; `array_remove()` would shorten one series and
  * silently shift every later sample against the clock, corrupting the chart
- * rather than patching it. Coercing to 0 keeps the alignment and matches what
- * the write path already does (see sanitizeIntStreamArray/
- * sanitizeFloatStreamArray), so a row read back after a repair looks exactly
- * like a row written today. For `moving`, the boolean analogue is `false`.
+ * rather than patching it. Coercing to 0 keeps the alignment and follows the
+ * same rule the write path applies (see sanitizeIntStreamArray/
+ * sanitizeFloatStreamArray). For `moving`, the boolean analogue is `false`.
+ *
+ * The repair writes an exact `0`, whereas sanitizeFloatStreamArray writes
+ * `1e-9` for whole numbers on Float[] columns -- so a repaired float sample is
+ * not bit-identical to a freshly written one. Both read back as 0 for every
+ * consumer; the difference is only worth knowing when comparing rows directly.
  */
 const V2_INT_ARRAY_COLUMNS = [
   'time',
@@ -465,8 +469,17 @@ async function readV2WithNullRepair(
  *
  * 1. typed Prisma client (fast path, unchanged for clean rows);
  * 2. on a decode error, the raw repair read for the whole chunk;
- * 3. if even that fails, one typed read per id, so the batch loses only the
- *    rows that genuinely cannot be decoded rather than all of them.
+ * 3. if that *also* hits a decode error, one typed read per id, so the batch
+ *    loses only the rows that genuinely cannot be decoded rather than all.
+ *
+ * **Every escalation is gated on the error actually being a decode failure.**
+ * Tiers 2 and 3 exist to repair NULL array elements and nothing else, so an
+ * infrastructure error (pool timeout, statement timeout, connection reset)
+ * degrades immediately to the pre-CW-453 behaviour of returning nothing.
+ * Without that gate a single unhealthy database would fan a 200-id chunk out
+ * into 200 concurrent `findUnique` calls -- and `findManyByWorkoutIds` runs its
+ * chunks through `Promise.all`, so a 1000-id read would answer a database that
+ * just reported itself unhealthy with ~1000 simultaneous pool acquisitions.
  */
 async function readV2Chunk(
   workoutIds: readonly string[],
@@ -483,6 +496,9 @@ async function readV2Chunk(
     return await (prisma as any).workoutStreamV2.findMany(findManyArgs)
   } catch (error) {
     logStreamReadFailure(operation, 'WorkoutStreamV2', workoutIds, error)
+    // Not a decode failure -> there is nothing for the repair read to fix, and
+    // retrying a struggling database harder is the last thing it needs.
+    if (extractDecodeColumn(error) === null) return []
   }
 
   const columns = select ? Object.keys(select) : ALL_V2_COLUMNS
@@ -490,6 +506,9 @@ async function readV2Chunk(
     return await readV2WithNullRepair(workoutIds, columns)
   } catch (error) {
     logStreamReadFailure(`${operation}:null-repair`, 'WorkoutStreamV2', workoutIds, error)
+    // Same gate: per-row isolation only earns its N queries when the failure is
+    // a decode error that a subset of the rows may not share.
+    if (extractDecodeColumn(error) === null) return []
   }
 
   const rows = await Promise.all(


### PR DESCRIPTION
Fixes CW-453

## Problem

Postgres allows NULL *elements* inside an `integer[]` / `double precision[]`; the Prisma client does not. Reading such a row throws `Expected an integer in column 'cadence[593]', got object: null`, and nine bare `.catch()` handlers in `workoutStreamRepository.ts` discarded that error. 24% of production `WorkoutStreamV2` rows (858 users) were therefore invisible: no power/HR/cadence charts, no stream-derived analysis. Worse, the batch handlers returned `[]`, so **one bad row blanked an entire `findManyByWorkoutIds` batch** — good workouts lost their streams too.

## Fix

Every `WorkoutStreamV2` read now goes through a new `readV2Chunk()` that degrades instead of returning nothing:

1. **typed Prisma client** — unchanged fast path, so the ~76% of clean rows pay nothing;
2. **raw SQL repair read** on a decode error — `array_replace(col, NULL, 0)` per column, so the damaged row comes back usable;
3. **one typed read per id** if even that fails — the batch then loses only the rows that genuinely cannot be decoded.

`findByWorkoutId`, `findManyByWorkoutIds` and `findWattsByWorkoutIds` all route through it.

### NULL element -> `0`, never dropped (per-column decision)

| columns | NULL element becomes |
| -- | -- |
| `time`, `heartrate`, `cadence`, `watts`, `temp`, `torque`, `leftRightBalance`, `targetPower` (`Int[]`) | `0` |
| `distance`, `velocity`, `altitude`, `lat`, `lng`, `grade`, `hrv`, `respiration` (`Float[]`) | `0` |
| `moving` (`Boolean[]`) | `false` |

Every series in a row is **index-aligned with `time`**. `array_remove()` would shorten one series and silently shift every later sample against the clock — that corrupts the chart rather than repairing it, and it would do so invisibly. Coercing to `0` preserves alignment and matches what the write path has done since `84347257`, so a repaired read is indistinguishable from a row written today.

The tradeoff to be aware of: a repaired sample reads as a genuine `0` (0 W, 0 rpm, 0 bpm) rather than a gap. For power/cadence that is what a dropout physically means anyway; for `heartrate` a 0 is not physiological, but the alternative — a shifted time axis — is strictly worse, and the affected samples are already lost data. The real remedy for the existing rows is the backfill in **CW-582**, which this PR deliberately does not attempt.

### No more silent swallows

All remaining `.catch()` handlers route through `logStreamReadFailure()`, which logs the operation, table, workout ids (capped at 10 per line) and the offending column parsed out of the Prisma message (`cadence[593]`). The presence-only SQL probes and `updateMetadata`'s id-only lookup decode no arrays, but they log too — a quiet failure there silently redirects a metadata write to the legacy V1 row.

### Write path can no longer produce NULL elements

`upsert()`'s payload is now built by iterating a single `V2_ARRAY_WRITE_SANITIZERS` column-to-sanitizer map (instead of 17 inline calls) and then passes through `enforceNoNullStreamElements()` as a final invariant check. It logs loudly rather than repairing in silence, and deliberately skips JSON metadata such as `lapSplits`, which may legitimately contain nulls.

## Out of scope (unchanged, as specified)

- No production data was touched — the 90,833 already-bad rows are **CW-582**, pending human sign-off.
- The legacy `WorkoutStream` v1 table is untouched.

## Verification

```
pnpm test:unit server/utils/repositories/workoutStreamRepository.test.ts
  Test Files  2 passed (2)
       Tests  35 passed (35)

pnpm typecheck && pnpm lint
  typecheck: clean
  lint: 116 problems (0 errors, 116 warnings) - all pre-existing vue/require-default-prop
         warnings in unrelated email templates; none in the changed files
```

Full unit suite also run as a regression check: **381 files / 2515 tests passed**. The pre-existing `tests/unit/server/utils/repositories/workoutStreamRepository.test.ts` (24 tests) passes unmodified.

New `server/utils/repositories/workoutStreamRepository.test.ts` covers: a row with NULL elements decodes to usable data; a batch with one undecodable row is repaired in SQL; when the repair itself fails, the good rows still come back and only the bad one is omitted; a decode failure emits the log with workout id and column; the clean path takes no fallback and logs nothing; the write guard blocks nulls and leaves JSON metadata alone.

UX critique: skipped — backend-only change, no user-completable flow affected.