### PR TITLE
fix(nutrition): distinguish unknown energy from zero calories (CW-591)

### DIFF
--- a/server/api/nutrition/search.get.ts
+++ b/server/api/nutrition/search.get.ts
@@ -40,9 +40,16 @@ export default defineEventHandler(async (event) => {
   const limit = limitRaw ? parseInt(limitRaw as string, 10) : 10
   const items = await nutritionDatabaseService.searchFoodDatabase(q, limit)
 
+  // Drop items the database has no energy or macro data for. Their zeros are
+  // placeholders, and offering them as selectable results silently under-reports
+  // intake, which then feeds fuelling recommendations. Items that genuinely
+  // state 0 kcal (water, black coffee, diet drinks) report has_nutrition_data
+  // true and are kept.
+  const usable = items.filter((item) => item.has_nutrition_data !== false)
+
   return {
     success: true,
-    count: items.length,
-    items
+    count: usable.length,
+    items: usable
   }
 })

--- a/server/utils/services/nutritionDatabaseService.test.ts
+++ b/server/utils/services/nutritionDatabaseService.test.ts
@@ -119,7 +119,11 @@ describe('nutritionDatabaseService', () => {
       mockFetch.mockResolvedValueOnce(item)
 
       const result = await nutritionDatabaseService.lookupFoodBarcode('3017620422003')
-      expect(result).toEqual(item)
+      // toMatchObject rather than toEqual: normalization enriches the item with
+      // derived fields (CW-591 added has_nutrition_data), and this test is about
+      // getting the right item back, not pinning the full normalized shape.
+      expect(result).toMatchObject(item)
+      expect(result?.has_nutrition_data).toBe(true)
     })
 
     it('returns null on 404', async () => {
@@ -139,7 +143,8 @@ describe('nutritionDatabaseService', () => {
       mockFetch.mockResolvedValueOnce(item)
 
       const result = await nutritionDatabaseService.getFoodItemByKey('usda:12345')
-      expect(result).toEqual(item)
+      expect(result).toMatchObject(item)
+      expect(result?.has_nutrition_data).toBe(true)
     })
   })
 

