### PR TITLE
fix(nutrition): reject malformed and repeated date params on metabolic-wave (CW-506)

### DIFF
--- a/server/api/nutrition/metabolic-wave.get.ts
+++ b/server/api/nutrition/metabolic-wave.get.ts
@@ -15,11 +15,50 @@ import { summariseIntakeConfidence } from '../../utils/nutrition/intake-confiden
 const MAX_WAVE_RANGE_DAYS = 62
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
-function parseDateOnlyUtc(value: string, field: string) {
-  const parsed = new Date(`${value.slice(0, 10)}T00:00:00Z`)
-  if (Number.isNaN(parsed.getTime())) {
-    throw createError({ statusCode: 400, message: `Invalid ${field}: ${value}` })
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Absolute plausible-date window (CW-506).
+ *
+ * The span cap above bounds how *much* work one request costs, but says nothing about *where* the
+ * range sits: `?startDate=9999-01-01&endDate=9999-02-01` is a legal 32-day span that still runs 32
+ * days of simulation plus the repository queries behind it. That is a caller bug, not an
+ * amplification vector, so the window is deliberately generous — far wider than the activities
+ * calendar could reach by month-stepping — and exists only to turn obvious nonsense into a 400.
+ */
+const MIN_DATE_YEAR = 1900
+const MAX_DATE_YEAR = 2200
+
+/**
+ * Strict `YYYY-MM-DD` parsing, matching `extended-wave.get.ts`'s policy of 400ing on malformed input
+ * rather than coercing it (CW-506).
+ *
+ * `value` is `unknown` on purpose: Nitro hands back an array for a repeated query parameter
+ * (`?startDate=a&startDate=b`), and the previous `String(value).slice(0, 10)` joined that array and
+ * silently kept the first date. The same slice also swallowed trailing junk (`2026-01-01junk`).
+ * Anything that is not exactly one `YYYY-MM-DD` string is now a caller bug worth surfacing.
+ */
+function parseDateOnlyUtc(value: unknown, field: string) {
+  const expected = `Expected a single date in YYYY-MM-DD format between ${MIN_DATE_YEAR} and ${MAX_DATE_YEAR}.`
+
+  if (typeof value !== 'string' || !DATE_ONLY_PATTERN.test(value)) {
+    throw createError({
+      statusCode: 400,
+      message: `Invalid ${field}: ${String(value)}. ${expected}`
+    })
   }
+
+  // Shape-valid but not a real calendar date (e.g. 2026-02-30, 2026-13-01) parses to Invalid Date.
+  const parsed = new Date(`${value}T00:00:00Z`)
+  if (Number.isNaN(parsed.getTime())) {
+    throw createError({ statusCode: 400, message: `Invalid ${field}: ${value}. ${expected}` })
+  }
+
+  const year = parsed.getUTCFullYear()
+  if (year < MIN_DATE_YEAR || year > MAX_DATE_YEAR) {
+    throw createError({ statusCode: 400, message: `Invalid ${field}: ${value}. ${expected}` })
+  }
+
   return parsed
 }
 
@@ -33,18 +72,23 @@ defineRouteMeta({
         name: 'startDate',
         in: 'query',
         required: true,
+        description: 'Single YYYY-MM-DD date. Repeated or malformed values are rejected.',
         schema: { type: 'string', format: 'date' }
       },
       {
         name: 'endDate',
         in: 'query',
         required: true,
+        description: 'Single YYYY-MM-DD date. Repeated or malformed values are rejected.',
         schema: { type: 'string', format: 'date' }
       }
     ],
     responses: {
       200: { description: 'Success' },
-      400: { description: 'Missing, malformed, inverted, or too wide a date range (max 62 days)' },
+      400: {
+        description:
+          'Missing, repeated, malformed, implausible, inverted, or too wide a date range (max 62 days)'
+      },
       401: { description: 'Unauthorized' }
     }
   }
@@ -65,15 +109,15 @@ export default defineEventHandler(async (event) => {
     }
   }
   const query = getQuery(event)
-  const startStr = query.startDate as string
-  const endStr = query.endDate as string
+  const startStr: unknown = query.startDate
+  const endStr: unknown = query.endDate
 
   if (!startStr || !endStr) {
     throw createError({ statusCode: 400, message: 'Start and End date required' })
   }
 
-  const startDate = parseDateOnlyUtc(String(startStr), 'startDate')
-  const endDate = parseDateOnlyUtc(String(endStr), 'endDate')
+  const startDate = parseDateOnlyUtc(startStr, 'startDate')
+  const endDate = parseDateOnlyUtc(endStr, 'endDate')
 
   if (endDate.getTime() < startDate.getTime()) {
     throw createError({ statusCode: 400, message: 'endDate must not be before startDate' })

--- a/server/api/nutrition/metabolic-wave.get.ts
+++ b/server/api/nutrition/metabolic-wave.get.ts
@@ -48,9 +48,19 @@ function parseDateOnlyUtc(value: unknown, field: string) {
     })
   }
 
