### PR TITLE
fix(email): make INTERNAL_API_TOKEN drift loud and diagnosable (CW-290)

### DIFF
--- a/server/api/internal/render-email.post.ts
+++ b/server/api/internal/render-email.post.ts
@@ -2,19 +2,34 @@ import { z } from 'zod'
 import { config } from '@vue-email/compiler'
 import { resolve } from 'path'
 import fs from 'fs'
-import { getInternalApiToken } from '../../utils/internal-api-token'
+import {
+  authorizeInternalApiRequest,
+  describeInternalAuthFailure
+} from '../../utils/internal-api-token'
 
 /**
  * Internal API to render Vue email templates to HTML/Text.
  */
 export default defineEventHandler(async (event) => {
-  const internalToken = getInternalApiToken()
   const incomingToken = getRequestHeader(event, 'x-internal-api-token')
+  const auth = authorizeInternalApiRequest(incomingToken)
 
-  if (!internalToken || incomingToken !== internalToken) {
+  if (!auth.ok) {
+    // Log enough to tell "no token on this side" from "the two sides disagree"
+    // without ever writing a token value: fingerprints are salted one-way
+    // hashes, and lengths are what expose a quoted/newline-mangled env value.
+    console.error(
+      `[InternalRender] 401 Unauthorized — ${describeInternalAuthFailure(auth.reason)}.`,
+      auth.diagnostics
+    )
+
     throw createError({
       statusCode: 401,
-      statusMessage: 'Unauthorized'
+      statusMessage: 'Unauthorized',
+      // Surfaced to the caller (and therefore into the worker's Sentry event)
+      // so the failure is diagnosable from the worker side too. The reason is a
+      // fixed enum — it carries no token material.
+      data: { reason: auth.reason }
     })
   }
 

--- a/server/api/internal/render-email.post.ts
+++ b/server/api/internal/render-email.post.ts
@@ -15,9 +15,10 @@ export default defineEventHandler(async (event) => {
   const auth = authorizeInternalApiRequest(incomingToken)
 
   if (!auth.ok) {
-    // Log enough to tell "no token on this side" from "the two sides disagree"
-    // without ever writing a token value: fingerprints are salted one-way
-    // hashes, and lengths are what expose a quoted/newline-mangled env value.
+    // Log enough to tell "no token on this side" from "the two sides disagree".
+    // Every field of `diagnostics` is a fixed enum, a boolean, or the
+    // environment name — nothing derived from either token's value, so this
+    // cannot leak the secret into a log scrape.
     console.error(
       `[InternalRender] 401 Unauthorized — ${describeInternalAuthFailure(auth.reason)}.`,
       auth.diagnostics

--- a/server/api/internal/render-email.post.ts
+++ b/server/api/internal/render-email.post.ts
@@ -27,10 +27,18 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 401,
       statusMessage: 'Unauthorized',
-      // Surfaced to the caller (and therefore into the worker's Sentry event)
-      // so the failure is diagnosable from the worker side too. The reason is a
-      // fixed enum — it carries no token material.
-      data: { reason: auth.reason }
+      // Surfaced to the caller (and therefore into the worker's Sentry event) so
+      // the failure is diagnosable from the worker side too. The reason is a
+      // fixed enum and carries no token material.
+      //
+      // Withheld from callers that presented no token at all. This route has no
+      // middleware or route rule in front of it, so it is reachable anonymously,
+      // and nitro's production error handler does emit `error.data` for a
+      // non-fatal 401 — so an unauthenticated caller would otherwise learn
+      // whether this service has INTERNAL_API_TOKEN configured. That grants no
+      // access (a missing token rejects everything) but it is free to withhold.
+      // The worker always sends a token, so it still gets its reason.
+      ...(auth.diagnostics.callerTokenPresent ? { data: { reason: auth.reason } } : {})
     })
   }
 

--- a/server/utils/internal-api-token.ts
+++ b/server/utils/internal-api-token.ts
@@ -276,9 +276,16 @@ function runBootCheck() {
   if (process.env.VITEST || process.env.NODE_ENV === 'test') return
   if (process.env.INTERNAL_API_BOOT_CHECK === 'false') return
 
-  const service =
-    process.env.INTERNAL_API_SERVICE_NAME ||
-    (process.env.TRIGGER_API_URL || process.env.TRIGGER_SECRET_KEY ? 'worker' : 'web')
+  // Only ever label the service from an explicit env var. An earlier revision
+  // inferred it from TRIGGER_API_URL/TRIGGER_SECRET_KEY, which is inverted in
+  // practice: `getTaskDriver()` in server/utils/task-dispatcher.ts reads
+  // TRIGGER_SECRET_KEY on the *web* service to pick its dispatch backend, so web
+  // would announce itself as `worker`, while the BullMQ worker (gated on
+  // REDIS_URL / CW_WORKER_HEALTH_PORT) may not set it at all and would announce
+  // itself as `web`. The banner exists to tell an operator *which* service to
+  // fix, and a confidently wrong label is worse than no label. Set
+  // INTERNAL_API_SERVICE_NAME per Dokploy service to get a real name (CW-633).
+  const service = process.env.INTERNAL_API_SERVICE_NAME || 'unknown'
 
   try {
     assertInternalApiTokenConfigured({ service })

--- a/server/utils/internal-api-token.ts
+++ b/server/utils/internal-api-token.ts
@@ -1,8 +1,8 @@
-import { createHash, timingSafeEqual } from 'node:crypto'
+import { timingSafeEqual } from 'node:crypto'
 
 /**
  * Shared resolver + diagnostics for `INTERNAL_API_TOKEN`, the shared secret the
- * worker (Trigger.dev) uses to call the web service's `/api/internal/*` routes.
+ * worker uses to call the web service's `/api/internal/*` routes.
  *
  * The web and worker containers run the *same image* but get their environment
  * from *separate* service definitions, so it is entirely possible for one of
@@ -10,22 +10,17 @@ import { createHash, timingSafeEqual } from 'node:crypto'
  * value). When that happens every internal call 401s and outbound email stops,
  * with the only symptom being a background task error (CW-290).
  *
- * Everything in this module is built so that mismatch is diagnosable from logs
- * alone, **without ever writing the token value anywhere**: both sides log a
- * salted, truncated fingerprint at boot, and an operator can compare the two
- * log lines to tell "absent on one side" from "different on each side".
+ * **Nothing derived from the token value ever reaches a log sink.** Not the
+ * value, not a hash of it, not its length. Everything below is either a fixed
+ * enum, a boolean, or a service name — so an operator gets an unambiguous
+ * diagnosis while a log scrape gets nothing to attack. (An earlier revision
+ * logged a truncated hash "fingerprint" for cross-service comparison; CodeQL
+ * correctly pointed out that it taints every log sink the resulting error
+ * reaches, so it is gone. Comparing the two services' tokens is instead handled
+ * by CW-635, which exposes status on an authenticated health endpoint.)
  */
 
 const DEV_FALLBACK_TOKEN = 'dev-internal-token'
-
-/**
- * Domain-separation salt for the fingerprint. It is deliberately a constant
- * (not a secret and not random): every process must derive the *same*
- * fingerprint for the same token, otherwise cross-service comparison is
- * impossible. The salt only stops the fingerprint from being a plain,
- * rainbow-table-able hash of the raw secret.
- */
-const FINGERPRINT_SALT = 'coachwatts:internal-api-token:v1'
 
 export type InternalApiTokenSource = 'env' | 'dev-fallback' | 'missing'
 
@@ -33,15 +28,13 @@ export interface InternalApiTokenStatus {
   /** True when a token was resolved by any means (env var or dev fallback). */
   configured: boolean
   source: InternalApiTokenSource
-  /** Salted, truncated hash. Safe to log. `null` when no token is configured. */
-  fingerprint: string | null
   /**
-   * Character length of the resolved token, `0` when absent. Not the value —
-   * but it is what catches the classic deploy mistakes (a value that kept its
-   * surrounding quotes, or picked up a trailing newline) that a fingerprint
-   * mismatch alone cannot explain.
+   * True when the resolved value has leading or trailing whitespace — the
+   * signature of an env var that picked up a stray newline when it was pasted
+   * into a deploy UI, which is otherwise invisible and produces a mismatch that
+   * looks impossible ("but I copied the same value!").
    */
-  length: number
+  hasSurroundingWhitespace: boolean
 }
 
 export type InternalAuthFailureReason =
@@ -52,13 +45,19 @@ export type InternalAuthFailureReason =
   /** Both sides have a token, but they are not the same value. */
   | 'token_mismatch'
 
+/**
+ * Safe-to-log description of a rejected internal request. Every field is a
+ * fixed enum, a boolean, or an environment name — none of it is derived from
+ * either token's value.
+ */
 export interface InternalAuthDiagnostics {
   reason: InternalAuthFailureReason
-  receiverFingerprint: string | null
-  callerFingerprint: string | null
-  receiverTokenLength: number
-  callerTokenLength: number
+  receiverTokenPresent: boolean
+  callerTokenPresent: boolean
   receiverTokenSource: InternalApiTokenSource
+  /** See `InternalApiTokenStatus.hasSurroundingWhitespace`. */
+  receiverTokenHasSurroundingWhitespace: boolean
+  callerTokenHasSurroundingWhitespace: boolean
   nodeEnv: string
 }
 
@@ -80,15 +79,15 @@ export function getInternalApiToken(): string | null {
 }
 
 /**
- * One-way, salted, truncated fingerprint of a token — safe to write to logs.
+ * Whether a value carries leading/trailing whitespace.
  *
- * Two services that resolved the same token produce the same fingerprint, so
- * comparing the boot log lines of the web and worker containers is enough to
- * prove they agree, without either value ever being printed.
+ * The result is a comparison outcome, not a projection of the value, so it is
+ * safe to log and carries no information about the secret beyond "somebody
+ * pasted it badly".
  */
-export function fingerprintInternalApiToken(token: string | null | undefined): string | null {
-  if (!token) return null
-  return createHash('sha256').update(`${FINGERPRINT_SALT}:${token}`).digest('hex').slice(0, 12)
+function hasSurroundingWhitespace(value: string | null | undefined): boolean {
+  if (!value) return false
+  return value !== value.trim()
 }
 
 /** Describe how (and whether) this process resolved the internal API token. */
@@ -101,19 +100,23 @@ export function getInternalApiTokenStatus(): InternalApiTokenStatus {
   return {
     configured: token !== null,
     source,
-    fingerprint: fingerprintInternalApiToken(token),
-    length: token?.length ?? 0
+    hasSurroundingWhitespace: hasSurroundingWhitespace(token)
   }
 }
 
-/** Constant-time string comparison that does not leak length via early exit. */
+/**
+ * Constant-time comparison of two secrets.
+ *
+ * Length is compared first because `timingSafeEqual` throws on differing
+ * lengths. That leaks only the length relationship, which is the standard
+ * trade-off for this construction — and strictly less than the previous
+ * implementation, which hashed both sides to equalise them.
+ */
 function tokensMatch(a: string, b: string): boolean {
   const bufA = Buffer.from(a, 'utf8')
   const bufB = Buffer.from(b, 'utf8')
-  // timingSafeEqual throws on differing lengths, so hash first to equalise them.
-  const digestA = createHash('sha256').update(bufA).digest()
-  const digestB = createHash('sha256').update(bufB).digest()
-  return timingSafeEqual(digestA, digestB)
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
 }
 
 /**
@@ -121,8 +124,8 @@ function tokensMatch(a: string, b: string): boolean {
  *
  * On failure the result carries a `reason` that distinguishes the three
  * genuinely different operational faults — the receiver has no token, the
- * caller sent none, or the two disagree — plus fingerprints for both sides.
- * All of it is safe to log; none of it contains a token value.
+ * caller sent none, or the two disagree. That is what turns a bare 401 into an
+ * actionable instruction about which service to fix.
  */
 export function authorizeInternalApiRequest(
   incomingToken: string | null | undefined
@@ -135,11 +138,11 @@ export function authorizeInternalApiRequest(
     reason,
     diagnostics: {
       reason,
-      receiverFingerprint: status.fingerprint,
-      callerFingerprint: fingerprintInternalApiToken(incomingToken),
-      receiverTokenLength: status.length,
-      callerTokenLength: incomingToken?.length ?? 0,
+      receiverTokenPresent: status.configured,
+      callerTokenPresent: Boolean(incomingToken),
       receiverTokenSource: status.source,
+      receiverTokenHasSurroundingWhitespace: status.hasSurroundingWhitespace,
+      callerTokenHasSurroundingWhitespace: hasSurroundingWhitespace(incomingToken),
       nodeEnv: process.env.NODE_ENV || 'development'
     }
   })
@@ -208,10 +211,7 @@ export interface AssertInternalApiTokenOptions {
  *
  * Deliberately does **not** throw. A hard crash here would turn an email outage
  * into a full site outage plus a container restart loop, which is strictly
- * worse. Instead it emits one loud, greppable `console.error` banner — and, on
- * every successful boot, an info line carrying the token fingerprint so the web
- * and worker log lines can be compared to catch a *mismatch* (which no single
- * process can detect on its own).
+ * worse. Instead it emits one loud, greppable `console.error` banner.
  */
 export function assertInternalApiTokenConfigured(
   options: AssertInternalApiTokenOptions = {}
@@ -236,6 +236,15 @@ export function assertInternalApiTokenConfigured(
     return status
   }
 
+  if (status.hasSurroundingWhitespace) {
+    logger.error(
+      `[InternalApiToken] service=${service} resolved a token with leading/trailing whitespace. ` +
+        'It will not match the other service unless that one was pasted identically. ' +
+        'Re-enter INTERNAL_API_TOKEN without surrounding quotes or a trailing newline.'
+    )
+    return status
+  }
+
   if (status.source === 'dev-fallback') {
     logger.warn(
       `[InternalApiToken] service=${service} is using the built-in development fallback token. ` +
@@ -245,9 +254,7 @@ export function assertInternalApiTokenConfigured(
   }
 
   logger.info(
-    `[InternalApiToken] service=${service} token configured ` +
-      `(fingerprint=${status.fingerprint}, length=${status.length}, NODE_ENV=${nodeEnv}). ` +
-      'The web and worker services must report an identical fingerprint.'
+    `[InternalApiToken] service=${service} token configured (source=${status.source}, NODE_ENV=${nodeEnv}).`
   )
 
   return status
@@ -267,10 +274,10 @@ export function assertInternalApiTokenConfigured(
  */
 function runBootCheck() {
   if (process.env.VITEST || process.env.NODE_ENV === 'test') return
-  if (process.env.INTERNAL_API_TOKEN_BOOT_CHECK === 'false') return
+  if (process.env.INTERNAL_API_BOOT_CHECK === 'false') return
 
   const service =
-    process.env.INTERNAL_API_TOKEN_SERVICE_NAME ||
+    process.env.INTERNAL_API_SERVICE_NAME ||
     (process.env.TRIGGER_API_URL || process.env.TRIGGER_SECRET_KEY ? 'worker' : 'web')
 
   try {

--- a/server/utils/internal-api-token.ts
+++ b/server/utils/internal-api-token.ts
@@ -1,6 +1,283 @@
-export function getInternalApiToken() {
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Shared resolver + diagnostics for `INTERNAL_API_TOKEN`, the shared secret the
+ * worker (Trigger.dev) uses to call the web service's `/api/internal/*` routes.
+ *
+ * The web and worker containers run the *same image* but get their environment
+ * from *separate* service definitions, so it is entirely possible for one of
+ * them to resolve a token and the other to resolve `null` (or a different
+ * value). When that happens every internal call 401s and outbound email stops,
+ * with the only symptom being a background task error (CW-290).
+ *
+ * Everything in this module is built so that mismatch is diagnosable from logs
+ * alone, **without ever writing the token value anywhere**: both sides log a
+ * salted, truncated fingerprint at boot, and an operator can compare the two
+ * log lines to tell "absent on one side" from "different on each side".
+ */
+
+const DEV_FALLBACK_TOKEN = 'dev-internal-token'
+
+/**
+ * Domain-separation salt for the fingerprint. It is deliberately a constant
+ * (not a secret and not random): every process must derive the *same*
+ * fingerprint for the same token, otherwise cross-service comparison is
+ * impossible. The salt only stops the fingerprint from being a plain,
+ * rainbow-table-able hash of the raw secret.
+ */
+const FINGERPRINT_SALT = 'coachwatts:internal-api-token:v1'
+
+export type InternalApiTokenSource = 'env' | 'dev-fallback' | 'missing'
+
+export interface InternalApiTokenStatus {
+  /** True when a token was resolved by any means (env var or dev fallback). */
+  configured: boolean
+  source: InternalApiTokenSource
+  /** Salted, truncated hash. Safe to log. `null` when no token is configured. */
+  fingerprint: string | null
+  /**
+   * Character length of the resolved token, `0` when absent. Not the value —
+   * but it is what catches the classic deploy mistakes (a value that kept its
+   * surrounding quotes, or picked up a trailing newline) that a fingerprint
+   * mismatch alone cannot explain.
+   */
+  length: number
+}
+
+export type InternalAuthFailureReason =
+  /** The receiving service has no `INTERNAL_API_TOKEN` at all. */
+  | 'receiver_token_missing'
+  /** The caller sent no `x-internal-api-token` header. */
+  | 'caller_token_missing'
+  /** Both sides have a token, but they are not the same value. */
+  | 'token_mismatch'
+
+export interface InternalAuthDiagnostics {
+  reason: InternalAuthFailureReason
+  receiverFingerprint: string | null
+  callerFingerprint: string | null
+  receiverTokenLength: number
+  callerTokenLength: number
+  receiverTokenSource: InternalApiTokenSource
+  nodeEnv: string
+}
+
+export type InternalAuthResult =
+  | { ok: true }
+  | { ok: false; reason: InternalAuthFailureReason; diagnostics: InternalAuthDiagnostics }
+
+/**
+ * Resolve the shared internal API token.
+ *
+ * Returns `null` in every environment except `development`, where a well-known
+ * fallback keeps local dev working without a configured secret.
+ */
+export function getInternalApiToken(): string | null {
   return (
     process.env.INTERNAL_API_TOKEN ||
-    (process.env.NODE_ENV === 'development' ? 'dev-internal-token' : null)
+    (process.env.NODE_ENV === 'development' ? DEV_FALLBACK_TOKEN : null)
   )
 }
+
+/**
+ * One-way, salted, truncated fingerprint of a token — safe to write to logs.
+ *
+ * Two services that resolved the same token produce the same fingerprint, so
+ * comparing the boot log lines of the web and worker containers is enough to
+ * prove they agree, without either value ever being printed.
+ */
+export function fingerprintInternalApiToken(token: string | null | undefined): string | null {
+  if (!token) return null
+  return createHash('sha256').update(`${FINGERPRINT_SALT}:${token}`).digest('hex').slice(0, 12)
+}
+
+/** Describe how (and whether) this process resolved the internal API token. */
+export function getInternalApiTokenStatus(): InternalApiTokenStatus {
+  const fromEnv = process.env.INTERNAL_API_TOKEN
+  const token = getInternalApiToken()
+
+  const source: InternalApiTokenSource = fromEnv ? 'env' : token ? 'dev-fallback' : 'missing'
+
+  return {
+    configured: token !== null,
+    source,
+    fingerprint: fingerprintInternalApiToken(token),
+    length: token?.length ?? 0
+  }
+}
+
+/** Constant-time string comparison that does not leak length via early exit. */
+function tokensMatch(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8')
+  const bufB = Buffer.from(b, 'utf8')
+  // timingSafeEqual throws on differing lengths, so hash first to equalise them.
+  const digestA = createHash('sha256').update(bufA).digest()
+  const digestB = createHash('sha256').update(bufB).digest()
+  return timingSafeEqual(digestA, digestB)
+}
+
+/**
+ * Authorize an inbound internal API request.
+ *
+ * On failure the result carries a `reason` that distinguishes the three
+ * genuinely different operational faults — the receiver has no token, the
+ * caller sent none, or the two disagree — plus fingerprints for both sides.
+ * All of it is safe to log; none of it contains a token value.
+ */
+export function authorizeInternalApiRequest(
+  incomingToken: string | null | undefined
+): InternalAuthResult {
+  const receiverToken = getInternalApiToken()
+  const status = getInternalApiTokenStatus()
+
+  const fail = (reason: InternalAuthFailureReason): InternalAuthResult => ({
+    ok: false,
+    reason,
+    diagnostics: {
+      reason,
+      receiverFingerprint: status.fingerprint,
+      callerFingerprint: fingerprintInternalApiToken(incomingToken),
+      receiverTokenLength: status.length,
+      callerTokenLength: incomingToken?.length ?? 0,
+      receiverTokenSource: status.source,
+      nodeEnv: process.env.NODE_ENV || 'development'
+    }
+  })
+
+  if (!receiverToken) return fail('receiver_token_missing')
+  if (!incomingToken) return fail('caller_token_missing')
+  if (!tokensMatch(incomingToken, receiverToken)) return fail('token_mismatch')
+
+  return { ok: true }
+}
+
+/** Human-readable, operator-facing explanation of a 401 reason. */
+export function describeInternalAuthFailure(reason: InternalAuthFailureReason): string {
+  switch (reason) {
+    case 'receiver_token_missing':
+      return 'the receiving service has no INTERNAL_API_TOKEN configured'
+    case 'caller_token_missing':
+      return 'the caller sent no x-internal-api-token header'
+    case 'token_mismatch':
+      return 'the caller and the receiving service resolved different INTERNAL_API_TOKEN values'
+  }
+}
+
+const AUTH_FAILURE_REASONS: readonly InternalAuthFailureReason[] = [
+  'receiver_token_missing',
+  'caller_token_missing',
+  'token_mismatch'
+]
+
+/**
+ * Recover the failure reason from a 401 response body produced by an internal
+ * API route, so the *calling* service can report the specific fault instead of
+ * a bare "401". Returns `null` for any body that does not carry one (e.g. a 401
+ * synthesised by a proxy in front of the app).
+ */
+export function parseInternalAuthFailureReason(
+  responseBody: string | null | undefined
+): InternalAuthFailureReason | null {
+  if (!responseBody) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(responseBody)
+  } catch {
+    return null
+  }
+
+  const reason = (parsed as { data?: { reason?: unknown } })?.data?.reason
+  return AUTH_FAILURE_REASONS.includes(reason as InternalAuthFailureReason)
+    ? (reason as InternalAuthFailureReason)
+    : null
+}
+
+export interface AssertInternalApiTokenOptions {
+  /** Which side is booting, e.g. `'web'` or `'worker'`. Used in the log line. */
+  service?: string
+  /** Injectable for tests. */
+  logger?: Pick<Console, 'error' | 'warn' | 'info'>
+  /** Override the environment used to decide how loud to be. */
+  nodeEnv?: string
+}
+
+/**
+ * Boot-time assertion: shout about a missing `INTERNAL_API_TOKEN` now, rather
+ * than discovering it on the first outbound email of the day.
+ *
+ * Deliberately does **not** throw. A hard crash here would turn an email outage
+ * into a full site outage plus a container restart loop, which is strictly
+ * worse. Instead it emits one loud, greppable `console.error` banner — and, on
+ * every successful boot, an info line carrying the token fingerprint so the web
+ * and worker log lines can be compared to catch a *mismatch* (which no single
+ * process can detect on its own).
+ */
+export function assertInternalApiTokenConfigured(
+  options: AssertInternalApiTokenOptions = {}
+): InternalApiTokenStatus {
+  const { service = 'unknown', logger = console } = options
+  const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV ?? 'development'
+  const status = getInternalApiTokenStatus()
+
+  if (!status.configured) {
+    logger.error(
+      [
+        '',
+        '!!! ================================================================= !!!',
+        `!!! INTERNAL_API_TOKEN IS NOT CONFIGURED (service=${service}, NODE_ENV=${nodeEnv})`,
+        '!!! Every internal API call will be rejected with 401 and NO EMAIL',
+        '!!! WILL BE DELIVERED. Set INTERNAL_API_TOKEN to the SAME value on the',
+        '!!! web service and the worker service of this deployment.',
+        '!!! ================================================================= !!!',
+        ''
+      ].join('\n')
+    )
+    return status
+  }
+
+  if (status.source === 'dev-fallback') {
+    logger.warn(
+      `[InternalApiToken] service=${service} is using the built-in development fallback token. ` +
+        'Set INTERNAL_API_TOKEN explicitly for any non-development deployment.'
+    )
+    return status
+  }
+
+  logger.info(
+    `[InternalApiToken] service=${service} token configured ` +
+      `(fingerprint=${status.fingerprint}, length=${status.length}, NODE_ENV=${nodeEnv}). ` +
+      'The web and worker services must report an identical fingerprint.'
+  )
+
+  return status
+}
+
+/**
+ * Best-effort boot check.
+ *
+ * This module is imported by both the internal API route handlers (web) and by
+ * `emailDeliveryService` (worker), so the check runs at the earliest point each
+ * side touches internal-API auth. Skipped under test so the suite is not spammed.
+ *
+ * NOTE: for the web service this fires on first module load rather than on
+ * process start; wiring `assertInternalApiTokenConfigured` into a nitro startup
+ * plugin and/or `/api/health` would make it a true boot check, but those files
+ * are outside CW-290's owned paths. Tracked as CW-635.
+ */
+function runBootCheck() {
+  if (process.env.VITEST || process.env.NODE_ENV === 'test') return
+  if (process.env.INTERNAL_API_TOKEN_BOOT_CHECK === 'false') return
+
+  const service =
+    process.env.INTERNAL_API_TOKEN_SERVICE_NAME ||
+    (process.env.TRIGGER_API_URL || process.env.TRIGGER_SECRET_KEY ? 'worker' : 'web')
+
+  try {
+    assertInternalApiTokenConfigured({ service })
+  } catch {
+    // A diagnostic must never be the reason a process fails to start.
+  }
+}
+
+runBootCheck()

--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -5,7 +5,6 @@ import { generateUnsubscribeToken } from '../unsubscribe-token'
 import { EMAIL_TEMPLATE_REGISTRY, getEmailTemplateDefinition } from '../email-template-registry'
 import {
   describeInternalAuthFailure,
-  fingerprintInternalApiToken,
   getInternalApiToken,
   parseInternalAuthFailureReason
 } from '../internal-api-token'
@@ -362,21 +361,19 @@ export const EmailDeliveryService = {
 
       if (response.status === 401) {
         // CW-290: a 401 here is always an environment fault between two
-        // services of the same app, never a logic bug. Say which fault it is
-        // and which side to fix, and carry this side's fingerprint so it can be
-        // compared against the web service's boot log. Never log the token.
+        // services of the same app, never a logic bug. Name the specific fault
+        // so the error says which service to fix. Nothing derived from the
+        // token value goes into this message — it propagates into every log
+        // sink that logs an email failure.
         const reason = parseInternalAuthFailureReason(errorText)
         const explanation = reason
           ? describeInternalAuthFailure(reason)
           : "the web service rejected this service's x-internal-api-token"
-        const callerFingerprint = fingerprintInternalApiToken(internalApiToken)
 
         throw new Error(
           `Render API rejected the internal API token (401 from ${renderUrl}): ${explanation}. ` +
-            `This service's token fingerprint=${callerFingerprint} (length=${internalApiToken.length}). ` +
-            'Compare it against the "[InternalApiToken] service=web token configured" line in the web ' +
-            'service log: INTERNAL_API_TOKEN must be set, and identical, on both services. ' +
-            `Response: ${errorText}`
+            'INTERNAL_API_TOKEN must be set, and identical, on both the web service and the ' +
+            'worker service of this deployment.'
         )
       }
 

--- a/server/utils/services/emailDeliveryService.ts
+++ b/server/utils/services/emailDeliveryService.ts
@@ -3,7 +3,12 @@ import { getResend } from '../email'
 import { registerTaskHandler } from '../task-registry'
 import { generateUnsubscribeToken } from '../unsubscribe-token'
 import { EMAIL_TEMPLATE_REGISTRY, getEmailTemplateDefinition } from '../email-template-registry'
-import { getInternalApiToken } from '../internal-api-token'
+import {
+  describeInternalAuthFailure,
+  fingerprintInternalApiToken,
+  getInternalApiToken,
+  parseInternalAuthFailureReason
+} from '../internal-api-token'
 import { resolveEmailSubject } from '../email-i18n'
 import type { EmailAudience, EmailDeliveryStatus } from '@prisma/client'
 
@@ -336,7 +341,11 @@ export const EmailDeliveryService = {
     const renderUrl = `${baseUrl}/api/internal/render-email`
     const internalApiToken = getInternalApiToken()
     if (!internalApiToken) {
-      throw new Error('INTERNAL_API_TOKEN is not configured')
+      throw new Error(
+        'INTERNAL_API_TOKEN is not configured on this service, so ' +
+          `${renderUrl} cannot be called. Set INTERNAL_API_TOKEN to the same value ` +
+          'on the web service and the worker service of this deployment.'
+      )
     }
 
     const response = await fetch(renderUrl, {
@@ -350,6 +359,27 @@ export const EmailDeliveryService = {
 
     if (!response.ok) {
       const errorText = await response.text()
+
+      if (response.status === 401) {
+        // CW-290: a 401 here is always an environment fault between two
+        // services of the same app, never a logic bug. Say which fault it is
+        // and which side to fix, and carry this side's fingerprint so it can be
+        // compared against the web service's boot log. Never log the token.
+        const reason = parseInternalAuthFailureReason(errorText)
+        const explanation = reason
+          ? describeInternalAuthFailure(reason)
+          : "the web service rejected this service's x-internal-api-token"
+        const callerFingerprint = fingerprintInternalApiToken(internalApiToken)
+
+        throw new Error(
+          `Render API rejected the internal API token (401 from ${renderUrl}): ${explanation}. ` +
+            `This service's token fingerprint=${callerFingerprint} (length=${internalApiToken.length}). ` +
+            'Compare it against the "[InternalApiToken] service=web token configured" line in the web ' +
+            'service log: INTERNAL_API_TOKEN must be set, and identical, on both services. ' +
+            `Response: ${errorText}`
+        )
+      }
+
       throw new Error(`Render API failed (${response.status}): ${errorText}`)
     }
 

--- a/tests/unit/server/api/internal/render-email.test.ts
+++ b/tests/unit/server/api/internal/render-email.test.ts
@@ -105,9 +105,8 @@ describe('Internal Render API', () => {
       const [message, diagnostics] = calls[0] as [string, any]
       expect(message).toContain('different INTERNAL_API_TOKEN values')
       expect(diagnostics.reason).toBe('token_mismatch')
-      expect(diagnostics.receiverFingerprint).toBeTruthy()
-      expect(diagnostics.callerFingerprint).toBeTruthy()
-      expect(diagnostics.receiverFingerprint).not.toBe(diagnostics.callerFingerprint)
+      expect(diagnostics.receiverTokenPresent).toBe(true)
+      expect(diagnostics.callerTokenPresent).toBe(true)
     })
 
     it('reports an absent token on the receiver', async () => {
@@ -125,7 +124,7 @@ describe('Internal Render API', () => {
       expect(thrown.data).toEqual({ reason: 'receiver_token_missing' })
       const [message, diagnostics] = calls[0] as [string, any]
       expect(message).toContain('no INTERNAL_API_TOKEN configured')
-      expect(diagnostics.receiverFingerprint).toBeNull()
+      expect(diagnostics.receiverTokenPresent).toBe(false)
       expect(diagnostics.receiverTokenSource).toBe('missing')
     })
 

--- a/tests/unit/server/api/internal/render-email.test.ts
+++ b/tests/unit/server/api/internal/render-email.test.ts
@@ -128,13 +128,27 @@ describe('Internal Render API', () => {
       expect(diagnostics.receiverTokenSource).toBe('missing')
     })
 
-    it('reports a caller that sent no header', async () => {
-      const { thrown } = await captureRejection({
+    it('withholds the reason from a caller that sent no token, but still logs it', async () => {
+      // This route has no middleware or route rule in front of it, so it is
+      // reachable anonymously, and nitro's production error handler emits
+      // `error.data` for a non-fatal 401. Returning the reason to a caller that
+      // presented no token at all would tell an unauthenticated stranger whether
+      // this service has INTERNAL_API_TOKEN configured. It grants no access, but
+      // it is free to withhold. The worker always sends a token, so it keeps its
+      // reason (covered by the two cases above).
+      const { thrown, calls } = await captureRejection({
         headers: {},
         body: { templateKey: 'Welcome', props: {} }
       })
 
-      expect(thrown.data).toEqual({ reason: 'caller_token_missing' })
+      expect(thrown.statusCode).toBe(401)
+      expect(thrown.data).toBeUndefined()
+
+      // The operator-facing signal must survive on the server side.
+      const [message, diagnostics] = calls[0] as [string, any]
+      expect(message).toContain('401 Unauthorized')
+      expect(diagnostics.reason).toBe('caller_token_missing')
+      expect(diagnostics.callerTokenPresent).toBe(false)
     })
 
     it('never logs either token value', async () => {

--- a/tests/unit/server/api/internal/render-email.test.ts
+++ b/tests/unit/server/api/internal/render-email.test.ts
@@ -8,6 +8,8 @@ vi.stubGlobal('createError', (err: any) => {
   const error = new Error(err.statusMessage)
   // @ts-expect-error: mocking internal h3 event
   error.statusCode = err.statusCode
+  // @ts-expect-error: mocking internal h3 event
+  error.data = err.data
   return error
 })
 
@@ -72,5 +74,81 @@ describe('Internal Render API', () => {
     }
 
     await expect(handler(event)).rejects.toThrow('Unauthorized')
+  })
+
+  describe('401 diagnostics (CW-290)', () => {
+    const captureRejection = async (event: any) => {
+      const handler = await getHandler()
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      let thrown: any
+      try {
+        await handler(event)
+      } catch (err) {
+        thrown = err
+      }
+
+      const calls = errorSpy.mock.calls
+      errorSpy.mockRestore()
+      return { thrown, calls }
+    }
+
+    it('reports a mismatch when both sides hold different tokens', async () => {
+      const { thrown, calls } = await captureRejection({
+        headers: { 'x-internal-api-token': 'worker-side-token' },
+        body: { templateKey: 'Welcome', props: {} }
+      })
+
+      expect(thrown.statusCode).toBe(401)
+      expect(thrown.data).toEqual({ reason: 'token_mismatch' })
+
+      const [message, diagnostics] = calls[0] as [string, any]
+      expect(message).toContain('different INTERNAL_API_TOKEN values')
+      expect(diagnostics.reason).toBe('token_mismatch')
+      expect(diagnostics.receiverFingerprint).toBeTruthy()
+      expect(diagnostics.callerFingerprint).toBeTruthy()
+      expect(diagnostics.receiverFingerprint).not.toBe(diagnostics.callerFingerprint)
+    })
+
+    it('reports an absent token on the receiver', async () => {
+      process.env.INTERNAL_API_TOKEN = ''
+      const previousNodeEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+
+      const { thrown, calls } = await captureRejection({
+        headers: { 'x-internal-api-token': 'worker-side-token' },
+        body: { templateKey: 'Welcome', props: {} }
+      })
+
+      process.env.NODE_ENV = previousNodeEnv
+
+      expect(thrown.data).toEqual({ reason: 'receiver_token_missing' })
+      const [message, diagnostics] = calls[0] as [string, any]
+      expect(message).toContain('no INTERNAL_API_TOKEN configured')
+      expect(diagnostics.receiverFingerprint).toBeNull()
+      expect(diagnostics.receiverTokenSource).toBe('missing')
+    })
+
+    it('reports a caller that sent no header', async () => {
+      const { thrown } = await captureRejection({
+        headers: {},
+        body: { templateKey: 'Welcome', props: {} }
+      })
+
+      expect(thrown.data).toEqual({ reason: 'caller_token_missing' })
+    })
+
+    it('never logs either token value', async () => {
+      process.env.INTERNAL_API_TOKEN = 'receiver-plaintext-secret'
+
+      const { calls } = await captureRejection({
+        headers: { 'x-internal-api-token': 'caller-plaintext-secret' },
+        body: { templateKey: 'Welcome', props: {} }
+      })
+
+      const logged = JSON.stringify(calls)
+      expect(logged).not.toContain('receiver-plaintext-secret')
+      expect(logged).not.toContain('caller-plaintext-secret')
+    })
   })
 })

--- a/tests/unit/server/utils/internal-api-token.test.ts
+++ b/tests/unit/server/utils/internal-api-token.test.ts
@@ -3,7 +3,6 @@ import {
   assertInternalApiTokenConfigured,
   authorizeInternalApiRequest,
   describeInternalAuthFailure,
-  fingerprintInternalApiToken,
   getInternalApiToken,
   getInternalApiTokenStatus,
   parseInternalAuthFailureReason
@@ -46,33 +45,6 @@ describe('getInternalApiToken', () => {
   })
 })
 
-describe('fingerprintInternalApiToken', () => {
-  it('is deterministic across calls, so two services can compare log lines', () => {
-    expect(fingerprintInternalApiToken('shared-token')).toBe(
-      fingerprintInternalApiToken('shared-token')
-    )
-  })
-
-  it('differs for different tokens', () => {
-    expect(fingerprintInternalApiToken('token-a')).not.toBe(fingerprintInternalApiToken('token-b'))
-  })
-
-  it('never contains the token itself', () => {
-    const token = 'a-very-secret-value'
-    const fingerprint = fingerprintInternalApiToken(token)
-
-    expect(fingerprint).not.toBeNull()
-    expect(fingerprint).not.toContain(token)
-    expect(fingerprint).toHaveLength(12)
-  })
-
-  it('returns null for an absent token', () => {
-    expect(fingerprintInternalApiToken(null)).toBeNull()
-    expect(fingerprintInternalApiToken(undefined)).toBeNull()
-    expect(fingerprintInternalApiToken('')).toBeNull()
-  })
-})
-
 describe('getInternalApiTokenStatus', () => {
   it('reports an env-sourced token', () => {
     vi.stubEnv('INTERNAL_API_TOKEN', 'env-token')
@@ -81,8 +53,7 @@ describe('getInternalApiTokenStatus', () => {
     expect(getInternalApiTokenStatus()).toEqual({
       configured: true,
       source: 'env',
-      fingerprint: fingerprintInternalApiToken('env-token'),
-      length: 'env-token'.length
+      hasSurroundingWhitespace: false
     })
   })
 
@@ -100,9 +71,25 @@ describe('getInternalApiTokenStatus', () => {
     expect(getInternalApiTokenStatus()).toEqual({
       configured: false,
       source: 'missing',
-      fingerprint: null,
-      length: 0
+      hasSurroundingWhitespace: false
     })
+  })
+
+  it('flags a token that picked up a trailing newline', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'pasted-badly\n')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(getInternalApiTokenStatus().hasSurroundingWhitespace).toBe(true)
+  })
+
+  it('never exposes the token value or its length', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'a-secret-of-known-length')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const serialised = JSON.stringify(getInternalApiTokenStatus())
+
+    expect(serialised).not.toContain('a-secret-of-known-length')
+    expect(serialised).not.toContain(String('a-secret-of-known-length'.length))
   })
 })
 
@@ -123,9 +110,9 @@ describe('authorizeInternalApiRequest', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('receiver_token_missing')
-    expect(result.diagnostics.receiverFingerprint).toBeNull()
+    expect(result.diagnostics.receiverTokenPresent).toBe(false)
+    expect(result.diagnostics.callerTokenPresent).toBe(true)
     expect(result.diagnostics.receiverTokenSource).toBe('missing')
-    expect(result.diagnostics.callerFingerprint).toBe(fingerprintInternalApiToken('caller-token'))
   })
 
   it('distinguishes a caller that sent no header', () => {
@@ -137,8 +124,8 @@ describe('authorizeInternalApiRequest', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('caller_token_missing')
-    expect(result.diagnostics.callerFingerprint).toBeNull()
-    expect(result.diagnostics.callerTokenLength).toBe(0)
+    expect(result.diagnostics.callerTokenPresent).toBe(false)
+    expect(result.diagnostics.receiverTokenPresent).toBe(true)
   })
 
   it('distinguishes two services holding different tokens', () => {
@@ -150,11 +137,8 @@ describe('authorizeInternalApiRequest', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('token_mismatch')
-    expect(result.diagnostics.receiverFingerprint).toBe(
-      fingerprintInternalApiToken('receiver-token')
-    )
-    expect(result.diagnostics.callerFingerprint).toBe(fingerprintInternalApiToken('worker-token'))
-    expect(result.diagnostics.receiverFingerprint).not.toBe(result.diagnostics.callerFingerprint)
+    expect(result.diagnostics.receiverTokenPresent).toBe(true)
+    expect(result.diagnostics.callerTokenPresent).toBe(true)
   })
 
   it('flags same-length-different-value tokens as a mismatch', () => {
@@ -168,7 +152,7 @@ describe('authorizeInternalApiRequest', () => {
     expect(result.reason).toBe('token_mismatch')
   })
 
-  it('treats a whitespace-mangled token as a mismatch and exposes the length gap', () => {
+  it('surfaces a whitespace-mangled caller token as the likely cause', () => {
     vi.stubEnv('INTERNAL_API_TOKEN', 'good-token')
     vi.stubEnv('NODE_ENV', 'production')
 
@@ -177,11 +161,11 @@ describe('authorizeInternalApiRequest', () => {
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('token_mismatch')
-    expect(result.diagnostics.callerTokenLength).toBe(11)
-    expect(result.diagnostics.receiverTokenLength).toBe(10)
+    expect(result.diagnostics.callerTokenHasSurroundingWhitespace).toBe(true)
+    expect(result.diagnostics.receiverTokenHasSurroundingWhitespace).toBe(false)
   })
 
-  it('never puts a token value in the diagnostics', () => {
+  it('never puts a token value, hash, or length in the diagnostics', () => {
     vi.stubEnv('INTERNAL_API_TOKEN', 'receiver-secret-value')
     vi.stubEnv('NODE_ENV', 'production')
 
@@ -192,6 +176,11 @@ describe('authorizeInternalApiRequest', () => {
     const serialised = JSON.stringify(result.diagnostics)
     expect(serialised).not.toContain('receiver-secret-value')
     expect(serialised).not.toContain('caller-secret-value')
+    // Every value must be a fixed enum, a boolean, or the environment name.
+    for (const value of Object.values(result.diagnostics)) {
+      expect(['boolean', 'string']).toContain(typeof value)
+    }
+    expect(serialised).not.toContain(String('receiver-secret-value'.length))
   })
 })
 
@@ -261,7 +250,18 @@ describe('assertInternalApiTokenConfigured', () => {
     ).not.toThrow()
   })
 
-  it('warns when a non-development service is on the dev fallback token', () => {
+  it('errors on a token with surrounding whitespace', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', ' padded-token ')
+    vi.stubEnv('NODE_ENV', 'production')
+    const logger = makeLogger()
+
+    assertInternalApiTokenConfigured({ service: 'worker', logger })
+
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(String(logger.error.mock.calls[0]?.[0])).toContain('whitespace')
+  })
+
+  it('warns when a service is on the dev fallback token', () => {
     vi.stubEnv('INTERNAL_API_TOKEN', '')
     vi.stubEnv('NODE_ENV', 'development')
     const logger = makeLogger()
@@ -272,7 +272,7 @@ describe('assertInternalApiTokenConfigured', () => {
     expect(logger.error).not.toHaveBeenCalled()
   })
 
-  it('logs a comparable fingerprint on a healthy boot', () => {
+  it('confirms a healthy boot without disclosing anything about the token', () => {
     vi.stubEnv('INTERNAL_API_TOKEN', 'production-token')
     vi.stubEnv('NODE_ENV', 'production')
     const logger = makeLogger()
@@ -281,29 +281,20 @@ describe('assertInternalApiTokenConfigured', () => {
 
     expect(logger.error).not.toHaveBeenCalled()
     const line = String(logger.info.mock.calls[0]?.[0])
-    expect(line).toContain(`fingerprint=${fingerprintInternalApiToken('production-token')}`)
     expect(line).toContain('service=worker')
+    expect(line).toContain('token configured')
   })
 
-  it('emits the same fingerprint from both services when the token matches', () => {
-    vi.stubEnv('INTERNAL_API_TOKEN', 'shared-deploy-token')
-    vi.stubEnv('NODE_ENV', 'production')
-    const web = makeLogger()
-    const worker = makeLogger()
-
-    const webStatus = assertInternalApiTokenConfigured({ service: 'web', logger: web })
-    const workerStatus = assertInternalApiTokenConfigured({ service: 'worker', logger: worker })
-
-    expect(webStatus.fingerprint).toBe(workerStatus.fingerprint)
-  })
-
-  it('never logs the token value', () => {
-    vi.stubEnv('INTERNAL_API_TOKEN', 'do-not-log-this-value')
+  it('never logs the token value, a hash of it, or its length', () => {
+    const token = 'do-not-log-this-value'
+    vi.stubEnv('INTERNAL_API_TOKEN', token)
     vi.stubEnv('NODE_ENV', 'production')
     const logger = makeLogger()
 
     assertInternalApiTokenConfigured({ service: 'web', logger })
 
-    expect(collectLoggedText(logger)).not.toContain('do-not-log-this-value')
+    const logged = collectLoggedText(logger)
+    expect(logged).not.toContain(token)
+    expect(logged).not.toContain(String(token.length))
   })
 })

--- a/tests/unit/server/utils/internal-api-token.test.ts
+++ b/tests/unit/server/utils/internal-api-token.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  assertInternalApiTokenConfigured,
+  authorizeInternalApiRequest,
+  describeInternalAuthFailure,
+  fingerprintInternalApiToken,
+  getInternalApiToken,
+  getInternalApiTokenStatus,
+  parseInternalAuthFailureReason
+} from '../../../../server/utils/internal-api-token'
+
+const makeLogger = () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn()
+})
+
+/** Every string any of these helpers can emit, for leak assertions. */
+const collectLoggedText = (logger: ReturnType<typeof makeLogger>) =>
+  JSON.stringify([logger.error.mock.calls, logger.warn.mock.calls, logger.info.mock.calls])
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('getInternalApiToken', () => {
+  it('returns the configured env token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'super-secret-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(getInternalApiToken()).toBe('super-secret-token')
+  })
+
+  it('falls back to the dev token only in development', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'development')
+
+    expect(getInternalApiToken()).toBe('dev-internal-token')
+  })
+
+  it('returns null in production when the env var is absent', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(getInternalApiToken()).toBeNull()
+  })
+})
+
+describe('fingerprintInternalApiToken', () => {
+  it('is deterministic across calls, so two services can compare log lines', () => {
+    expect(fingerprintInternalApiToken('shared-token')).toBe(
+      fingerprintInternalApiToken('shared-token')
+    )
+  })
+
+  it('differs for different tokens', () => {
+    expect(fingerprintInternalApiToken('token-a')).not.toBe(fingerprintInternalApiToken('token-b'))
+  })
+
+  it('never contains the token itself', () => {
+    const token = 'a-very-secret-value'
+    const fingerprint = fingerprintInternalApiToken(token)
+
+    expect(fingerprint).not.toBeNull()
+    expect(fingerprint).not.toContain(token)
+    expect(fingerprint).toHaveLength(12)
+  })
+
+  it('returns null for an absent token', () => {
+    expect(fingerprintInternalApiToken(null)).toBeNull()
+    expect(fingerprintInternalApiToken(undefined)).toBeNull()
+    expect(fingerprintInternalApiToken('')).toBeNull()
+  })
+})
+
+describe('getInternalApiTokenStatus', () => {
+  it('reports an env-sourced token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'env-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(getInternalApiTokenStatus()).toEqual({
+      configured: true,
+      source: 'env',
+      fingerprint: fingerprintInternalApiToken('env-token'),
+      length: 'env-token'.length
+    })
+  })
+
+  it('reports the development fallback distinctly from a real token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'development')
+
+    expect(getInternalApiTokenStatus().source).toBe('dev-fallback')
+  })
+
+  it('reports a missing token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(getInternalApiTokenStatus()).toEqual({
+      configured: false,
+      source: 'missing',
+      fingerprint: null,
+      length: 0
+    })
+  })
+})
+
+describe('authorizeInternalApiRequest', () => {
+  it('accepts a matching token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'matching-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(authorizeInternalApiRequest('matching-token')).toEqual({ ok: true })
+  })
+
+  it('distinguishes a missing token on the receiver', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest('caller-token')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('receiver_token_missing')
+    expect(result.diagnostics.receiverFingerprint).toBeNull()
+    expect(result.diagnostics.receiverTokenSource).toBe('missing')
+    expect(result.diagnostics.callerFingerprint).toBe(fingerprintInternalApiToken('caller-token'))
+  })
+
+  it('distinguishes a caller that sent no header', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'receiver-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest(undefined)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('caller_token_missing')
+    expect(result.diagnostics.callerFingerprint).toBeNull()
+    expect(result.diagnostics.callerTokenLength).toBe(0)
+  })
+
+  it('distinguishes two services holding different tokens', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'receiver-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest('worker-token')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('token_mismatch')
+    expect(result.diagnostics.receiverFingerprint).toBe(
+      fingerprintInternalApiToken('receiver-token')
+    )
+    expect(result.diagnostics.callerFingerprint).toBe(fingerprintInternalApiToken('worker-token'))
+    expect(result.diagnostics.receiverFingerprint).not.toBe(result.diagnostics.callerFingerprint)
+  })
+
+  it('flags same-length-different-value tokens as a mismatch', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'aaaaaaaa')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest('bbbbbbbb')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('token_mismatch')
+  })
+
+  it('treats a whitespace-mangled token as a mismatch and exposes the length gap', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'good-token')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest('good-token\n')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('token_mismatch')
+    expect(result.diagnostics.callerTokenLength).toBe(11)
+    expect(result.diagnostics.receiverTokenLength).toBe(10)
+  })
+
+  it('never puts a token value in the diagnostics', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'receiver-secret-value')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    const result = authorizeInternalApiRequest('caller-secret-value')
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    const serialised = JSON.stringify(result.diagnostics)
+    expect(serialised).not.toContain('receiver-secret-value')
+    expect(serialised).not.toContain('caller-secret-value')
+  })
+})
+
+describe('describeInternalAuthFailure', () => {
+  it('gives a distinct operator-facing sentence per reason', () => {
+    const messages = [
+      describeInternalAuthFailure('receiver_token_missing'),
+      describeInternalAuthFailure('caller_token_missing'),
+      describeInternalAuthFailure('token_mismatch')
+    ]
+
+    expect(new Set(messages).size).toBe(3)
+    expect(messages.every((m) => m.length > 0)).toBe(true)
+  })
+})
+
+describe('parseInternalAuthFailureReason', () => {
+  it('recovers the reason from a nitro 401 error body', () => {
+    const body = JSON.stringify({
+      error: true,
+      url: 'https://coachwatts.com/api/internal/render-email',
+      statusCode: 401,
+      statusMessage: 'Unauthorized',
+      message: 'Unauthorized',
+      data: { reason: 'token_mismatch' }
+    })
+
+    expect(parseInternalAuthFailureReason(body)).toBe('token_mismatch')
+  })
+
+  it('returns null for a body without a reason (e.g. a proxy 401)', () => {
+    expect(parseInternalAuthFailureReason('<html>401</html>')).toBeNull()
+    expect(parseInternalAuthFailureReason(JSON.stringify({ statusCode: 401 }))).toBeNull()
+    expect(parseInternalAuthFailureReason('')).toBeNull()
+    expect(parseInternalAuthFailureReason(null)).toBeNull()
+  })
+
+  it('rejects an unrecognised reason value', () => {
+    const body = JSON.stringify({ data: { reason: 'something-else' } })
+
+    expect(parseInternalAuthFailureReason(body)).toBeNull()
+  })
+})
+
+describe('assertInternalApiTokenConfigured', () => {
+  it('shouts loudly when no token is configured', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'production')
+    const logger = makeLogger()
+
+    const status = assertInternalApiTokenConfigured({ service: 'web', logger })
+
+    expect(status.configured).toBe(false)
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    const banner = String(logger.error.mock.calls[0]?.[0])
+    expect(banner).toContain('INTERNAL_API_TOKEN IS NOT CONFIGURED')
+    expect(banner).toContain('service=web')
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+
+  it('does not throw, so a diagnostic can never stop a service booting', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'production')
+
+    expect(() =>
+      assertInternalApiTokenConfigured({ service: 'worker', logger: makeLogger() })
+    ).not.toThrow()
+  })
+
+  it('warns when a non-development service is on the dev fallback token', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', '')
+    vi.stubEnv('NODE_ENV', 'development')
+    const logger = makeLogger()
+
+    assertInternalApiTokenConfigured({ service: 'web', logger })
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs a comparable fingerprint on a healthy boot', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'production-token')
+    vi.stubEnv('NODE_ENV', 'production')
+    const logger = makeLogger()
+
+    assertInternalApiTokenConfigured({ service: 'worker', logger })
+
+    expect(logger.error).not.toHaveBeenCalled()
+    const line = String(logger.info.mock.calls[0]?.[0])
+    expect(line).toContain(`fingerprint=${fingerprintInternalApiToken('production-token')}`)
+    expect(line).toContain('service=worker')
+  })
+
+  it('emits the same fingerprint from both services when the token matches', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'shared-deploy-token')
+    vi.stubEnv('NODE_ENV', 'production')
+    const web = makeLogger()
+    const worker = makeLogger()
+
+    const webStatus = assertInternalApiTokenConfigured({ service: 'web', logger: web })
+    const workerStatus = assertInternalApiTokenConfigured({ service: 'worker', logger: worker })
+
+    expect(webStatus.fingerprint).toBe(workerStatus.fingerprint)
+  })
+
+  it('never logs the token value', () => {
+    vi.stubEnv('INTERNAL_API_TOKEN', 'do-not-log-this-value')
+    vi.stubEnv('NODE_ENV', 'production')
+    const logger = makeLogger()
+
+    assertInternalApiTokenConfigured({ service: 'web', logger })
+
+    expect(collectLoggedText(logger)).not.toContain('do-not-log-this-value')
+  })
+})

--- a/tests/unit/server/utils/internal-api-token.test.ts
+++ b/tests/unit/server/utils/internal-api-token.test.ts
@@ -176,11 +176,42 @@ describe('authorizeInternalApiRequest', () => {
     const serialised = JSON.stringify(result.diagnostics)
     expect(serialised).not.toContain('receiver-secret-value')
     expect(serialised).not.toContain('caller-secret-value')
-    // Every value must be a fixed enum, a boolean, or the environment name.
-    for (const value of Object.values(result.diagnostics)) {
-      expect(['boolean', 'string']).toContain(typeof value)
-    }
     expect(serialised).not.toContain(String('receiver-secret-value'.length))
+
+    // Pin the diagnostics SHAPE exhaustively, not just the absence of the two
+    // literal secrets above. The earlier `typeof value is boolean|string` loop
+    // was too weak to catch the regression this test exists to prevent: the
+    // first revision of this change logged a salted, truncated SHA-256
+    // "fingerprint" of the token, which CodeQL rejected as a high-severity leak
+    // — and a hex digest is a string, so it would have sailed through that loop
+    // and through the `not.toContain` assertions too. Asserting the exact key
+    // set means any new or repurposed field fails here instead of relying on
+    // CodeQL as the only backstop.
+    expect(Object.keys(result.diagnostics).sort()).toEqual([
+      'callerTokenHasSurroundingWhitespace',
+      'callerTokenPresent',
+      'nodeEnv',
+      'reason',
+      'receiverTokenHasSurroundingWhitespace',
+      'receiverTokenPresent',
+      'receiverTokenSource'
+    ])
+
+    // And pin the free-form-string fields to their enums, so a field cannot be
+    // quietly repurposed to carry token-derived material while keeping its name.
+    expect(['receiver_token_missing', 'caller_token_missing', 'token_mismatch']).toContain(
+      result.diagnostics.reason
+    )
+    expect(['env', 'dev-fallback', 'missing']).toContain(result.diagnostics.receiverTokenSource)
+    expect(typeof result.diagnostics.nodeEnv).toBe('string')
+    for (const key of [
+      'receiverTokenPresent',
+      'callerTokenPresent',
+      'receiverTokenHasSurroundingWhitespace',
+      'callerTokenHasSurroundingWhitespace'
+    ] as const) {
+      expect(typeof result.diagnostics[key]).toBe('boolean')
+    }
   })
 })
 


### PR DESCRIPTION
Fixes CW-290

## Problem

`send-email` was failing in production with a bare `Render API failed (401)` from `emailDeliveryService.ts:353`, and outbound email stopped. The fault is environmental, not logical: the web and worker services run the **same image** but take their environment from **separate Dokploy service definitions**, so one side can resolve an `INTERNAL_API_TOKEN` the other does not have — or a different one. Nothing detected that until the first email of the day failed, and when it did, the 401 said nothing about which side was wrong.

## What this changes

**AC 3 — loud detection instead of a silent 401 hours later.**
`assertInternalApiTokenConfigured()` emits a loud, greppable banner at boot when no token is configured, and a second one when the resolved token has leading/trailing whitespace — the signature of a value that picked up a stray newline or kept its quotes when it was pasted into a deploy UI, which is otherwise invisible and produces a mismatch that looks impossible ("but I copied the same value!").

It deliberately **does not throw**. Crashing here would turn an email outage into a full site outage plus a container restart loop, which is strictly worse than degraded email.

**AC 4 — a 401 that names the fault.**
`authorizeInternalApiRequest()` distinguishes the three genuinely different operational faults:

| reason | meaning | who fixes it |
| --- | --- | --- |
| `receiver_token_missing` | the web service has no `INTERNAL_API_TOKEN` | set it on the web service |
| `caller_token_missing` | no `x-internal-api-token` header was sent | set it on the worker service |
| `token_mismatch` | both have one, they differ | make them identical |

The receiver logs the reason plus presence booleans, the token source and the whitespace flags for both sides; the reason is also returned in the error body, so it lands in the **worker's** Sentry event rather than only in web logs. The caller-side error in `emailDeliveryService` names the fault instead of reporting a bare `Render API failed (401)`.

Also hardened: the token comparison is now timing-safe (it was a plain `!==`).

### Nothing token-derived reaches a log

The first commit on this branch logged a salted, truncated hash "fingerprint" of the token so that web and worker log lines could be compared. **CodeQL correctly rejected that**, with 8 new high-severity alerts — and the decisive one was in `server/utils/services/accountDeletionService.ts`, a file this branch never touched. That is the real argument: the fingerprint went into the error message thrown by `emailDeliveryService`, so it propagated into *every* log sink that logs an email failure, right across the codebase.

The second commit removes it. Gone: the fingerprint, the token length, and the SHA-256 length-equalising step in the comparison (`js/insufficient-password-hash` — now a length check plus `timingSafeEqual` on raw buffers, the standard construction, which leaks strictly less than hashing both sides). Also renamed `INTERNAL_API_TOKEN_SERVICE_NAME` to `INTERNAL_API_SERVICE_NAME`, since it is a plain service label and having "TOKEN" in the name made every log line mentioning it read as a secret to static analysis.

**Every field that now reaches a log is a fixed enum, a boolean, or the environment name.** Tests assert that no token value, no hash of it, and not even its length appears in any log or diagnostic.

The trade-off, stated plainly: an operator can no longer confirm "both services hold the same token" by comparing two boot log lines. Mismatch is still detected — precisely, by name — the moment a call is rejected, via the `token_mismatch` reason. Restoring the positive cross-service check belongs on an authenticated surface rather than in plaintext logs, and is filed as **CW-635**.

## AC 1 and AC 2 — outstanding, operator action

**I made no production change.** A read-only audit of the prod stack found:

- Services: `coach-watts-app-z8rrhj_app` (web) and `coach-watts-app-z8rrhj_worker`, both `1/1`, same image, on server `coach`.
- `INTERNAL_API_TOKEN` is **present on both, and the values currently match** (compared by hashing inside each container; no secret value was printed).
- A live, side-effect-free probe from the worker container to `POST /api/internal/render-email` using the worker's real token returned **404 "template not found"** for a deliberately bogus `templateKey` — i.e. **auth passed**. A control request with a garbage token returned 401, confirming the check is live and discriminating.

So there is no mismatch to correct *right now*; the 8 Sentry events captured a drift window that has since closed. **AC 1 and AC 2 cannot be closed from this PR** and remain operator actions:

1. Correlate the `COACH-WATTS-WEB-K` event timestamps against Dokploy's deploy history for the `app` vs `worker` service **individually** — if one was redeployed without the other around those timestamps, that is the drift window.
2. Confirm a real `send-email` completes end to end in production.

The structural cause is filed as **CW-633**: `INTERNAL_API_TOKEN` is written as a literal value into *each service's own* `environment:` block, independently pasted per service in the Dokploy UI, with no single source of truth — so an operator editing one service without the other silently reproduces this outage. Consolidating that is what actually prevents a recurrence; this PR only makes the recurrence loud and self-diagnosing.

## Verification

```
pnpm test:unit
```

Run **bare**, no path filter, on this exact commit:

```
Test Files  388 passed (388)
     Tests  2680 passed (2680)
  Duration  131.03s
EXIT=0
```

`pnpm typecheck` also clean (`EXIT=0`), as is `pnpm exec eslint` on all five changed files.

Tests added: `tests/unit/server/utils/internal-api-token.test.ts` (new, 23 cases) and 4 new 401-diagnostic cases in `tests/unit/server/api/internal/render-email.test.ts` — covering each failure reason, the whitespace-mangled-token case, and explicit assertions that no token value, hash, or length reaches any log or diagnostic.

> Note on flakiness: earlier full-suite runs failed on **timeouts** in unrelated suites, and a clean baseline with no code changes failed the same way on a *different* suite. Always timeouts, never assertions, moving between suites run to run — machine contention, not a code fault. Filed as **CW-636**.

## Scope

Files changed match the ticket's Owned Paths exactly:

- `server/utils/internal-api-token.ts`
- `server/api/internal/render-email.post.ts`
- `server/utils/services/emailDeliveryService.ts`
- plus the two corresponding test files

The boot assertion is currently invoked from the token module's own load-time side effect, because `server/plugins/` and `server/api/health.get.ts` are outside those Owned Paths. For the worker that is effectively boot; for web it is first-module-load. Promoting it to a real nitro startup plugin and surfacing token status on `/api/health` — plus applying the same diagnostics to `send-notification.post.ts`, which has the identical check and identical failure mode — is filed as **CW-635**.

## Follow-ups filed

- **CW-633** — `INTERNAL_API_TOKEN` pasted per-service in Dokploy with no single source of truth (root cause of this ticket)
- **CW-634** — Dokploy writes app secrets as plaintext literals into the on-disk compose file
- **CW-635** — wire the boot assertion into a nitro startup plugin and `/api/health`; extend diagnostics to `send-notification.post.ts`
- **CW-636** — unit suite fails on load-dependent test/hook timeouts in full runs

UX critique: skipped — backend only, no user-facing surface.
