### PR TITLE
fix(integrations): abort garmin-backfill immediately when no integration exists (CW-512)

### DIFF
--- a/tests/unit/trigger/imports.test.ts
+++ b/tests/unit/trigger/imports.test.ts
@@ -15,6 +15,7 @@ const triggers = [
   'daily-coach',
   'deduplicate-workouts',
   'delete-user-account',
+  'garmin-backfill',
   'generate-ad-hoc-workout',
   'generate-athlete-profile',
   'generate-custom-report',

--- a/trigger/garmin-backfill.ts
+++ b/trigger/garmin-backfill.ts
@@ -26,8 +26,12 @@ export const garminBackfillTask = task({
       //  - `no-integration`: nothing was requested at all; the run did no work. CW-512: this is
       //    deterministic — the user has no Garmin integration, and no retry can create one — so
       //    it throws `AbortTaskRunError`, which Trigger.dev treats as terminal and fails without
-      //    consuming the remaining attempts. Retrying it burned ~90s of queue time re-running the
-      //    `delaySeconds` wait below from the top of the run on each of the 3 attempts.
+      //    consuming the remaining attempts. Retrying it re-ran the `delaySeconds` wait from the
+      //    top of the run on each of the 3 attempts, ~90s of queue time in total; aborting cuts
+      //    that to ~30s. Attempt 1 still pays the initial wait: the wait runs before
+      //    `startBackfill()`, and it is `startBackfill()` that reports the integration is
+      //    missing, so the status is not knowable any earlier. Skipping the wait entirely would
+      //    mean hoisting an integration-existence check above it.
       //  - `failed`: every backfill request was rejected — almost always a token/registration
       //    problem that a retry can genuinely resolve (typically the "User not registered with
       //    consumer" propagation race right after connect). This keeps the plain `Error` throw

--- a/trigger/garmin-backfill.ts
+++ b/trigger/garmin-backfill.ts
@@ -1,4 +1,4 @@
-import { task, logger } from '@trigger.dev/sdk/v3'
+import { task, logger, AbortTaskRunError } from '@trigger.dev/sdk/v3'
 import { GarminService } from '../server/utils/services/garminService'
 import { userIngestionQueue } from './queues'
 import { waitForTaskSeconds } from '../server/utils/task-runtime'
@@ -22,10 +22,16 @@ export const garminBackfillTask = task({
 
       // CW-95: an incomplete backfill must not look like a complete one.
       //
-      // Hard failures (throw, so the run is marked failed and retried):
-      //  - `no-integration`: nothing was requested at all; the run did no work.
+      // Hard failures (throw, so the run is marked failed):
+      //  - `no-integration`: nothing was requested at all; the run did no work. CW-512: this is
+      //    deterministic — the user has no Garmin integration, and no retry can create one — so
+      //    it throws `AbortTaskRunError`, which Trigger.dev treats as terminal and fails without
+      //    consuming the remaining attempts. Retrying it burned ~90s of queue time re-running the
+      //    `delaySeconds` wait below from the top of the run on each of the 3 attempts.
       //  - `failed`: every backfill request was rejected — almost always a token/registration
-      //    problem that a retry can genuinely resolve.
+      //    problem that a retry can genuinely resolve (typically the "User not registered with
+      //    consumer" propagation race right after connect). This keeps the plain `Error` throw
+      //    precisely so it still retries; do not collapse it into the aborted case above.
       //
       // Partial failure succeeds *with a summary* rather than throwing, deliberately:
       // each type is an independent Garmin request, so throwing would retry the whole run and
@@ -35,7 +41,9 @@ export const garminBackfillTask = task({
       // `failed[]` carries the per-type error so an operator can see exactly which types are
       // missing from the run output.
       if (result.status === 'no-integration') {
-        throw new Error(`Garmin backfill aborted: no Garmin integration found for user ${userId}`)
+        throw new AbortTaskRunError(
+          `Garmin backfill aborted: no Garmin integration found for user ${userId}`
+        )
       }
 
       if (result.status === 'failed') {


### PR DESCRIPTION
Fixes CW-512

## What

`trigger/garmin-backfill.ts` threw a plain `Error` for the `no-integration` status. Combined with the 30s `delaySeconds` wait at the top of the run, a deterministic non-retryable condition consumed the full retry budget (`maxAttempts: 3`), re-executing the wait from the top on every attempt — three 30s waits, ~90s of queue time and three red attempts for a condition that cannot resolve itself: the user simply has no Garmin integration.

`no-integration` now throws `AbortTaskRunError` from `@trigger.dev/sdk/v3`, which Trigger.dev treats as terminal (`taskExecutor.js:680` skips retrying when `error.name === "AbortTaskRunError"`). The delay is never re-executed.

**Real saving is ~90s → ~30s, not → 0s.** Attempt 1 still pays the initial 30s wait, because the wait at `:13-16` runs *before* `GarminService.startBackfill()` at `:21`, and `startBackfill()` is what reports the missing integration — the status is not knowable any earlier. Fully skipping the wait would require hoisting an integration-existence check above it, a design change beyond this ticket.

`failed` deliberately **keeps** its plain-`Error` throw — retry genuinely helps there, since the common cause is the "User not registered with consumer" propagation race right after connect. The two cases are documented as distinct in the comment block so they don't get collapsed later.

This introduces `AbortTaskRunError` as a **new pattern** — the repo did not use it anywhere before.

## Test coverage for the changed file

`tests/unit/trigger/imports.test.ts` holds a hardcoded module list and asserts each imports cleanly; `garmin-backfill` was **missing** from it. Combined with `trigger/` sitting outside every tsconfig project (CW-560), that meant no CI check exercised this file at all. Added the one entry.

**Scope of that guard, measured rather than assumed** — I ran two negative controls against it:

| Injected fault | Guard result |
|---|---|
| `from '@trigger.dev/sdk/v3-NONEXISTENT'` | ✅ **FAILS** the test |
| `import { AbortTaskRunErrorTYPO }` from the valid module | ❌ **still passes** |

So the guard covers *"is the module specifier right?"* but **not** *"is this named export real?"* — esbuild lowers named imports to namespace property accesses, so a bogus name binds `undefined` and only throws at call time. The specifier was the ticket's stated concern, so this is worth having, but it does not fully close the import risk on its own. The manual runtime checks below remain the evidence for the export itself.

## Known gap: the self-hosted BullMQ path still retries this

AC 3 asked me to confirm the self-hosted fallback treats the abort as terminal. **It does not.** Reported rather than fixed, because the fix lands outside this PR's owned path:

- BullMQ 5.79.3 only short-circuits retries when `err instanceof UnrecoverableError || err.name == 'UnrecoverableError'` (`bullmq/dist/cjs/classes/job.js:492`).
- `AbortTaskRunError` sets `this.name = "AbortTaskRunError"` (`@trigger.dev/core/dist/esm/v3/errors.js:26-30`), so BullMQ does not recognise it.
- The `mainTaskQueue` worker (`cli/worker/start.ts:1174-1191`) catches, publishes a run-update event, and rethrows unchanged — no terminal-error classification. `grep` for `UnrecoverableError|.discard()` across `server/ cli/ trigger/` returns zero hits repo-wide.
- `cli/worker/task-handler-loader.ts:123` registers this same task file for the redis driver, so that path runs identical code and still burns `DEFAULT_REDIS_ATTEMPTS` (3, `server/utils/task-dispatcher.ts:46`) plus three 30s waits.

The two detections key off the same `name` field with mutually exclusive expected values, so this **cannot** be resolved from inside `trigger/garmin-backfill.ts` alone. Tracked as CW-602, which also covers a third unfixed path (`server/utils/task-dispatcher.ts:322-346`, an inline retry loop with no terminal classification at all).

Net effect today: Trigger.dev gets the full fix; the self-hosted fallback is unchanged, no worse than before.

## Verification

```
$ pnpm test:unit tests/unit/trigger/imports.test.ts tests/unit/server/utils/services/garminService.test.ts
 Test Files  2 passed (2)
      Tests  103 passed (103)

$ pnpm typecheck
exit 0
```

Import resolution, verified by execution — the second check loads the edited module itself:

```
$ pnpm exec tsx -e "import { AbortTaskRunError } from '@trigger.dev/sdk/v3'; ..."
typeof: function
name: AbortTaskRunError | instanceof Error: true

$ pnpm exec tsx -e "import('./trigger/garmin-backfill.ts')..."
MODULE LOADED OK. exports: [ 'garminBackfillTask' ]
task id: garmin-backfill
```

`@trigger.dev/sdk@4.5.4` re-exports `AbortTaskRunError` from `@trigger.dev/core/v3` (`dist/esm/v3/index.d.ts:26`). The `/v3` specifier matches local convention — every file under `trigger/` and `trigger.config.ts` imports from `@trigger.dev/sdk/v3`.

UX critique: skipped — background task retry behaviour, no UI surface.