### PR TITLE
fix(cli): close realtime bus and exit non-zero on failure (CW-597)

### DIFF
--- a/cli/support/tickets.ts
+++ b/cli/support/tickets.ts
@@ -4,10 +4,18 @@ import { PrismaClient, BugStatus } from '@prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 import pg from 'pg'
 import { sendToUser } from '../../server/utils/ws-state'
+import { stopRealtimeSubscription } from '../../server/utils/realtime-bus'
 
 export const ticketsCommand = new Command('tickets').description(
   'Manage support tickets (Bug Reports)'
 )
+
+/**
+ * Derived from the Prisma enum rather than hand-written, so the `--help` text
+ * cannot drift from what the command actually accepts. It previously advertised
+ * DUPLICATE and WONT_FIX, neither of which exists in `BugStatus`.
+ */
+export const VALID_STATUSES = Object.values(BugStatus)
 
 const getPrisma = (isProd: boolean) => {
   const connectionString = isProd ? process.env.DATABASE_URL_PROD : process.env.DATABASE_URL
@@ -18,6 +26,30 @@ const getPrisma = (isProd: boolean) => {
   const pool = new pg.Pool({ connectionString })
   const adapter = new PrismaPg(pool)
   return { prisma: new PrismaClient({ adapter }), pool }
+}
+
+/**
+ * Release every handle a command may have opened.
+ *
+ * `sendToUser` publishes through `realtime-bus`, which lazily opens an ioredis
+ * publisher and keeps it open. In the long-running server that is correct; in a
+ * one-shot CLI it keeps the event loop alive forever, so the command commits its
+ * write and then hangs until something kills it. Closing the bus here fixes that
+ * without a `process.exit()`, which would risk truncating the notification write.
+ */
+export const closeResources = async (prisma: PrismaClient, pool: pg.Pool) => {
+  await prisma.$disconnect()
+  await pool.end()
+  await stopRealtimeSubscription()
+}
+
+/**
+ * Report failure to scripted callers. Without this a command prints an error and
+ * still exits 0, so a batch script records success for work that never happened.
+ */
+const failed = (message: string, error?: unknown) => {
+  console.error(chalk.red(message), error ?? '')
+  process.exitCode = 1
 }
 
 async function createUserNotificationWithClient(
@@ -93,7 +125,7 @@ ticketsCommand
       })
 
       if (!ticket) {
-        console.log(chalk.red(`Ticket ${id} not found.`))
+        failed(`Ticket ${id} not found.`)
         return
       }
 
@@ -140,28 +172,23 @@ ticketsCommand
         )
       )
     } catch (error) {
-      console.error(chalk.red('Error:'), error)
+      failed('Error:', error)
     } finally {
-      await prisma.$disconnect()
-      await pool.end()
+      await closeResources(prisma, pool)
     }
   })
 
 ticketsCommand
   .command('update-status <id> <status>')
-  .description(
-    'Update the status of a ticket (OPEN, IN_PROGRESS, RESOLVED, CLOSED, DUPLICATE, WONT_FIX)'
-  )
+  .description(`Update the status of a ticket (${VALID_STATUSES.join(', ')})`)
   .option('--prod', 'Use production database')
   .action(async (id, status, options) => {
     const { prisma, pool } = getPrisma(options.prod)
     try {
       if (options.prod) console.log(chalk.yellow('⚠️  Using PRODUCTION database.'))
 
-      if (!Object.values(BugStatus).includes(status as BugStatus)) {
-        console.error(
-          chalk.red(`Invalid status. Must be one of: ${Object.values(BugStatus).join(', ')}`)
-        )
+      if (!VALID_STATUSES.includes(status as BugStatus)) {
+        failed(`Invalid status. Must be one of: ${VALID_STATUSES.join(', ')}`)
         return
       }
 
@@ -179,10 +206,9 @@ ticketsCommand
 
       console.log(chalk.green(`Successfully updated ticket ${id} to status ${status}`))
     } catch (error) {
-      console.error(chalk.red('Error updating ticket:'), error)
+      failed('Error updating ticket:', error)
     } finally {
-      await prisma.$disconnect()
-      await pool.end()
+      await closeResources(prisma, pool)
     }
   })
 
@@ -202,7 +228,7 @@ ticketsCommand
 
       const type = options.type.toUpperCase()
       if (type !== 'NOTE' && type !== 'MESSAGE') {
-        console.error(chalk.red('Invalid type. Must be NOTE or MESSAGE.'))
+        failed('Invalid type. Must be NOTE or MESSAGE.')
         return
       }
 
@@ -238,11 +264,7 @@ ticketsCommand
         }
 
         if (!userId) {
-          console.error(
-            chalk.red(
-              'No user-id provided, SUPPORT_AGENT_USER not found, and no ADMIN found in DB.'
-            )
-          )
+          failed('No user-id provided, SUPPORT_AGENT_USER not found, and no ADMIN found in DB.')
           return
         }
       }
