### PR TITLE
fix(chat): expire stale TEMPORARY memories from the prompt (CW-589)

### DIFF
--- a/server/utils/services/userMemoryService.ts
+++ b/server/utils/services/userMemoryService.ts
@@ -25,6 +25,18 @@ const ACTIVE_MEMORY_STATUS: UserMemoryStatus = 'ACTIVE'
 const PROMPT_GLOBAL_LIMIT = 8
 const PROMPT_ROOM_LIMIT = 4
 
+/**
+ * How long a TEMPORARY memory stays eligible for the prompt.
+ *
+ * TEMPORARY is the classifier's default bucket, so it collects things that are
+ * only true for a few days — "HRV is 45ms today", "sore after Sunday's race",
+ * "unavailable 19-25 July". Nothing ever expired them, so they kept their place
+ * in the prompt indefinitely and crowded out durable facts: one athlete's
+ * memory block still described soreness and a rest period from a race six weeks
+ * earlier, which is why the coach kept treating a finished event as current.
+ */
+const TEMPORARY_MEMORY_TTL_DAYS = 30
+
 function createServiceError(statusCode: number, message: string) {
   const error = new Error(message) as Error & {
     statusCode: number
@@ -89,6 +101,32 @@ export function isSensitiveMemoryContent(content: string) {
   return /\b(injury|injured|pain|medical|health|surgery|illness|allergy|menstru|pregnan|anxiety|depression)\b/i.test(
     content
   )
+}
+
+/**
+ * True when a TEMPORARY memory has aged out of usefulness.
+ *
+ * Only TEMPORARY is subject to this — PREFERENCE, CONSTRAINT, GOAL, PROFILE and
+ * COMMUNICATION describe durable facts and instructions and must never expire.
+ * That distinction matters: the same athlete whose stale soreness notes caused
+ * this bug had also told the coach to stop mentioning a race, and that
+ * instruction is a PREFERENCE which has to survive.
+ *
+ * Pinned memories are exempt — pinning is an explicit "keep this".
+ */
+export function isStaleTemporaryMemory(
+  memory: Pick<UserMemory, 'category' | 'pinned' | 'lastConfirmedAt' | 'updatedAt'>,
+  now: Date = new Date()
+) {
+  if (memory.category !== 'TEMPORARY' || memory.pinned) return false
+
+  const lastTouched = Math.max(
+    memory.lastConfirmedAt ? new Date(memory.lastConfirmedAt).getTime() : 0,
+    memory.updatedAt ? new Date(memory.updatedAt).getTime() : 0
+  )
+  if (!lastTouched) return false
+
+  return now.getTime() - lastTouched > TEMPORARY_MEMORY_TTL_DAYS * 24 * 60 * 60 * 1000
 }
 
 function rankMemory(
@@ -373,7 +411,14 @@ class UserMemoryService {
       }
     }
 
-    const globalMemories = (
+    // Stale TEMPORARY memories are dropped from the prompt only. They stay in
+    // the store and remain visible to the memory management tools, so nothing
+    // the athlete saved silently disappears from their view.
+    const now = new Date()
+    const promptEligible = (memories: UserMemory[]) =>
+      memories.filter((memory) => !isStaleTemporaryMemory(memory, now))
+
+    const globalMemories = promptEligible(
       await this.listMemories({
         userId: params.userId,
         scope: 'GLOBAL',
@@ -384,7 +429,7 @@ class UserMemoryService {
       .slice(0, PROMPT_GLOBAL_LIMIT)
 
     const roomMemories = params.roomId
-      ? (
+      ? promptEligible(
           await this.listMemories({
             userId: params.userId,
             scope: 'ROOM',

--- a/tests/unit/server/utils/services/userMemoryService.stale-temporary.test.ts
+++ b/tests/unit/server/utils/services/userMemoryService.stale-temporary.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { isStaleTemporaryMemory } from '../../../../../server/utils/services/userMemoryService'
+
+// CW-589: TEMPORARY memories never expired, so short-lived facts ("sore after
+// Sunday's race", "resting until 8 July") stayed in the prompt indefinitely and
+// kept a finished event alive in the coach's context weeks later.
+
+const NOW = new Date('2026-08-12T12:00:00Z')
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000)
+
+const memory = (over: Partial<Parameters<typeof isStaleTemporaryMemory>[0]> = {}) =>
+  ({
+    category: 'TEMPORARY',
+    pinned: false,
+    lastConfirmedAt: null,
+    updatedAt: daysAgo(45),
+    ...over
+  }) as Parameters<typeof isStaleTemporaryMemory>[0]
+
+describe('isStaleTemporaryMemory (CW-589)', () => {
+  it('treats a TEMPORARY memory older than the TTL as stale', () => {
+    expect(isStaleTemporaryMemory(memory({ updatedAt: daysAgo(45) }), NOW)).toBe(true)
+  })
+
+  it('keeps a recent TEMPORARY memory', () => {
+    expect(isStaleTemporaryMemory(memory({ updatedAt: daysAgo(3) }), NOW)).toBe(false)
+  })
+
+  it('keeps a TEMPORARY memory that was recently reconfirmed even if updated long ago', () => {
+    expect(
+      isStaleTemporaryMemory(memory({ updatedAt: daysAgo(90), lastConfirmedAt: daysAgo(2) }), NOW)
+    ).toBe(false)
+  })
+
+  it('never expires a pinned TEMPORARY memory', () => {
+    expect(isStaleTemporaryMemory(memory({ pinned: true, updatedAt: daysAgo(365) }), NOW)).toBe(
+      false
+    )
+  })
+
+  // The durable categories must survive: the athlete who hit this bug had also
+  // told the coach to stop mentioning a race, stored as a PREFERENCE.
+  it.each(['PREFERENCE', 'CONSTRAINT', 'GOAL', 'PROFILE', 'COMMUNICATION'] as const)(
+    'never expires a %s memory regardless of age',
+    (category) => {
+      expect(isStaleTemporaryMemory(memory({ category, updatedAt: daysAgo(365) }), NOW)).toBe(false)
+    }
+  )
+
+  it('does not expire a memory with no usable timestamps', () => {
+    expect(
+      isStaleTemporaryMemory(
+        memory({ updatedAt: null as unknown as Date, lastConfirmedAt: null }),
+        NOW
+      )
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes CW-589

## Problem

An athlete reported the coach repeatedly citing a triathlon he **completed on 28 June** as an upcoming objective, and continuing to frame his training around a different event he is not entered for — after explicitly telling it to stop.

My original ticket guessed this was past events leaking into goal context. Investigating production showed that was wrong, in a useful way.

**What I checked, and what it ruled out:**

- His `Goal` rows: two ACTIVE, neither is the completed race.
- His `Event` rows: `Triathlon Embrun` (2026-06-28, −45d) exists, but `Event` is never read into chat context — only `checkin-service` queries it, and that correctly filters `date >= today`.
- His `UserMemory` rows: **ten of twenty-five mention the completed race**, including post-race soreness and a rest period that ended 8 July.

The memory store is the actual source. `TEMPORARY` is the classifier's default bucket, so it collects facts true only for days — "HRV is 45ms today", "sore after the race", "unavailable 19–25 July". **Nothing ever expired them**: the schema has no expiry field, and `TEMPORARY` has exactly the same lifetime as `PROFILE`. They keep their place in the prompt forever and crowd out durable facts, which is how a finished event stays permanently current.

## Fix

Drop `TEMPORARY` memories from the prompt once they have gone `TEMPORARY_MEMORY_TTL_DAYS` (30) without being updated or reconfirmed.

Deliberately narrow, because the blast radius here is every user's coach:

- **Only `TEMPORARY` expires.** `PREFERENCE`, `CONSTRAINT`, `GOAL`, `PROFILE`, `COMMUNICATION` are durable. This matters concretely: the same athlete's *"never mention this race"* instruction is stored as a `PREFERENCE` and has to survive. Expiring it would make the reported problem worse.
- **Pinned memories never expire** — pinning is an explicit keep-this.
- **Prompt path only.** Filtering is in `composePromptMemoryBlock`, not `listMemories`. Rows stay in the store and remain visible to the memory management tools, so nothing the athlete saved silently disappears from their view.

## Verification

```
pnpm test:unit tests/unit/server/utils/services/userMemoryService.stale-temporary.test.ts   # 10 passed
```

Coverage includes the five durable categories staying put, pinned exemption, reconfirmation refreshing the clock, and the no-timestamp edge case.

## Not addressed here

The ticket's remaining criterion — durably honouring "stop mentioning X" — is a separate problem. This athlete has **three near-duplicate `PREFERENCE` memories** all saying the same thing, which shows he had to repeat himself and that such instructions accumulate rather than dedupe. Worth its own ticket; removing the stale-memory noise should reduce the pressure that caused it.