### PR TITLE
fix(ci): stop shadow-runner jobs racing on the shared pnpm install path (CW-630)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          # Install into the job's own RUNNER_TEMP, never the action's default
+          # `~/setup-pnpm`. On the self-hosted shadow host, several runner
+          # registrations share one `$HOME`, so the default path is shared state:
+          # two of this workflow's four jobs landing on the same host raced to
+          # self-update pnpm into it and both died before running anything
+          # (`ENOTEMPTY: rmdir '/home/hdkiller/setup-pnpm'` and
+          # `self-installer exits with code 1`). RUNNER_TEMP is allocated per job
+          # and cleaned between jobs, so two jobs cannot collide here regardless
+          # of how the runners are registered. See CW-630.
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -57,6 +68,17 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          # Install into the job's own RUNNER_TEMP, never the action's default
+          # `~/setup-pnpm`. On the self-hosted shadow host, several runner
+          # registrations share one `$HOME`, so the default path is shared state:
+          # two of this workflow's four jobs landing on the same host raced to
+          # self-update pnpm into it and both died before running anything
+          # (`ENOTEMPTY: rmdir '/home/hdkiller/setup-pnpm'` and
+          # `self-installer exits with code 1`). RUNNER_TEMP is allocated per job
+          # and cleaned between jobs, so two jobs cannot collide here regardless
+          # of how the runners are registered. See CW-630.
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -83,6 +105,17 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          # Install into the job's own RUNNER_TEMP, never the action's default
+          # `~/setup-pnpm`. On the self-hosted shadow host, several runner
+          # registrations share one `$HOME`, so the default path is shared state:
+          # two of this workflow's four jobs landing on the same host raced to
+          # self-update pnpm into it and both died before running anything
+          # (`ENOTEMPTY: rmdir '/home/hdkiller/setup-pnpm'` and
+          # `self-installer exits with code 1`). RUNNER_TEMP is allocated per job
+          # and cleaned between jobs, so two jobs cannot collide here regardless
+          # of how the runners are registered. See CW-630.
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -109,6 +142,17 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          # Install into the job's own RUNNER_TEMP, never the action's default
+          # `~/setup-pnpm`. On the self-hosted shadow host, several runner
+          # registrations share one `$HOME`, so the default path is shared state:
+          # two of this workflow's four jobs landing on the same host raced to
+          # self-update pnpm into it and both died before running anything
+          # (`ENOTEMPTY: rmdir '/home/hdkiller/setup-pnpm'` and
+          # `self-installer exits with code 1`). RUNNER_TEMP is allocated per job
+          # and cleaned between jobs, so two jobs cannot collide here regardless
+          # of how the runners are registered. See CW-630.
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7


### PR DESCRIPTION
Fixes CW-630

## Why

`develop` CI is red on `acfc49d7` — `Unit tests` and `Lint` both failed, and `Build and Deploy` is `skipped` behind them. **The code is fine.** Both jobs died inside `Setup pnpm`, before any test or lint ran; their `Run unit tests` / `Run ESLint` steps show `skipped`.

Verified independently on a clean local checkout of the same commit:

```
pnpm test:unit  ->  Test Files 387 passed (387) | Tests 2651 passed (2651)
pnpm lint       ->  116 problems (0 errors, 116 warnings)
```

## Root cause

`pnpm/action-setup` defaults its install `dest` to `~/setup-pnpm`. On the self-hosted shadow host that is the runner user's home directory, **shared across every runner registration on the box**. `ci.yml` fans out four concurrent jobs, so two landed on the same host and both tried to install/self-update pnpm into that one directory:

```
actions-runner-org-1   [ERROR] Worker pnpm#1 exited with code 1
                       Something went wrong, self-installer exits with code 1
actions-runner-org-2   Error: ENOTEMPTY: directory not empty,
                       rmdir '/home/hdkiller/setup-pnpm'
```

`Typecheck` and `MCP tests` passed on the same commit — consistent with those two not being contended at that instant.

Introduced by the move to self-hosted runners (`14b386b6`, `357673d6`); this was the first `develop` CI run after that change.

## Fix

Point `dest` at `${{ runner.temp }}/setup-pnpm` in all four jobs. `RUNNER_TEMP` is allocated per job and cleaned between jobs, so two jobs **cannot** share it regardless of how the runner registrations are laid out.

`runner.tool_cache` would also have worked, but only because the registrations happen to have separate install trees — `runner.temp` holds structurally. That distinction matters here: this failure is probabilistic, so a green run alone is not evidence of a fix, and the guarantee needs to come from the path being per-job by construction.

## Verification

- `.github/workflows/ci.yml` parses; all four jobs (`typecheck`, `lint`, `unit-tests`, `mcp-tests`) carry the `dest`.
- The real gate is **this PR's own CI going green across all four jobs** — that exercises the changed workflow directly.

## Scope

Touched only `.github/workflows/ci.yml` (the ticket's `Owned Paths`).

`e2e.yml` and `reusable-trigger-deploy.yml` each run a single job, so they cannot race against themselves; `deploy.yml` is owned by CW-608. A follow-up covers hardening those against cross-workflow collision rather than widening a CI-critical diff.

UX critique: skipped — CI workflow configuration, no user-facing surface.