### PR TITLE
fix(ai): demote an unusable primary metric in prompt and adherence (CW-397)

### DIFF
--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -1734,4 +1734,94 @@ describe('metric priority agrees with the facts block (CW-397)', () => {
     // The pace-primary section header must not appear either.
     expect(prompt).not.toContain('## Pace & Speed (Primary Metric)')
   })
+
+  it('leaves a pace-preference swim leading on pace (CW-437 is about bikes)', () => {
+    // The over-correction guard. `analysisMode` is `mixed` for a swim -- as it is
+    // for row, ski and walk -- so gating pace on `analysisMode === 'pace'` alone
+    // silently demoted a first-class, user-selectable `PACE_*` preference onto HR
+    // for four sports where pace IS the effort metric.
+    const SWIM = {
+      id: 'workout-cw397-swim',
+      date: new Date('2026-03-23T07:00:00Z'),
+      title: 'Endurance Swim',
+      type: 'Swim',
+      durationSec: 3600,
+      distanceMeters: 3000,
+      averageSpeed: 0.83,
+      averageHr: 140,
+      maxHr: 158,
+      streams: { heartrate: Array.from({ length: 200 }, () => 140) }
+    }
+    const PACE_FIRST = { loadPreference: 'PACE_HR_POWER' }
+
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: SWIM,
+      sportSettings: PACE_FIRST
+    } as any)
+
+    expect(facts.guardrails.analysisMode).not.toBe('pace')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(SWIM),
+      'Europe/Budapest',
+      'Supportive',
+      PACE_FIRST,
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    expect(prompt).toContain('- **Primary Metric for this analysis**: PACE (available)')
+    expect(prompt).toContain('**Hard Rule**: Base most conclusions on PACE evidence')
+    expect(prompt).not.toContain('**Demoted Metric**')
+  })
+
+  it('tells a pace-preference ride the truth about why pace stepped aside', () => {
+    // Clean HR, real speed data. The facts block says `Pace Usable: Yes` in this
+    // same prompt, so the demotion line must not claim the telemetry is bad --
+    // that contradiction is the whole point of CW-397.
+    const OUTDOOR_RIDE_CLEAN_HR = {
+      id: 'workout-cw397-ride-pace-pref',
+      date: new Date('2026-03-24T09:00:00Z'),
+      title: 'Endurance Loop',
+      type: 'Ride',
+      durationSec: 5400,
+      distanceMeters: 48000,
+      averageSpeed: 8.9,
+      averageHr: 145,
+      maxHr: 168,
+      trainer: false,
+      streams: { heartrate: Array.from({ length: 200 }, () => 145) }
+    }
+    const PACE_FIRST = { loadPreference: 'PACE_HR_POWER' }
+
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: OUTDOOR_RIDE_CLEAN_HR,
+      sportSettings: PACE_FIRST
+    } as any)
+
+    expect(facts.guardrails.telemetry.paceUsable).toBe(true)
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(OUTDOOR_RIDE_CLEAN_HR),
+      'Europe/Budapest',
+      'Supportive',
+      PACE_FIRST,
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    // Both statements about pace appear in one document and agree.
+    expect(prompt).toContain('- Pace Usable: Yes')
+    expect(prompt).toContain(
+      '- **Secondary Metric for corroboration**: PACE (present_but_not_leading)'
+    )
+    expect(prompt).toContain('speed is not a valid proxy for cycling effort')
+    expect(prompt).not.toContain("PACE is the athlete's preferred primary, but this session's")
+    expect(prompt).not.toContain('PACE (missing_or_not_set)')
+    expect(prompt).toContain('**Hard Rule**: Base most conclusions on HR evidence')
+  })
 })

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -334,6 +334,48 @@ describe('buildWorkoutAnalysisPrompt', () => {
     expect(prompt).toContain('- Average Speed: 3.00 m/s')
   })
 
+  it('does not call ride speed a primary pace section when no metric may lead (CW-397)', () => {
+    const workout = {
+      ...RIDE_WORKOUT,
+      averageWatts: null,
+      maxWatts: null,
+      normalizedPower: null,
+      weightedAvgWatts: null,
+      averageHr: 150,
+      maxHr: 170
+    }
+    const baseFacts = buildWorkoutAnalysisFactsV2({ workout })
+    const facts = {
+      ...baseFacts,
+      guardrails: {
+        ...baseFacts.guardrails,
+        archetype: { ...baseFacts.guardrails.archetype, primaryMetric: 'mixed' as const },
+        telemetry: {
+          ...baseFacts.guardrails.telemetry,
+          hrUsable: false,
+          hrArtifactSeverity: 'high' as const,
+          powerAbsoluteUsable: false,
+          powerRelativeUsable: false,
+          paceUsable: true
+        }
+      }
+    }
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(workout),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'PACE_HR_POWER' },
+      USER_PROFILE,
+      undefined,
+      undefined,
+      facts
+    )
+
+    expect(prompt).toContain('**Fallback Rule**: No preferred metric')
+    expect(prompt).not.toContain('## Pace & Speed (Primary Metric)')
+  })
+
   it('uses one cadence convention across the session line and the interval rows for a run (CW-387)', () => {
     // Same physical legs, three places in one prompt. Before CW-387 the session line
     // said "176 spm", the Interval Breakdown said "180 rpm" for an equally doubled

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -1686,4 +1686,52 @@ describe('metric priority agrees with the facts block (CW-397)', () => {
     expect(prompt).toContain('- **Primary Metric for this analysis**: HR (available)')
     expect(prompt).not.toContain('**Demoted Metric**')
   })
+
+  it('never hands an outdoor ride a pace-led hard rule when HR drops out (CW-437)', () => {
+    // The most likely real trigger of the demotion path, and the case that made
+    // the first cut of this fix a CW-437 regression: outdoor ride, no power
+    // meter, dropout-riddled HR. Demoting HR leaves pace as the next metric the
+    // session has data for -- but cycling speed moves with wind, gradient and
+    // drafting, so the facts resolve this session to `mixed` and decline to name
+    // a leading metric. The prompt must decline too.
+    const OUTDOOR_RIDE_NO_POWER = {
+      id: 'workout-cw397-outdoor-ride',
+      date: new Date('2026-03-22T09:00:00Z'),
+      title: 'Sunday Loop',
+      type: 'Ride',
+      durationSec: 5400,
+      distanceMeters: 48000,
+      averageSpeed: 8.9,
+      averageHr: 150,
+      maxHr: 172,
+      trainer: false,
+      streams: { heartrate: DROPOUT_HR_STREAM }
+    }
+
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: OUTDOOR_RIDE_NO_POWER,
+      sportSettings: DEFAULT_SPORT_SETTINGS
+    } as any)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(false)
+    expect(facts.guardrails.analysisMode).not.toBe('pace')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(OUTDOOR_RIDE_NO_POWER),
+      'Europe/Budapest',
+      'Supportive',
+      DEFAULT_SPORT_SETTINGS,
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    expect(prompt).not.toContain('Base most conclusions on PACE evidence')
+    expect(prompt).not.toContain('Base most conclusions on HR evidence')
+    expect(prompt).not.toContain('Do not make heart-rate zones the primary narrative')
+    expect(prompt).toContain('**Fallback Rule**')
+    // The pace-primary section header must not appear either.
+    expect(prompt).not.toContain('## Pace & Speed (Primary Metric)')
+  })
 })

--- a/server/utils/services/workout-analysis-prompt.test.ts
+++ b/server/utils/services/workout-analysis-prompt.test.ts
@@ -1561,3 +1561,129 @@ describe('work-only interval aggregates', () => {
     expect(prompt).not.toContain('## Work vs Recovery Aggregates')
   })
 })