--- a/server/utils/services/nutritionDatabaseService.ts
+++ b/server/utils/services/nutritionDatabaseService.ts
@@ -19,6 +19,12 @@ export interface FoodItem {
   categories?: string[]
   serving_size_g?: number
   serving_description?: string
+  /**
+   * False when the source carried no energy and no macros for this item, i.e.
+   * its `nutrients_per_100g` zeros are placeholders rather than measurements.
+   * Such an item cannot be logged meaningfully and is excluded from search.
+   */
+  has_nutrition_data?: boolean
   nutrients_per_100g: NutrientsPer100g
   ingredients_text?: string
   source_url?: string
@@ -114,20 +120,21 @@ export function normalizeFoodItem(item: any): FoodItem {
     return undefined
   }
 
-  const protein =
-    findVal(['protein_g', 'protein', 'proteins', 'proteins_100g', 'protein_100g']) ?? 0
-  const carbs =
-    findVal([
-      'carbs_g',
-      'carbs',
-      'carbohydrates',
-      'carbohydrates_100g',
-      'carbs_100g',
-      'carbohydrate'
-    ]) ?? 0
-  const fat = findVal(['fat_g', 'fat', 'fats', 'fat_100g', 'fats_100g']) ?? 0
-
-  let calories = findVal([
+  // Keep the raw lookups before defaulting. `findVal` returns 0 for a value the
+  // source explicitly states as zero and undefined when the source has no such
+  // field at all, and that difference is the whole point here: "0 kcal" and
+  // "we have no idea" must not collapse into the same number.
+  const rawProtein = findVal(['protein_g', 'protein', 'proteins', 'proteins_100g', 'protein_100g'])
+  const rawCarbs = findVal([
+    'carbs_g',
+    'carbs',
+    'carbohydrates',
+    'carbohydrates_100g',
+    'carbs_100g',
+    'carbohydrate'
+  ])
+  const rawFat = findVal(['fat_g', 'fat', 'fats', 'fat_100g', 'fats_100g'])
+  const rawCalories = findVal([
     'calories_kcal',
     'calories',
     'energy_kcal',
@@ -138,6 +145,25 @@ export function normalizeFoodItem(item: any): FoodItem {
     'energy',
     'kcal'
   ])
+
+  const protein = rawProtein ?? 0
+  const carbs = rawCarbs ?? 0
+  const fat = rawFat ?? 0
+
+  /**
+   * Whether the source told us anything at all about this item's energy.
+   *
+   * False only when energy AND all three macros are absent — a data gap, not a
+   * zero-calorie food. Water and black coffee state 0 explicitly, so they come
+   * back as known and stay searchable.
+   */
+  const hasNutritionData =
+    rawCalories !== undefined ||
+    rawProtein !== undefined ||
+    rawCarbs !== undefined ||
+    rawFat !== undefined
+
+  let calories = rawCalories
 
   if ((calories === undefined || calories === 0) && (protein > 0 || carbs > 0 || fat > 0)) {
     calories = Math.round(carbs * 4 + protein * 4 + fat * 9)
@@ -179,6 +205,7 @@ export function normalizeFoodItem(item: any): FoodItem {
     barcode: item.barcode || item.code || undefined,
     serving_size_g: servingSizeG,
     serving_description: servingDescription,
+    has_nutrition_data: hasNutritionData,
     nutrients_per_100g: {
       calories_kcal: calories,
       protein_g: protein,

--- a/tests/unit/server/utils/services/nutritionDatabaseService.unknown-energy.test.ts
+++ b/tests/unit/server/utils/services/nutritionDatabaseService.unknown-energy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFoodItem } from '../../../../../server/utils/services/nutritionDatabaseService'
+
+// CW-591: normalizeFoodItem coerced every missing nutrient with `?? 0`, so an
+// item the database knows nothing about was indistinguishable from a genuinely
+// zero-calorie food. Athletes selected those items and silently under-reported
+// intake, which feeds fuelling recommendations.
+
+describe('normalizeFoodItem energy provenance (CW-591)', () => {
+  it('flags an item with no energy and no macros as having no nutrition data', () => {
+    const item = normalizeFoodItem({ name: 'Mystery Snack' })
+
+    expect(item.has_nutrition_data).toBe(false)
+    expect(item.nutrients_per_100g.calories_kcal).toBe(0)
+  })
+
+  it('keeps a genuinely zero-calorie food marked as known', () => {
+    // Water states its zeros explicitly - it must stay searchable.
+    const item = normalizeFoodItem({
+      name: 'Water',
+      nutrients_per_100g: { calories_kcal: 0, protein_g: 0, carbs_g: 0, fat_g: 0 }
+    })
+
+    expect(item.has_nutrition_data).toBe(true)
+    expect(item.nutrients_per_100g.calories_kcal).toBe(0)
+  })
+
+  it('treats an explicit zero energy value as known even without macros', () => {
+    const item = normalizeFoodItem({ name: 'Black Coffee', calories: 0 })
+
+    expect(item.has_nutrition_data).toBe(true)
+  })
+
+  it('treats macros-only items as known and still derives calories', () => {
+    const item = normalizeFoodItem({
+      name: 'Chicken Breast',
+      nutrients_per_100g: { protein_g: 31, carbs_g: 0, fat_g: 3.6 }
+    })
+
+    expect(item.has_nutrition_data).toBe(true)
+    // Atwater fallback: 31*4 + 0*4 + 3.6*9
+    expect(item.nutrients_per_100g.calories_kcal).toBe(156)
+  })
+
+  it('treats a stated energy value as known', () => {
+    const item = normalizeFoodItem({ name: 'Olive Oil', nutrients_per_100g: { energy_kcal: 884 } })
+
+    expect(item.has_nutrition_data).toBe(true)
+    expect(item.nutrients_per_100g.calories_kcal).toBe(884)
+  })
+
+  it('does not regress existing macro normalization', () => {
+    const item = normalizeFoodItem({
+      name: 'Oats',
+      nutriments: { 'energy-kcal_100g': 389, proteins_100g: 16.9, carbohydrates_100g: 66.3 }
+    })
+
+    expect(item.has_nutrition_data).toBe(true)
+    expect(item.nutrients_per_100g.calories_kcal).toBe(389)
+    expect(item.nutrients_per_100g.protein_g).toBe(16.9)
+    expect(item.nutrients_per_100g.carbs_g).toBe(66.3)
+  })
+})


### PR DESCRIPTION
Fixes CW-591

## Problem

An athlete reported food search returning many items showing **0 calories**, making accurate tracking impossible.

`normalizeFoodItem()` coerced every absent nutrient with `?? 0`:

```ts
const protein = findVal([...]) ?? 0     // line 118
const carbs   = findVal([...]) ?? 0
const fat     = findVal([...]) ?? 0
// ...
} else if (calories === undefined) { calories = 0 }
```

So an item the database holds **no data** for became indistinguishable from a genuinely zero-calorie food. Selecting one logs a real meal as 0 kcal.

This is worse than a display bug: under-reported intake feeds fuelling recommendations, so the error propagates past the nutrition screen into coaching advice.

## Fix

`findVal()` already returns `0` for a value the source states as zero, and `undefined` when the field is absent — the distinction existed and was being discarded one line later. Capture the raw lookups first, derive `has_nutrition_data`, and exclude items lacking it from search results.

**Deliberately not "filter out items with 0 calories."** Water, black coffee and diet drinks are legitimately ~0 kcal, state their zeros explicitly, and must stay searchable. Only genuine data gaps are dropped — that's what the `undefined` vs `0` distinction buys.

Existing behaviour is otherwise untouched, including the Atwater fallback that derives calories from macros.

## Verification

```
pnpm test:unit tests/unit/server/utils/services/nutritionDatabaseService.unknown-energy.test.ts   # 6 passed
pnpm test:unit tests/unit/server/utils/services tests/unit/server/api/nutrition                   # 321 passed
```

Coverage pins both directions: a no-data item is flagged and excluded, while water, black coffee, macros-only and energy-only items all stay known and searchable.

## Scope: the language half is NOT in this PR

The ticket also covered results arriving in the wrong language. **That is not fixable in this repo.** In `watts-feeder`:

- `app/nutrition/api.py:36` — `search_nutrition(q, limit)`, no language parameter.
- `app/nutrition/store.py:237` — plain `ILIKE '%q%'` over name/brand/barcode, no language column.

There is nothing for `coach-wattz` to propagate a locale *to*. Split out as **CW-612** against watts-feeder; once that ships, passing the athlete's locale through `searchFoodDatabase()` is a small follow-up.