### PR TITLE
fix(security): keep the Tolgee API key out of the client payload (CW-610)

### DIFF
--- a/app/plugins/tolgee.ts
+++ b/app/plugins/tolgee.ts
@@ -322,9 +322,23 @@ const LANGUAGE_MAP: Record<string, string> = {
   Korean: 'ko'
 }
 
+/**
+ * Credentials for Tolgee's in-context translation DevTools.
+ *
+ * These live in `runtimeConfig.public.tolgee`, which nuxt.config.ts declares
+ * *only* under its `$development` block — a production build has no such key
+ * (CW-610). Access is therefore optional and guarded by `import.meta.dev`,
+ * which Vite replaces with `false` at build time so the lookup is dropped
+ * entirely from the production bundle.
+ */
+type TolgeeDevCredentials = { apiUrl?: string; apiKey?: string }
+
 export default defineNuxtPlugin((nuxtApp) => {
   const config = useRuntimeConfig()
-  const { apiUrl, apiKey } = config.public.tolgee
+  const { apiUrl, apiKey }: TolgeeDevCredentials = import.meta.dev
+    ? (((config.public as Record<string, unknown>).tolgee as TolgeeDevCredentials | undefined) ??
+      {})
+    : {}
   const canUseDevTools = import.meta.client && import.meta.dev && Boolean(apiUrl) && Boolean(apiKey)
 
   const builder = Tolgee().use(FormatIcu())

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -379,16 +379,10 @@ export default defineNuxtConfig({
               process.env.APPLE_KEY_ID &&
               process.env.APPLE_PRIVATE_KEY)))
       ),
-      tolgee: {
-        apiUrl:
-          process.env.TOLGEE_API_ENABLED === 'true'
-            ? process.env.NUXT_PUBLIC_TOLGEE_API_URL || process.env.TOLGEE_API_URL
-            : undefined,
-        apiKey:
-          process.env.TOLGEE_API_ENABLED === 'true'
-            ? process.env.NUXT_PUBLIC_TOLGEE_API_KEY || process.env.TOLGEE_API_KEY
-            : undefined
-      },
+      // NOTE: `tolgee` is deliberately absent here. The Tolgee API key is a
+      // secret and `runtimeConfig.public` is serialised into the client payload
+      // for every visitor. It is declared only under `$development` below, so a
+      // production build never carries the key. See CW-610.
       gtag: {
         // Overridden at runtime by NUXT_PUBLIC_GTAG_ID (Dokploy). Empty at build
         // is fine — the client plugin no-ops until an id is present.
@@ -396,6 +390,42 @@ export default defineNuxtConfig({
         enabled: true
       },
       realtimeBusEnabled: !!process.env.REDIS_URL
+    }
+  },
+
+  // Dev-server-only public runtime config (CW-610).
+  //
+  // Tolgee's in-context translation DevTools need `apiUrl` + `apiKey` in the
+  // browser, but `runtimeConfig.public` is serialised into the HTML payload of
+  // every response — so a key placed there ships to every visitor, in every
+  // environment, regardless of `import.meta.dev`.
+  //
+  // `$development` is applied by c12 only when `nuxt.options.dev` is true, i.e.
+  // `nuxt dev`. `nuxt build` never merges this block, so `public.tolgee` is not
+  // a key of the inlined runtime config at all in a production build. That also
+  // closes the runtime env-override path: nitro's `applyEnv`
+  // (nitropack/dist/runtime/internal/utils.env.mjs) walks `for (const key in
+  // obj)`, so `NUXT_PUBLIC_TOLGEE_API_KEY` can only overwrite a key that is
+  // already declared — it cannot create one. Setting `TOLGEE_API_ENABLED=true`
+  // on a deployed stack is therefore inert instead of leaking the key.
+  //
+  // Do NOT move this back under `runtimeConfig.public`, and do NOT add an
+  // empty-string `apiKey` default there to "keep the shape stable" — declaring
+  // the key is exactly what reopens the env-override path.
+  $development: {
+    runtimeConfig: {
+      public: {
+        tolgee: {
+          apiUrl:
+            process.env.TOLGEE_API_ENABLED === 'true'
+              ? process.env.NUXT_PUBLIC_TOLGEE_API_URL || process.env.TOLGEE_API_URL
+              : undefined,
+          apiKey:
+            process.env.TOLGEE_API_ENABLED === 'true'
+              ? process.env.NUXT_PUBLIC_TOLGEE_API_KEY || process.env.TOLGEE_API_KEY
+              : undefined
+        }
+      }
     }
   },
 

