### PR TITLE
fix(i18n): resolve raw keys on the /join sign-up page (CW-539)

### DIFF
--- a/app/pages/join/index.vue
+++ b/app/pages/join/index.vue
@@ -14,8 +14,8 @@
             <h2
               class="font-athletic mt-6 text-3xl font-bold uppercase leading-[0.95] tracking-tight text-white"
             >
-              {{ t('join.hero_title') }}
-              <span class="text-primary-400">{{ t('join.hero_title_accent') }}</span>
+              {{ joinHeroTitle }}
+              <span class="text-primary-400">{{ joinHeroTitleAccent }}</span>
             </h2>
             <p class="mt-4 text-sm font-medium leading-relaxed text-gray-400">
               {{ joinTagline }}
@@ -162,6 +162,17 @@
   import { buildAcquisitionContext } from '#shared/analytics-events'
 
   const { t } = useTranslate('auth')
+
+  // Tolgee resolves these keys from bundled static data in production, but in dev it
+  // replaces the namespace with whatever the Tolgee platform returns. Any key that has
+  // not been pushed to the platform yet would then render as its raw key, so every
+  // lookup on this public page carries its English source string as a fallback.
+  const translateOrFallback = (key: string, fallback: string, invalidValues: string[] = []) =>
+    computed(() => {
+      const translated = t.value(key)
+      return translated === key || invalidValues.includes(translated) ? fallback : translated
+    })
+
   const { signIn } = useAuth()
   const route = useRoute()
   const toast = useToast()
@@ -179,15 +190,27 @@
 
   const callbackUrl = (route.query.callbackUrl as string) || '/dashboard'
 
+  const joinHeroTitle = translateOrFallback('join.hero_title', 'Eliminate the')
+  const joinHeroTitleAccent = translateOrFallback('join.hero_title_accent', 'guesswork')
+  const joinSeoTitle = translateOrFallback('join.seo_title', 'Create your account')
+  const joinSeoOgTitle = translateOrFallback(
+    'join.seo_og_title',
+    'Join Coach Watts - AI Endurance Coaching'
+  )
+  const joinSeoDescription = translateOrFallback(
+    'join.seo_description',
+    'Create your Coach Watts account and get personalized AI training, recovery analytics, and daily coaching insights.'
+  )
+
   useSeoMeta({
-    title: () => t.value('join.seo_title'),
-    ogTitle: () => t.value('join.seo_og_title'),
-    description: () => t.value('join.seo_description'),
-    ogDescription: () => t.value('join.seo_description'),
+    title: () => joinSeoTitle.value,
+    ogTitle: () => joinSeoOgTitle.value,
+    description: () => joinSeoDescription.value,
+    ogDescription: () => joinSeoDescription.value,
     ogImage: '/images/og-image.png',
     twitterCard: 'summary_large_image',
-    twitterTitle: () => t.value('join.seo_og_title'),
-    twitterDescription: () => t.value('join.seo_description'),
+    twitterTitle: () => joinSeoOgTitle.value,
+    twitterDescription: () => joinSeoDescription.value,
     twitterImage: '/images/og-image.png'
   })
 
@@ -195,12 +218,6 @@
   const loadingApple = ref(false)
   const loadingStrava = ref(false)
   const loadingIntervals = ref(false)
-
-  const translateOrFallback = (key: string, fallback: string, invalidValues: string[] = []) =>
-    computed(() => {
-      const translated = t.value(key)
-      return translated === key || invalidValues.includes(translated) ? fallback : translated
-    })
 
   const joinTitle = translateOrFallback('join.title', 'Create your')
   const joinSubtitle = translateOrFallback('join.subtitle', 'account')
@@ -247,26 +264,42 @@
 
   const referral = computed(() => (route.query.ref as string) || '')
 
-  const userInquiry = computed(() => {
-    if (referral.value === 'hall-of-fame') {
-      return t.value('join.hall_of_fame_user_message')
-    }
-    return t.value('join.user_message')
-  })
+  const joinUserMessage = translateOrFallback(
+    'join.user_message',
+    'My legs feel super heavy today. Should I push through?'
+  )
+  const joinHallOfFameUserMessage = translateOrFallback(
+    'join.hall_of_fame_user_message',
+    'I want to break my 5K personal best. Can you help?'
+  )
+  const joinAiGreeting = translateOrFallback(
+    'join.ai_greeting',
+    "I noticed your <span class='text-primary-400 font-bold'>HRV</span> dropped to 28ms overnight."
+  )
+  const joinHallOfFameAiGreeting = translateOrFallback(
+    'join.hall_of_fame_ai_greeting',
+    'Absolutely. I see your current best is 18:42 from last June.'
+  )
+  const joinAiAdvice = translateOrFallback(
+    'join.ai_advice',
+    "Let's swap your intervals for a <span class='font-bold text-primary-400'>Zone 2 Recovery Ride</span>. We'll get back to intensity tomorrow."
+  )
+  const joinHallOfFameAiAdvice = translateOrFallback(
+    'join.hall_of_fame_ai_advice',
+    "Based on your current fatigue profile, we need to focus on <span class='font-bold text-primary-400'>Threshold Intervals</span> this week to push that ceiling."
+  )
 
-  const aiGreeting = computed(() => {
-    if (referral.value === 'hall-of-fame') {
-      return t.value('join.hall_of_fame_ai_greeting')
-    }
-    return t.value('join.ai_greeting')
-  })
+  const userInquiry = computed(() =>
+    referral.value === 'hall-of-fame' ? joinHallOfFameUserMessage.value : joinUserMessage.value
+  )
 
