### PR TITLE
fix(chat): sanitize tool-approval history on the Telegram webhook path (CW-294)

### DIFF
--- a/server/api/integrations/telegram/webhook.post.ts
+++ b/server/api/integrations/telegram/webhook.post.ts
@@ -6,6 +6,7 @@ import { generateText, isStepCount } from 'ai'
 import { buildPersistedToolCalls, expandStoredChatMessages } from '../../../utils/chat/history'
 import { transformHistoryToCoreMessages } from '../../../utils/ai-history'
 import { normalizeCoreMessagesForGemini } from '../../../utils/chat/core-message-normalizer'
+import { sanitizeCoreMessagesForToolApprovals } from '../../chat/sanitize-tool-approval'
 
 export default defineEventHandler(async (event) => {
   const secretToken = getHeader(event, 'x-telegram-bot-api-secret-token')
@@ -209,7 +210,12 @@ export default defineEventHandler(async (event) => {
     })
 
     const expandedHistory = expandStoredChatMessages(history.reverse())
-    const coreMessages = await transformHistoryToCoreMessages(expandedHistory)
+    // Mirror the main chat turn executor: malformed `tool-approval-response` parts in
+    // stored history crash `standardizePrompt` with AI_TypeValidationError (CW-209 /
+    // CW-293), so repair or drop them before the prompt is built. (CW-294)
+    const coreMessages = sanitizeCoreMessagesForToolApprovals(
+      await transformHistoryToCoreMessages(expandedHistory)
+    )
     const normalizedMessages = normalizeCoreMessagesForGemini(coreMessages)
 
     // Generate Response

--- a/server/api/integrations/telegram/webhook.post.ts
+++ b/server/api/integrations/telegram/webhook.post.ts
@@ -210,9 +210,16 @@ export default defineEventHandler(async (event) => {
     })
 
     const expandedHistory = expandStoredChatMessages(history.reverse())
-    // Mirror the main chat turn executor: malformed `tool-approval-response` parts in
-    // stored history crash `standardizePrompt` with AI_TypeValidationError (CW-209 /
-    // CW-293), so repair or drop them before the prompt is built. (CW-294)
+    // Parity with the main chat turn executor, which applies this same guard in this same
+    // position. Malformed `tool-approval-response` parts crash `standardizePrompt` with
+    // AI_TypeValidationError (CW-209 / CW-293); no history shape this handler can build
+    // today produces one, so this is defensive — it matters if the Telegram path ever
+    // accepts client-submitted messages or `expandStoredChatMessage` learns to emit
+    // `approval-responded` parts. It is a no-op for valid history. (CW-294)
+    //
+    // The main path's *other* guard, `sanitizeChatMessagesForToolApprovals` (via
+    // `normalizeMessagesForSdk`), covers client-submitted UI messages. Telegram has no
+    // such input — messages come only from the DB — so its absence here is deliberate.
     const coreMessages = sanitizeCoreMessagesForToolApprovals(
       await transformHistoryToCoreMessages(expandedHistory)
     )

--- a/tests/unit/server/api/telegram-webhook-tool-approvals.test.ts
+++ b/tests/unit/server/api/telegram-webhook-tool-approvals.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * CW-294: the Telegram webhook builds its prompt from stored chat history without the
- * `sanitizeCoreMessagesForToolApprovals` guard the main chat turn executor applies, so a
- * Telegram-linked conversation holding malformed `tool-approval-response` parts reproduced
- * the AI_TypeValidationError class fixed by CW-209 / CW-293 on that path.
+ * CW-294: the Telegram webhook built its prompt from stored chat history without the
+ * `sanitizeCoreMessagesForToolApprovals` guard the main chat turn executor applies. No
+ * DB-derived history shape reaches `generateText` with a `tool-approval-response` part
+ * today, so this is parity hardening rather than a fix for a reproducible crash — these
+ * tests pin the guard's presence and its no-op behaviour on valid history.
  */
 
 vi.stubGlobal('defineEventHandler', (fn: any) => fn)
@@ -30,6 +31,13 @@ const sendTelegramMessage = vi.fn()
 const sendTelegramAction = vi.fn()
 
 /**
+ * Records every `sanitizeCoreMessagesForToolApprovals` call the handler makes, with the real
+ * implementation still doing the work. Reverting the handler change leaves this spy uncalled,
+ * which is what keeps the assertions below honest.
+ */
+const sanitizeSpy = vi.fn()
+
+/**
  * `transformHistoryToCoreMessages` is shared with the main chat path; overriding it per test
  * pins the contract this ticket is about — whatever model messages the transform produces,
  * the webhook must sanitize them before the prompt is built.
@@ -52,6 +60,18 @@ vi.mock('../../../../server/utils/ai-history', async (importOriginal) => {
       transformOverride
         ? transformOverride(history)
         : actual.transformHistoryToCoreMessages(history)
+  }
+})
+
+vi.mock('../../../../server/api/chat/sanitize-tool-approval', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    sanitizeCoreMessagesForToolApprovals: (messages: any[]) => {
+      const output = actual.sanitizeCoreMessagesForToolApprovals(messages)
+      sanitizeSpy({ input: messages, output })
+      return output
+    }
   }
 })
 
@@ -180,7 +200,7 @@ describe('POST /api/integrations/telegram/webhook tool-approval sanitization (CW
     )
   })
 
-  it('repairs recoverable tool-role approval responses instead of dropping the turn', async () => {
+  it('runs the transformed history through the sanitizer, repairing recoverable tool-role responses', async () => {
     transformOverride = () => [
       {
         role: 'tool',
@@ -194,13 +214,21 @@ describe('POST /api/integrations/telegram/webhook tool-approval sanitization (CW
       { role: 'user', content: [{ type: 'text', text: 'and my sleep?' }] }
     ]
 
-    const { sanitizeCoreMessagesForToolApprovals } =
-      await import('../../../../server/api/chat/sanitize-tool-approval')
+    await runWebhook()
 
-    // The webhook's sanitizer step must produce exactly this before Gemini normalization.
-    expect(
-      sanitizeCoreMessagesForToolApprovals(await (transformOverride as any)([]))[0].content
-    ).toEqual([
+    // Asserted at the sanitizer boundary inside the handler, not on the messages that reach
+    // generateText: normalizeCoreMessagesForGemini keeps only `tool-result` parts in tool
+    // messages, so a post-normalization assertion about approval parts would be vacuously
+    // true whether or not the handler sanitizes anything.
+    expect(sanitizeSpy).toHaveBeenCalledTimes(1)
+    const { input, output } = sanitizeSpy.mock.calls[0][0]
+
+    // The handler hands the sanitizer the transform output, unmodified
+    expect(input[0].content).toHaveLength(2)
+
+    // Recoverable response repaired (approvalId filled in, `approved` coerced to boolean),
+    // irreparable one dropped — the turn itself survives.
+    expect(output[0].content).toEqual([
       {
         type: 'tool-approval-response',
         approvalId: 'call_1',
@@ -208,21 +236,10 @@ describe('POST /api/integrations/telegram/webhook tool-approval sanitization (CW
         approved: true
       }
     ])
+    expect(output[1]).toEqual({ role: 'user', content: [{ type: 'text', text: 'and my sleep?' }] })
 
-    await runWebhook()
-
-    const messages = messagesSentToModel()
-    const approvalParts = collectParts(messages).filter(
-      ({ part }) => part.type === 'tool-approval-response'
-    )
-
-    // No approval response may survive with a missing approvalId or a non-boolean `approved`
-    expect(
-      approvalParts.every(
-        ({ part }) => typeof part.approvalId === 'string' && typeof part.approved === 'boolean'
-      )
-    ).toBe(true)
-    expect(messages.at(-1)).toEqual({ role: 'user', content: 'and my sleep?' })
+    // ...and the sanitized array is what the prompt is built from
+    expect(messagesSentToModel().at(-1)).toEqual({ role: 'user', content: 'and my sleep?' })
   })
 
   it('leaves valid tool-call history untouched on the Telegram path', async () => {
@@ -310,5 +327,11 @@ describe('POST /api/integrations/telegram/webhook tool-approval sanitization (CW
       }
     ])
     expect(sendTelegramMessage).toHaveBeenCalledWith('12345', 'Logged your oats.')
+
+    // The guard ran and was a strict no-op on this history — a sanitizer that eats valid
+    // tool-call history would be worse than the gap it closes.
+    expect(sanitizeSpy).toHaveBeenCalledTimes(1)
+    const { input, output } = sanitizeSpy.mock.calls[0][0]
+    expect(output).toEqual(input)
   })
 })

--- a/tests/unit/server/api/telegram-webhook-tool-approvals.test.ts
+++ b/tests/unit/server/api/telegram-webhook-tool-approvals.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * CW-294: the Telegram webhook builds its prompt from stored chat history without the
+ * `sanitizeCoreMessagesForToolApprovals` guard the main chat turn executor applies, so a
+ * Telegram-linked conversation holding malformed `tool-approval-response` parts reproduced
+ * the AI_TypeValidationError class fixed by CW-209 / CW-293 on that path.
+ */
+
+vi.stubGlobal('defineEventHandler', (fn: any) => fn)
+vi.stubGlobal('createError', (err: any) => {
+  const error = new Error(err.message || err.statusMessage)
+  ;(error as any).statusCode = err.statusCode
+  return error
+})
+vi.stubGlobal('readBody', async (event: any) => event.body)
+vi.stubGlobal('getHeader', (event: any, name: string) => event.headers?.[name])
+
+const generateTextMock = vi.fn()
+const integrationFindFirst = vi.fn()
+const chatRoomFindFirst = vi.fn()
+const chatRoomCreate = vi.fn()
+const chatMessageFindMany = vi.fn()
+const webhookLogCreate = vi.fn()
+const prepareAI = vi.fn()
+const saveUserMessage = vi.fn()
+const saveAiMessage = vi.fn()
+const logLlmUsage = vi.fn()
+const sendTelegramMessage = vi.fn()
+const sendTelegramAction = vi.fn()
+
+/**
+ * `transformHistoryToCoreMessages` is shared with the main chat path; overriding it per test
+ * pins the contract this ticket is about — whatever model messages the transform produces,
+ * the webhook must sanitize them before the prompt is built.
+ */
+let transformOverride: ((history: any[]) => any[] | Promise<any[]>) | null = null
+
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    generateText: (...args: any[]) => generateTextMock(...args)
+  }
+})
+
+vi.mock('../../../../server/utils/ai-history', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  return {
+    ...actual,
+    transformHistoryToCoreMessages: async (history: any[]) =>
+      transformOverride
+        ? transformOverride(history)
+        : actual.transformHistoryToCoreMessages(history)
+  }
+})
+
+vi.mock('../../../../server/utils/db', () => ({
+  prisma: {
+    integration: { findFirst: integrationFindFirst },
+    chatRoom: { findFirst: chatRoomFindFirst, create: chatRoomCreate },
+    chatMessage: { findMany: chatMessageFindMany },
+    webhookLog: { create: webhookLogCreate }
+  }
+}))
+
+vi.mock('../../../../server/utils/services/chatService', () => ({
+  chatService: {
+    prepareAI,
+    saveUserMessage,
+    saveAiMessage,
+    logLlmUsage
+  }
+}))
+
+vi.mock('../../../../server/utils/telegram', () => ({
+  sendTelegramMessage,
+  sendTelegramAction
+}))
+
+const NOW = new Date('2026-07-27T07:00:00Z')
+
+function telegramEvent(text = 'log my oats') {
+  return {
+    headers: { 'x-telegram-bot-api-secret-token': 'test-secret' },
+    body: {
+      message: {
+        text,
+        chat: { id: 12345 }
+      }
+    }
+  } as any
+}
+
+async function runWebhook(event = telegramEvent()) {
+  const mod = await import('../../../../server/api/integrations/telegram/webhook.post')
+  return mod.default(event)
+}
+
+function messagesSentToModel() {
+  expect(generateTextMock).toHaveBeenCalled()
+  return generateTextMock.mock.calls[0][0].messages as any[]
+}
+
+function collectParts(messages: any[]) {
+  return messages.flatMap((message: any) =>
+    Array.isArray(message.content)
+      ? message.content.map((part: any) => ({ role: message.role, part }))
+      : []
+  )
+}
+
+describe('POST /api/integrations/telegram/webhook tool-approval sanitization (CW-294)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transformOverride = null
+    process.env.TELEGRAM_WEBHOOK_SECRET = 'test-secret'
+
+    integrationFindFirst.mockResolvedValue({ userId: 'user-1', provider: 'telegram' })
+    chatRoomFindFirst.mockResolvedValue({
+      id: 'room-1',
+      createdAt: NOW,
+      messages: [{ createdAt: new Date() }]
+    })
+    chatMessageFindMany.mockResolvedValue([])
+    webhookLogCreate.mockResolvedValue({})
+    saveUserMessage.mockResolvedValue({ id: 'msg-user' })
+    saveAiMessage.mockResolvedValue({ id: 'msg-ai' })
+    logLlmUsage.mockResolvedValue(undefined)
+    sendTelegramMessage.mockResolvedValue(undefined)
+    sendTelegramAction.mockResolvedValue(undefined)
+    prepareAI.mockResolvedValue({
+      google: (modelName: string) => ({ modelId: modelName }),
+      modelName: 'gemini-flash',
+      tools: {},
+      systemInstruction: 'You are Coach Watts.'
+    })
+    generateTextMock.mockResolvedValue({
+      text: 'Logged your oats.',
+      toolCalls: [],
+      toolResults: [],
+      usage: { inputTokens: 10, outputTokens: 5 },
+      response: { messages: [] }
+    })
+  })
+
+  it('strips malformed tool-approval-response parts before the prompt reaches generateText', async () => {
+    transformOverride = () => [
+      { role: 'user', content: [{ type: 'text', text: 'log my oats' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Logging that now.' },
+          // Only tool-role messages may carry approval responses; anywhere else this
+          // crashes standardizePrompt.
+          { type: 'tool-approval-response', toolCallId: 'call_1', approved: true }
+        ]
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool-approval-response', approved: 'yes' }]
+      }
+    ]
+
+    const result = await runWebhook()
+
+    expect(result).toEqual({ status: 'processed' })
+
+    const messages = messagesSentToModel()
+    const approvalParts = collectParts(messages).filter(
+      ({ part }) => part.type === 'tool-approval-response'
+    )
+
+    expect(approvalParts).toEqual([])
+    expect(messages[1].content).toEqual([{ type: 'text', text: 'Logging that now.' }])
+    // An assistant message emptied by sanitization must still carry content
+    expect(messages[2].content).toEqual([{ type: 'text', text: ' ' }])
+    expect(webhookLogCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'PROCESSED' }) })
+    )
+  })
+
+  it('repairs recoverable tool-role approval responses instead of dropping the turn', async () => {
+    transformOverride = () => [
+      {
+        role: 'tool',
+        content: [
+          // Repairable: toolCallId stands in for approvalId, stringy `approved` is coerced
+          { type: 'tool-approval-response', toolCallId: 'call_1', approved: 'true' },
+          // Irreparable: no id at all
+          { type: 'tool-approval-response', approved: true }
+        ]
+      },
+      { role: 'user', content: [{ type: 'text', text: 'and my sleep?' }] }
+    ]
+
+    const { sanitizeCoreMessagesForToolApprovals } =
+      await import('../../../../server/api/chat/sanitize-tool-approval')
+
+    // The webhook's sanitizer step must produce exactly this before Gemini normalization.
+    expect(
+      sanitizeCoreMessagesForToolApprovals(await (transformOverride as any)([]))[0].content
+    ).toEqual([
+      {
+        type: 'tool-approval-response',
+        approvalId: 'call_1',
+        toolCallId: 'call_1',
+        approved: true
+      }
+    ])
+
+    await runWebhook()
+
+    const messages = messagesSentToModel()
+    const approvalParts = collectParts(messages).filter(
+      ({ part }) => part.type === 'tool-approval-response'
+    )
+
+    // No approval response may survive with a missing approvalId or a non-boolean `approved`
+    expect(
+      approvalParts.every(
+        ({ part }) => typeof part.approvalId === 'string' && typeof part.approved === 'boolean'
+      )
+    ).toBe(true)
+    expect(messages.at(-1)).toEqual({ role: 'user', content: 'and my sleep?' })
+  })
+
+  it('leaves valid tool-call history untouched on the Telegram path', async () => {
+    chatMessageFindMany.mockResolvedValue(
+      [
+        {
+          id: 'm1',
+          senderId: 'user-1',
+          content: 'how did I train?',
+          files: [],
+          metadata: {},
+          createdAt: NOW
+        },
+        {
+          id: 'm2',
+          senderId: 'ai_agent',
+          content: 'Here you go',
+          files: [],
+          createdAt: NOW,
+          metadata: {
+            toolCalls: [
+              {
+                toolCallId: 'call_1',
+                name: 'get_recent_workouts',
+                args: { days: 7 },
+                response: { workouts: [{ type: 'Ride' }] }
+              }
+            ]
+          }
+        },
+        {
+          id: 'm3',
+          senderId: 'system_tool',
+          content: '',
+          files: [],
+          createdAt: NOW,
+          metadata: {
+            toolResponse: [
+              {
+                type: 'tool-result',
+                toolCallId: 'call_1',
+                toolName: 'get_recent_workouts',
+                result: { workouts: [{ type: 'Ride' }] }
+              }
+            ]
+          }
+        },
+        {
+          id: 'm4',
+          senderId: 'user-1',
+          content: 'and my sleep?',
+          files: [],
+          metadata: {},
+          createdAt: NOW
+        }
+        // findMany orders newest-first; the handler reverses it back to chronological order
+      ].reverse()
+    )
+
+    await runWebhook(telegramEvent('and my sleep?'))
+
+    const messages = messagesSentToModel()
+
+    expect(messages.map((message: any) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+      'user'
+    ])
+
+    const toolCalls = messages[1].content.filter((part: any) => part.type === 'tool-call')
+    expect(toolCalls).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({
+      toolCallId: 'call_1',
+      toolName: 'get_recent_workouts',
+      input: { days: 7 }
+    })
+
+    expect(messages[2].content).toEqual([
+      {
+        type: 'tool-result',
+        toolCallId: 'call_1',
+        toolName: 'get_recent_workouts',
+        output: { type: 'json', value: { workouts: [{ type: 'Ride' }] } }
+      }
+    ])
+    expect(sendTelegramMessage).toHaveBeenCalledWith('12345', 'Logged your oats.')
+  })
+})


