### PR TITLE
fix(nutrition): stop string input fragmenting logged items (CW-586)

### DIFF
--- a/server/utils/nutrition/totals.ts
+++ b/server/utils/nutrition/totals.ts
@@ -134,7 +134,28 @@ function inferHydrationFactor(item: Record<string, any>): number {
   return 1
 }
 
-export function normalizeFluidFields(item: Record<string, any>): Record<string, any> {
+/**
+ * Coerce a logged item into an object carrying derived hydration fields.
+ *
+ * The guard matters because of the spread below. Spreading a string explodes it
+ * into an object keyed by character index — `{...'pasta'}` becomes
+ * `{0:'p',1:'a',2:'s',3:'t',4:'a'}` — which then persists as an item with no
+ * name and no macros. An athlete reported exactly that shape: nutrition entries
+ * displayed with no description and zero calories, whose stored items were
+ * "strings split into objects with numeric keys". Every nutrition write path
+ * calls this function, so a single caller passing a bare string was enough to
+ * corrupt a day's log.
+ */
+export function normalizeFluidFields(rawItem: Record<string, any>): Record<string, any> {
+  // Coerce rather than throw. Several callers run this over items already stored
+  // in the database (e.g. the remove-hydration tool iterating a day's meals), and
+  // corrupt rows from before this guard exist in production - throwing there
+  // would turn a read into a hard failure for precisely the affected athletes.
+  // A string yields an item with no name and no macros, which the caller can see
+  // and skip, instead of one keyed 0,1,2,3.
+  const item: Record<string, any> =
+    rawItem && typeof rawItem === 'object' && !Array.isArray(rawItem) ? rawItem : {}
+
   const fluidMl = Math.max(0, Math.round(inferFluidMl(item)))
   const hydrationFactor = inferHydrationFactor(item)
   const hydrationContributionMl = Math.max(0, Math.round(fluidMl * hydrationFactor))

--- a/tests/unit/server/utils/nutrition/totals-fragmentation.test.ts
+++ b/tests/unit/server/utils/nutrition/totals-fragmentation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFluidFields } from '../../../../../server/utils/nutrition/totals'
+
+// CW-586: normalizeFluidFields spreads its argument. Spreading a string explodes
+// it into character-indexed keys - {...'pasta'} => {0:'p',1:'a',...} - which then
+// persists as an item with no name and no macros. An athlete reported exactly
+// that: nutrition entries with no description and zero calories, whose stored
+// items were "strings split into objects with numeric keys".
+
+const numericKeys = (obj: Record<string, any>) => Object.keys(obj).filter((k) => /^\d+$/.test(k))
+
+describe('normalizeFluidFields input guard (CW-586)', () => {
+  it('does not fragment a string into character-indexed keys', () => {
+    const result = normalizeFluidFields('pasta' as unknown as Record<string, any>)
+
+    expect(numericKeys(result)).toEqual([])
+    expect(result.name).toBeUndefined()
+  })
+
+  it.each([null, undefined, 42, true])('tolerates %p without producing junk keys', (input) => {
+    const result = normalizeFluidFields(input as unknown as Record<string, any>)
+
+    expect(numericKeys(result)).toEqual([])
+    expect(result.fluidMl).toBe(0)
+  })
+
+  it('tolerates an array without spreading its indices', () => {
+    const result = normalizeFluidFields(['a', 'b'] as unknown as Record<string, any>)
+
+    expect(numericKeys(result)).toEqual([])
+  })
+
+  // Reads run over already-stored rows, and corrupt ones exist in production -
+  // this must degrade, not throw, or the affected athletes lose those tools.
+  it('does not throw on malformed stored input', () => {
+    expect(() => normalizeFluidFields('bad' as unknown as Record<string, any>)).not.toThrow()
+  })
+
+  it('leaves a well-formed food item intact', () => {
+    const item = { name: 'Oatmeal', calories: 320, carbs: 54, protein: 11, fat: 6 }
+
+    const result = normalizeFluidFields(item)
+
+    expect(result).toMatchObject(item)
+    expect(result.fluidMl).toBe(0)
+  })
+
+  it('still derives hydration fields for a fluid item', () => {
+    const result = normalizeFluidFields({ name: 'Water', entryType: 'HYDRATION', waterMl: 500 })
+
+    expect(result.name).toBe('Water')
+    expect(result.fluidMl).toBe(500)
+    expect(result.hydrationContributionMl).toBe(500)
+  })
+})


### PR DESCRIPTION
Fixes CW-586

## Problem

`normalizeFluidFields()` spreads its argument, and **every** nutrition write path calls it. Spreading a string explodes it into character-indexed keys:

```js
{ ...'pasta' }   // => { 0:'p', 1:'a', 2:'s', 3:'t', 4:'a' }
```

That then persists as an item with no name and no macros. An athlete reported exactly that shape — nutrition entries displayed with no description and zero calories, whose stored items were *"strings split into objects with numeric keys"*.

## Fix

Coerce non-object input to an empty item so the spread cannot fragment.

**Coerce rather than throw, deliberately.** Several callers run this over rows *already in the database* — the remove-hydration AI tool iterates a whole day's meals — and corrupt rows written before this guard exist in production. Throwing would turn a read into a hard failure for precisely the athletes already affected. A malformed item now degrades to one the caller can see and skip.

## Verification

```
pnpm test:unit tests/unit/server/utils/nutrition/totals-fragmentation.test.ts   # 9 passed
pnpm test:unit                                                                 # 381 files, 2536 tests passed
```

Coverage pins the fragmentation cases (string, array, null, number, boolean) and that well-formed food and hydration items are untouched.

Full-suite run is deliberate: this repo keeps tests both under `tests/` and colocated in `server/`, and a path-filtered run misses the latter.

## Honest scope: the headline symptom does not currently reproduce

The ticket says food logged via the Nutrition module does not persist. Checking the reporting athlete's production data (`9bf5199e-…`, last 20 days) shows otherwise:

| date | items | kcal |
|---|---|---|
| 2026-08-03 | 9 | 1874 |
| 2026-08-04 | 16 | 1656 |
| 2026-08-10 | 4 | 320 |

**Zero fragmented items remain**, and all three of those days are *after* his report. Item sources across the window: `none` 28, `dashboard` 12, `manual` 1 — so multiple write paths are persisting food.

So this PR is a **guard against the corruption shape he saw recurring**, not a fix for a live failure. I'd rather ship that and say so than claim a repair I can't demonstrate. The athlete has been asked to confirm whether it still happens and via which exact control.