-  const aiAdvice = computed(() => {
-    if (referral.value === 'hall-of-fame') {
-      return t.value('join.hall_of_fame_ai_advice')
-    }
-    return t.value('join.ai_advice')
-  })
+  const aiGreeting = computed(() =>
+    referral.value === 'hall-of-fame' ? joinHallOfFameAiGreeting.value : joinAiGreeting.value
+  )
+
+  const aiAdvice = computed(() =>
+    referral.value === 'hall-of-fame' ? joinHallOfFameAiAdvice.value : joinAiAdvice.value
+  )
 
   function showSignupError(
     description: string,


### PR DESCRIPTION
Fixes CW-539

## What was wrong

`/join` rendered raw i18n keys under non-English locales: the tab title showed `join.seo_title`, and the hero heading showed `JOIN.HERO_TITLE JOIN.HERO_TITLE_ACCENT`.

## Root cause — neither of the two theories in the ticket

The ticket proposed (1) dotted keys violating the flat-underscore convention, or (2) a missing `fallbackLanguage`. **Both were wrong**, and it is worth recording why, because the next i18n bug will probably reach for the same two explanations:

- **Dotted keys are fine here.** `app/i18n/en/auth.json` is nested (`{ "join": { "hero_title": ... } }`), and Tolgee 7 resolves `t('join.hero_title')` against that nested shape natively. Verified directly against `@tolgee/web@7.1.2`: `join.hero_title` → `"Hagyd el a"`, while the flat-underscore `join_hero_title` → unresolved. (`structureDelimiter` no longer exists in Tolgee 7; nested lookup is the built-in behaviour.) Renaming these keys to flat-underscore would have *broken* the working ones and orphaned their existing Hungarian translations.
- **`fallbackLanguage` was already there.** `app/plugins/tolgee.ts` already sets `fallbackLanguage: 'en'` (line 392) and already registers `hu:auth` in `staticData` (line 472).

**The actual mechanism:** the bundled static JSON and the Tolgee *platform* are two different sources of truth, and in dev the platform silently wins.

`app/plugins/tolgee.ts` passes `apiUrl`/`apiKey` only when `canUseDevTools` is true (`import.meta.client && import.meta.dev && ...`). When it does, Tolgee fetches the `auth` namespace from the platform after first paint and **replaces** the bundled static data for that namespace — it does not merge. The platform's `auth` namespace holds only **25** of the 31 `join.*` keys this page uses; these 10 were never pushed:

```
join.hero_title   join.hero_title_accent   join.seo_title   join.seo_og_title
join.seo_description   join.apple   join.error_apple
join.ai_advice   join.ai_greeting   join.hall_of_fame_*
```

So the page rendered correctly for ~1s from static data, then the platform fetch landed and every unpushed key fell back to its raw key name. Most call sites already went through the page's own `translateOrFallback()` helper and degraded to readable English, which is why the page looked *partly* translated — including the reported `CREATE ACCOUNT WITH APPLE` sitting next to `FIÓK LÉTREHOZÁSA GOOGLE-LAL`. The only three call sites using a bare `t()` / `t.value()` with no default — the hero title, the hero accent, and the SEO title — were exactly the ones that showed raw keys.

**Recognising this class of bug elsewhere:** raw keys that appear only in dev, only after a short delay, and only in non-English locales = a key that exists in the repo JSON but was never pushed to the Tolgee platform. Grep for bare `t(...)`/`t.value(...)` without a fallback; those are the call sites that will expose it. Production is **not** affected — it ships static data only, so `/join` renders correctly there today.

## The fix

`app/pages/join/index.vue` only:
- Hoisted the existing `translateOrFallback()` helper above `useSeoMeta()` so the SEO getters can use it.
- Routed the hero title, hero accent, and SEO title/og-title/description through it.
- Hardened the chat-preview lookups (`join.user_message`, `join.ai_greeting`, `join.ai_advice` + `hall_of_fame_*`), which had the same bare-`t.value()` defect.
- Zero bare `t()` / `t.value()` `join.*` call sites remain.

No JSON changed — all 31 keys already had English source values in `app/i18n/en/auth.json`. **No non-English locale JSON touched**; missing `hu` values remain the translators' job and now degrade to English instead of to a raw key.

## Verification

`pnpm typecheck && pnpm lint` → **exit 0** (116 lint warnings are pre-existing `vue/require-default-prop` in email templates; `app/pages/join/index.vue` contributes none). Re-run after rebasing onto `develop`.

Manual gate, measured after the async platform fetch settles:

| | before | after |
|---|---|---|
| tab title (hu) | `join.seo_title - Coach Watts` | `Create your account - Coach Watts` |
| hero heading (hu) | `JOIN.HERO_TITLE JOIN.HERO_TITLE_ACCENT` | `ELIMINATE THE GUESSWORK` |
| raw keys in body (hu) | 3 | **0** |
| raw keys in body (en) | 0 | **0** |

Hungarian still renders Hungarian wherever a value exists. Screenshots on CW-539.

## UX critique: required — verdict **SHIP**

`factory-ux-critic`, persona: Hungarian-speaking cyclist invited by her coach, on mobile. All three acceptance criteria pass on both locales and both viewports; no raw keys anywhere; touch targets and contrast good. No FIX-FIRST findings. Its findings were the dev-only text swap described above, the untranslated Apple button (translator content gap), and two hardcoded English literals in the sidebar — all reported to the coordinator as follow-ups rather than fixed here.

## Note for the reviewer

The ticket's `Owned Paths` named `app/pages/join.vue`, which **does not exist** on `develop` — the route lives at `app/pages/join/index.vue` (restructured by #545). Changing that file is the intended scope, not scope drift; the coordinator has confirmed this is a ticket defect and is correcting it.