### PR DESCRIPTION
Fixes CW-294

## What this is

**Defensive hardening and parity restoration — not a fix for a reproducible crash.**

The main chat turn executor guards its prompt with `sanitizeCoreMessagesForToolApprovals` (`server/utils/chat/turn-executor.ts:1268`). The Telegram webhook, which builds a prompt from the same stored history through the same transform, did not. This PR restores that parity.

**The malformed shape is not currently reachable from DB-derived history**, and this PR does not claim to close a live `AI_TypeValidationError` path. Verified against today's code:

- `expandStoredChatMessage` (`server/utils/chat/history.ts:198-282`) synthesizes assistant parts from scratch and only ever emits `state: 'approval-requested'` — never `approval-responded`. `transformHistoryToCoreMessages` then filters `tool-approval-request` out of assistant content (`server/utils/ai-history.ts:400`).
- Tool rows go through the transform's tool branch, which *converts* `tool-approval-response` into `tool-result` (`server/utils/ai-history.ts:204-222`), so it never emerges as an approval part.
- User rows carrying `metadata.toolResponse` approval parts are dropped by `convertToModelMessages`.
- Separately, `normalizeCoreMessagesForGemini` keeps only `tool-result` parts inside tool messages, so tool-role approval parts would not survive to the provider anyway.

