### PR TITLE
fix(coaching): distinguish load failure from empty state on the athletes list (CW-526)

### DIFF
--- a/app/pages/coaching/athletes/index.vue
+++ b/app/pages/coaching/athletes/index.vue
@@ -45,10 +45,42 @@
           </p>
         </div>
 
-        <!-- Load failures for the requests/invites sub-requests, grouped at the top of the page so
-             a coach scanning for "anything wrong" cannot scroll past one. A failure must never be
-             rendered as an empty list — missing a real connection request costs a client. -->
-        <div v-if="requestsError || invitesError" class="px-4 sm:px-0 space-y-3">
+        <!-- Load failures for the roster and the requests/invites sub-requests, grouped at the top
+             of the page so a coach scanning for "anything wrong" cannot scroll past one. A failure
+             must never be rendered as an empty list — missing a real connection request costs a
+             client, and a roster that failed to load must not read as "you have no athletes". -->
+        <div v-if="listError || requestsError || invitesError" class="px-4 sm:px-0 space-y-3">
+          <UAlert
+            v-if="listError"
+            color="error"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            :title="tr('athletes_list_error_title', 'Could not load your athletes')"
+            :description="
+              tr(
+                'athletes_list_error_desc',
+                'We could not reach the server, so your roster, groups and teams are not shown. This is a loading error — your athletes are still connected to you.'
+              )
+            "
+          >
+            <template #actions>
+              <UButton
+                color="error"
+                variant="outline"
+                size="xs"
+                icon="i-heroicons-arrow-path"
+                class="font-bold"
+                :loading="retryingList"
+                :label="tr('athletes_list_error_retry', 'Retry')"
+                @click="
+                  () => {
+                    void retryList()
+                  }
+                "
+              />
+            </template>
+          </UAlert>
+
           <UAlert
             v-if="requestsError"
             color="error"
@@ -249,8 +281,10 @@
           </UCard>
         </div>
 
+        <!-- Onboarding empty state is for a confirmed-empty roster only. When the fetch failed we
+             do not know whether the coach has athletes, so the alert above speaks instead. -->
         <div
-          v-else-if="athletes.length === 0"
+          v-else-if="athletes.length === 0 && !listError"
           class="py-12 text-center flex flex-col items-center justify-center border-2 border-dashed border-gray-200 dark:border-gray-800 rounded-lg"
         >
           <div class="bg-neutral-100 dark:bg-neutral-800 p-4 rounded-full mb-4">
@@ -321,7 +355,10 @@
           </p>
         </div>
 
+        <!-- Hidden on a failed load: urging a coach to grow their roster is actively misleading
+             when we could not even read the roster we already have. -->
         <UCard
+          v-if="!listError"
           class="overflow-hidden border-2 border-primary-500/20 bg-primary-50/30 dark:bg-primary-950/10"
           :ui="{
             ...mobileListCardUi,
@@ -669,8 +706,10 @@
   const inviteEmail = ref('')
   const pendingInvites = ref<any[]>([])
   const pendingRequests = ref<any[]>([])
+  const listError = ref(false)
   const invitesError = ref(false)
   const requestsError = ref(false)
+  const retryingList = ref(false)
   const retryingInvites = ref(false)
   const retryingRequests = ref(false)
   const revokingInviteId = ref<string | null>(null)
@@ -770,22 +809,54 @@
     }
   }
 