@@ -275,10 +297,9 @@ ticketsCommand
 
       console.log(chalk.green(`Successfully added ${type} to ticket ${id}`))
     } catch (error) {
-      console.error(chalk.red('Error adding comment:'), error)
+      failed('Error adding comment:', error)
     } finally {
-      await prisma.$disconnect()
-      await pool.end()
+      await closeResources(prisma, pool)
     }
   })
 
@@ -328,9 +349,8 @@ ticketsCommand
         )
       }
     } catch (error) {
-      console.error(chalk.red('Error fetching tickets:'), error)
+      failed('Error fetching tickets:', error)
     } finally {
-      await prisma.$disconnect()
-      await pool.end()
+      await closeResources(prisma, pool)
     }
   })

--- a/tests/unit/cli/support-tickets.test.ts
+++ b/tests/unit/cli/support-tickets.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { BugStatus } from '@prisma/client'
+
+// CW-597: `sendToUser` publishes through realtime-bus, which lazily opens an
+// ioredis publisher. The support CLI never closed it, so every comment /
+// update-status committed its write and then hung until something killed it.
+const stopRealtimeSubscription = vi.fn(async () => {})
+
+vi.mock('../../../server/utils/ws-state', () => ({
+  sendToUser: vi.fn(async () => {})
+}))
+
+vi.mock('../../../server/utils/realtime-bus', () => ({
+  stopRealtimeSubscription
+}))
+
+const { closeResources, VALID_STATUSES } = await import('../../../cli/support/tickets')
+
+describe('support tickets CLI teardown (CW-597)', () => {
+  beforeEach(() => {
+    stopRealtimeSubscription.mockClear()
+  })
+
+  it('closes the realtime bus so the process can exit', async () => {
+    const prisma = { $disconnect: vi.fn(async () => {}) }
+    const pool = { end: vi.fn(async () => {}) }
+
+    await closeResources(prisma as any, pool as any)
+
+    expect(prisma.$disconnect).toHaveBeenCalledTimes(1)
+    expect(pool.end).toHaveBeenCalledTimes(1)
+    // The regression: without this the ioredis handle keeps the event loop alive.
+    expect(stopRealtimeSubscription).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('support tickets CLI status validation (CW-597)', () => {
+  it('derives the accepted status list from the Prisma enum', () => {
+    // Guards against the help text drifting from validation again.
+    expect(VALID_STATUSES).toEqual(Object.values(BugStatus))
+  })
+
+  it('does not advertise statuses the enum does not define', () => {
+    expect(VALID_STATUSES).not.toContain('WONT_FIX')
+    expect(VALID_STATUSES).not.toContain('DUPLICATE')
+  })
+})


### PR DESCRIPTION
Fixes CW-597

## Problem

Two defects in `cli/support/tickets.ts`, both found while replying to a batch of production support tickets.

**1. `comment` and `update-status` committed their write, then hung forever.**

`sendToUser` publishes through `realtime-bus`, which lazily opens an `ioredis` publisher and keeps it open. That is correct for the long-running server, but in a one-shot CLI it keeps the event loop alive indefinitely. The write had already landed — the process just never exited.

The practical cost: every call needed an external `timeout` wrapper, turning a 15-ticket reply run into ~30 minutes of mostly waiting, and making failures ambiguous (`rc=124` was indistinguishable from a real failure without re-reading the ticket afterwards).

**2. Failure paths printed an error and still exited 0.**

A scripted caller recorded success for work that never happened. This bit for real: a batch reported `rc=0` for a status change that had been *rejected*, and it was only caught by re-reading the queue. Silent success in a scripted path is the more dangerous of the two bugs.

Related: `--help` advertised `DUPLICATE` and `WONT_FIX`, neither of which exists in the `BugStatus` enum — so the documented values were rejected at runtime.

## Fix

- Teardown now calls the **existing** `stopRealtimeSubscription()` alongside `prisma.$disconnect()` / `pool.end()`. Deliberately not `process.exit()`, which would risk truncating the in-flight notification write.
- Every failure path sets `process.exitCode = 1` — invalid status, invalid comment type, ticket not found, missing admin user, and all four `catch` blocks.
- The accepted status list is derived from `Object.values(BugStatus)` and interpolated into the `--help` text, so the two cannot drift apart again.

## Verification

Measured end-to-end with a probe against a real Redis, importing the same modules as the CLI:

| | result |
|---|---|
| before (no `stopRealtimeSubscription`) | **hung — killed at 45s, `rc=124`** |
| after | **clean exit in 3s, `rc=0`** |

Exit code, against a local DB:

```
$ tsx cli/index.ts support tickets update-status <id> WONT_FIX
Invalid status. Must be one of: OPEN, IN_PROGRESS, NEED_MORE_INFO, RESOLVED, CLOSED
rc=1          # was rc=0
```

Note the list is now accurate — it previously advertised `WONT_FIX` as valid.

```
pnpm test:unit tests/unit/cli    # 23 passed (3 new)
```

Local `pnpm typecheck` was starved by parallel worktree builds and did not finish; leaving it to CI, which runs the same check.