-  // Shape-valid but not a real calendar date (e.g. 2026-02-30, 2026-13-01) parses to Invalid Date.
+  // Shape-valid but not a real calendar date. Two distinct failure modes, both caught here:
+  //
+  //   - Out-of-range month/day (`2026-13-01`, `2026-01-00`, `2026-01-32`) -> Invalid Date.
+  //   - A day that overflows its month (`2026-02-30`, `2026-04-31`, `2025-02-29`) does NOT produce
+  //     an Invalid Date: V8 falls back to its lenient legacy parser and rolls the date over, so
+  //     `2026-02-30T00:00:00Z` becomes 2026-03-02. Round-tripping back to `YYYY-MM-DD` is what
+  //     catches that — otherwise the endpoint would quietly answer for a range the caller never
+  //     asked for, which is exactly the silent coercion this ticket removes.
+  //
+  // The round-trip introduces no false rejections: any in-window real date formats back identically
+  // (`toISOString()` pads years to 4 digits, and the whole window is 1900-2200).
   const parsed = new Date(`${value}T00:00:00Z`)
-  if (Number.isNaN(parsed.getTime())) {
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
     throw createError({ statusCode: 400, message: `Invalid ${field}: ${value}. ${expected}` })
   }
 

--- a/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
+++ b/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
@@ -176,14 +176,56 @@ describe('GET /api/nutrition/metabolic-wave date parameter strictness (CW-506)',
     expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
   })
 