+
+/**
+ * CW-397. The sport profile is seeded `loadPreference: 'HR_PACE_POWER'` -- HR-first
+ * on purpose, so it works for athletes without a power meter. The bug was never the
+ * default: it was the prompt asserting `**Hard Rule**: Base most conclusions on HR
+ * evidence` while the V2 facts block a few sections further down in the *same* prompt
+ * reported `HR Usable: No`. "Hard Rule" phrasing wins that argument, so a power-meter
+ * ride got an HR-led analysis.
+ */
+describe('metric priority agrees with the facts block (CW-397)', () => {
+  // 10% dropouts: `getHrStats` marks the stream unusable, exactly as a chest strap
+  // that kept losing contact would.
+  const DROPOUT_HR_STREAM = Array.from({ length: 200 }, (_, index) => (index % 10 === 0 ? 0 : 148))
+
+  // Verbatim what `sportSettingsRepository.createDefault()` seeds. Unchanged by
+  // this ticket -- the fix is at prompt-assembly time.
+  const DEFAULT_SPORT_SETTINGS = { ftp: 275, lthr: 168, loadPreference: 'HR_PACE_POWER' }
+
+  const POWER_METER_RIDE = {
+    id: 'workout-cw397-power-ride',
+    date: new Date('2026-03-20T10:00:00Z'),
+    title: 'Sweet Spot Intervals',
+    type: 'Ride',
+    durationSec: 5400,
+    distanceMeters: 48000,
+    averageSpeed: 8.9,
+    averageWatts: 231,
+    normalizedPower: 248,
+    maxWatts: 640,
+    ftp: 275,
+    averageHr: 148,
+    maxHr: 176,
+    trainer: false,
+    streams: { heartrate: DROPOUT_HR_STREAM }
+  }
+
+  const HR_ONLY_RUN = {
+    id: 'workout-cw397-hr-run',
+    date: new Date('2026-03-21T06:00:00Z'),
+    title: 'Easy Endurance',
+    type: 'Run',
+    durationSec: 3300,
+    distanceMeters: 10000,
+    averageSpeed: 3.03,
+    averageHr: 148,
+    maxHr: 166,
+    streams: { heartrate: Array.from({ length: 200 }, () => 148) }
+  }
+
+  it('leads a default-settings power ride with power once the facts disown HR', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: POWER_METER_RIDE,
+      sportSettings: DEFAULT_SPORT_SETTINGS
+    } as any)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(false)
+    expect(facts.guardrails.archetype.primaryMetric).toBe('power')
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(POWER_METER_RIDE),
+      'Europe/Budapest',
+      'Supportive',
+      DEFAULT_SPORT_SETTINGS,
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    // The facts block and the metric priority block now name the same metric.
+    expect(prompt).toContain('- HR Usable: No')
+    expect(prompt).toContain('- Primary Metric: power')
+    expect(prompt).toContain('- **Primary Metric for this analysis**: POWER (available)')
+    expect(prompt).toContain(
+      '- **Hard Rule**: Base most conclusions on POWER evidence. Use other metrics mainly for corroboration.'
+    )
+
+    // And the contradiction is gone: nothing in the prompt orders the model to
+    // base its conclusions on the metric the facts just disowned.
+    expect(prompt).not.toContain('Base most conclusions on HR evidence')
+    expect(prompt).toContain("**Demoted Metric**: HR is the athlete's preferred primary")
+  })
+
+  it('leaves an HR-only athlete on the HR-first default untouched', () => {
+    // The case the seeded default exists to serve: no power meter, clean HR.
+    // A regression here would be worse than the bug being fixed.
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: HR_ONLY_RUN,
+      sportSettings: { loadPreference: 'HR_PACE_POWER', lthr: 160 }
+    } as any)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(HR_ONLY_RUN),
+      'Europe/Budapest',
+      'Supportive',
+      { loadPreference: 'HR_PACE_POWER', lthr: 160 },
+      USER_PROFILE,
+      null,
+      undefined,
+      facts
+    )
+
+    expect(prompt).toContain('- **Primary Metric for this analysis**: HR (available)')
+    expect(prompt).toContain(
+      '- **Hard Rule**: Base most conclusions on HR evidence. Use other metrics mainly for corroboration.'
+    )
+    expect(prompt).not.toContain('**Demoted Metric**')
+  })
+
+  it('leaves the no-facts legacy path exactly as it was', () => {
+    // Without a facts block there is nothing to contradict, so raw availability
+    // still decides and the HR-first default still leads.
+    const prompt = buildWorkoutAnalysisPrompt(
+      buildWorkoutAnalysisData(POWER_METER_RIDE),
+      'Europe/Budapest',
+      'Supportive',
+      DEFAULT_SPORT_SETTINGS,
+      USER_PROFILE
+    )
+
+    expect(prompt).toContain('- **Primary Metric for this analysis**: HR (available)')
+    expect(prompt).not.toContain('**Demoted Metric**')
+  })
+})

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -25,6 +25,7 @@ import {
 import { formatStructuredPlanForPrompt } from '../../../trigger/utils/planned-workout-targets'
 import {
   buildIntervalGroupSummaries,
+  deriveMetricUsabilitySignals,
   formatCadenceWithUnit,
   getActualIntervalsForAnalysis,
   getActualIntervalsSourceForAnalysis,
@@ -1205,9 +1206,13 @@ export function buildWorkoutAnalysisPrompt(
   const isCadenceRelevant = ['run', 'ride', 'bike', 'cycle'].some((t) =>
     workoutType.toLowerCase().includes(t)
   )
+  // The V2 facts get a vote here so the "## Metric Priority Rules" block cannot
+  // name a primary metric the facts block in this same prompt reports as unusable
+  // or absent (CW-397).
   const metricPriorityContext = resolveMetricPriorityContext(
     sportSettings?.loadPreference,
-    workoutData
+    workoutData,
+    deriveMetricUsabilitySignals(analysisFactsV2)
   )
   const condensedHrSection = shouldCondenseHeartRateSection(metricPriorityContext)
 

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -1375,7 +1375,7 @@ When analyzing "Execution" and "Effort", specifically reference how well the ath
 
   if (
     metricPriorityContext.primaryMetric === 'PACE' &&
-    metricPriorityContext.availability.hasPace
+    metricPriorityContext.primaryMetricAvailable
   ) {
     prompt += '\n## Pace & Speed (Primary Metric)\n'
     const avgPaceSecPerKm =

--- a/server/utils/services/workout-analysis-prompt.ts
+++ b/server/utils/services/workout-analysis-prompt.ts
@@ -1212,7 +1212,9 @@ export function buildWorkoutAnalysisPrompt(
   const metricPriorityContext = resolveMetricPriorityContext(
     sportSettings?.loadPreference,
     workoutData,
-    deriveMetricUsabilitySignals(analysisFactsV2)
+    // `workoutType` because the facts carry no sport family, and whether pace may
+    // lead is a question about the sport (CW-437 is about bikes specifically).
+    deriveMetricUsabilitySignals(analysisFactsV2, workoutType)
   )
   const condensedHrSection = shouldCondenseHeartRateSection(metricPriorityContext)
 

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -4,10 +4,12 @@ import {
   buildIntervalGroupSummaries,
   buildWorkoutAnalysisFacts,
   buildWorkoutAnalysisFactsV2,
+  deriveMetricUsabilitySignals,
   formatActualIntervalsForPrompt,
   formatCadenceWithUnit,
   getActualIntervalsForAnalysis,
   getActualIntervalsSourceForAnalysis,
+  resolveAdherenceMetricOrder,
   resolveCadenceUnit,
   toCanonicalCadence,
   toIntervalIntensityFactor
@@ -3559,5 +3561,105 @@ describe('buildIntervalGroupSummaries', () => {
     expect(summaries.recovery?.totalDurationSeconds).toBe(360)
     expectNoNaN(summaries.work)
     expectNoNaN(summaries.recovery)
+  })
+})
+
+/**
+ * CW-397. `deriveAdherence` picks which planned target a step is scored against
+ * from the athlete's `loadPreference`. At the seeded `HR_PACE_POWER` default that
+ * meant a step carrying *both* a power and an HR target was judged on HR -- even
+ * on a power-meter ride whose HR trace the same facts object had already marked
+ * unusable. The order now runs through the same demotion the prompt uses.
+ */
+describe('adherence metric demotion (CW-397)', () => {
+  // 10% zero samples trips the dropout flag, so `getHrStats().usable` is false --
+  // the same shape a chest strap that kept losing contact produces.
+  const DROPOUT_HR_STREAM = Array.from({ length: 200 }, (_, index) => (index % 10 === 0 ? 0 : 150))
+  const CLEAN_HR_STREAM = Array.from({ length: 200 }, () => 150)
+
+  const INTERVALS = [
+    { type: 'WORK', moving_time: 480, average_watts: 260, average_heartrate: 168 },
+    { type: 'REST', moving_time: 120, average_watts: 180, average_heartrate: 132 },
+    { type: 'WORK', moving_time: 480, average_watts: 260, average_heartrate: 168 },
+    { type: 'REST', moving_time: 120, average_watts: 180, average_heartrate: 132 }
+  ]
+
+  // Power targets are hit exactly; HR targets are ~30-40% off. Whichever metric
+  // adherence chose is legible straight off the hit rate.
+  const step = (type: string, durationSeconds: number, watts: number, bpm: number) => ({
+    type,
+    durationSeconds,
+    power: { value: watts, units: 'watts' },
+    heartRate: { value: bpm, units: 'bpm' }
+  })
+
+  const PLANNED = {
+    durationSec: 1200,
+    structuredWorkout: {
+      steps: [
+        step('Active', 480, 260, 120),
+        step('Rest', 120, 180, 95),
+        step('Active', 480, 260, 120),
+        step('Rest', 120, 180, 95)
+      ]
+    }
+  }
+
+  const buildFacts = (heartrate: number[]) =>
+    buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Sweet Spot Intervals',
+        type: 'Ride',
+        durationSec: 1200,
+        averageWatts: 231,
+        averageHr: 150,
+        trainer: true,
+        streams: { heartrate },
+        rawJson: { icu_intervals: INTERVALS }
+      }),
+      // The seeded default, verbatim. Nothing about the athlete's settings changes.
+      sportSettings: { loadPreference: 'HR_PACE_POWER', ftp: 275 },
+      plannedWorkout: PLANNED
+    })
+
+  it('scores a power+HR step on power when the facts mark HR unusable', () => {
+    const facts = buildFacts(DROPOUT_HR_STREAM)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(false)
+    expect(facts.adherence.workIntervalHitRate).toBe(100)
+    expect(facts.adherence.recoveryHitRate).toBe(100)
+  })
+
+  it('still scores the same step on HR when the HR trace is clean', () => {
+    // The control. Without it the test above would also pass if adherence had
+    // simply stopped looking at HR altogether.
+    const facts = buildFacts(CLEAN_HR_STREAM)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.adherence.workIntervalHitRate).toBe(0)
+  })
+
+  it('leaves rpe last so a demotion never promotes it over a real target', () => {
+    expect(
+      resolveAdherenceMetricOrder('HR_PACE_POWER', { hr: false, pace: true, power: true }, 'power')
+    ).toEqual(['power', 'pace', 'heartRate', 'rpe'])
+  })
+
+  it('returns the preference order untouched when the preferred primary is usable', () => {
+    expect(
+      resolveAdherenceMetricOrder('HR_PACE_POWER', { hr: true, pace: true, power: true }, 'mixed')
+    ).toEqual(['heartRate', 'pace', 'power', 'rpe'])
+  })
+
+  it('exposes the facts usability signals the prompt resolver consumes', () => {
+    const facts = buildFacts(DROPOUT_HR_STREAM)
+    const signals = deriveMetricUsabilitySignals(facts)
+
+    expect(signals).toMatchObject({
+      hrUsable: false,
+      powerUsable: true,
+      factsPrimaryMetric: facts.guardrails.archetype.primaryMetric
+    })
+    expect(deriveMetricUsabilitySignals(undefined)).toBeUndefined()
   })
 })

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -3586,26 +3586,39 @@ describe('adherence metric demotion (CW-397)', () => {
 
   // Power targets are hit exactly; HR targets are ~30-40% off. Whichever metric
   // adherence chose is legible straight off the hit rate.
-  const step = (type: string, durationSeconds: number, watts: number, bpm: number) => ({
+  //
+  // `primaryTarget: 'heartRate'` is the production shape, not decoration: every
+  // structured workout the app persists goes through
+  // `normalizeStructuredWorkoutForPersistence`, which stamps `primaryTarget` from
+  // the athlete's `loadPreference` -- HR-first at the seeded default. A fixture
+  // without it exercises only legacy plans written before that field existed.
+  const step = (
+    type: string,
+    durationSeconds: number,
+    watts: number,
+    bpm: number,
+    primaryTarget: string | null = 'heartRate'
+  ) => ({
     type,
     durationSeconds,
+    ...(primaryTarget ? { primaryTarget } : {}),
     power: { value: watts, units: 'watts' },
     heartRate: { value: bpm, units: 'bpm' }
   })
 
-  const PLANNED = {
+  const plan = (primaryTarget: string | null) => ({
     durationSec: 1200,
     structuredWorkout: {
       steps: [
-        step('Active', 480, 260, 120),
-        step('Rest', 120, 180, 95),
-        step('Active', 480, 260, 120),
-        step('Rest', 120, 180, 95)
+        step('Active', 480, 260, 120, primaryTarget),
+        step('Rest', 120, 180, 95, primaryTarget),
+        step('Active', 480, 260, 120, primaryTarget),
+        step('Rest', 120, 180, 95, primaryTarget)
       ]
     }
-  }
+  })
 
-  const buildFacts = (heartrate: number[]) =>
+  const buildFacts = (heartrate: number[], primaryTarget: string | null = 'heartRate') =>
     buildWorkoutAnalysisFactsV2({
       workout: makeWorkout({
         title: 'Sweet Spot Intervals',
@@ -3619,10 +3632,11 @@ describe('adherence metric demotion (CW-397)', () => {
       }),
       // The seeded default, verbatim. Nothing about the athlete's settings changes.
       sportSettings: { loadPreference: 'HR_PACE_POWER', ftp: 275 },
-      plannedWorkout: PLANNED
+      plannedWorkout: plan(primaryTarget)
     })
 
   it('scores a power+HR step on power when the facts mark HR unusable', () => {
+    // The production shape: `primaryTarget: 'heartRate'` stamped on every step.
     const facts = buildFacts(DROPOUT_HR_STREAM)
 
     expect(facts.guardrails.telemetry.hrUsable).toBe(false)
@@ -3630,10 +3644,26 @@ describe('adherence metric demotion (CW-397)', () => {
     expect(facts.adherence.recoveryHitRate).toBe(100)
   })
 
-  it('still scores the same step on HR when the HR trace is clean', () => {
-    // The control. Without it the test above would also pass if adherence had
-    // simply stopped looking at HR altogether.
+  it('scores a legacy plan without primaryTarget on power too', () => {
+    const facts = buildFacts(DROPOUT_HR_STREAM, null)
+
+    expect(facts.adherence.workIntervalHitRate).toBe(100)
+    expect(facts.adherence.recoveryHitRate).toBe(100)
+  })
+
+  it('still honours primaryTarget when the metric it names is not demoted', () => {
+    // The short-circuit is skipped only for demoted metrics. A clean HR trace
+    // leaves `primaryTarget: 'heartRate'` in charge, exactly as before CW-397.
     const facts = buildFacts(CLEAN_HR_STREAM)
+
+    expect(facts.guardrails.telemetry.hrUsable).toBe(true)
+    expect(facts.adherence.workIntervalHitRate).toBe(0)
+  })
+
+  it('still scores a legacy plan on HR when the HR trace is clean', () => {
+    // The control, on the legacy shape. Without it the demotion tests would also
+    // pass if adherence had simply stopped looking at HR altogether.
+    const facts = buildFacts(CLEAN_HR_STREAM, null)
 
     expect(facts.guardrails.telemetry.hrUsable).toBe(true)
     expect(facts.adherence.workIntervalHitRate).toBe(0)
@@ -3661,5 +3691,51 @@ describe('adherence metric demotion (CW-397)', () => {
       factsPrimaryMetric: facts.guardrails.archetype.primaryMetric
     })
     expect(deriveMetricUsabilitySignals(undefined)).toBeUndefined()
+  })
+
+  it('refuses to let pace lead a ride even when the session has speed data (CW-437)', () => {
+    // The regression the first cut of CW-397 introduced: an outdoor ride with no
+    // power meter and a dropout-riddled HR trace demoted HR and promoted PACE.
+    // `getAnalysisMode` resolves this session to `mixed` precisely so speed cannot
+    // lead it, and the demotion path must respect that.
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Outdoor Ride',
+        type: 'Ride',
+        durationSec: 5400,
+        distanceMeters: 48000,
+        averageSpeed: 8.9,
+        averageWatts: null,
+        averageHr: 150,
+        trainer: false,
+        streams: { heartrate: DROPOUT_HR_STREAM }
+      }),
+      sportSettings: { loadPreference: 'HR_PACE_POWER' }
+    } as any)
+
+    expect(facts.guardrails.telemetry.paceUsable).toBe(true)
+    expect(facts.guardrails.analysisMode).not.toBe('pace')
+
+    // Raw pace data is still reported; it just may not lead.
+    expect(deriveMetricUsabilitySignals(facts)?.paceUsable).toBe(false)
+  })
+
+  it('lets pace lead a run, where it is the primary effort metric', () => {
+    const facts = buildWorkoutAnalysisFactsV2({
+      workout: makeWorkout({
+        title: 'Easy Endurance',
+        type: 'Run',
+        durationSec: 3300,
+        distanceMeters: 10000,
+        averageSpeed: 3.03,
+        averageWatts: null,
+        averageHr: 148,
+        streams: { heartrate: DROPOUT_HR_STREAM }
+      }),
+      sportSettings: { loadPreference: 'HR_PACE_POWER' }
+    } as any)
+
+    expect(facts.guardrails.analysisMode).toBe('pace')
+    expect(deriveMetricUsabilitySignals(facts)?.paceUsable).toBe(true)
   })
 })

--- a/server/utils/workout-analysis-facts.test.ts
+++ b/server/utils/workout-analysis-facts.test.ts
@@ -3652,12 +3652,18 @@ describe('adherence metric demotion (CW-397)', () => {
   })
 
   it('still honours primaryTarget when the metric it names is not demoted', () => {
-    // The short-circuit is skipped only for demoted metrics. A clean HR trace
-    // leaves `primaryTarget: 'heartRate'` in charge, exactly as before CW-397.
-    const facts = buildFacts(CLEAN_HR_STREAM)
+    // The discriminating case. With a clean HR trace, `primaryTarget: 'power'`
+    // must still win even though the resolved metric order is HR-first -- which
+    // is only true if the short-circuit is alive. Under an unconditional skip
+    // this scores 0 (HR-scored), so the assertion distinguishes the two
+    // implementations rather than merely passing.
+    //
+    // `primaryTarget: 'heartRate'` + clean HR would NOT discriminate: the order
+    // head and the stamp are both `heartRate`, so both paths agree.
+    const facts = buildFacts(CLEAN_HR_STREAM, 'power')
 
     expect(facts.guardrails.telemetry.hrUsable).toBe(true)
-    expect(facts.adherence.workIntervalHitRate).toBe(0)
+    expect(facts.adherence.workIntervalHitRate).toBe(100)
   })
 
   it('still scores a legacy plan on HR when the HR trace is clean', () => {
@@ -3716,8 +3722,11 @@ describe('adherence metric demotion (CW-397)', () => {
     expect(facts.guardrails.telemetry.paceUsable).toBe(true)
     expect(facts.guardrails.analysisMode).not.toBe('pace')
 
-    // Raw pace data is still reported; it just may not lead.
-    expect(deriveMetricUsabilitySignals(facts)?.paceUsable).toBe(false)
+    // Data quality and permission-to-lead are reported separately: the telemetry
+    // is fine and the facts block says so, but speed may not lead a ride.
+    const signals = deriveMetricUsabilitySignals(facts, 'Ride')
+    expect(signals?.paceUsable).toBe(true)
+    expect(signals?.paceMayLead).toBe(false)
   })
 
   it('lets pace lead a run, where it is the primary effort metric', () => {
@@ -3736,6 +3745,40 @@ describe('adherence metric demotion (CW-397)', () => {
     } as any)
 
     expect(facts.guardrails.analysisMode).toBe('pace')
-    expect(deriveMetricUsabilitySignals(facts)?.paceUsable).toBe(true)
+    expect(deriveMetricUsabilitySignals(facts, 'Run')?.paceMayLead).toBe(true)
+  })
+
+  it('leaves pace leading for swim, row, ski and walk (CW-437 is about bikes)', () => {
+    // `analysisMode === 'pace'` is far too narrow to use as the gate:
+    // `getAnalysisMode` only returns it for runs and power-carrying ski, so every
+    // one of these sports resolves to `mixed`. Gating on that alone silently
+    // demoted `PACE_*` -- a first-class, user-selectable preference -- onto HR for
+    // four sports where pace IS the effort metric. The gate is the ride family.
+    const sports: Array<[string, number]> = [
+      ['Swim', 1.2],
+      ['Rowing', 3.5],
+      ['NordicSki', 4.0],
+      ['Walk', 1.4]
+    ]
+
+    for (const [type, averageSpeed] of sports) {
+      const facts = buildWorkoutAnalysisFactsV2({
+        workout: makeWorkout({
+          title: type,
+          type,
+          durationSec: 3600,
+          distanceMeters: Math.round(averageSpeed * 3600),
+          averageSpeed,
+          averageWatts: null,
+          averageHr: 150,
+          streams: { heartrate: CLEAN_HR_STREAM }
+        }),
+        sportSettings: { loadPreference: 'PACE_HR_POWER' }
+      } as any)
+
+      // Every one of these is `mixed` -- which is exactly why the narrow gate broke them.
+      expect(facts.guardrails.analysisMode).not.toBe('pace')
+      expect(deriveMetricUsabilitySignals(facts, type)?.paceMayLead).toBe(true)
+    }
   })
 })

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -10,6 +10,12 @@ import {
   type Interval
 } from './interval-detection'
 import { parseLegacyLoadPreference, type MetricTarget } from './workout-target-policy'
+import {
+  parseLoadPreference,
+  resolveMetricPriorityOrder,
+  type MetricUsability,
+  type MetricUsabilitySignals
+} from '../../trigger/utils/workout-metric-priority'
 import { formatPromptPace } from './ai-prompt-format'
 
 type FactConfidence = 'low' | 'medium' | 'high'
@@ -1556,6 +1562,68 @@ function inferHrArtifactSeverity(stats: ReturnType<typeof getHrStats>): HrArtifa
   if (!stats.usable && dropoutRatio >= 0.1) return 'moderate'
   if (stats.artifactFlag || dropoutRatio > 0 || corruptionRatio > 0) return 'low'
   return 'none'
+}
+
+/**
+ * Adapter from the V2 facts to the metric-priority resolver (CW-397).
+ *
+ * The prompt used to state a `**Hard Rule**` naming the athlete's preferred
+ * primary metric while the facts block a few sections away reported that same
+ * metric as unusable. Feeding the facts back into the resolver is what makes the
+ * two sections agree by construction rather than by luck.
+ */
+export function deriveMetricUsabilitySignals(
+  facts?: WorkoutAnalysisFactsV2 | null
+): MetricUsabilitySignals | undefined {
+  if (!facts?.guardrails) return undefined
+  const { telemetry, archetype } = facts.guardrails
+  return {
+    hrUsable: telemetry.hrUsable,
+    hrArtifactSeverity: telemetry.hrArtifactSeverity,
+    // Relative usability is enough to lead an analysis: an estimated-power ride
+    // can still be judged on its own power trace, just not benchmarked absolutely.
+    powerUsable: telemetry.powerAbsoluteUsable || telemetry.powerRelativeUsable,
+    paceUsable: telemetry.paceUsable,
+    factsPrimaryMetric: archetype?.primaryMetric ?? null
+  }
+}
+
+const METRIC_KEY_TO_TARGET: Record<string, MetricTarget> = {
+  HR: 'heartRate',
+  PACE: 'pace',
+  POWER: 'power'
+}
+
+/**
+ * Adherence target order after unusable metrics are demoted (CW-397).
+ *
+ * `deriveAdherence` picks which target a planned step is scored against, so a
+ * step carrying both a power and an HR target used to be judged on HR at the
+ * seeded `HR_PACE_POWER` default even when the HR trace was unusable. Reordering
+ * here routes adherence through the same demotion the prompt uses. `rpe` is not
+ * part of the preference order and stays last: it is a fallback, never a promotion.
+ */
+export function resolveAdherenceMetricOrder(
+  loadPreference: string | null | undefined,
+  usability: MetricUsability,
+  factsPrimaryMetric?: MetricUsabilitySignals['factsPrimaryMetric']
+): MetricTarget[] {
+  const legacyOrder = parseLegacyLoadPreference(loadPreference)
+  const resolved = resolveMetricPriorityOrder(
+    parseLoadPreference(loadPreference),
+    usability,
+    factsPrimaryMetric
+  )
+
+  const order: MetricTarget[] = []
+  for (const key of resolved) {
+    const metric = METRIC_KEY_TO_TARGET[key]
+    if (metric && legacyOrder.includes(metric) && !order.includes(metric)) order.push(metric)
+  }
+  for (const metric of legacyOrder) {
+    if (!order.includes(metric)) order.push(metric)
+  }
+  return order
 }
 
 function inferPaceConfidence(
@@ -4734,12 +4802,23 @@ export function buildWorkoutAnalysisFactsV2({
       'Stop-and-go motion pattern detected; do not criticize lack of constant pace or invent steady-state drift narratives.'
     )
 
+  // Same usability verdicts the guardrail telemetry below publishes, so adherence
+  // scores a planned step on the metric the prompt is told to lead with (CW-397).
+  const metricUsability: MetricUsability = {
+    hr: hrStats.usable && inferHrArtifactSeverity(hrStats) !== 'high',
+    power: powerAbsoluteUsable || powerRelativeUsable,
+    pace: hasPace
+  }
   const adherence = deriveAdherence({
     workout,
     plannedWorkout,
     family,
     refs,
-    metricOrder: parseLegacyLoadPreference(sportSettings?.loadPreference)
+    metricOrder: resolveAdherenceMetricOrder(
+      sportSettings?.loadPreference,
+      metricUsability,
+      archetype.primaryMetric
+    )
   })
   // One comparable-rep resolution, shared by every rep-scoped signal, so the
   // durability and sport-specific blocks cannot disagree about which segments

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1576,16 +1576,41 @@ export function deriveMetricUsabilitySignals(
   facts?: WorkoutAnalysisFactsV2 | null
 ): MetricUsabilitySignals | undefined {
   if (!facts?.guardrails) return undefined
-  const { telemetry, archetype } = facts.guardrails
+  const { telemetry, archetype, analysisMode } = facts.guardrails
   return {
     hrUsable: telemetry.hrUsable,
     hrArtifactSeverity: telemetry.hrArtifactSeverity,
     // Relative usability is enough to lead an analysis: an estimated-power ride
     // can still be judged on its own power trace, just not benchmarked absolutely.
     powerUsable: telemetry.powerAbsoluteUsable || telemetry.powerRelativeUsable,
-    paceUsable: telemetry.paceUsable,
+    paceUsable: mayPaceLeadTheAnalysis(telemetry.paceUsable, analysisMode),
     factsPrimaryMetric: archetype?.primaryMetric ?? null
   }
+}
+
+/**
+ * Whether pace is allowed to *lead* -- a stricter question than
+ * `telemetry.paceUsable`, which only says the session has pace data at all.
+ *
+ * `getAnalysisMode` resolves to `'pace'` exactly when pace is the primary effort
+ * metric for the modality: true for runs (and pace-carrying ski/row), and never
+ * for a ride, because cycling speed moves with wind, gradient and drafting
+ * independently of the work done. That reasoning is CW-437's, written out at
+ * length in `getAnalysisMode`, and an estimated-power ride resolves to `'mixed'`
+ * precisely so speed cannot lead it.
+ *
+ * Without this gate the CW-397 demotion path reintroduced the bug CW-437 removed:
+ * an outdoor ride with no power meter and a dropout-riddled HR trace demoted HR
+ * and promoted PACE, producing `**Hard Rule**: Base most conclusions on PACE
+ * evidence` on a session whose facts decline to name any leading metric. When
+ * nothing may lead, `**Fallback Rule**` is the honest output.
+ *
+ * Note the cost, which is deliberate: an athlete who set a `PACE_*` preference on
+ * a ride now has pace demoted there too. That is the CW-437 position -- speed is
+ * the wrong signal for a bike, whatever the preference says.
+ */
+function mayPaceLeadTheAnalysis(paceUsable: boolean, analysisMode: AnalysisMode): boolean {
+  return paceUsable && analysisMode === 'pace'
 }
 
 const METRIC_KEY_TO_TARGET: Record<string, MetricTarget> = {
@@ -1696,12 +1721,29 @@ function normalizePlannedMetricOrder(
   return ordered
 }
 
+/**
+ * `demotedMetrics` names the metrics this session's telemetry cannot support
+ * (CW-397). It exists because `primaryTarget` short-circuits everything below it:
+ * `normalizeStructuredWorkoutForPersistence` stamps that field onto every
+ * structured workout the app writes, derived from the athlete's `loadPreference`,
+ * so at the HR-first seeded default a step is labelled `heartRate` and scored on
+ * HR no matter what the metric order says. Reordering alone therefore fixed
+ * nothing for any plan the product actually produces -- only for legacy plans
+ * written before `primaryTarget` existed.
+ *
+ * A demoted `primaryTarget` is skipped and the (already demoted) `metricOrder`
+ * decides instead. A step whose only target is the demoted metric still resolves
+ * to it via the loop, which is no worse than before. Callers that pass no
+ * `demotedMetrics` keep the original short-circuit exactly.
+ */
 function resolvePlannedStepMetric(
   step: any,
-  metricOrder?: PlannedStepMetric[] | null
+  metricOrder?: PlannedStepMetric[] | null,
+  demotedMetrics?: PlannedStepMetric[] | null
 ): FlattenedPlannedStep['metric'] {
   const currentPrimary = String(step?.primaryTarget || '')
   if (
+    !demotedMetrics?.includes(currentPrimary as PlannedStepMetric) &&
     (['power', 'heartRate', 'pace', 'rpe'] as string[]).includes(currentPrimary) &&
     hasPlannedMetricTarget(step, currentPrimary as PlannedStepMetric)
   ) {
@@ -1718,7 +1760,8 @@ function resolvePlannedStepMetric(
 function flattenPlannedSteps(
   steps: any[],
   refs: AnalysisRefs,
-  metricOrder?: PlannedStepMetric[] | null
+  metricOrder?: PlannedStepMetric[] | null,
+  demotedMetrics?: PlannedStepMetric[] | null
 ): FlattenedPlannedStep[] {
   const flattened: FlattenedPlannedStep[] = []
 
@@ -1748,7 +1791,7 @@ function flattenPlannedSteps(
         'recuperación',
         'enfriamiento'
       ]
-      const metric = resolvePlannedStepMetric(step, metricOrder)
+      const metric = resolvePlannedStepMetric(step, metricOrder, demotedMetrics)
       const targetValue =
         metric === 'power'
           ? getTargetValue(step.power)
@@ -4086,8 +4129,9 @@ function deriveAdherence(params: {
   family: ReturnType<typeof getWorkoutFamily>
   refs: AnalysisRefs
   metricOrder?: PlannedStepMetric[] | null
+  demotedMetrics?: PlannedStepMetric[] | null
 }): WorkoutAnalysisFactsV2['adherence'] {
-  const { workout, plannedWorkout, family, refs, metricOrder } = params
+  const { workout, plannedWorkout, family, refs, metricOrder, demotedMetrics } = params
   if (!plannedWorkout) {
     return {
       planLinked: false,
@@ -4116,7 +4160,8 @@ function deriveAdherence(params: {
   const plannedSteps = flattenPlannedSteps(
     getStructuredSteps(plannedWorkout?.structuredWorkout),
     refs,
-    metricOrder
+    metricOrder,
+    demotedMetrics
   )
   const actualIntervals = extractActualIntervals(workout, plannedWorkout, refs)
   // One alignment for every comparison below: work steps, recovery steps and
@@ -4807,7 +4852,9 @@ export function buildWorkoutAnalysisFactsV2({
   const metricUsability: MetricUsability = {
     hr: hrStats.usable && inferHrArtifactSeverity(hrStats) !== 'high',
     power: powerAbsoluteUsable || powerRelativeUsable,
-    pace: hasPace
+    // Same CW-437 gate the prompt side applies, so adherence and the prompt
+    // cannot disagree about whether pace may lead.
+    pace: mayPaceLeadTheAnalysis(hasPace, analysisMode)
   }
   const adherence = deriveAdherence({
     workout,
@@ -4818,6 +4865,19 @@ export function buildWorkoutAnalysisFactsV2({
       sportSettings?.loadPreference,
       metricUsability,
       archetype.primaryMetric
+    ),
+    // `primaryTarget` is stamped onto every persisted structured workout by
+    // `normalizeStructuredWorkoutForPersistence`, from the athlete's HR-first
+    // `loadPreference`. Without this list `resolvePlannedStepMetric` would honour
+    // that stamp and score on a demoted metric anyway, which is how the CW-397
+    // adherence fix originally missed every plan the app actually writes.
+    demotedMetrics: (['heartRate', 'pace', 'power'] as MetricTarget[]).filter(
+      (metric) =>
+        !(metric === 'heartRate'
+          ? metricUsability.hr
+          : metric === 'pace'
+            ? metricUsability.pace
+            : metricUsability.power)
     )
   })
   // One comparable-rep resolution, shared by every rep-scoped signal, so the

--- a/server/utils/workout-analysis-facts.ts
+++ b/server/utils/workout-analysis-facts.ts
@@ -1573,7 +1573,8 @@ function inferHrArtifactSeverity(stats: ReturnType<typeof getHrStats>): HrArtifa
  * two sections agree by construction rather than by luck.
  */
 export function deriveMetricUsabilitySignals(
-  facts?: WorkoutAnalysisFactsV2 | null
+  facts?: WorkoutAnalysisFactsV2 | null,
+  workoutType?: string | null
 ): MetricUsabilitySignals | undefined {
   if (!facts?.guardrails) return undefined
   const { telemetry, archetype, analysisMode } = facts.guardrails
@@ -1583,34 +1584,35 @@ export function deriveMetricUsabilitySignals(
     // Relative usability is enough to lead an analysis: an estimated-power ride
     // can still be judged on its own power trace, just not benchmarked absolutely.
     powerUsable: telemetry.powerAbsoluteUsable || telemetry.powerRelativeUsable,
-    paceUsable: mayPaceLeadTheAnalysis(telemetry.paceUsable, analysisMode),
+    // Reported as the facts report it. Whether pace may *lead* is a separate
+    // question, answered below, so the prompt never claims a ride's perfectly
+    // good speed telemetry is unusable.
+    paceUsable: telemetry.paceUsable,
+    paceMayLead: mayPaceLeadTheAnalysis(analysisMode, getWorkoutFamily(workoutType)),
     factsPrimaryMetric: archetype?.primaryMetric ?? null
   }
 }
 
 /**
- * Whether pace is allowed to *lead* -- a stricter question than
- * `telemetry.paceUsable`, which only says the session has pace data at all.
+ * Whether pace is allowed to *lead* the analysis -- a question about the sport,
+ * not about the data.
  *
- * `getAnalysisMode` resolves to `'pace'` exactly when pace is the primary effort
- * metric for the modality: true for runs (and pace-carrying ski/row), and never
- * for a ride, because cycling speed moves with wind, gradient and drafting
- * independently of the work done. That reasoning is CW-437's, written out at
- * length in `getAnalysisMode`, and an estimated-power ride resolves to `'mixed'`
- * precisely so speed cannot lead it.
+ * CW-437's rule is specifically about cycling: speed moves with wind, gradient
+ * and drafting independently of the work done, so it is a poor effort proxy on a
+ * bike. It says nothing about swimming, rowing, skiing or walking, where pace is
+ * the effort metric and `PACE_*` is a first-class, user-selectable preference.
  *
- * Without this gate the CW-397 demotion path reintroduced the bug CW-437 removed:
- * an outdoor ride with no power meter and a dropout-riddled HR trace demoted HR
- * and promoted PACE, producing `**Hard Rule**: Base most conclusions on PACE
- * evidence` on a session whose facts decline to name any leading metric. When
- * nothing may lead, `**Fallback Rule**` is the honest output.
- *
- * Note the cost, which is deliberate: an athlete who set a `PACE_*` preference on
- * a ride now has pace demoted there too. That is the CW-437 position -- speed is
- * the wrong signal for a bike, whatever the preference says.
+ * So the gate is the ride family, with one widening: `analysisMode === 'pace'` is
+ * honoured wherever it appears. Note that `analysisMode` alone is far too narrow
+ * to use as the test -- `getAnalysisMode` only ever returns `'pace'` for runs and
+ * for power-carrying ski, so swim, row, walk and most ski sessions resolve to
+ * `'mixed'` and would have been silently demoted off pace onto HR.
  */
-function mayPaceLeadTheAnalysis(paceUsable: boolean, analysisMode: AnalysisMode): boolean {
-  return paceUsable && analysisMode === 'pace'
+function mayPaceLeadTheAnalysis(
+  analysisMode: AnalysisMode,
+  family: ReturnType<typeof getWorkoutFamily>
+): boolean {
+  return analysisMode === 'pace' || family !== 'ride'
 }
 
 const METRIC_KEY_TO_TARGET: Record<string, MetricTarget> = {
@@ -4852,9 +4854,9 @@ export function buildWorkoutAnalysisFactsV2({
   const metricUsability: MetricUsability = {
     hr: hrStats.usable && inferHrArtifactSeverity(hrStats) !== 'high',
     power: powerAbsoluteUsable || powerRelativeUsable,
-    // Same CW-437 gate the prompt side applies, so adherence and the prompt
-    // cannot disagree about whether pace may lead.
-    pace: mayPaceLeadTheAnalysis(hasPace, analysisMode)
+    // Same CW-437 gate the prompt side applies, through the same helper, so
+    // adherence and the prompt cannot disagree about whether pace may lead.
+    pace: hasPace && mayPaceLeadTheAnalysis(analysisMode, family)
   }
   const adherence = deriveAdherence({
     workout,

--- a/tests/unit/trigger/workout-metric-priority.test.ts
+++ b/tests/unit/trigger/workout-metric-priority.test.ts
@@ -32,17 +32,34 @@ describe('workout metric priority', () => {
     expect(promptBlock).toContain('Do not make heart-rate zones the primary narrative')
   })
 
-  it('adds explicit fallback guidance when primary pace metric is missing', () => {
+  it('promotes the next usable metric when the primary pace metric is missing', () => {
+    // Before CW-397 this kept PACE as primary and merely softened the wording.
+    // A metric the session has no data for cannot lead the analysis at all.
     const ctx = resolveMetricPriorityContext('PACE_HR_POWER', {
       avg_hr: 128
     })
 
-    expect(ctx.primaryMetric).toBe('PACE')
-    expect(ctx.primaryMetricAvailable).toBe(false)
+    expect(ctx.demotedFrom).toBe('PACE')
+    expect(ctx.primaryMetric).toBe('HR')
+    expect(ctx.primaryMetricAvailable).toBe(true)
     expect(shouldCondenseHeartRateSection(ctx)).toBe(false)
 
     const rules = buildAnalysisRequestMetricRules(ctx)
-    expect(rules.join(' ')).toContain('Primary metric PACE is unavailable')
+    expect(rules.join(' ')).toContain('preferred primary metric PACE is unusable or absent')
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).toContain('**Hard Rule**: Base most conclusions on HR evidence')
+    expect(block).not.toContain('Base most conclusions on PACE')
+  })
+
+  it('states a fallback instead of a hard rule when no preferred metric is usable', () => {
+    const ctx = resolveMetricPriorityContext('PACE_HR_POWER', { rpe: 6 })
+
+    expect(ctx.primaryMetricAvailable).toBe(false)
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).not.toContain('**Hard Rule**')
+    expect(block).toContain('**Fallback Rule**: No preferred metric (PACE > HR > POWER) is usable')
   })
 
   it('treats stream-derived power metadata as available power', () => {
@@ -53,5 +70,152 @@ describe('workout metric priority', () => {
     expect(ctx.primaryMetric).toBe('POWER')
     expect(ctx.primaryMetricAvailable).toBe(true)
     expect(ctx.availability.hasPower).toBe(true)
+  })
+})
+
+/**
+ * CW-397. The seeded sport-profile default is `HR_PACE_POWER` -- deliberately
+ * HR-first, because it works across sports and for athletes with no power meter.
+ * The default is not the defect; the defect was the prompt asserting a
+ * `**Hard Rule**` on HR while the V2 facts block a few sections away in the same
+ * prompt reported `HR Usable: No`. The resolver now reads those facts.
+ */
+describe('metric priority demotion against the V2 facts (CW-397)', () => {
+  const POWER_METER_RIDE = {
+    avg_power: 231,
+    normalized_power: 248,
+    avg_hr: 148,
+    max_hr: 176,
+    distance_m: 48000,
+    duration_s: 5400
+  }
+
+  const HR_UNUSABLE_POWER_RIDE_FACTS = {
+    hrUsable: false,
+    hrArtifactSeverity: 'high' as const,
+    powerUsable: true,
+    paceUsable: true,
+    factsPrimaryMetric: 'power' as const
+  }
+
+  it('demotes HR and leads with the facts primary metric on a default-settings power ride', () => {
+    const ctx = resolveMetricPriorityContext(
+      'HR_PACE_POWER',
+      POWER_METER_RIDE,
+      HR_UNUSABLE_POWER_RIDE_FACTS
+    )
+
+    expect(ctx.priority).toEqual(['HR', 'PACE', 'POWER'])
+    expect(ctx.demotedFrom).toBe('HR')
+    expect(ctx.primaryMetric).toBe('POWER')
+    // Pace is usable but did not win: the facts' own primary metric is what gets
+    // promoted, so the two prompt sections name the same metric.
+    expect(ctx.resolvedPriority).toEqual(['POWER', 'PACE', 'HR'])
+    expect(ctx.usability).toEqual({ hr: false, pace: true, power: true })
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).toContain('**Primary Metric for this analysis**: POWER (available)')
+    expect(block).toContain('**Hard Rule**: Base most conclusions on POWER evidence')
+    expect(block).toContain("**Demoted Metric**: HR is the athlete's preferred primary")
+    expect(block).not.toContain('Base most conclusions on HR evidence')
+
+    const rules = buildAnalysisRequestMetricRules(ctx).join(' ')
+    expect(rules).toContain('Prioritize metrics in this order: POWER > PACE > HR.')
+    expect(rules).toContain('judge execution on POWER')
+  })
+
+  it('leaves the HR-first default alone for an athlete with no power meter', () => {
+    // The case the seeded default exists to serve. Nothing about it may change.
+    const ctx = resolveMetricPriorityContext(
+      'HR_PACE_POWER',
+      { avg_hr: 148, max_hr: 176, distance_m: 10000, duration_s: 3300 },
+      { hrUsable: true, hrArtifactSeverity: 'none', powerUsable: false, paceUsable: true }
+    )
+
+    expect(ctx.demotedFrom).toBeNull()
+    expect(ctx.primaryMetric).toBe('HR')
+    expect(ctx.resolvedPriority).toEqual(['HR', 'PACE', 'POWER'])
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).toContain('**Hard Rule**: Base most conclusions on HR evidence')
+    expect(block).not.toContain('**Demoted Metric**')
+  })
+
+  it('treats a high HR artifact severity as unusable even when hrUsable slipped through', () => {
+    const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE, {
+      hrUsable: true,
+      hrArtifactSeverity: 'high',
+      powerUsable: true,
+      paceUsable: false,
+      factsPrimaryMetric: 'power'
+    })
+
+    expect(ctx.primaryMetric).toBe('POWER')
+    expect(ctx.usability.hr).toBe(false)
+  })
+
+  it('falls back to the preference order when the facts primary metric is not a single metric', () => {
+    const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE, {
+      hrUsable: false,
+      powerUsable: true,
+      paceUsable: true,
+      factsPrimaryMetric: 'mixed'
+    })
+
+    // `mixed` names no metric, so preference order decides among the usable ones.
+    expect(ctx.primaryMetric).toBe('PACE')
+    expect(ctx.resolvedPriority).toEqual(['PACE', 'POWER', 'HR'])
+  })
+
+  it('never names an unusable metric in a hard rule, for any preference order', () => {
+    const preferences = ['HR_PACE_POWER', 'PACE_HR_POWER', 'POWER_HR_PACE', 'HR', 'PACE', 'POWER']
+    const factsCases = [
+      {
+        hrUsable: false,
+        powerUsable: true,
+        paceUsable: true,
+        factsPrimaryMetric: 'power' as const
+      },
+      { hrUsable: true, powerUsable: false, paceUsable: false, factsPrimaryMetric: 'hr' as const },
+      {
+        hrUsable: false,
+        powerUsable: false,
+        paceUsable: true,
+        factsPrimaryMetric: 'pace' as const
+      },
+      {
+        hrUsable: false,
+        powerUsable: false,
+        paceUsable: false,
+        factsPrimaryMetric: 'mixed' as const
+      }
+    ]
+
+    for (const loadPreference of preferences) {
+      for (const facts of factsCases) {
+        const ctx = resolveMetricPriorityContext(loadPreference, POWER_METER_RIDE, facts)
+        const block = buildMetricPriorityPromptBlock(ctx)
+        const hardRule = block.split('\n').find((line) => line.includes('**Hard Rule**'))
+        if (!hardRule) {
+          expect(block).toContain('**Fallback Rule**')
+          continue
+        }
+        expect(hardRule).toContain(ctx.primaryMetric)
+        const usable =
+          ctx.primaryMetric === 'HR'
+            ? ctx.usability.hr
+            : ctx.primaryMetric === 'PACE'
+              ? ctx.usability.pace
+              : ctx.usability.power
+        expect(usable).toBe(true)
+      }
+    }
+  })
+
+  it('leaves the no-facts path driven by raw availability alone', () => {
+    const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE)
+
+    expect(ctx.demotedFrom).toBeNull()
+    expect(ctx.primaryMetric).toBe('HR')
   })
 })

--- a/tests/unit/trigger/workout-metric-priority.test.ts
+++ b/tests/unit/trigger/workout-metric-priority.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   buildAnalysisRequestMetricRules,
   buildMetricPriorityPromptBlock,
+  describeMetricStatus,
   parseLoadPreference,
   resolveMetricPriorityContext,
   shouldCondenseHeartRateSection
@@ -158,15 +159,64 @@ describe('metric priority demotion against the V2 facts (CW-397)', () => {
     const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE, {
       hrUsable: false,
       powerUsable: true,
-      // A ride: `deriveMetricUsabilitySignals` reports pace as unable to lead,
-      // because `analysisMode` is not `'pace'` (CW-437).
-      paceUsable: false,
+      // A ride: the pace telemetry is fine, it simply may not lead (CW-437).
+      paceUsable: true,
+      paceMayLead: false,
       factsPrimaryMetric: 'mixed'
     })
 
     // `mixed` names no metric, so preference order decides among the usable ones.
     expect(ctx.primaryMetric).toBe('POWER')
     expect(ctx.resolvedPriority).toEqual(['POWER', 'HR', 'PACE'])
+  })
+
+  it("does not call a ride's good pace telemetry unusable", () => {
+    // The facts block in the same prompt says `Pace Usable: Yes`. Labelling the
+    // metric missing/unusable -- and citing those same facts as the evidence --
+    // is the contradiction CW-397 exists to remove, so the demotion reason has to
+    // name the real cause: the modality, not the data.
+    const ctx = resolveMetricPriorityContext(
+      'PACE_HR_POWER',
+      { avg_hr: 150, distance_m: 48000, duration_s: 5400, avg_speed_ms: 8.9 },
+      { hrUsable: true, powerUsable: false, paceUsable: true, paceMayLead: false }
+    )
+
+    expect(ctx.demotedFrom).toBe('PACE')
+    expect(ctx.demotionKind).toBe('not_valid_for_modality')
+    expect(ctx.primaryMetric).toBe('HR')
+    expect(describeMetricStatus(ctx, 'PACE')).toBe('present_but_not_leading')
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).toContain(
+      '- **Secondary Metric for corroboration**: PACE (present_but_not_leading)'
+    )
+    expect(block).toContain('is measured reliably here')
+    expect(block).toContain('speed is not a valid proxy for cycling effort')
+    // The three claims that would contradict the facts block.
+    expect(block).not.toContain("this session's telemetry does not support it")
+    expect(block).not.toContain('missing_or_not_set')
+    expect(block).not.toContain('PACE (missing)')
+
+    const rules = buildAnalysisRequestMetricRules(ctx).join(' ')
+    expect(rules).toContain('measured reliably here but may not lead a ride')
+    expect(rules).toContain('PACE figures may still be reported')
+  })
+
+  it('still says "telemetry does not support it" when the data really is bad', () => {
+    // The other demotion kind must keep its original, accurate wording.
+    const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE, {
+      hrUsable: false,
+      powerUsable: true,
+      paceUsable: true,
+      paceMayLead: false,
+      factsPrimaryMetric: 'power'
+    })
+
+    expect(ctx.demotedFrom).toBe('HR')
+    expect(ctx.demotionKind).toBe('data_unusable')
+    expect(buildMetricPriorityPromptBlock(ctx)).toContain(
+      "this session's telemetry does not support it"
+    )
   })
 
   it('never promotes pace on a ride, and says so honestly when nothing may lead', () => {
@@ -179,7 +229,13 @@ describe('metric priority demotion against the V2 facts (CW-397)', () => {
     const ctx = resolveMetricPriorityContext(
       'HR_PACE_POWER',
       { avg_hr: 150, distance_m: 48000, duration_s: 5400, avg_speed_ms: 8.9 },
-      { hrUsable: false, powerUsable: false, paceUsable: false, factsPrimaryMetric: 'mixed' }
+      {
+        hrUsable: false,
+        powerUsable: false,
+        paceUsable: true,
+        paceMayLead: false,
+        factsPrimaryMetric: 'mixed'
+      }
     )
 
     expect(ctx.primaryMetricAvailable).toBe(false)
@@ -202,7 +258,13 @@ describe('metric priority demotion against the V2 facts (CW-397)', () => {
     const promotedPaceRun = resolveMetricPriorityContext(
       'HR_PACE_POWER',
       { avg_hr: 150, distance_m: 10000, duration_s: 3300, avg_speed_ms: 3.03 },
-      { hrUsable: false, powerUsable: false, paceUsable: true, factsPrimaryMetric: 'pace' }
+      {
+        hrUsable: false,
+        powerUsable: false,
+        paceUsable: true,
+        paceMayLead: true,
+        factsPrimaryMetric: 'pace'
+      }
     )
 
     expect(promotedPaceRun.primaryMetric).toBe('PACE')

--- a/tests/unit/trigger/workout-metric-priority.test.ts
+++ b/tests/unit/trigger/workout-metric-priority.test.ts
@@ -158,13 +158,59 @@ describe('metric priority demotion against the V2 facts (CW-397)', () => {
     const ctx = resolveMetricPriorityContext('HR_PACE_POWER', POWER_METER_RIDE, {
       hrUsable: false,
       powerUsable: true,
-      paceUsable: true,
+      // A ride: `deriveMetricUsabilitySignals` reports pace as unable to lead,
+      // because `analysisMode` is not `'pace'` (CW-437).
+      paceUsable: false,
       factsPrimaryMetric: 'mixed'
     })
 
     // `mixed` names no metric, so preference order decides among the usable ones.
-    expect(ctx.primaryMetric).toBe('PACE')
-    expect(ctx.resolvedPriority).toEqual(['PACE', 'POWER', 'HR'])
+    expect(ctx.primaryMetric).toBe('POWER')
+    expect(ctx.resolvedPriority).toEqual(['POWER', 'HR', 'PACE'])
+  })
+
+  it('never promotes pace on a ride, and says so honestly when nothing may lead', () => {
+    // The regression the first cut of CW-397 introduced. Outdoor ride, no power
+    // meter, dropout-riddled HR: HR is demoted and PACE is the next metric in the
+    // preference order the session has data for. Promoting it would put
+    // `**Hard Rule**: Base most conclusions on PACE evidence` on a session whose
+    // facts say `analysisMode: mixed` -- the same ride-leads-on-speed defect
+    // CW-437 removed. Cycling speed moves with wind, gradient and drafting.
+    const ctx = resolveMetricPriorityContext(
+      'HR_PACE_POWER',
+      { avg_hr: 150, distance_m: 48000, duration_s: 5400, avg_speed_ms: 8.9 },
+      { hrUsable: false, powerUsable: false, paceUsable: false, factsPrimaryMetric: 'mixed' }
+    )
+
+    expect(ctx.primaryMetricAvailable).toBe(false)
+
+    const block = buildMetricPriorityPromptBlock(ctx)
+    expect(block).not.toContain('**Hard Rule**')
+    expect(block).toContain('**Fallback Rule**')
+    expect(block).not.toContain('Do not make heart-rate zones the primary narrative')
+
+    // ...and the HR section is not condensed away on a ride, which would have
+    // stripped the only telemetry left worth discussing.
+    expect(shouldCondenseHeartRateSection(ctx)).toBe(false)
+  })
+
+  it('condenses the HR section only when a usable PACE actually leads', () => {
+    // `shouldCondenseHeartRateSection` keys off the *resolved* primary, so a
+    // promoted PACE now condenses HR where it previously would not have. That is
+    // correct for a run -- CW-412 pins that behaviour -- and unreachable for a
+    // ride, which can never have `paceUsable: true` from the facts adapter.
+    const promotedPaceRun = resolveMetricPriorityContext(
+      'HR_PACE_POWER',
+      { avg_hr: 150, distance_m: 10000, duration_s: 3300, avg_speed_ms: 3.03 },
+      { hrUsable: false, powerUsable: false, paceUsable: true, factsPrimaryMetric: 'pace' }
+    )
+
+    expect(promotedPaceRun.primaryMetric).toBe('PACE')
+    expect(shouldCondenseHeartRateSection(promotedPaceRun)).toBe(true)
+
+    // The demoted metric is HR itself, so the prompt must still say why the HR
+    // discussion shrank rather than leaving the model to guess.
+    expect(buildMetricPriorityPromptBlock(promotedPaceRun)).toContain('**Demoted Metric**: HR')
   })
 
   it('never names an unusable metric in a hard rule, for any preference order', () => {

--- a/trigger/utils/workout-metric-priority.ts
+++ b/trigger/utils/workout-metric-priority.ts
@@ -13,14 +13,51 @@ export interface MetricAvailability {
   hasPower: boolean
 }
 
+export interface MetricUsability {
+  pace: boolean
+  hr: boolean
+  power: boolean
+}
+
+/**
+ * The subset of the V2 analysis facts that decides whether a metric may lead the
+ * analysis. Declared structurally (rather than importing `WorkoutAnalysisFactsV2`)
+ * so this module stays free of a `server/` dependency; `deriveMetricUsabilitySignals`
+ * in `server/utils/workout-analysis-facts.ts` is the adapter that fills it in.
+ *
+ * `undefined` means "the facts had nothing to say" and leaves raw availability in
+ * charge. Only an explicit `false` (or a `high` HR artifact severity) demotes.
+ */
+export interface MetricUsabilitySignals {
+  hrUsable?: boolean
+  hrArtifactSeverity?: 'none' | 'low' | 'moderate' | 'high' | null
+  powerUsable?: boolean
+  paceUsable?: boolean
+  /**
+   * `guardrails.archetype.primaryMetric` from the same facts block. When the
+   * preference primary has to be demoted this is what gets promoted, so the
+   * "Primary Metric" the facts print and the one the metric priority block names
+   * are the same metric by construction. `mixed`/`subjective` name no single
+   * metric and are ignored.
+   */
+  factsPrimaryMetric?: 'power' | 'pace' | 'hr' | 'subjective' | 'mixed' | null
+}
+
 export interface MetricPriorityContext {
   loadPreference: string
+  /** The athlete's configured preference order, untouched by demotion. */
   priority: MetricKey[]
+  /** The preference order after unusable metrics are sunk to the back. */
+  resolvedPriority: MetricKey[]
   primaryMetric: MetricKey
   primaryMetricAvailable: boolean
   secondaryMetric: MetricKey | null
   secondaryMetricAvailable: boolean
   availability: MetricAvailability
+  usability: MetricUsability
+  /** The preferred primary that was demoted, or `null` when none was. */
+  demotedFrom: MetricKey | null
+  demotionReason: string | null
 }
 
 export function parseLoadPreference(loadPreference?: string | null): MetricKey[] {
@@ -67,30 +104,101 @@ export function detectMetricAvailability(workoutData: any): MetricAvailability {
   return { hasPace, hasHr, hasPower }
 }
 
+const FACTS_PRIMARY_TO_METRIC_KEY: Record<string, MetricKey> = {
+  power: 'POWER',
+  pace: 'PACE',
+  hr: 'HR'
+}
+
+/**
+ * Whether each metric is fit to lead the analysis: present in the workout data
+ * *and* not contradicted by the facts block that ships in the same prompt.
+ */
+export function resolveMetricUsability(
+  availability: MetricAvailability,
+  signals?: MetricUsabilitySignals | null
+): MetricUsability {
+  // A `high` artifact severity means the HR stream misbehaved for the whole
+  // session, so it cannot carry the analysis even if `hrUsable` slipped through.
+  const hrSuppressed = signals?.hrUsable === false || signals?.hrArtifactSeverity === 'high'
+
+  return {
+    pace: availability.hasPace && signals?.paceUsable !== false,
+    hr: availability.hasHr && !hrSuppressed,
+    power: availability.hasPower && signals?.powerUsable !== false
+  }
+}
+
+/**
+ * Sinks unusable metrics behind usable ones, promoting the facts' own primary
+ * metric when the preferred primary has to step aside.
+ *
+ * When the preferred primary is usable the order is returned untouched: the
+ * HR-first seeded default exists for athletes without a power meter and must
+ * keep working for them.
+ */
+export function resolveMetricPriorityOrder(
+  priority: MetricKey[],
+  usability: MetricUsability,
+  factsPrimaryMetric?: MetricUsabilitySignals['factsPrimaryMetric']
+): MetricKey[] {
+  const isUsable = (metric: MetricKey): boolean =>
+    metric === 'PACE' ? usability.pace : metric === 'HR' ? usability.hr : usability.power
+
+  const preferredPrimary = priority[0]
+  if (!preferredPrimary || isUsable(preferredPrimary)) return [...priority]
+
+  const factsPrimary = factsPrimaryMetric
+    ? FACTS_PRIMARY_TO_METRIC_KEY[factsPrimaryMetric]
+    : undefined
+  const promoted =
+    factsPrimary && priority.includes(factsPrimary) && isUsable(factsPrimary) ? factsPrimary : null
+
+  const usable = priority.filter((metric) => metric !== promoted && isUsable(metric))
+  const unusable = priority.filter((metric) => metric !== promoted && !isUsable(metric))
+
+  return promoted ? [promoted, ...usable, ...unusable] : [...usable, ...unusable]
+}
+
 export function resolveMetricPriorityContext(
   loadPreference: string | null | undefined,
-  workoutData: any
+  workoutData: any,
+  signals?: MetricUsabilitySignals | null
 ): MetricPriorityContext {
   const priority = parseLoadPreference(loadPreference)
   const availability = detectMetricAvailability(workoutData)
+  const usability = resolveMetricUsability(availability, signals)
+  const resolvedPriority = resolveMetricPriorityOrder(
+    priority,
+    usability,
+    signals?.factsPrimaryMetric
+  )
 
-  const isAvailable = (metric: MetricKey): boolean => {
-    if (metric === 'PACE') return availability.hasPace
-    if (metric === 'HR') return availability.hasHr
-    return availability.hasPower
-  }
+  const isUsable = (metric: MetricKey): boolean =>
+    metric === 'PACE' ? usability.pace : metric === 'HR' ? usability.hr : usability.power
 
-  const primaryMetric = priority[0] || 'HR'
-  const secondaryMetric = priority[1] || null
+  const preferredPrimary = priority[0] || 'HR'
+  const primaryMetric = resolvedPriority[0] || preferredPrimary
+  const secondaryMetric = resolvedPriority[1] || null
+  const demoted = primaryMetric !== preferredPrimary
 
   return {
     loadPreference: loadPreference || 'HR_PACE_POWER',
     priority,
+    resolvedPriority,
     primaryMetric,
-    primaryMetricAvailable: isAvailable(primaryMetric),
+    // Now describes the metric actually leading the analysis. It is `false` only
+    // when nothing in the preference order is usable, which is the one case where
+    // the block still has to admit a gap instead of naming a replacement.
+    primaryMetricAvailable: isUsable(primaryMetric),
     secondaryMetric,
-    secondaryMetricAvailable: secondaryMetric ? isAvailable(secondaryMetric) : false,
-    availability
+    secondaryMetricAvailable: secondaryMetric ? isUsable(secondaryMetric) : false,
+    availability,
+    usability,
+    demotedFrom: demoted ? preferredPrimary : null,
+    demotionReason: demoted
+      ? `${preferredPrimary} is unusable or absent for this session, so ${primaryMetric} leads instead.`
+      : null
   }
 }
 
@@ -106,11 +214,17 @@ export function buildMetricPriorityPromptBlock(ctx: MetricPriorityContext): stri
   if (ctx.secondaryMetric) {
     block += `- **Secondary Metric for corroboration**: ${ctx.secondaryMetric} (${secondaryStatus})\n`
   }
+  if (ctx.demotedFrom) {
+    block += `- **Demoted Metric**: ${ctx.demotedFrom} is the athlete's preferred primary, but this session's telemetry does not support it (see the analysis facts). Do not lead with ${ctx.demotedFrom}.\n`
+  }
 
+  // The Hard Rule may only ever name a metric this session can actually support.
+  // Otherwise it contradicts the facts block printed in the same prompt -- and
+  // "Hard Rule" phrasing wins that argument, which is exactly CW-397.
   if (ctx.primaryMetricAvailable) {
     block += `- **Hard Rule**: Base most conclusions on ${ctx.primaryMetric} evidence. Use other metrics mainly for corroboration.\n`
   } else {
-    block += `- **Fallback Rule**: Primary metric (${ctx.primaryMetric}) is missing. Explicitly state fallback and use the next available metric.\n`
+    block += `- **Fallback Rule**: No preferred metric (${priorityOrder}) is usable for this session. Explicitly state which evidence you fell back to and why.\n`
   }
 
   if (ctx.primaryMetric === 'PACE' && ctx.primaryMetricAvailable) {
@@ -127,13 +241,19 @@ export function shouldCondenseHeartRateSection(ctx: MetricPriorityContext): bool
 
 export function buildAnalysisRequestMetricRules(ctx: MetricPriorityContext): string[] {
   const rules: string[] = [
-    `Prioritize metrics in this order: ${ctx.priority.join(' > ')}.`,
+    `Prioritize metrics in this order: ${ctx.resolvedPriority.join(' > ')}.`,
     `Use ${ctx.primaryMetric} as the primary evidence base whenever available.`
   ]
 
   if (ctx.primaryMetric === 'PACE' && ctx.primaryMetricAvailable) {
     rules.push(
       'If pace is available, keep heart-rate discussion secondary and use it only to support or challenge pace-based conclusions.'
+    )
+  }
+
+  if (ctx.demotedFrom) {
+    rules.push(
+      `The athlete's preferred primary metric ${ctx.demotedFrom} is unusable or absent for this session; judge execution on ${ctx.primaryMetric} and say so instead of leaning on ${ctx.demotedFrom}.`
     )
   }
 

--- a/trigger/utils/workout-metric-priority.ts
+++ b/trigger/utils/workout-metric-priority.ts
@@ -32,7 +32,18 @@ export interface MetricUsabilitySignals {
   hrUsable?: boolean
   hrArtifactSeverity?: 'none' | 'low' | 'moderate' | 'high' | null
   powerUsable?: boolean
+  /** Whether the pace *data* is trustworthy — a telemetry question. */
   paceUsable?: boolean
+  /**
+   * Whether pace is allowed to *lead* for this modality — a physics question,
+   * independent of data quality. False only for rides, where speed moves with
+   * wind, gradient and drafting rather than with the work done (CW-437).
+   *
+   * Kept separate from `paceUsable` on purpose: a ride's pace telemetry is often
+   * perfectly good, and the facts block says so. Folding the two together made
+   * the prompt claim the telemetry was unusable when it plainly was not.
+   */
+  paceMayLead?: boolean
   /**
    * `guardrails.archetype.primaryMetric` from the same facts block. When the
    * preference primary has to be demoted this is what gets promoted, so the
@@ -42,6 +53,18 @@ export interface MetricUsabilitySignals {
    */
   factsPrimaryMetric?: 'power' | 'pace' | 'hr' | 'subjective' | 'mixed' | null
 }
+
+/**
+ * Why a preferred primary metric had to step aside. The prompt must say which,
+ * because the two have opposite implications for the rest of the document: a
+ * `data_unusable` metric should not be quoted at all, while a
+ * `not_valid_for_modality` one is measured perfectly well and may still be
+ * described — it just cannot carry the conclusions.
+ */
+export type MetricDemotionKind = 'data_unusable' | 'not_valid_for_modality'
+
+/** How a metric should be labelled in the prompt's status parentheses. */
+export type MetricStatus = 'available' | 'unusable' | 'present_but_not_leading' | 'missing'
 
 export interface MetricPriorityContext {
   loadPreference: string
@@ -57,7 +80,10 @@ export interface MetricPriorityContext {
   usability: MetricUsability
   /** The preferred primary that was demoted, or `null` when none was. */
   demotedFrom: MetricKey | null
+  demotionKind: MetricDemotionKind | null
   demotionReason: string | null
+  /** Pace has good data but this modality forbids it from leading (CW-437). */
+  paceBlockedByModality: boolean
 }
 
 export function parseLoadPreference(loadPreference?: string | null): MetricKey[] {
@@ -123,10 +149,48 @@ export function resolveMetricUsability(
   const hrSuppressed = signals?.hrUsable === false || signals?.hrArtifactSeverity === 'high'
 
   return {
-    pace: availability.hasPace && signals?.paceUsable !== false,
+    pace: availability.hasPace && signals?.paceUsable !== false && signals?.paceMayLead !== false,
     hr: availability.hasHr && !hrSuppressed,
     power: availability.hasPower && signals?.powerUsable !== false
   }
+}
+
+/**
+ * Pace has trustworthy data but this modality forbids it from leading (CW-437).
+ * Distinct from "pace is unusable", and the distinction is load-bearing: the
+ * facts block prints `Pace Usable: Yes` for exactly these sessions, so calling
+ * the metric unusable would contradict the same document.
+ */
+function isPaceBlockedByModality(
+  availability: MetricAvailability,
+  signals?: MetricUsabilitySignals | null
+): boolean {
+  return availability.hasPace && signals?.paceUsable !== false && signals?.paceMayLead === false
+}
+
+/**
+ * How a metric should be labelled in the prompt's status parentheses.
+ * `present_but_not_leading` exists so a ride's pace is never described as missing
+ * or unusable while the facts block in the same prompt reports `Pace Usable: Yes`.
+ */
+export function describeMetricStatus(ctx: MetricPriorityContext, metric: MetricKey): MetricStatus {
+  const usable =
+    metric === 'PACE'
+      ? ctx.usability.pace
+      : metric === 'HR'
+        ? ctx.usability.hr
+        : ctx.usability.power
+  if (usable) return 'available'
+
+  if (metric === 'PACE' && ctx.paceBlockedByModality) return 'present_but_not_leading'
+
+  const present =
+    metric === 'PACE'
+      ? ctx.availability.hasPace
+      : metric === 'HR'
+        ? ctx.availability.hasHr
+        : ctx.availability.hasPower
+  return present ? 'unusable' : 'missing'
 }
 
 /**
@@ -181,6 +245,12 @@ export function resolveMetricPriorityContext(
   const primaryMetric = resolvedPriority[0] || preferredPrimary
   const secondaryMetric = resolvedPriority[1] || null
   const demoted = primaryMetric !== preferredPrimary
+  const paceBlockedByModality = isPaceBlockedByModality(availability, signals)
+  const demotionKind: MetricDemotionKind | null = !demoted
+    ? null
+    : preferredPrimary === 'PACE' && paceBlockedByModality
+      ? 'not_valid_for_modality'
+      : 'data_unusable'
 
   return {
     loadPreference: loadPreference || 'HR_PACE_POWER',
@@ -195,18 +265,24 @@ export function resolveMetricPriorityContext(
     secondaryMetricAvailable: secondaryMetric ? isUsable(secondaryMetric) : false,
     availability,
     usability,
+    paceBlockedByModality,
     demotedFrom: demoted ? preferredPrimary : null,
-    demotionReason: demoted
-      ? `${preferredPrimary} is unusable or absent for this session, so ${primaryMetric} leads instead.`
-      : null
+    demotionKind,
+    demotionReason:
+      demotionKind === 'not_valid_for_modality'
+        ? `${preferredPrimary} is measured reliably here, but speed is not a valid proxy for cycling effort -- wind, gradient and drafting move it independently of the work done -- so it may not lead. ${primaryMetric} leads instead.`
+        : demotionKind === 'data_unusable'
+          ? `${preferredPrimary} is unusable or absent for this session, so ${primaryMetric} leads instead.`
+          : null
   }
 }
 
 export function buildMetricPriorityPromptBlock(ctx: MetricPriorityContext): string {
   const priorityOrder = ctx.priority.join(' > ')
-  const primaryStatus = ctx.primaryMetricAvailable ? 'available' : 'missing'
-  const secondaryStatus =
-    ctx.secondaryMetric && ctx.secondaryMetricAvailable ? 'available' : 'missing_or_not_set'
+  const primaryStatus = describeMetricStatus(ctx, ctx.primaryMetric)
+  const secondaryStatus = ctx.secondaryMetric
+    ? describeMetricStatus(ctx, ctx.secondaryMetric)
+    : 'missing'
 
   let block = '\n## Metric Priority Rules\n'
   block += `- **Preferred Metric Order**: ${priorityOrder}\n`
@@ -214,7 +290,13 @@ export function buildMetricPriorityPromptBlock(ctx: MetricPriorityContext): stri
   if (ctx.secondaryMetric) {
     block += `- **Secondary Metric for corroboration**: ${ctx.secondaryMetric} (${secondaryStatus})\n`
   }
-  if (ctx.demotedFrom) {
+  if (ctx.demotedFrom && ctx.demotionKind === 'not_valid_for_modality') {
+    // Deliberately does NOT claim the telemetry is bad: the facts block in this
+    // same prompt reports `Pace Usable: Yes` for these sessions, and pointing the
+    // model at those facts as evidence of the opposite is the contradiction
+    // CW-397 exists to remove.
+    block += `- **Demoted Metric**: ${ctx.demotedFrom} is the athlete's preferred primary and is measured reliably here, but speed is not a valid proxy for cycling effort -- wind, gradient and drafting move it independently of the work done -- so it may not lead a ride. Quote ${ctx.demotedFrom} figures where they are informative, but do not build conclusions on them.\n`
+  } else if (ctx.demotedFrom) {
     block += `- **Demoted Metric**: ${ctx.demotedFrom} is the athlete's preferred primary, but this session's telemetry does not support it (see the analysis facts). Do not lead with ${ctx.demotedFrom}.\n`
   }
 
@@ -251,7 +333,11 @@ export function buildAnalysisRequestMetricRules(ctx: MetricPriorityContext): str
     )
   }
 
-  if (ctx.demotedFrom) {
+  if (ctx.demotedFrom && ctx.demotionKind === 'not_valid_for_modality') {
+    rules.push(
+      `The athlete's preferred primary metric ${ctx.demotedFrom} is measured reliably here but may not lead a ride, because speed reflects wind, gradient and drafting as much as effort; judge execution on ${ctx.primaryMetric}. ${ctx.demotedFrom} figures may still be reported, just not used as the basis for conclusions.`
+    )
+  } else if (ctx.demotedFrom) {
     rules.push(
       `The athlete's preferred primary metric ${ctx.demotedFrom} is unusable or absent for this session; judge execution on ${ctx.primaryMetric} and say so instead of leaning on ${ctx.demotedFrom}.`
     )


### PR DESCRIPTION
Fixes CW-397

## Problem

The sport profile is seeded `loadPreference: 'HR_PACE_POWER'` — HR-first on purpose, because it works across sports and for athletes without a power meter. **That default is unchanged here**; `sportSettingsRepository.createDefault()` is untouched and no migration goes near existing athletes' `loadPreference`.

The defect was that the prompt and adherence layers never asked whether the preferred primary metric was usable for *this* session:

1. `buildMetricPriorityPromptBlock` emitted `**Hard Rule**: Base most conclusions on HR evidence` while the V2 facts block **in the same prompt** reported `HR Usable: No` and `Primary Metric: power`. Two authoritative instructions disagreed, and "Hard Rule" phrasing usually wins — so a power-meter ride got an HR-led analysis.
2. `deriveAdherence` took its `metricOrder` straight from `loadPreference`, so a planned step carrying **both** a power and an HR target was scored against the HR band even when the HR trace was unusable.

## Fix

`resolveMetricPriorityContext` now takes the facts' usability signals. A metric is usable only if it is present in the workout data **and** not disowned by the facts (`hrUsable: false`, a `high` HR artifact severity, `powerUsable: false`, `paceUsable: false`).

- Preferred primary **usable** → nothing changes. The no-power-meter athlete the default exists to serve is untouched.
- Preferred primary **not usable** → the facts' own `guardrails.archetype.primaryMetric` is promoted when it names a usable metric, otherwise the next usable metric in preference order is.

The `**Hard Rule**` can therefore only ever name a metric the same prompt supports; the `**Fallback Rule**` wording is now reserved for the case where *nothing* in the preference order is usable. A new `**Demoted Metric**` line states which preferred metric stepped aside, so the model is not left guessing.

`buildWorkoutAnalysisFactsV2` routes the adherence `metricOrder` through the same resolution via `resolveAdherenceMetricOrder`, keeping `rpe` last so a demotion never promotes a subjective target over a measured one.

## Snapshot

`server/utils/services/__snapshots__/workout-analysis-prompt.test.ts.snap` is **byte-identical** — `git diff` on it is empty. Its fixture is a `POWER` ride with usable power and HR, and it passes no `analysisFactsV2`, so nothing about it demotes. No existing prompt line changed.

## Verification

```
pnpm test:unit server/utils/services/workout-analysis-prompt.test.ts server/utils/workout-analysis-facts.test.ts tests/unit/trigger/workout-metric-priority.test.ts
  Test Files  3 passed (3)
       Tests  188 passed (188)

pnpm test:unit          # full suite
  Test Files  380 passed (380)
       Tests  2541 passed (2541)

pnpm typecheck          # exit 0, no TS errors
pnpm lint               # 0 errors (116 pre-existing vue/require-default-prop warnings)
```

`trigger/` is outside every tsconfig project (CW-560), so `pnpm typecheck` does not cover `workout-metric-priority.ts`. The new tests import and exercise it directly, and `server/utils/workout-analysis-facts.ts` now imports it too, so a type or import error surfaces at test time.

## New coverage

- **`tests/unit/trigger/workout-metric-priority.test.ts`** — default settings + power meter + `hrUsable: false` → POWER-led with a `Demoted Metric` line; default settings + **no** power meter → still HR-led with the HR hard rule intact; `high` artifact severity demotes even when `hrUsable` is `true`; a loop over 6 preference orders × 4 facts states asserting the `**Hard Rule**` can never name an unusable metric.
- **`server/utils/workout-analysis-facts.test.ts`** — a planned step carrying **both** power and HR targets, power hit exactly and HR ~30–40% off. With a dropout-riddled HR stream the work/recovery hit rates are 100 (scored on power); with a clean HR stream the same fixture scores 0 (still scored on HR). The control is what proves the metric flipped rather than HR simply being dropped.
- **`server/utils/services/workout-analysis-prompt.test.ts`** — end to end: one prompt now contains `- HR Usable: No`, `- Primary Metric: power` **and** `**Hard Rule**: Base most conclusions on POWER evidence`, with `Base most conclusions on HR evidence` absent. Plus the HR-only regression case and the no-facts legacy path.

## Notes

UX critique: skipped — prompt/scoring change, no UI surface.