--- a/tests/unit/app/plugins/tolgee-api-key-not-public.test.ts
+++ b/tests/unit/app/plugins/tolgee-api-key-not-public.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * CW-610 — the Tolgee API key must never reach the client payload.
+ *
+ * `runtimeConfig.public` is serialised into the HTML of every response, so a
+ * secret declared there ships to every visitor in every environment. The key is
+ * therefore declared only under nuxt.config.ts's `$development` block, which
+ * c12 merges when `nuxt.options.dev` is true (i.e. `nuxt dev`) and never during
+ * `nuxt build`.
+ *
+ * Declaring it (even as an empty string) is what these tests guard against: a
+ * declared key can be overwritten at runtime by `NUXT_PUBLIC_TOLGEE_API_KEY`,
+ * because nitro's `applyEnv` walks `for (const key in obj)` and can only
+ * overwrite keys that already exist — it cannot create them.
+ */
+
+// Sentinels — deliberately fake. Never put a real key in a fixture.
+const API_KEY_SENTINEL = 'tgpak_cw610_fake_key_sentinel_do_not_use'
+const PUBLIC_API_KEY_SENTINEL = 'tgpak_cw610_fake_public_key_sentinel_do_not_use'
+const API_URL_SENTINEL = 'https://tolgee.cw610.invalid'
+
+type LoadedNuxtConfig = {
+  runtimeConfig?: { public?: Record<string, unknown> }
+  $development?: { runtimeConfig?: { public?: Record<string, unknown> } }
+}
+
+const TOLGEE_ENV_KEYS = [
+  'TOLGEE_API_ENABLED',
+  'TOLGEE_API_KEY',
+  'TOLGEE_API_URL',
+  'NUXT_PUBLIC_TOLGEE_API_KEY',
+  'NUXT_PUBLIC_TOLGEE_API_URL'
+] as const
+
+let savedEnv: Record<string, string | undefined> = {}
+
+/**
+ * Evaluate nuxt.config.ts with Tolgee fully enabled, the way a misconfigured
+ * deployment would have it, and hand back the raw config object.
+ */
+async function loadNuxtConfig(): Promise<LoadedNuxtConfig> {
+  vi.resetModules()
+  vi.stubGlobal('defineNuxtConfig', (config: LoadedNuxtConfig) => config)
+  const mod = await import('../../../../nuxt.config')
+  return mod.default as unknown as LoadedNuxtConfig
+}
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(TOLGEE_ENV_KEYS.map((key) => [key, process.env[key]]))
+
+  // The worst realistic misconfiguration: every Tolgee env var set on a stack.
+  process.env.TOLGEE_API_ENABLED = 'true'
+  process.env.TOLGEE_API_URL = API_URL_SENTINEL
+  process.env.TOLGEE_API_KEY = API_KEY_SENTINEL
+  process.env.NUXT_PUBLIC_TOLGEE_API_URL = API_URL_SENTINEL
+  process.env.NUXT_PUBLIC_TOLGEE_API_KEY = PUBLIC_API_KEY_SENTINEL
+})
+
+afterEach(() => {
+  for (const key of TOLGEE_ENV_KEYS) {
+    if (savedEnv[key] === undefined) {
+      Reflect.deleteProperty(process.env, key)
+    } else {
+      process.env[key] = savedEnv[key]
+    }
+  }
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('CW-610: Tolgee credentials stay out of runtimeConfig.public', () => {
+  it('does not declare a `tolgee` key in runtimeConfig.public', async () => {
+    const config = await loadNuxtConfig()
+    const publicConfig = config.runtimeConfig?.public ?? {}
+
+    // `in` rather than a truthiness check: an undefined-but-declared key is
+    // still overridable by NUXT_PUBLIC_TOLGEE_API_KEY at runtime.
+    expect('tolgee' in publicConfig).toBe(false)
+  })
+
+  it('declares no public runtime config key that looks Tolgee-related', async () => {
+    const config = await loadNuxtConfig()
+    const publicConfig = config.runtimeConfig?.public ?? {}
+
+    expect(Object.keys(publicConfig).filter((key) => /tolgee/i.test(key))).toEqual([])
+  })
+
+  it('serialises runtimeConfig.public without either API key sentinel', async () => {
+    const config = await loadNuxtConfig()
+
+    // This is the value Nuxt embeds in the HTML payload sent to every browser.
+    const serialisedPayload = JSON.stringify(config.runtimeConfig?.public ?? {})
+
+    expect(serialisedPayload).not.toContain(API_KEY_SENTINEL)
+    expect(serialisedPayload).not.toContain(PUBLIC_API_KEY_SENTINEL)
+  })
+
+  it('still hands the dev server its Tolgee credentials via $development', async () => {
+    const config = await loadNuxtConfig()
+    const devTolgee = config.$development?.runtimeConfig?.public?.tolgee as
+      { apiUrl?: string; apiKey?: string } | undefined
+
+    // In-context translation must keep working in local development.
+    expect(devTolgee?.apiUrl).toBe(API_URL_SENTINEL)
+    expect(devTolgee?.apiKey).toBe(PUBLIC_API_KEY_SENTINEL)
+  })
+
+  it('leaves $development.tolgee empty when TOLGEE_API_ENABLED is not "true"', async () => {
+    process.env.TOLGEE_API_ENABLED = 'false'
+
+    const config = await loadNuxtConfig()
+    const devTolgee = config.$development?.runtimeConfig?.public?.tolgee as
+      { apiUrl?: string; apiKey?: string } | undefined
+
+    expect(devTolgee?.apiUrl).toBeUndefined()
+    expect(devTolgee?.apiKey).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes CW-610

> **:lock: Secrets-handling change — please review before merging.** This touches how a secret is (not) delivered to the browser. Do not auto-merge on green CI alone.

## Problem

`runtimeConfig.public` is serialised into the HTML payload of **every** response, for every visitor, in every environment. `nuxt.config.ts` declared the Tolgee `apiKey` there, gated only on `TOLGEE_API_ENABLED === 'true'`.

`import.meta.dev` gated the DevTools **fetch**, so a production build never *called* the Tolgee API — but nothing gated **the key itself**. Setting `TOLGEE_API_ENABLED=true` on any deployed stack (prod, testing, or a preview) would have embedded the key in the page source. A Tolgee project key generally permits reading and, depending on scope, **writing** translations, so disclosure would let anyone rewrite the strings shown to users.

Pre-existing; surfaced by the merge review of #561 (CW-539), not introduced by it.

## Was it ever actually exposed? No.

- **No `TOLGEE_*` env var is set on any deployed container** — checked `coach-watts-app-z8rrhj_app`, `_worker`, and `coach-watts-dev-wievmw_app-dev` via `docker inspect` (env **key names only**; no values read or printed).
- **Live payloads were clean**: both `https://coachwatts.com` and `https://testing.coachwatts.com` were serving `tolgee:{apiUrl:"",apiKey:""}` — both empty.

**No key rotation is required.** The severity was latent — one env var away — not an active leak.

## Fix

Move the entire `tolgee` block out of `runtimeConfig.public` into a new top-level **`$development`** override.

c12 merges `$development` only when `nuxt.options.dev` is true (i.e. `nuxt dev`). `nuxt build` never merges it, so `public.tolgee` is **not a key of the inlined runtime config at all** in a production build.

That is what makes the gate structural rather than a matter of operator discipline, and it closes the runtime override path too. Nitro's `applyEnv` (`nitropack/dist/runtime/internal/utils.env.mjs`) walks:

```js
export function applyEnv(obj, opts, parentKey = "") {
  for (const key in obj) { ... }
}
```

It can only overwrite keys that **already exist** — it cannot create them. So `NUXT_PUBLIC_TOLGEE_API_KEY` now has nothing to bind to, and `TOLGEE_API_ENABLED=true` on a deployed stack is inert instead of leaking. This is also why the fix is *not* "set the key to an empty string by default": an empty-but-**declared** key is still overridable at runtime. Both the config and the test comments call this out so it does not get "tidied" back.

`app/plugins/tolgee.ts` reads the credentials optionally behind `import.meta.dev`, which Vite replaces with `false` at build time, so the lookup is dead-code-eliminated from the production bundle.

## Build-artifact evidence

Ran a real `pnpm build` with the **worst-case env deliberately set** — all five Tolgee vars on, with two *distinct fake sentinel* strings so each source of the key could be traced independently:

```
TOLGEE_API_ENABLED=true
TOLGEE_API_KEY=tgpak_cw610_build_sentinel_alpha
NUXT_PUBLIC_TOLGEE_API_KEY=tgpak_cw610_build_sentinel_beta
TOLGEE_API_URL=NUXT_PUBLIC_TOLGEE_API_URL=https://tolgee.cw610.invalid
```

Grep over the complete build output (`.output/public`: 2167 files / 72 MB, `.output/server`: 196 MB):

```
tgpak_cw610_build_sentinel_alpha    public=0  server=0
tgpak_cw610_build_sentinel_beta     public=0  server=0
tolgee.cw610.invalid                public=0  server=0

"tolgee": occurrences in .output/server = 0
"tolgee": occurrences in .output/public = 0
```

**Positive control** — so the greps are not vacuously passing. The inlined public runtime config *is* present in that same artifact (`.output/server/chunks/nitro/nitro.mjs`), parsed straight out of the bundle, 32 keys, names only:

```
appleSignInEnabled, auth, authBypassEnabled, authBypassName, authBypassUser, buildCodename,
buildDate, buildVersion, commitHash, content, gtag, mdc, nativeSubscriptionsEnabled,
nuxtApiShield, realtimeBusEnabled, sentryDsn, sentryEnabled, sentryRelease, siteUrl,
socialShare, stravaEnabled, stripeProAnnualEurPriceId, stripeProAnnualPriceId,
stripeProMonthlyEurPriceId, stripeProMonthlyPriceId, stripePublishableKey,
stripeSupporterAnnualEurPriceId, stripeSupporterAnnualPriceId,
stripeSupporterMonthlyEurPriceId, stripeSupporterMonthlyPriceId, subscriptionsEnabled,
version

"tolgee" in runtimeConfig.public : False
```

Every other public key survives the build; `tolgee` is simply gone. This is the artifact that decides the question — `runtimeConfig.public` reaches the browser through the SSR-injected `__NUXT__` payload sourced from this bundle, not through the static client chunks.

No real key value appears in this PR, the tests, or the ticket — only fake sentinels and match counts.

## Regression guard

`tests/unit/app/plugins/tolgee-api-key-not-public.test.ts` (5 tests) evaluates the **real `nuxt.config.ts`** with every Tolgee env var set and asserts the key is absent from `runtimeConfig.public`.

It checks `'tolgee' in publicConfig` rather than truthiness, precisely because an undefined-but-declared key would still be runtime-overridable.

**Mutation-tested** — re-adding `tolgee: { apiKey: process.env.TOLGEE_API_KEY }` to `runtimeConfig.public` turns it red (`Tests 3 failed | 2 passed`); reverting turns it green. It fails for the right reason.

## Localisation regression check (the risky part of this change)

`staticData` registration and the locale-resolution ladder are **untouched** — the diff does not go near them. Verified against the running dev server (`bin/worktree-dev.sh`, port 3210):

| Page | Raw-key markers |
| --- | --- |
| `/dashboard` | 0 |
| `/dashboard?lang=hu` | 0 |
| `/pricing` | 0 |
| `/pricing?lang=de` | 0 |
| `/settings` | 0 |

And i18n is genuinely live, not merely key-free — `?lang=` still resolves at SSR:

```
hu==en rendered text: False
  Ingyenes   hu= 5  en= 0
  Havi       hu= 3  en= 0
  Free       hu= 0  en= 5
  Monthly    hu= 0  en= 1
```

Tolgee in-context editing still works locally: the dev payload carries a non-empty `tolgee.apiKey`, confirming `$development` is applied by `nuxt dev`.

## What a reviewer should check

1. **`$development` is the right gate.** It keys on `nuxt.options.dev`, so `nuxt dev` gets the key and `nuxt build` never does. If any deployment path runs the app via `nuxt dev`, this gate would not hold there — I do not believe one exists (the Dokploy stacks run `node .output/server/index.mjs`), but it is the assumption the fix rests on.
2. **The key must stay undeclared.** Adding `tolgee: { apiKey: '' }` back to `runtimeConfig.public` "for shape stability" silently reopens the `NUXT_PUBLIC_TOLGEE_API_KEY` override path. The test catches it; the comments explain it.
3. **The plugin's optional access is deliberate.** `.nuxt/types/runtime-config.d.ts` *does* list `tolgee` (Nuxt merges `$development` for **types**, not values), so the generated type claims it always exists. At runtime in production it does not. The `Record<string, unknown>` cast is there so the code matches reality rather than the type.
4. **No rotation needed** — see the exposure check above.

## Verification

```
pnpm test:unit && pnpm typecheck && pnpm lint
```

```
Test Files  388 passed (388)
     Tests  2656 passed (2656)

typecheck: exit 0
lint:      exit 0  (116 pre-existing warnings, 0 errors, none in changed files)
```

Run bare, no path filter, per the repo's split test layout.

> One flake seen on an intermediate run: `tests/unit/server/utils/task-handler-loader.test.ts` timed out at 30s while a dev server and a 12 GB build were competing for the machine. It passes in 3.5s standalone and passed in both clean full runs. Unrelated to this change.

## Files changed vs Owned Paths

| File | Owned? |
| --- | --- |
| `nuxt.config.ts` | yes |
| `app/plugins/tolgee.ts` | yes |
| `tests/unit/app/plugins/tolgee-api-key-not-public.test.ts` | yes (test file for those modules) |

Nothing outside the ticket's Owned Paths was touched.

## Notes

- **UX critique: skipped — config/security change, no user-facing surface change.** Localisation output is required to be byte-identical, which is a regression check (done above), not a UX change.
- `pnpm build` sets no `--max-old-space-size` (unlike `pnpm typecheck`, which sets 8 GB) and OOM'd at the Nitro step on the first attempt; the evidence build used a 12 GB heap. Not caused by this change, and not filed — CI may well have more headroom.
- Follow-up filed: **CW-632** (Triage) — `docs/04-guides/localization.md` §9 omits `TOLGEE_API_ENABLED=true`, so the documented in-context-editor setup does not actually work as written. Out of this ticket's Owned Paths.