-  async function fetchData() {
-    loading.value = true
+  // The roster, groups and teams load as one unit because they render as one — a group tab
+  // is meaningless without the athletes behind it, so a partial failure is still a failed
+  // list. Same contract as the loaders above: `listError` drives an explicit error state
+  // with a retry, and a successful empty response clears it so a real "no athletes yet"
+  // roster still reaches the onboarding state.
+  //
+  // Deliberately does NOT blank the arrays on failure, unlike the sub-request loaders. This
+  // also runs on refetch (connect, invite, approve), and dropping a roster the coach is
+  // looking at because a refresh failed is worse than showing it beside an error banner.
+  async function loadAthleteList() {
     try {
       const [athletesData, groupsData, teamsData] = await Promise.all([
         $fetch<any, string & {}>('/api/coaching/athletes'),
         $fetch<any, string & {}>('/api/coaching/groups'),
-        $fetch<any, string & {}>('/api/coaching/teams'),
-        loadPendingInvites(),
-        loadPendingRequests()
+        $fetch<any, string & {}>('/api/coaching/teams')
       ])
       athletes.value = athletesData as any[]
       groups.value = groupsData as any[]
       teams.value = teamsData as any[]
+      listError.value = false
+      return true
     } catch (e) {
       console.error(e)
-      toast.add({ title: 'Failed to load coaching data', color: 'error' })
+      listError.value = true
+      return false
+    }
+  }
+
+  async function retryList() {
+    retryingList.value = true
+    try {
+      const ok = await loadAthleteList()
+      if (!ok) {
+        toast.add({
+          title: tr('athletes_list_error_toast', 'Still unable to load your athletes'),
+          color: 'error'
+        })
+      }
+    } finally {
+      retryingList.value = false
+    }
+  }
+
+  // Each loader owns its own failure, so one section going down no longer blanks the others.
+  async function fetchData() {
+    loading.value = true
+    try {
+      await Promise.all([loadAthleteList(), loadPendingInvites(), loadPendingRequests()])
     } finally {
       loading.value = false
     }


### PR DESCRIPTION
Fixes CW-526

## Problem

`fetchData()` put the three list fetches (`athletes`, `groups`, `teams`) in the same `Promise.all` as the invite/request loaders. Those loaders swallow their own errors (CW-154), but the raw `$fetch` calls did not — so any one of them rejecting skipped all three assignments, leaving `athletes` at `[]`. The page then rendered the **"No Athletes Yet" onboarding empty state**, backed only by a toast that auto-dismisses after 5 seconds.

A coach who glanced away for five seconds saw a page telling them they had no athletes. This is the same "failure looks like nothing here" bug CW-154 fixed for the sub-requests, one level up.

## Change

Mirrors the CW-154 idiom rather than inventing a second error-handling style in the same file:

- **`loadAthleteList()`** extracted in the shape of `loadPendingInvites()` / `loadPendingRequests()` — owns its failure, sets `listError`, clears it on a successful (possibly empty) response.
- **`fetchData()`** now composes the three independent loaders, so one section going down no longer blanks the others. That decoupling is the root-cause fix.
- **`retryList()`** + `retryingList` mirroring `retryPendingInvites()`, including the "still unable" toast on a repeat failure.
- The list alert joins the **existing grouped-at-top alert block** with the same `UAlert` + Retry shape.
- The empty state and the onboarding CTA card are both gated on `!listError` — urging a coach to grow a roster we could not read is actively misleading (AC 3).

One deliberate deviation, documented in a code comment: unlike the sub-request loaders, this one does **not** blank its arrays on failure. It also runs on refetch (connect / invite / approve), and dropping a roster the coach is looking at because a refresh failed would be a regression. Stale roster beside a persistent error banner beats a roster that vanishes.

## Verification

```
pnpm typecheck && pnpm lint
→ typecheck: exit 0
→ lint:      exit 0 — 116 problems (0 errors, 116 warnings)
             0 findings in app/pages/coaching/athletes/index.vue
             (all 116 are pre-existing vue/require-default-prop warnings in email templates)
```
Re-run green after rebasing onto current `develop`.

**Manual gate** — driven on the real page, failure injected by rejecting only `/api/coaching/{athletes,groups,teams}` so the sub-request endpoints stayed healthy (no source change needed):

| Scenario | Result |
|---|---|
| Load fails | Persistent alert + Retry; empty state and onboarding CTA both absent |
| Retry while still down | "Still unable to load your athletes" toast, alert persists |
| Retry after recovery | Alert clears, list refetches in place, no page reload |
| Genuine empty response | "No Athletes Yet" onboarding state renders normally, no alert |
| Refetch fails with a populated roster | Roster stays on screen beside the alert (share link created while the endpoints were down) |

Confirmed against unmodified code: the original shows "No Athletes Yet" + the CTA, and by the 6s mark the toast had already auto-dismissed, leaving no trace of the failure.

**Screenshots on CW-526** (before, after-failure, genuine-empty, roster-preserved).

## UX critique: required — verdict **SHIP**

`factory-ux-critic` walked the failure, recovery, genuine-empty and mobile paths as a coach on dropping hotel wifi. No FIX-FIRST findings. It praised the copy ("This is a loading error — your athletes are still connected to you" answers the real fear), the Retry feedback, and the in-place recovery.

Two non-blocking findings, both reported to the dispatcher rather than fixed here:
1. Retry touch target is ~24px on mobile — but it is `size="xs"` matching the two pre-existing error alerts it sits with; fixing only the new one would make it inconsistent. Belongs in a follow-up covering all three.
2. Large dead space below the alert on failure. Judged optional polish; filling it would mean new copy and a visual pattern the sibling alerts do not have, i.e. exactly the second idiom this ticket asked not to invent.

The critic flagged that it could not exercise the "populated roster survives a failed refetch" path (dev account has 0 athletes) and verified it by code reading only. That gap was then closed by driving it for real — last row of the table above.

## Files vs Owned Paths

`app/pages/coaching/athletes/index.vue` — the only file changed, matching Owned Paths exactly.

## Note for the i18n sweep

Four new keys (`athletes_list_error_title` / `_desc` / `_retry` / `_toast`) go through `tr(key, fallback)`, this file's own idiom. `app/i18n/en/coaching.json` is outside this ticket's Owned Paths and was not touched — same as CW-154 (`bb3cfa971`), whose error keys were backfilled later by the separate i18n ticket CW-106. These four need the same follow-up sweep.