All four shapes were probed through the real expand + transform: zero `tool-approval-response` parts in every case, before and after normalization.

It is still worth applying: it costs nothing, it is provably a no-op for valid history (test 3), it restores parity with the main path, and it removes a real footgun if the Telegram path ever gains client-submitted messages or `expandStoredChatMessage` learns to emit `approval-responded`.

## Change

- `server/api/integrations/telegram/webhook.post.ts`: wrap `await transformHistoryToCoreMessages(expandedHistory)` in `sanitizeCoreMessagesForToolApprovals(...)`, in the same position as the main chat path — after the transform, before `normalizeCoreMessagesForGemini` and `generateText`.
- The shared sanitizer `server/api/chat/sanitize-tool-approval.ts` is **unchanged** (empty diff), so main chat sanitization behaviour is untouched by construction.

### Deliberately not added

The main path applies a *second* guard, `sanitizeChatMessagesForToolApprovals` (via `normalizeMessagesForSdk`), to **client-submitted** UI messages. Telegram has no client-submitted message input — history comes only from the DB — so its absence here is correct, not a gap. Recorded in a comment at the call site so a future reader does not "fix" it.

## Test

`tests/unit/server/api/telegram-webhook-tool-approvals.test.ts` drives the real webhook handler (prisma / chatService / telegram / `generateText` mocked):

