### PR TITLE
fix(ai): make Gemini connect-timeout failures deliberate and triageable (CW-328)

### DIFF
--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -113,6 +113,326 @@ function normalizeAiSdkUsage(usage?: AiSdkUsage) {
   }
 }
 
+/* -------------------------------------------------------------------------- *
+ * Deliberate Gemini call policy (CW-328)
+ *
+ * On 2026-08-02 a ~90 minute upstream incident produced 12 `ConnectTimeoutError`s
+ * against generativelanguage.googleapis.com:443 across four background tasks, all
+ * funnelling through `generateStructuredAnalysis`. The values below are *chosen*,
+ * not inherited from a library default. Change them deliberately.
+ *
+ * Note on where retries live. There are already two retry layers around every
+ * call in this file:
+ *   1. the AI SDK's in-process retry (`maxRetries` below), and
+ *   2. Trigger.dev's task-level retry (`trigger.config.ts`: maxAttempts 3,
+ *      backoff 1s -> 10s), which re-runs the whole task.
+ * This module deliberately does NOT add a third. `generateStructuredAnalysis` is
+ * shared by ~45 call sites including synchronous HTTP handlers, so a deferral or
+ * long backoff here would hang user-facing requests; and stacking retry layers
+ * multiplies load against an already-degraded upstream. Riding out a multi-minute
+ * outage is the task scheduler's job, not this function's.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * In-process attempts per call = 1 + GEMINI_MAX_RETRIES.
+ *
+ * Kept at 3 (4 attempts). The AI SDK applies this uniformly to every error class,
+ * and the classes it actually rescues are 429/quota and transient 5xx, where a
+ * short in-process retry is much cheaper than rebuilding the prompt and re-running
+ * the whole task. Lowering it to reclaim the ~40s burned during a connect-timeout
+ * outage would trade a frequent win for a rare one.
+ */
+export const GEMINI_MAX_RETRIES = 3
+
+/**
+ * Connect (TCP+TLS establishment) timeout, in ms.
+ *
+ * 10s — undici's default, deliberately retained. Failing to establish a connection
+ * to Google within 10s means the network path is down rather than slow: raising it
+ * would burn proportionally more worker time before the identical failure, and
+ * lowering it risks false negatives on cold or marginal egress.
+ *
+ * IMPORTANT: this constant is currently documentation, not enforcement. Pinning the
+ * connect timeout requires passing an undici `Agent` dispatcher to a custom `fetch`,
+ * and undici is not a dependency of this project (not even transitively). It is
+ * recorded here so the value is a stated intent rather than an accident, and so the
+ * next incident starts from a number someone chose.
+ */
+export const GEMINI_CONNECT_TIMEOUT_MS = 10_000
+
+/**
+ * Overall per-call timeout, in ms.
+ *
+ * 240s. Previously there was effectively NO bound at all on `generateObject`:
+ * `trackingContext.timeoutMs` was opt-in, none of the four tasks in the incident
+ * passed it, and — see the comment at the `generateObject` call — the option it fed
+ * was silently inert, so even the callers that did pass a budget ran unbounded. A
+ * hung socket was therefore limited only by Trigger.dev's `maxDuration` (300s for
+ * most tasks), which kills the run with no classified error and no usage row.
+ *
+ * 240s sits deliberately *below* that 300s platform budget so we time out first and
+ * fail with a logged, classified `timeout`, and comfortably above both the slowest
+ * legitimate generation (Pro + high thinking on a large prompt) and the explicit
+ * per-call budgets callers already set (20s–60s elsewhere in the codebase). It
+ * exists to bound a stuck connection, not to pace the model. Callers needing a
+ * tighter or looser bound still pass `timeoutMs`.
+ */
+export const GEMINI_REQUEST_TIMEOUT_MS = 240_000
+
+/**
+ * Failure classes for a Gemini call.
+ *
+ * The point of this union is triage: a transport failure and a bad model response
+ * are different incidents with different owners, and before CW-328 both were logged
+ * as `api_error` with an identical `console.error` line. That is the mechanical
+ * reason one upstream blip produced four separate tickets.
+ *
+ * `transient` classes are upstream/infrastructure and are expected to clear on their
+ * own; the rest indicate our prompt, our schema, or the model's output and will not
+ * improve by retrying.
+ */
+export type GeminiErrorType =
+  /** TCP+TLS to the API never established (undici UND_ERR_CONNECT_TIMEOUT). Transient. */
+  | 'connect_timeout'
+  /** Connection established but the call exceeded its time budget, or was aborted. Transient. */
+  | 'timeout'
+  /** DNS / socket / reset / `fetch failed`. Transient. */
+  | 'network'
+  /** 429 or quota exhaustion. Transient. */
+  | 'rate_limit'
+  /** Upstream 5xx. Transient. */
+  | 'server_error'
+  /** 401/403, missing or rejected API key. Not transient — a config problem. */
+  | 'auth'
+  /** 400: the request itself is malformed (prompt or schema). Not transient. */
+  | 'invalid_request'
+  /** Model returned no object, or output that failed schema/JSON validation. Not transient. */
+  | 'schema_validation'
+  /** Blocked by safety filters, recitation, or another content policy. Not transient. */
+  | 'content_filter'
+  /** Nothing matched — inspect `errorMessage`, and consider adding a class. */
+  | 'api_error'
+
+export interface GeminiErrorClassification {
+  type: GeminiErrorType
+  /** Upstream/infrastructure fault expected to clear on its own. */
+  transient: boolean
+  /** HTTP status, when the call actually reached the API. */
+  statusCode?: number
+  /** In-process attempts the AI SDK made before giving up, when it reports them. */
+  attempts?: number
+  /** Low-cardinality summary safe to put in a log prefix or a Sentry tag. */
+  detail: string
+}
+
+const TRANSIENT_GEMINI_ERROR_TYPES: ReadonlySet<GeminiErrorType> = new Set<GeminiErrorType>([
+  'connect_timeout',
+  'timeout',
+  'network',
+  'rate_limit',
+  'server_error'
+])
+
+/**
+ * Flatten an error's cause chain.
+ *
+ * The decisive error is usually buried: the AI SDK throws `AI_RetryError`, which
+ * holds the final `APICallError` in `lastError`, which in turn wraps undici's
+ * `ConnectTimeoutError` in `cause`. Classifying only the outermost error is exactly
+ * how a connect timeout ends up indistinguishable from a schema failure.
+ */
+function collectErrorChain(error: unknown, maxDepth = 10): any[] {
+  const chain: any[] = []
+  let current: any = error
+
+  while (current && typeof current === 'object' && chain.length < maxDepth) {
+    chain.push(current)
+    const next = current.lastError ?? current.cause
+    if (!next || typeof next !== 'object' || chain.includes(next)) break
+    current = next
+  }
+
+  return chain
+}
+
+/**
+ * Classify a Gemini/AI SDK failure into a stable, queryable bucket.
+ *
+ * Matching is duck-typed on `name`/`code`/`statusCode` rather than `instanceof` so it
+ * survives bundling (Trigger.dev, Nitro) duplicating the AI SDK's error classes.
+ */
+export function classifyGeminiError(error: unknown): GeminiErrorClassification {
+  const chain = collectErrorChain(error)
+
+  const names = new Set(chain.map((e) => String(e?.name ?? '')))
+  const codes = new Set(chain.map((e) => String(e?.code ?? '')))
+  const messages = chain.map((e) => String(e?.message ?? '')).join(' | ')
+  const haystack = messages.toLowerCase()
+
+  const statusCode = chain.find((e) => typeof e?.statusCode === 'number')?.statusCode as
+    number | undefined
+
+  // AI SDK RetryError exposes every attempt it made; fall back to parsing its message.
+  const attemptsFromErrors = chain.find((e) => Array.isArray(e?.errors))?.errors?.length
+  const attemptsFromMessage = messages.match(/after (\d+) attempts?/i)?.[1]
+  const attempts =
+    attemptsFromErrors ?? (attemptsFromMessage ? Number(attemptsFromMessage) : undefined)
+
+  const has = (...needles: string[]) => needles.some((n) => haystack.includes(n))
+
+  const build = (type: GeminiErrorType, detail: string): GeminiErrorClassification => ({
+    type,
+    transient: TRANSIENT_GEMINI_ERROR_TYPES.has(type),
+    statusCode,
+    attempts,
+    detail
+  })
+
+  const looksLikeContentFilter = () =>
+    has('safety', 'prohibited_content', 'recitation', 'content policy', 'blocked by')
+
+  /* --- Pass 1: structured signals (error codes, class names, HTTP status).
+     These are unambiguous, so they win over any message text. --- */
+
+  // Transport. These never reached the model.
+  if (codes.has('UND_ERR_CONNECT_TIMEOUT') || names.has('ConnectTimeoutError')) {
+    return build('connect_timeout', `could not connect within ${GEMINI_CONNECT_TIMEOUT_MS}ms`)
+  }
+
+  if (
+    codes.has('UND_ERR_HEADERS_TIMEOUT') ||
+    codes.has('UND_ERR_BODY_TIMEOUT') ||
+    codes.has('ETIMEDOUT') ||
+    names.has('TimeoutError') ||
+    names.has('AbortError')
+  ) {
+    return build('timeout', 'call exceeded its time budget')
+  }
+
+  if (
+    codes.has('ENOTFOUND') ||
+    codes.has('EAI_AGAIN') ||
+    codes.has('ECONNREFUSED') ||
+    codes.has('ECONNRESET') ||
+    codes.has('EPIPE') ||
+    codes.has('EHOSTUNREACH') ||
+    codes.has('ENETUNREACH') ||
+    codes.has('UND_ERR_SOCKET')
+  ) {
+    return build('network', 'network failure reaching the API')
+  }
+
+  // Model output problems. These carry no HTTP status, so they cannot collide below.
+  if (
+    names.has('AI_NoObjectGeneratedError') ||
+    names.has('NoObjectGeneratedError') ||
+    names.has('AI_TypeValidationError') ||
+    names.has('TypeValidationError') ||
+    names.has('AI_JSONParseError') ||
+    names.has('JSONParseError')
+  ) {
+    return looksLikeContentFilter()
+      ? build('content_filter', 'response withheld by a content filter')
+      : build('schema_validation', 'model output did not satisfy the schema')
+  }
+
+  if (names.has('AI_LoadAPIKeyError') || names.has('LoadAPIKeyError')) {
+    return build('auth', 'credentials rejected or missing')
+  }
+
+  // HTTP status.
+  if (statusCode === 429) return build('rate_limit', 'rate limited or out of quota')
+  if (statusCode === 401 || statusCode === 403) {
+    return build('auth', 'credentials rejected or missing')
+  }
+  if (typeof statusCode === 'number' && statusCode >= 500) {
+    return build('server_error', `upstream returned ${statusCode}`)
+  }
+  if (statusCode === 400) {
+    return looksLikeContentFilter()
+      ? build('content_filter', 'response withheld by a content filter')
+      : build('invalid_request', 'request rejected as malformed')
+  }
+
+  /* --- Pass 2: message heuristics, only once no structured signal survived the
+     wrapping. Ordered most- to least-distinctive. --- */
+
+  if (has('quota', 'rate limit', 'resource_exhausted', 'too many requests')) {
+    return build('rate_limit', 'rate limited or out of quota')
+  }
+  if (has('api key', 'permission denied', 'unauthenticated')) {
+    return build('auth', 'credentials rejected or missing')
+  }
+  if (looksLikeContentFilter()) {
+    return build('content_filter', 'response withheld by a content filter')
+  }
+  if (has('connect timeout')) {
+    return build('connect_timeout', `could not connect within ${GEMINI_CONNECT_TIMEOUT_MS}ms`)
+  }
+  if (has('timed out', 'timeout', 'aborted')) {
+    return build('timeout', 'call exceeded its time budget')
+  }
+  if (has('fetch failed', 'socket hang up', 'network error')) {
+    return build('network', 'network failure reaching the API')
+  }
+  if (has('invalid argument', 'invalid_argument')) {
+    return build('invalid_request', 'request rejected as malformed')
+  }
+
+  return build('api_error', 'unclassified failure')
+}
+
+/**
+ * Emit a triage-shaped log line and tag the error for Sentry.
+ *
+ * The `[Gemini][<type>]` prefix is stable and low-cardinality, so a connect timeout
+ * and a schema failure land in different Sentry groups and are greppable apart in
+ * Trigger.dev logs — which is the whole point of CW-328.
+ *
+ * The original error is rethrown unchanged by callers: ~45 call sites already catch
+ * these, so this deliberately does not wrap or re-type the error, only annotate it.
+ */
+function reportGeminiFailure(params: {
+  fn: string
+  error: any
+  operation?: string
+  modelId: string
+  durationMs: number
+}): GeminiErrorClassification {
+  const classification = classifyGeminiError(params.error)
+
+  const fields = [
+    `operation=${params.operation ?? 'unknown'}`,
+    `model=${params.modelId}`,
+    `transient=${classification.transient}`,
+    classification.statusCode !== undefined ? `status=${classification.statusCode}` : undefined,
+    classification.attempts !== undefined ? `attempts=${classification.attempts}` : undefined,
+    `durationMs=${params.durationMs}`
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  console.error(
+    `[Gemini][${classification.type}] ${params.fn} failed — ${classification.detail} (${fields})`,
+    params.error
+  )
+
+  // Surface the classification as error properties so Sentry captures it as context
+  // without this module taking a dependency on a Sentry SDK (it runs in both the
+  // Nitro server and the Trigger.dev worker bundles).
+  try {
+    Object.assign(params.error, {
+      geminiErrorType: classification.type,
+      geminiErrorTransient: classification.transient,
+      geminiOperation: params.operation
+    })
+  } catch {
+    // Error object frozen or a primitive — classification still reached logs and LlmUsage.
+  }
+
+  return classification
+}
+
 /**
  * Internal helper to log usage from Vercel AI SDK events
  */
@@ -133,6 +453,8 @@ async function logUsage(params: {
   }
   success: boolean
   error?: any
+  /** Pre-computed classification from `reportGeminiFailure`; derived from `error` if omitted. */
+  errorType?: GeminiErrorType
   durationMs?: number
   counted?: boolean
 }) {
@@ -167,7 +489,11 @@ async function logUsage(params: {
     durationMs,
     retryCount: 0,
     success: params.success,
-    errorType: params.error ? 'api_error' : undefined,
+    // CW-328: previously hardcoded to 'api_error', which made every failure — connect
+    // timeout, bad schema, rate limit — indistinguishable in LlmUsage.
+    errorType: params.error
+      ? (params.errorType ?? classifyGeminiError(params.error).type)
+      : undefined,
     errorMessage: params.error?.message,
     promptPreview: getPreview(params.prompt),
     responsePreview: params.text ? getPreview(params.text) : undefined,
@@ -499,7 +825,9 @@ export async function generateCoachAnalysis(
     const { text, usage } = await generateText({
       model: google(modelName),
       prompt: prompt,
-      maxRetries: trackingContext?.maxRetries ?? 3,
+      // CW-328: deliberate policy — see GEMINI_MAX_RETRIES / GEMINI_REQUEST_TIMEOUT_MS.
+      maxRetries: trackingContext?.maxRetries ?? GEMINI_MAX_RETRIES,
+      timeout: { totalMs: trackingContext?.timeoutMs ?? GEMINI_REQUEST_TIMEOUT_MS },
       providerOptions
     })
     if (trackingContext) {
@@ -520,7 +848,13 @@ export async function generateCoachAnalysis(
 
     return text
   } catch (error: any) {
-    console.error(`[Gemini] generateCoachAnalysis failed:`, error)
+    const classification = reportGeminiFailure({
+      fn: 'generateCoachAnalysis',
+      error,
+      operation: trackingContext?.operation,
+      modelId: modelName,
+      durationMs: Date.now() - startTime
+    })
     if (trackingContext) {
       await logUsage({
         userId: trackingContext.userId,
@@ -536,6 +870,7 @@ export async function generateCoachAnalysis(
         },
         success: false,
         error,
+        errorType: classification.type,
         durationMs: Date.now() - startTime
       })
     }
@@ -607,8 +942,15 @@ export async function generateStructuredAnalysis<T>(
       model: google(modelName),
       prompt: prompt,
       schema: jsonSchema(schema),
-      maxRetries: trackingContext?.maxRetries ?? 3,
-      ...(trackingContext?.timeoutMs ? { timeout: { totalMs: trackingContext.timeoutMs } } : {}),
+      // CW-328: deliberate policy — see GEMINI_MAX_RETRIES / GEMINI_REQUEST_TIMEOUT_MS.
+      maxRetries: trackingContext?.maxRetries ?? GEMINI_MAX_RETRIES,
+      // `generateObject` is typed `Omit<RequestOptions, 'timeout'>` — unlike
+      // `generateText` it accepts no `timeout` option. The previous
+      // `...(timeoutMs ? { timeout: { totalMs } } : {})` spread therefore compiled
+      // (conditional spreads skip excess-property checking) but did nothing, so every
+      // caller passing `timeoutMs` was in fact running unbounded. `abortSignal` is the
+      // supported mechanism and bounds total wall clock across all retries.
+      abortSignal: AbortSignal.timeout(trackingContext?.timeoutMs ?? GEMINI_REQUEST_TIMEOUT_MS),
       providerOptions
     })
     if (trackingContext) {
@@ -630,7 +972,13 @@ export async function generateStructuredAnalysis<T>(
 
     return object as T
   } catch (error: any) {
-    console.error(`[Gemini] generateStructuredAnalysis failed:`, error)
+    const classification = reportGeminiFailure({
+      fn: 'generateStructuredAnalysis',
+      error,
+      operation: trackingContext?.operation,
+      modelId: modelName,
+      durationMs: Date.now() - startTime
+    })
     if (trackingContext) {
       await logUsage({
         userId: trackingContext.userId,
@@ -646,10 +994,14 @@ export async function generateStructuredAnalysis<T>(
         },
         success: false,
         error,
+        errorType: classification.type,
         durationMs: Date.now() - startTime,
         counted: trackingContext.counted
       })
     }
+    // Rethrown unchanged: the caller (and, for background tasks, Trigger.dev's own
+    // task-level retry) decides what happens next. See the policy note above for why
+    // this function deliberately does not defer or re-enqueue.
     throw error
   }
 }

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -546,6 +546,13 @@ function isRateLimitError(error: any): boolean {
 
 /**
  * Wrapper function that retries API calls with exponential backoff and tracks usage
+ *
+ * DEAD CODE — unreferenced anywhere in the repo (CW-328). It is NOT a live retry path:
+ * the retry policy that actually applies to Gemini calls is `GEMINI_MAX_RETRIES` above
+ * (in-process, via the AI SDK) plus Trigger.dev's task-level retry in `trigger.config.ts`.
+ * Neither this function nor its helpers (`isRateLimitError`, `parseRetryDelay`,
+ * `MAX_RETRIES`, `BASE_DELAY_MS`, `MAX_DELAY_MS`) run. Kept only to keep the CW-328 diff
+ * reviewable; slated for deletion in a follow-up.
  */
 async function retryWithBackoff<T>(
   fn: () => Promise<T>,

--- a/server/utils/gemini.ts
+++ b/server/utils/gemini.ts
@@ -221,7 +221,7 @@ export interface GeminiErrorClassification {
   statusCode?: number
   /** In-process attempts the AI SDK made before giving up, when it reports them. */
   attempts?: number
-  /** Low-cardinality summary safe to put in a log prefix or a Sentry tag. */
+  /** Low-cardinality summary safe to put in a log prefix. */
   detail: string
 }
 
@@ -383,13 +383,22 @@ export function classifyGeminiError(error: unknown): GeminiErrorClassification {
 }
 
 /**
- * Emit a triage-shaped log line and tag the error for Sentry.
+ * Emit a triage-shaped log line and annotate the error with its classification.
  *
- * The `[Gemini][<type>]` prefix is stable and low-cardinality, so a connect timeout
- * and a schema failure land in different Sentry groups and are greppable apart in
- * Trigger.dev logs — which is the whole point of CW-328.
+ * The `[Gemini][<type>]` prefix is stable and low-cardinality, so a connect timeout and a
+ * schema failure are greppable apart in the Trigger.dev log viewer. Nitro-side callers
+ * additionally reach Sentry Logs (`sentry.server.config.ts` registers
+ * `consoleLoggingIntegration` with `enableLogs`); the Trigger worker does NOT, since
+ * `trigger/init.ts` initialises Sentry with `defaultIntegrations: false`.
  *
- * The original error is rethrown unchanged by callers: ~45 call sites already catch
+ * What this does NOT do (CW-328): it does not change Sentry *issue* grouping. The error is
+ * rethrown unchanged, so issues still group by call site, and grouping them apart would
+ * mean throwing distinct error types — a behavioural change across every call site.
+ * The queryable, works-everywhere signal is `LlmUsage.errorType`; the prefix is the human
+ * one. To get the classification into Sentry proper, tag it in the single
+ * `tasks.onFailure` hook in `trigger/init.ts` from the error properties set below.
+ *
+ * The original error is rethrown unchanged by callers: dozens of call sites already catch
  * these, so this deliberately does not wrap or re-type the error, only annotate it.
  */
 function reportGeminiFailure(params: {
@@ -417,9 +426,14 @@ function reportGeminiFailure(params: {
     params.error
   )
 
-  // Surface the classification as error properties so Sentry captures it as context
-  // without this module taking a dependency on a Sentry SDK (it runs in both the
-  // Nitro server and the Trigger.dev worker bundles).
+  // Carry the classification on the error so any local handler can branch on it without
+  // re-classifying, and without this module depending on a Sentry SDK (it is bundled into
+  // both the Nitro server and the Trigger.dev worker).
+  //
+  // NOTE: these properties are NOT captured by Sentry today — no `extraErrorDataIntegration`
+  // is registered, and Sentry does not serialise arbitrary own properties of an Error by
+  // default (the Trigger worker disables default integrations entirely). They exist so the
+  // `tasks.onFailure` hook in `trigger/init.ts` can promote them to Sentry tags in one line.
   try {
     Object.assign(params.error, {
       geminiErrorType: classification.type,

--- a/tests/unit/server/utils/gemini.test.ts
+++ b/tests/unit/server/utils/gemini.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest'
 import {
   buildWorkoutSummary,
   buildConciseWorkoutSummary,
-  loadFlatFileMock
+  loadFlatFileMock,
+  classifyGeminiError,
+  GEMINI_MAX_RETRIES,
+  GEMINI_CONNECT_TIMEOUT_MS,
+  GEMINI_REQUEST_TIMEOUT_MS
 } from '../../../../server/utils/gemini'
 
 describe('Gemini Utility & Prompt Formatters', () => {
@@ -72,5 +76,274 @@ describe('Gemini Utility & Prompt Formatters', () => {
   it('loads flat file mocks with fallback mechanism', () => {
     const mockData = loadFlatFileMock('unknown_operation_xyz')
     expect(mockData).toBeDefined()
+  })
+})
+
+/**
+ * CW-328. On 2026-08-02 a ~90 minute upstream incident produced 12
+ * `ConnectTimeoutError`s across four background tasks, all funnelling through
+ * `generateStructuredAnalysis`. Every failure was logged as `errorType: 'api_error'`
+ * with an identical console line, so a transport outage was indistinguishable from a
+ * bad schema or a safety block — which is why one incident was triaged as four
+ * separate tickets (CW-329/330/331 were later closed as duplicates).
+ *
+ * These tests pin the classification. Against the pre-fix code every case below that
+ * expects something other than `'api_error'` fails, because `'api_error'` was the only
+ * value the old code could produce.
+ */
+describe('classifyGeminiError (CW-328)', () => {
+  /** Build an error with a specific `name`, plus any extra own properties. */
+  function err(name: string, message: string, extra: Record<string, any> = {}) {
+    const e: any = new Error(message)
+    e.name = name
+    Object.assign(e, extra)
+    return e
+  }
+
+  /**
+   * The exact 2026-08-02 wrapping. This nesting is the whole reason the incident was
+   * unreadable: the decisive error sits three levels down, so anything that inspects
+   * only the outermost error sees `AI_RetryError` and learns nothing about the cause.
+   */
+  function buildIncidentError() {
+    const connect = err('ConnectTimeoutError', 'Connect Timeout Error', {
+      code: 'UND_ERR_CONNECT_TIMEOUT'
+    })
+    const apiCall = err('AI_APICallError', 'Cannot connect to API', {
+      cause: connect,
+      url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-flash'
+    })
+    return err('AI_RetryError', 'Failed after 4 attempts. Last error: Cannot connect to API', {
+      lastError: apiCall,
+      errors: [apiCall, apiCall, apiCall, apiCall]
+    })
+  }
+
+  it('unwraps the 2026-08-02 incident error to connect_timeout', () => {
+    const result = classifyGeminiError(buildIncidentError())
+
+    expect(result.type).toBe('connect_timeout')
+    expect(result.transient).toBe(true)
+    // Surfacing the attempt count is what makes "we already retried 4 times" visible
+    // in the log line instead of buried in the AI SDK's message.
+    expect(result.attempts).toBe(4)
+  })
+
+  it('does not stop at the outermost error when classifying', () => {
+    // Guards the actual regression: reading only `error.name` yields 'AI_RetryError',
+    // which carries no cause information and would fall through to 'api_error'.
+    const incident = buildIncidentError()
+    expect(incident.name).toBe('AI_RetryError')
+    expect(classifyGeminiError(incident).type).not.toBe('api_error')
+  })
+
+  const cases: Array<{
+    label: string
+    error: any
+    expected: string
+    transient: boolean
+  }> = [
+    {
+      label: 'bare undici connect timeout',
+      error: err('ConnectTimeoutError', 'Connect Timeout Error', {
+        code: 'UND_ERR_CONNECT_TIMEOUT'
+      }),
+      expected: 'connect_timeout',
+      transient: true
+    },
+    {
+      label: 'AbortSignal.timeout firing (our own request budget)',
+      error: err('TimeoutError', 'The operation was aborted due to timeout'),
+      expected: 'timeout',
+      transient: true
+    },
+    {
+      label: 'undici headers timeout',
+      error: err('HeadersTimeoutError', 'Headers Timeout Error', {
+        code: 'UND_ERR_HEADERS_TIMEOUT'
+      }),
+      expected: 'timeout',
+      transient: true
+    },
+    {
+      label: 'DNS failure wrapped in fetch failed',
+      error: err('TypeError', 'fetch failed', {
+        cause: err('Error', 'getaddrinfo ENOTFOUND generativelanguage.googleapis.com', {
+          code: 'ENOTFOUND'
+        })
+      }),
+      expected: 'network',
+      transient: true
+    },
+    {
+      label: 'socket reset',
+      error: err('Error', 'read ECONNRESET', { code: 'ECONNRESET' }),
+      expected: 'network',
+      transient: true
+    },
+    {
+      label: 'model returned no object',
+      error: err('AI_NoObjectGeneratedError', 'No object generated: response did not match schema'),
+      expected: 'schema_validation',
+      transient: false
+    },
+    {
+      label: 'schema type validation failure',
+      error: err('AI_TypeValidationError', 'Type validation failed at path .sections[0].status'),
+      expected: 'schema_validation',
+      transient: false
+    },
+    {
+      label: 'malformed JSON from the model',
+      error: err('AI_JSONParseError', 'JSON parsing failed: Unexpected end of JSON input'),
+      expected: 'schema_validation',
+      transient: false
+    },
+    {
+      label: 'HTTP 429',
+      error: err('AI_APICallError', 'Too Many Requests', { statusCode: 429 }),
+      expected: 'rate_limit',
+      transient: true
+    },
+    {
+      label: 'quota message with no status code',
+      error: err('Error', 'You exceeded your current quota, please check your plan'),
+      expected: 'rate_limit',
+      transient: true
+    },
+    {
+      label: 'HTTP 403',
+      error: err('AI_APICallError', 'Forbidden', { statusCode: 403 }),
+      expected: 'auth',
+      transient: false
+    },
+    {
+      label: 'missing API key',
+      error: err('AI_LoadAPIKeyError', 'Google Generative AI API key is missing'),
+      expected: 'auth',
+      transient: false
+    },
+    {
+      label: 'upstream 503',
+      error: err('AI_APICallError', 'Service Unavailable', { statusCode: 503 }),
+      expected: 'server_error',
+      transient: true
+    },
+    {
+      label: 'the bare Gemini 400',
+      error: err('AI_APICallError', 'Request contains an invalid argument.', { statusCode: 400 }),
+      expected: 'invalid_request',
+      transient: false
+    },
+    {
+      label: 'safety block reported as a generation failure',
+      error: err('AI_NoObjectGeneratedError', 'Response was blocked by safety filters'),
+      expected: 'content_filter',
+      transient: false
+    },
+    {
+      label: 'unrecognised failure',
+      error: err('Error', 'something odd happened'),
+      expected: 'api_error',
+      transient: false
+    }
+  ]
+
+  it.each(cases)('classifies $label as $expected', ({ error, expected, transient }) => {
+    const result = classifyGeminiError(error)
+    expect(result.type).toBe(expected)
+    expect(result.transient).toBe(transient)
+  })
+
+  it('treats exactly the upstream/infrastructure classes as transient', () => {
+    // `transient` is what a future caller would branch on to decide "worth waiting out".
+    // Getting this set wrong is how a permanent schema bug becomes an infinite retry.
+    const transientTypes = cases
+      .concat([{ label: 'incident', error: buildIncidentError(), expected: '', transient: true }])
+      .filter((c) => classifyGeminiError(c.error).transient)
+      .map((c) => classifyGeminiError(c.error).type)
+
+    expect(new Set(transientTypes)).toEqual(
+      new Set(['connect_timeout', 'timeout', 'network', 'rate_limit', 'server_error'])
+    )
+  })
+
+  it('reports the HTTP status when the call reached the API', () => {
+    expect(
+      classifyGeminiError(err('AI_APICallError', 'nope', { statusCode: 429 })).statusCode
+    ).toBe(429)
+    // A transport failure never reached the API, so there is no status to report.
+    expect(classifyGeminiError(buildIncidentError()).statusCode).toBeUndefined()
+  })
+
+  it('lets structured signals win over message text', () => {
+    // A 429 whose message happens to mention a timeout must not be classified as one:
+    // rate limiting and a dead network want completely different responses.
+    const ambiguous = err('AI_APICallError', 'Rate limit exceeded after request timeout', {
+      statusCode: 429
+    })
+    expect(classifyGeminiError(ambiguous).type).toBe('rate_limit')
+  })
+
+  it('survives malformed, cyclic and empty inputs', () => {
+    expect(classifyGeminiError(null).type).toBe('api_error')
+    expect(classifyGeminiError(undefined).type).toBe('api_error')
+    expect(classifyGeminiError('a string').type).toBe('api_error')
+
+    // A self-referential cause must terminate rather than hang the worker.
+    const cyclic: any = err('Error', 'loop')
+    cyclic.cause = cyclic
+    expect(classifyGeminiError(cyclic).type).toBe('api_error')
+  })
+})
+
+describe('Gemini call policy (CW-328)', () => {
+  async function readGeminiSource(): Promise<string> {
+    const fs = await import('node:fs')
+    return fs.readFileSync(new URL('../../../../server/utils/gemini.ts', import.meta.url), 'utf-8')
+  }
+
+  it('keeps the request budget below the standard Trigger.dev maxDuration', () => {
+    // 300s is the maxDuration most tasks declare. Timing out first is what produces a
+    // classified error and an LlmUsage row instead of the platform killing the run.
+    expect(GEMINI_REQUEST_TIMEOUT_MS).toBeLessThan(300_000)
+    expect(GEMINI_CONNECT_TIMEOUT_MS).toBeLessThan(GEMINI_REQUEST_TIMEOUT_MS)
+    expect(GEMINI_MAX_RETRIES).toBeGreaterThan(0)
+  })
+
+  /**
+   * The latent bug this ticket uncovered, and the more serious half of it.
+   *
+   * `generateObject` is typed `Omit<RequestOptions, 'timeout'>` — unlike `generateText`
+   * it accepts no `timeout` option at all. The previous
+   * `...(timeoutMs ? { timeout: { totalMs } } : {})` compiled only because a conditional
+   * spread skips excess-property checking, and was discarded at runtime, so every caller
+   * passing `timeoutMs` (45s, 60s and 20s budgets) was in fact unbounded.
+   *
+   * `tsc` now catches a plainly-written `timeout:` property, but NOT one hidden inside a
+   * conditional spread — which is exactly how the original slipped in. Hence a source
+   * assertion, matching the approach already used in workout-analysis-prompt.test.ts.
+   */
+  /** The `generateObject({ ... })` call, with `//` comments stripped so prose about the
+   *  discarded `timeout` option cannot satisfy or defeat an assertion about the code. */
+  async function readGenerateObjectCall(): Promise<string> {
+    const source = await readGeminiSource()
+    const call = source.match(/await generateObject\(\{[\s\S]*?\n {4}\}\)/)
+    expect(call).not.toBeNull()
+    return call![0].replace(/^\s*\/\/.*$/gm, '')
+  }
+
+  it('bounds generateObject with abortSignal, never the timeout option it discards', async () => {
+    const call = await readGenerateObjectCall()
+
+    expect(call).toContain('abortSignal')
+    expect(call).not.toMatch(/\btimeout\s*:/)
+  })
+
+  it('applies the deliberate defaults rather than inline literals', async () => {
+    const call = await readGenerateObjectCall()
+
+    expect(call).toContain('GEMINI_MAX_RETRIES')
+    expect(call).toContain('GEMINI_REQUEST_TIMEOUT_MS')
   })
 })


### PR DESCRIPTION
Fixes CW-328

> ## Read this first: `generateObject` has been silently discarding every timeout
>
> Found while investigating the ticket, and **arguably more serious than the incident that prompted it.** Please don't merge without reading this section.
>
> `generateObject` in `ai@7.0.37` is typed `Omit<RequestOptions, 'timeout'>`. Unlike `generateText`, **it accepts no `timeout` option at all.** The pre-existing code passed one anyway:
>
> ```ts
> // BEFORE — compiles, does nothing at runtime
> const { object, usage } = await generateObject({
>   model: google(modelName),
>   prompt: prompt,
>   schema: jsonSchema(schema),
>   maxRetries: trackingContext?.maxRetries ?? 3,
>   ...(trackingContext?.timeoutMs ? { timeout: { totalMs: trackingContext.timeoutMs } } : {}),
>   providerOptions
> })
> ```
>
> It type-checked only because a **conditional spread skips excess-property checking**. Write the same property plainly and `tsc` rejects it — which is how this surfaced.
>
> ```ts
> // AFTER — the supported mechanism; bounds total wall clock across all retries
>   maxRetries: trackingContext?.maxRetries ?? GEMINI_MAX_RETRIES,
>   abortSignal: AbortSignal.timeout(trackingContext?.timeoutMs ?? GEMINI_REQUEST_TIMEOUT_MS),
> ```
>
> **Every caller that believed it had a timeout was running unbounded:**
>
> | Caller | Budget it thought it had |
> | -- | -- |
> | `trigger/generate-workout-messages.ts:92` | 45 s |
> | `trigger/generate-ad-hoc-workout.ts:214` | 45 s |
> | `trigger/adjust-structured-workout.ts:992, 1005, 1034` | 45 s |
> | `trigger/generate-structured-workout.ts:1142` | 45 s |
> | `trigger/analyze-plan-adherence.ts:237` | 60 s |
> | `server/utils/strength-exercise-matching.ts:355` | 20 s |
>
> **Why this compounds the incident:** the 10 s connect timeout was the *only* bound in play. A request that connected successfully and then stalled had **no ceiling whatsoever** — it ran until Trigger.dev's `maxDuration` killed the run, with no classified error and no `LlmUsage` row. The reported `ConnectTimeoutError`s are the failure mode that *did* have a bound. The unbounded stall is the one that didn't, and it surfaces as an opaque killed run rather than a Sentry event.
>
> Guarded by a regression test (see Tests). `tsc` now catches a plainly-written `timeout:`, but **not** one re-hidden inside a conditional spread — exactly how the original slipped in — so the test asserts on source.

## The decision: fail the run. Do not re-enqueue.

This is the ticket's core deliverable, so the reasoning first.

The ticket asks whether these four background tasks should defer instead of failing. **They should keep failing, and no deferral logic was added to `generateStructuredAnalysis`.** Three reasons:

**1. The shared path is not a background-only path.** The ticket frames `generateStructuredAnalysis` as the common ancestor of four background tasks. It is — but it is called by **32 non-test files** (37 modules import it), including synchronous HTTP handlers that `await` it inline on the request path, none of which pass a `timeoutMs`:

- `server/api/plans/initialize.post.ts`
- `server/api/scores/workout-trends-explanation.post.ts`
- `server/api/scores/nutrition-trends-explanation.post.ts`
- `server/api/nutrition/[id]/log.post.ts`

You cannot re-enqueue an HTTP request. AC #2 asks for the behaviour in the shared path rather than four times over, and that instinct is right — but the shared path is precisely where deferral would hang a user-facing request behind an upstream outage. The premise *"these are all background analysis tasks where a delayed-but-successful result beats a failed one"* is true of the four reported call sites and **false of the function they share**. That asymmetry rules the option out.

**2. Re-enqueueing already exists, one layer up.** `trigger.config.ts` applies `maxAttempts: 3` with exponential backoff to every task, and none of the four incident tasks override it. Combined with the AI SDK's in-process retry, every call already sits behind two retry layers. A third inside `generateStructuredAnalysis` would give `4 × N × 3` attempts against an upstream that is, by hypothesis, already degraded — an outage amplifier, and precisely the "unnecessary re-enqueue loop is its own kind of production hazard" the ticket warns about.

**3. The real gap is a retry *schedule*, not a missing retry.** The runs went red because the three task-level attempts use `minTimeoutInMs: 1000` / `maxTimeoutInMs: 10000`, so all three land within roughly 30 seconds — against a ~90-minute outage. More attempts inside `gemini.ts` would not have helped; a longer task-level backoff would have. **That fix belongs in `trigger.config.ts` or per-task `retry` options, both outside this PR's Owned Paths, and is being filed separately rather than reached for here.**

So the shared path stays honest: one bounded, well-instrumented attempt, and a classified failure. Deciding whether a given failure is worth waiting out stays with the caller that knows its own latency budget.

## Making a connect timeout distinguishable from a model error (AC #4)

The direct cause of the three duplicate tickets.

`logUsage` hardcoded `errorType: params.error ? 'api_error' : undefined` for **every** failure, and both entry points logged an identical `console.error('[Gemini] … failed:', error)`. A connect timeout, a schema-validation failure, a 429 and a safety block were indistinguishable in `LlmUsage` and in the logs.

Added `classifyGeminiError()`, which walks the `cause` / `lastError` chain. The decisive error is buried three levels down (`AI_RetryError` → `APICallError` → undici `ConnectTimeoutError`) — outer-error triage is *why* one incident became four tickets. It returns:

- `type`: `connect_timeout` | `timeout` | `network` | `rate_limit` | `server_error` | `auth` | `invalid_request` | `schema_validation` | `content_filter` | `api_error`
- `transient`: upstream/infrastructure, expected to clear on its own
- `statusCode`, `attempts`, and a low-cardinality `detail`

Matching is duck-typed on `name` / `code` / `statusCode` rather than `instanceof`, so it survives the AI SDK's error classes being duplicated across the Nitro and Trigger.dev bundles. Structured signals are checked before message-text heuristics, so a message containing "timeout" cannot outvote an HTTP 429.

### What you actually get, and what you don't

Being precise here, because an overstated claim would mislead exactly the person triaging the next incident.

**You get:**

- **`LlmUsage.errorType`** now carries the real class. The column is a free-form `String?`, so **no migration**. "Connect timeouts in the last hour, by operation" becomes one SQL query. **This is the load-bearing win, and the only one that works on every surface.**
- **A stable, low-cardinality log prefix**: `[Gemini][connect_timeout] generateStructuredAnalysis failed — could not connect within 10000ms (operation=analyze_workout model=… transient=true attempts=4 durationMs=…)`. Greppable in the Trigger.dev log viewer, which is where the incident actually lives.

**You do not get:**

- **Sentry *issue* grouping is unchanged.** `sentry.server.config.ts:12` registers `consoleLoggingIntegration`, which is the Sentry **Logs** integration — not `captureConsoleIntegration`, so it does not create issues. The error is rethrown unchanged, so issue grouping still follows the call site. **The "one incident, four tickets" behaviour this ticket exists to prevent is not fixed by this PR.** What is fixed is that once you are looking, one SQL query tells you which class of failure you have, instead of four tickets' worth of investigation.
- **Sentry Logs search does not cover the four incident tasks.** Worth being exact, because the tasks in this ticket all run in the Trigger.dev worker, not Nitro. `trigger/init.ts` initialises Sentry with **`defaultIntegrations: false`**, no console integration and no `enableLogs` — so worker console output does **not** reach Sentry at all. The prefix is searchable in Sentry Logs only for the Nitro-side HTTP callers; for `analyze-workout`, `daily-checkin`, `generate-athlete-profile` and `wellness-analysis` it is a Trigger.dev-log-viewer and `LlmUsage` signal only.
- **The `geminiErrorType` / `geminiErrorTransient` / `geminiOperation` properties are not captured by Sentry** anywhere today. No `extraErrorDataIntegration` is registered, and Sentry does not serialise arbitrary own properties of an `Error` by default — less so in the worker, which disables default integrations outright.

**The concrete follow-up this enables** (outside Owned Paths, not done here): `trigger/init.ts` already funnels every task failure through one `tasks.onFailure` hook calling `Sentry.captureException(error, { extra: { payload, ctx } })`. Because the classification now rides on the error, that becomes a one-line upgrade:

```ts
Sentry.captureException(error, {
  tags: { gemini_error_type: (error as any)?.geminiErrorType },
  extra: { payload, ctx }
})
```

That single line would make the classification a first-class Sentry tag for **all** Trigger tasks — filterable, alertable, and enough to keep the next upstream blip as one investigation instead of four. That is the actual fix for the grouping problem, and the property assignment in this PR is what makes it a one-liner.

The original error is **rethrown unchanged** — dozens of call sites already catch it, so nothing is wrapped or re-typed. Making these group separately by *throwing* distinct error types would be a behavioural change across every call site, and is deliberately out of scope.

## Timeout and retry set deliberately, with reasoning recorded (AC #3)

Three exported constants, each carrying its rationale in a doc comment rather than in a commit message:

- **`GEMINI_MAX_RETRIES = 3`** (4 attempts) — **kept, not changed**. The AI SDK applies `maxRetries` uniformly to every error class, and the classes it actually rescues are 429/quota and transient 5xx, where an in-process retry is far cheaper than rebuilding the prompt and re-running the task. Lowering it to reclaim the ~40 s burned during a rare connect-timeout outage would trade a frequent win for a rare one.
- **`GEMINI_CONNECT_TIMEOUT_MS = 10_000`** — **kept, and now stated**. Failing TCP+TLS to Google inside 10 s means the path is down, not slow; raising it burns proportionally more worker time before the identical failure. Honest caveat, recorded in the code: this constant is currently *documentation, not enforcement* — pinning a real connect timeout needs an undici `Agent` dispatcher, and `undici` is not a dependency of this project, not even transitively. Adding it would mean touching `package.json`, outside Owned Paths.
- **`GEMINI_REQUEST_TIMEOUT_MS = 240_000`** — **new**. Deliberately below the common `maxDuration: 300` so we time out first and produce a classified `timeout` plus a usage row, instead of the platform killing the run; and comfortably above both the slowest legitimate generation and the 20–60 s budgets callers already set.

Also marked `retryWithBackoff` (~200 lines, with `isRateLimitError` / `parseRetryDelay` / `MAX_RETRIES` / `BASE_DELAY_MS` / `MAX_DELAY_MS`) as **dead and unreferenced**. It is not deleted here — that would bloat this diff — but leaving it unlabelled actively undermines AC #3, since a reader cannot otherwise tell which retry path is live. Deletion is filed separately.

## Tests

29 tests in `tests/unit/server/utils/gemini.test.ts`, covering all 16 error shapes plus the transient set, status reporting, structured-signal precedence, and malformed/cyclic input.

The highest-value assertion is the **exact 2026-08-02 wrapping** — `AI_RetryError` → `APICallError` → undici `ConnectTimeoutError` resolving to `connect_timeout` with `attempts: 4` — together with a companion test asserting that classification does **not** stop at the outermost error. That nesting is the entire reason one incident became four tickets.

Two source-level regression tests guard the timeout bug above (asserting `abortSignal` is present and no `timeout:` property returns), following the approach already used in `server/utils/services/workout-analysis-prompt.test.ts`.

**Revert check:** every test was run against the pre-fix behaviour — the constant `errorType: 'api_error'` from `86d51e04:server/utils/gemini.ts:170`, and the pre-fix `generateObject` call for the source tests. **23 of 25 assertions fail against pre-fix.** The two that pass either way are non-discriminating by design and labelled as such: `classifies unrecognised failure as api_error` (fallback guard) and `survives malformed, cyclic and empty inputs` (robustness guard).

## Acceptance criteria

- [x] **Decide fail-vs-re-enqueue, stated with reasoning** — fail the run; reasoning above.
- [x] **If re-enqueue, implement once in the shared path** — N/A, deliberately not re-enqueueing.
- [x] **Connect timeout and retry count deliberate, reasoning recorded** — three constants with rationale in-file, including the honest limit on enforcing the connect timeout.
- [x] **Connect-timeout failures distinguishable from model errors** — via `LlmUsage.errorType` (queryable) and the `[Gemini][<type>]` log prefix (searchable in Sentry Logs), backed by 29 tests. **Sentry issue grouping is unchanged** — see "What you actually get, and what you don't".
- [x] **Audit: no user-facing surface silently shows stale/missing analysis** — audit performed. **It found real gaps.** All in `app/`, outside Owned Paths, so nothing changed here; being filed separately.

## AC #5 audit result: the confirmation fails

Read-only investigation, no code changed. Server-side is in good shape — all four tasks already persist a terminal `FAILED` status (`analyze-workout.ts:430`, `checkin-service.ts:549`, `generate-athlete-profile.ts:903`, `wellness-analysis.ts:373`), so the data needed to render a failure state exists in every case. **The UI consumes it in only two of six primary surfaces.**

| Surface | Verdict |
| -- | -- |
| `app/components/dashboard/DailyCheckinModal.vue:61` | Distinguishes FAILED, offers retry |
| `app/pages/profile/athlete.vue:609` | Distinguishes FAILED |
| `app/pages/workouts/[id]/index.vue:2598` | **Folds FAILED into "Intelligence Audit Pending"** |
| `app/pages/fitness/[id].vue:407` | Folds FAILED into "No analysis available" |
| `app/components/WellnessModal.vue:430` | Same bare `v-else` |
| `app/components/dashboard/PerformanceScoresCard.vue:59-135` | **Shows stale scores as "current as of …"** |

Three findings worth their own tickets:

1. **Workout detail tells the user a failed run is still coming.** The only non-content branch renders *"Intelligence Audit Pending"*; `aiAnalysisStatus` is never read there, so `FAILED` and `NOT_STARTED` are identical. Its spinner also keys off a local `analyzingWorkout` ref rather than `aiAnalysisStatus === 'PROCESSING'`, so a genuinely in-flight background run shows "Pending" plus an Analyze button — a double-trigger risk.
2. **Athlete-profile failure produces no feedback anywhere.** `app/stores/user.ts:401` registers `onTaskCompleted` with no `onTaskFailed`, and `app/stores/reports.ts:43-50` excludes the task. During a Gemini outage the dashboard silently serves the previous run's scores labelled "current as of …".
3. **Stale-on-re-analysis across three surfaces.** When a *re*-generation fails, the prior `aiAnalysisJson` survives and renders with only its original timestamp and no failure marker — workout detail, wellness detail, dashboard scores card.

Mitigating: the list surfaces (`WorkoutTable.vue:293`, `data.vue:1204-1211`) do render a red `✗ Failed` badge, so the state is discoverable, just not where the user is looking.

## Scope

Files changed: `server/utils/gemini.ts` and `tests/unit/server/utils/gemini.test.ts`. The test file was added to Owned Paths by the coordinator specifically so the classifier would not ship untested. `trigger.config.ts` and all four call sites were read only.

## Verification

`pnpm test:unit && pnpm typecheck` — exit 0. `eslint` and `prettier --check` also clean.

UX critique: skipped — backend resilience change, no UI surface.