-  it('rejects a shape-valid but non-existent calendar date', async () => {
-    await expect(get({ startDate: '2026-02-30', endDate: '2026-03-01' })).rejects.toMatchObject({
-      statusCode: 400
-    })
+  it('rejects an out-of-range month, which parses to Invalid Date', async () => {
     await expect(get({ startDate: '2026-13-01', endDate: '2026-13-02' })).rejects.toMatchObject({
       statusCode: 400
     })
+    await expect(get({ startDate: '2026-01-00', endDate: '2026-01-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2026-01-32', endDate: '2026-02-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
     expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  // V8 falls back to its lenient legacy parser for out-of-range *days*, so these do NOT produce an
+  // Invalid Date — `2026-02-30T00:00:00Z` silently rolls over to 2026-03-02. Without the
+  // round-trip check the handler would answer for a different range than the caller asked for,
+  // which is the same silent coercion removing `slice(0, 10)` was meant to eliminate.
+  //
+  // The end dates here are deliberately AFTER the rolled-over start date: an earlier version of
+  // this test used `2026-02-30..2026-03-01`, where the rollover to 2026-03-02 inverts the range,
+  // so the 400 came from the inverted-range guard and the assertion proved nothing about calendar
+  // validity. Each case below fails without the round-trip check in parseDateOnlyUtc.
+  it('rejects a day that overflows its month rather than silently rolling it over', async () => {
+    await expect(get({ startDate: '2026-02-30', endDate: '2026-03-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2026-04-31', endDate: '2026-05-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2025-02-29', endDate: '2025-03-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2026-11-31', endDate: '2026-12-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects an overflowing endDate too, not just startDate', async () => {
+    await expect(get({ startDate: '2026-02-01', endDate: '2026-02-30' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('still accepts a real leap day', async () => {
+    await get({ startDate: '2024-02-29', endDate: '2024-03-10' })
+
+    const [, start] = vi.mocked(metabolicService.getWaveRange).mock.calls[0] as any
+    expect(start.toISOString()).toBe('2024-02-29T00:00:00.000Z')
   })
 
   it('rejects an implausible year even when the span itself is within the cap', async () => {

--- a/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
+++ b/tests/unit/server/api/nutrition/metabolic-wave.get.test.ts
@@ -32,13 +32,15 @@ async function get(params: Record<string, unknown>) {
   return handler({} as any)
 }
 
+// File-level, not per-describe: the stubbed globals are shared by every block below, so tearing
+// them down when the first describe finishes would break the ones after it.
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
 // CW-73: startDate/endDate went straight from the query string into getWaveRange, so
 // `endDate=2100-01-01` ran decades of day simulations in a single request.
 describe('GET /api/nutrition/metabolic-wave range bounds (CW-73)', () => {
-  afterAll(() => {
-    vi.unstubAllGlobals()
-  })
-
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
@@ -115,5 +117,101 @@ describe('GET /api/nutrition/metabolic-wave range bounds (CW-73)', () => {
     await expect(get({ startDate: '2026-01-01', endDate: '2026-01-02' })).rejects.toMatchObject({
       statusCode: 401
     })
+  })
+})
+
+// CW-506: parseDateOnlyUtc did `String(value).slice(0, 10)`, so a repeated query parameter was
+// joined and silently truncated to its first value, and trailing junk was quietly dropped —
+// while the sibling extended-wave endpoint 400s on the same class of input.
+describe('GET /api/nutrition/metabolic-wave date parameter strictness (CW-506)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: 'user-1' } } as any)
+    vi.mocked(isNutritionTrackingEnabled).mockResolvedValue(true)
+    vi.mocked(metabolicService.getWaveRange).mockResolvedValue({
+      points: [],
+      journeyEvents: []
+    } as any)
+  })
+
+  it('rejects a repeated startDate instead of silently using the first value', async () => {
+    await expect(
+      get({ startDate: ['2026-02-01', '2026-02-05'], endDate: '2026-02-10' })
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a repeated endDate instead of silently using the first value', async () => {
+    await expect(
+      get({ startDate: '2026-02-01', endDate: ['2026-02-10', '2100-01-01'] })
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects trailing junk rather than slicing it off', async () => {
+    await expect(get({ startDate: '2026-02-01junk', endDate: '2026-02-10' })).rejects.toMatchObject(
+      {
+        statusCode: 400
+      }
+    )
+    await expect(get({ startDate: '2026-02-01', endDate: '2026-02-10junk' })).rejects.toMatchObject(
+      {
+        statusCode: 400
+      }
+    )
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a full ISO timestamp, which the old slice quietly accepted', async () => {
+    await expect(
+      get({ startDate: '2026-02-01T12:34:56Z', endDate: '2026-02-10' })
+    ).rejects.toMatchObject({ statusCode: 400 })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-string scalar such as a bare number', async () => {
+    await expect(get({ startDate: 20260201, endDate: '2026-02-10' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects a shape-valid but non-existent calendar date', async () => {
+    await expect(get({ startDate: '2026-02-30', endDate: '2026-03-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '2026-13-01', endDate: '2026-13-02' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('rejects an implausible year even when the span itself is within the cap', async () => {
+    // A legal 32-day span, but 32 days of simulation for a nonsense date.
+    await expect(get({ startDate: '9999-01-01', endDate: '9999-02-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    await expect(get({ startDate: '0001-01-01', endDate: '0001-02-01' })).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(metabolicService.getWaveRange).not.toHaveBeenCalled()
+  })
+
+  it('reports the offending field and value, like extended-wave does', async () => {
+    await expect(get({ startDate: '2026-02-01junk', endDate: '2026-02-10' })).rejects.toThrow(
+      /Invalid startDate: 2026-02-01junk/
+    )
+    await expect(get({ startDate: '2026-02-01', endDate: 'not-a-date' })).rejects.toThrow(
+      /Invalid endDate: not-a-date/
+    )
+  })
+
+  it('still accepts a well-formed range', async () => {
+    const result: any = await get({ startDate: '2026-02-01', endDate: '2026-02-10' })
+
+    expect(result.success).toBe(true)
+    const [, start, end] = vi.mocked(metabolicService.getWaveRange).mock.calls[0] as any
+    expect(start.toISOString()).toBe('2026-02-01T00:00:00.000Z')
+    expect(end.toISOString()).toBe('2026-02-10T00:00:00.000Z')
   })
 })


### PR DESCRIPTION
Fixes CW-506

## What

`metabolic-wave.get.ts` parsed dates with `String(value).slice(0, 10)`, which silently coerced two classes of bad input that the sibling `extended-wave.get.ts` deliberately 400s on:

- **Repeated params** — `?startDate=a&startDate=b` arrives as an array, `String()` joined it and the slice kept the first value.
- **Trailing junk** — `?startDate=2026-01-01junk` (and full ISO timestamps) were silently truncated.

`parseDateOnlyUtc` now takes `unknown`, requires a single string matching `^\d{4}-\d{2}-\d{2}$`, and still ISO-parses so shape-valid-but-unreal dates (`2026-02-30`, `2026-13-01`) are rejected. Error shape mirrors extended-wave's `resolveDaysAhead`: `createError({ statusCode: 400, message: 'Invalid <field>: <raw>. Expected ...' })`.

No behaviour change for well-formed requests.

## Absolute date bound: implemented

The ticket left this open. Implemented, as a deliberately generous year window (1900–2200) rather than a tight one:

- It exists only to turn obvious nonsense (`?startDate=9999-01-01&endDate=9999-02-01` — a legal 32-day span that passes both existing caps) into a caller-visible 400. Cost was already bounded by `MAX_WAVE_RANGE_DAYS`, so this is a correctness/consistency fix, not an amplification fix.
- The window is wide enough that the only real caller — the activities calendar, which month-steps `currentDate` — cannot reach either edge in practice, so no user-reachable navigation starts 400ing.

## Risk: existing callers

Audited every in-repo caller of `/api/nutrition/metabolic-wave`:

- `app/pages/activities.vue` — `calendarRange` sends `formatDateUTC(d, 'yyyy-MM-dd')`.
- `e2e/tests/nutrition-fueling.spec.ts` — sends `date.toISOString().slice(0, 10)`.

Both already send a single clean `YYYY-MM-DD`. Nothing in-repo relied on the lenient slice. External/API-token callers passing a full ISO timestamp (e.g. `2026-02-01T00:00:00Z`) would newly get a 400 — that is the intended contract change, and it is covered by a test.

## Test housekeeping

`vi.unstubAllGlobals()` moved from the first `describe`'s `afterAll` to file level — as a per-describe hook it tore down `getQuery`/`createError` before the second block ran.

## Verification

```
pnpm test:unit tests/unit/server/api/nutrition/   ->  10 files, 58 tests passed
pnpm typecheck                                     ->  exit 0
```

UX critique: skipped — API validation change, no UI surface.