1. **Malformed approval parts never reach `generateText`** — bare `tool-approval-response` parts on assistant model messages (the CW-293 shape), missing `approvalId`, stringy `approved`; an assistant message emptied by sanitization still carries content.
2. **The handler actually calls the guard, and repair works** — a delegating spy records the input and output of the handler's own `sanitizeCoreMessagesForToolApprovals` call: the transform output is what gets handed over, the recoverable response is repaired (`toolCallId` → `approvalId`, `'true'` → `true`), the irreparable one is dropped, and the turn survives. Asserted at that boundary rather than on the final prompt, because `normalizeCoreMessagesForGemini` drops tool-role approval parts regardless — a post-normalization assertion there would be vacuously true.
3. **Valid tool-call history is untouched** — real `expandStoredChatMessages` + real transform on a stored call/result fixture still yields `user / assistant(tool-call) / tool(tool-result) / user` with intact `input` and `output`, and the guard's output deep-equals its input (a strict no-op).

**All three tests fail with the handler change reverted** (verified by restoring the pre-change file from `HEAD~1`, running, then restoring):

```
× strips malformed tool-approval-response parts before the prompt reaches generateText
    AssertionError: expected [ { role: 'assistant', …(1) }, …(1) ] to deeply equal []
× runs the transformed history through the sanitizer, repairing recoverable tool-role responses
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
× leaves valid tool-call history untouched on the Telegram path
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

## Verification

```
pnpm vitest run tests/unit/server/api/chat.test.ts
  Test Files  1 passed (1)
       Tests  11 passed (11)

pnpm vitest run tests/unit/server/api/chat.test.ts tests/unit/server/api/telegram-webhook-tool-approvals.test.ts
  Test Files  2 passed (2)
       Tests  14 passed (14)

pnpm typecheck   # exit 0, 0 TS errors
eslint + prettier --check on both changed files → clean
```

Broader regression sweep (`server/utils/chat/turn-executor.test.ts`, `server/utils/ai-history.test.ts`, `tests/unit/server/api/`): 87 files / 361 tests passed.

UX critique: skipped — server-side webhook change, no UI surface.