### PR TITLE
fix(coaching): confirm and label act-as, dedupe exit banner (CW-541)

### DIFF
--- a/app/components/CoachingBanner.vue
+++ b/app/components/CoachingBanner.vue
@@ -1,32 +1,97 @@
 <template>
-  <div
-    v-if="coachingStore.isCoachingMode"
-    class="fixed bottom-4 left-1/2 -translate-x-1/2 z-[60] bg-primary-600 text-white py-2 px-4 rounded-full shadow-xl flex items-center gap-4 border border-white/20 whitespace-nowrap"
-  >
-    <div class="flex items-center gap-2 text-sm font-medium">
-      <UIcon name="i-heroicons-eye" class="w-5 h-5" />
-      <span>
-        {{ t('coaching_banner_active', { name: coachingStore.actingAsUserName }) }}
-      </span>
+  <!--
+    Mounted exactly once, from `app/app.vue`, above the router outlet — so the
+    exit affordance is reachable on every page, and never renders twice stacked
+    on top of itself (CW-541).
+  -->
+  <div>
+    <div
+      v-if="coachingStore.isCoachingMode"
+      role="status"
+      class="fixed bottom-4 left-1/2 -translate-x-1/2 z-[60] max-w-[calc(100vw-2rem)] bg-primary-600 text-white py-2 px-4 rounded-full shadow-xl flex items-center gap-4 border border-white/20 whitespace-nowrap"
+    >
+      <div class="flex items-center gap-2 text-sm font-medium min-w-0">
+        <UIcon name="i-heroicons-eye" class="w-5 h-5 shrink-0" />
+        <span class="truncate">
+          {{ tCommon('coaching_banner_active', { name: coachingStore.actingAsUserName }) }}
+        </span>
+      </div>
+      <div class="flex items-center gap-4">
+        <UButton
+          color="neutral"
+          variant="solid"
+          size="xs"
+          class="shrink-0"
+          :label="tCommon('banner_exit')"
+          :aria-label="t('act_as_exit_aria', { name: coachingStore.actingAsUserName ?? '' })"
+          @click="
+            () => {
+              coachingStore.stopActingAs()
+            }
+          "
+        />
+      </div>
     </div>
-    <div class="flex items-center gap-4">
-      <UButton
-        color="neutral"
-        variant="solid"
-        size="xs"
-        :label="t('banner_exit')"
-        @click="
-          () => {
-            void coachingStore.stopActingAs()
-          }
-        "
-      />
-    </div>
+
+    <UModal
+      :open="coachingStore.hasPendingActAsRequest"
+      :title="t('act_as_confirm_title', { name: pendingName })"
+      :description="t('act_as_confirm_description', { name: pendingName })"
+      @update:open="
+        (open) => {
+          if (!open) coachingStore.cancelActingAs()
+        }
+      "
+    >
+      <template #body>
+        <ul class="space-y-2 p-4 text-sm text-muted">
+          <li class="flex items-start gap-2">
+            <UIcon name="i-heroicons-eye" class="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{{ t('act_as_confirm_point_view', { name: pendingName }) }}</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <UIcon name="i-heroicons-arrow-path" class="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{{ t('act_as_confirm_point_persists') }}</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <UIcon name="i-heroicons-arrow-left-on-rectangle" class="w-4 h-4 mt-0.5 shrink-0" />
+            <span>{{ t('act_as_confirm_point_exit') }}</span>
+          </li>
+        </ul>
+      </template>
+      <template #footer>
+        <div class="flex w-full justify-end gap-2">
+          <UButton
+            color="neutral"
+            variant="ghost"
+            :label="t('act_as_confirm_cancel')"
+            @click="
+              () => {
+                coachingStore.cancelActingAs()
+              }
+            "
+          />
+          <UButton
+            color="primary"
+            :label="t('act_as_confirm_submit', { name: pendingName })"
+            @click="
+              () => {
+                coachingStore.confirmActingAs()
+              }
+            "
+          />
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
   import { useTranslate } from '@tolgee/vue'
-  const { t } = useTranslate('common')
+
+  const { t: tCommon } = useTranslate('common')
+  const { t } = useTranslate('coaching')
   const coachingStore = useCoachingStore()
+
+  const pendingName = computed(() => coachingStore.pendingActAs?.userName ?? '')
 </script>

--- a/app/components/coaching/AthleteCard.vue
+++ b/app/components/coaching/AthleteCard.vue
@@ -276,8 +276,14 @@
 
   // Named for screen readers and on hover/long-press: the bare eye icon gave no
   // hint that it switches the whole app to the athlete's identity (CW-541).
+  // Same fallback chain the three trigger sites use. `?? ''` produced the
+  // accessible name "View the app as " — with a trailing space and no subject —
+  // for an athlete with no name set, which is exactly the case a screen-reader
+  // user cannot recover from.
   const actAsLabel = computed(() =>
-    t.value('athlete_card_act_as_aria', { name: props.athlete?.name ?? '' })
+    t.value('athlete_card_act_as_aria', {
+      name: props.athlete?.name || props.athlete?.email || 'Athlete'
+    })
   )
 
   const currentWellness = computed(() => props.athlete.wellness?.[0] || null)

--- a/app/components/coaching/AthleteCard.vue
+++ b/app/components/coaching/AthleteCard.vue
@@ -226,12 +226,15 @@
             @click.stop="$emit('message', athlete)"
           />
         </UTooltip>
-        <UTooltip v-if="canInteract" text="Act As Athlete">
+        <UTooltip v-if="canInteract" :text="actAsLabel">
           <UButton
             color="neutral"
             variant="ghost"
             icon="i-heroicons-eye"
             size="sm"
+            :label="t('athlete_card_act_as')"
+            :aria-label="actAsLabel"
+            :title="actAsLabel"
             @click.stop="$emit('act-as', athlete)"
           />
         </UTooltip>
@@ -258,6 +261,7 @@
     Filler
   } from 'chart.js'
   import { formatDistanceToNow } from 'date-fns'
+  import { useTranslate } from '@tolgee/vue'
   import { mobileListCardUi } from '~/utils/mobile-surface-ui'
 
   ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler)
@@ -267,6 +271,14 @@
   }>()
 
   defineEmits(['view', 'message', 'act-as'])
+
+  const { t } = useTranslate('coaching')
+
+  // Named for screen readers and on hover/long-press: the bare eye icon gave no
+  // hint that it switches the whole app to the athlete's identity (CW-541).
+  const actAsLabel = computed(() =>
+    t.value('athlete_card_act_as_aria', { name: props.athlete?.name ?? '' })
+  )
 
   const currentWellness = computed(() => props.athlete.wellness?.[0] || null)
   const canInteract = computed(

--- a/app/i18n/en/coaching.json
+++ b/app/i18n/en/coaching.json
@@ -243,5 +243,15 @@
   "group_delete": "Delete Group",
   "group_remove_member": "Remove from group",
   "team_detail_remove_member": "Remove from team",
-  "team_detail_revoke_invite": "Revoke invite"
+  "team_detail_revoke_invite": "Revoke invite",
+  "athlete_card_act_as": "View as",
+  "athlete_card_act_as_aria": "View the app as {name}",
+  "act_as_confirm_title": "View the app as {name}?",
+  "act_as_confirm_description": "You will browse Coach Watts with {name}'s data and permissions instead of your own.",
+  "act_as_confirm_point_view": "You see what {name} sees — their dashboard, plans and activities.",
+  "act_as_confirm_point_persists": "It stays on until you exit — including after a reload or a new tab.",
+  "act_as_confirm_point_exit": "Exit any time from the banner at the bottom of the screen.",
+  "act_as_confirm_cancel": "Cancel",
+  "act_as_confirm_submit": "View as {name}",
+  "act_as_exit_aria": "Stop viewing as {name} and return to your own account"
 }

--- a/app/layouts/admin.vue
+++ b/app/layouts/admin.vue
@@ -474,7 +474,7 @@
 
     <ClientOnly>
       <ImpersonationBanner />
-      <CoachingBanner />
+      <!-- CoachingBanner is mounted once in app/app.vue (CW-541) -->
     </ClientOnly>
   </UDashboardGroup>
 </template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1430,7 +1430,7 @@
       <AiQuickCapture />
       <DashboardTriggerMonitor v-model="showTriggerMonitor" />
       <ImpersonationBanner />
-      <CoachingBanner />
+      <!-- CoachingBanner is mounted once in app/app.vue (CW-541) -->
     </ClientOnly>
   </UDashboardGroup>
 </template>

--- a/app/pages/coaching/index.vue
+++ b/app/pages/coaching/index.vue
@@ -74,7 +74,7 @@
           </div>
         </div>
 
-        <CoachingBanner />
+        <!-- CoachingBanner is mounted once in app/app.vue (CW-541) -->
 
         <!-- Loading State -->
         <div v-if="loading" class="grid grid-cols-1 lg:grid-cols-3 gap-0 lg:gap-8 px-0">

--- a/app/stores/coaching.ts
+++ b/app/stores/coaching.ts
@@ -29,9 +29,21 @@ function hardResetForIdentityChange(path?: string) {
   window.location.reload()
 }
 
+export interface PendingActAsRequest {
+  userId: string
+  userName: string
+}
+
 export const useCoachingStore = defineStore('coaching', () => {
   const actingAsUserId = ref<string | null>(null)
   const actingAsUserName = ref<string | null>(null)
+
+  /**
+   * Act-as switches identity for the whole app and survives reloads, so it is
+   * never entered on a single click. Every trigger stages the request here and
+   * `CoachingBanner` renders the confirmation that commits it (CW-541).
+   */
+  const pendingActAs = ref<PendingActAsRequest | null>(null)
 
   // Load from localStorage on init
   if (import.meta.client) {
@@ -45,8 +57,9 @@ export const useCoachingStore = defineStore('coaching', () => {
   }
 
   const isCoachingMode = computed(() => !!actingAsUserId.value)
+  const hasPendingActAsRequest = computed(() => !!pendingActAs.value)
 
-  function startActingAs(userId: string, userName: string) {
+  function commitActingAs(userId: string, userName: string) {
     actingAsUserId.value = userId
     actingAsUserName.value = userName
     if (import.meta.client) {
@@ -58,9 +71,32 @@ export const useCoachingStore = defineStore('coaching', () => {
     }
   }
 
+  /**
+   * Stage an act-as request. Does NOT change identity — it opens the global
+   * confirmation. Every "act as athlete" trigger in the app calls this.
+   */
+  function startActingAs(userId: string, userName: string) {
+    pendingActAs.value = { userId, userName }
+  }
+
+  /** Commit the staged request. No-op when nothing is pending. */
+  function confirmActingAs() {
+    const pending = pendingActAs.value
+    if (!pending) return
+    pendingActAs.value = null
+    commitActingAs(pending.userId, pending.userName)
+  }
+
+  /** Dismiss the staged request without changing identity. */
+  function cancelActingAs() {
+    pendingActAs.value = null
+  }
+
+  /** Drop every trace of act-as: in-memory state, both localStorage keys, the cookie. */
   function clearActingAs() {
     actingAsUserId.value = null
     actingAsUserName.value = null
+    pendingActAs.value = null
     if (import.meta.client) {
       localStorage.removeItem('coaching_act_as_id')
       localStorage.removeItem('coaching_act_as_name')
@@ -77,8 +113,12 @@ export const useCoachingStore = defineStore('coaching', () => {
   return {
     actingAsUserId,
     actingAsUserName,
+    pendingActAs,
     isCoachingMode,
+    hasPendingActAsRequest,
     startActingAs,
+    confirmActingAs,
+    cancelActingAs,
     clearActingAs,
     stopActingAs
   }

--- a/app/stores/coaching.ts
+++ b/app/stores/coaching.ts
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia'
+import { defineStore, skipHydrate } from 'pinia'
 
 const ACT_AS_COOKIE_NAME = 'coach_wattz_act_as_user'
 const ACT_AS_DASHBOARD_PATH = '/dashboard'
@@ -35,8 +35,25 @@ export interface PendingActAsRequest {
 }
 
 export const useCoachingStore = defineStore('coaching', () => {
-  const actingAsUserId = ref<string | null>(null)
-  const actingAsUserName = ref<string | null>(null)
+  // `skipHydrate` is load-bearing, not decoration (CW-637).
+  //
+  // `app/plugins/coaching-interceptor.ts` has no `.client` suffix, so it is
+  // universal and instantiates this store during SSR. The localStorage restore
+  // below is inside `if (import.meta.client)`, so the value Pinia serialises
+  // into the SSR payload is always `null`. On the client, @pinia/nuxt assigns
+  // `pinia.state.value = nuxtApp.payload.pinia`, and pinia's `createSetupStore`
+  // then walks every writable ref and applies `prop.value = initialState[key]`
+  // *after* the setup body has run — clobbering the restore with that `null`.
+  //
+  // The visible result was that `isCoachingMode` was false on the client after
+  // every full page load, so `CoachingBanner` never rendered, while the
+  // `coach_wattz_act_as_user` cookie kept the *server* impersonating. That
+  // combination — server impersonating, no client exit affordance — is what
+  // "no way out" actually was; the duplicate banner mounts were a red herring.
+  //
+  // Opting these two refs out of hydration lets the localStorage restore stand.
+  const actingAsUserId = skipHydrate(ref<string | null>(null))
+  const actingAsUserName = skipHydrate(ref<string | null>(null))
 
   /**
    * Act-as switches identity for the whole app and survives reloads, so it is
@@ -98,9 +115,19 @@ export const useCoachingStore = defineStore('coaching', () => {
     actingAsUserName.value = null
     pendingActAs.value = null
     if (import.meta.client) {
-      localStorage.removeItem('coaching_act_as_id')
-      localStorage.removeItem('coaching_act_as_name')
-      persistActAsCookie(null)
+      // Clear the cookie FIRST, and in a `finally` so a storage exception cannot
+      // skip it. The cookie is the only one of the three the *server* reads, so
+      // if a `removeItem` throws (storage disabled or over quota) with the
+      // cookie still set, the server keeps impersonating while the client
+      // believes it exited — and, with no client state left, renders no exit
+      // affordance. That is the half-impersonating state this ticket exists to
+      // eliminate, so it must not be reachable through the exit path itself.
+      try {
+        persistActAsCookie(null)
+      } finally {
+        localStorage.removeItem('coaching_act_as_id')
+        localStorage.removeItem('coaching_act_as_name')
+      }
     }
   }
 

--- a/tests/unit/app/stores/coaching.test.ts
+++ b/tests/unit/app/stores/coaching.test.ts
@@ -28,17 +28,56 @@ describe('useCoachingStore Pinia Store', () => {
     localStorage.clear()
   })
 
+  /** Enter act-as the way the UI does: request, then confirm. */
+  function enterActingAs(store: ReturnType<typeof useCoachingStore>) {
+    store.startActingAs('athlete-123', 'Ada Athlete')
+    store.confirmActingAs()
+  }
+
   it('initializes with empty act-as state', () => {
     const store = useCoachingStore()
     expect(store.actingAsUserId).toBeNull()
     expect(store.actingAsUserName).toBeNull()
     expect(store.isCoachingMode).toBe(false)
+    expect(store.pendingActAs).toBeNull()
+    expect(store.hasPendingActAsRequest).toBe(false)
   })
 
-  it('startActingAs persists identity and hard-navigates to dashboard', () => {
+  it('startActingAs only stages a request — a single click never switches identity', () => {
     const store = useCoachingStore()
     store.startActingAs('athlete-123', 'Ada Athlete')
 
+    expect(store.pendingActAs).toEqual({ userId: 'athlete-123', userName: 'Ada Athlete' })
+    expect(store.hasPendingActAsRequest).toBe(true)
+    // Nothing committed yet
+    expect(store.actingAsUserId).toBeNull()
+    expect(store.isCoachingMode).toBe(false)
+    expect(localStorage.getItem('coaching_act_as_id')).toBeNull()
+    expect(document.cookie).not.toContain('coach_wattz_act_as_user=athlete-123')
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('cancelActingAs discards the request and leaves the coach identity untouched', () => {
+    const store = useCoachingStore()
+    store.startActingAs('athlete-123', 'Ada Athlete')
+
+    store.cancelActingAs()
+
+    expect(store.pendingActAs).toBeNull()
+    expect(store.hasPendingActAsRequest).toBe(false)
+    expect(store.actingAsUserId).toBeNull()
+    expect(store.isCoachingMode).toBe(false)
+    expect(localStorage.getItem('coaching_act_as_id')).toBeNull()
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('confirmActingAs persists identity and hard-navigates to dashboard', () => {
+    const store = useCoachingStore()
+    enterActingAs(store)
+
+    expect(store.pendingActAs).toBeNull()
     expect(store.actingAsUserId).toBe('athlete-123')
     expect(store.actingAsUserName).toBe('Ada Athlete')
     expect(store.isCoachingMode).toBe(true)
@@ -49,9 +88,19 @@ describe('useCoachingStore Pinia Store', () => {
     expect(reloadSpy).not.toHaveBeenCalled()
   })
 
+  it('confirmActingAs is a no-op when nothing is pending', () => {
+    const store = useCoachingStore()
+
+    store.confirmActingAs()
+
+    expect(store.actingAsUserId).toBeNull()
+    expect(store.isCoachingMode).toBe(false)
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
   it('stopActingAs clears identity and reloads to restore coach session', () => {
     const store = useCoachingStore()
-    store.startActingAs('athlete-123', 'Ada Athlete')
+    enterActingAs(store)
     assignSpy.mockClear()
 
     store.stopActingAs()
@@ -65,16 +114,36 @@ describe('useCoachingStore Pinia Store', () => {
     expect(assignSpy).not.toHaveBeenCalled()
   })
 
+  it('stopActingAs expires the act-as cookie so the server stops impersonating', () => {
+    const store = useCoachingStore()
+    enterActingAs(store)
+
+    store.stopActingAs()
+
+    expect(document.cookie).not.toContain('coach_wattz_act_as_user=athlete-123')
+  })
+
   it('clearActingAs clears persistence without navigating', () => {
     const store = useCoachingStore()
-    store.startActingAs('athlete-123', 'Ada Athlete')
+    enterActingAs(store)
     assignSpy.mockClear()
 
     store.clearActingAs()
 
     expect(store.actingAsUserId).toBeNull()
     expect(localStorage.getItem('coaching_act_as_id')).toBeNull()
+    expect(localStorage.getItem('coaching_act_as_name')).toBeNull()
     expect(assignSpy).not.toHaveBeenCalled()
     expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('clearActingAs also discards a pending request', () => {
+    const store = useCoachingStore()
+    store.startActingAs('athlete-123', 'Ada Athlete')
+
+    store.clearActingAs()
+
+    expect(store.pendingActAs).toBeNull()
+    expect(store.hasPendingActAsRequest).toBe(false)
   })
 })


### PR DESCRIPTION
Fixes CW-541

## What changed

- **Deduped `CoachingBanner`.** It was mounted **four** times: `app/app.vue`, `app/layouts/default.vue`, `app/layouts/admin.vue`, `app/pages/coaching/index.vue`. Because `app.vue` sits above the layout, every page using `default`/`admin` rendered **two** stacked, identically-positioned banners (`fixed bottom-4 left-1/2 z-[60]`). Now mounted once, from `app.vue`.
- **Act-as is confirmed, not silent.** `startActingAs()` no longer switches identity — it stages a `pendingActAs` request, and `CoachingBanner` renders a confirmation dialog that commits it via `confirmActingAs()` / discards it via `cancelActingAs()`. Staging in the store means all three triggers (team page, athletes list, athlete detail) are covered **without editing those pages**, which are outside this ticket's Owned Paths.
- **The eye trigger is labelled.** `AthleteCard`'s act-as button gained a visible "View as" label, a tooltip, `title` and `aria-label`, all naming the athlete. Accessible name is now `View the app as {name}` (was: an unnamed button).
- **Exit leaves no half-state.** `clearActingAs()` now also discards a pending request, alongside the cookie and both localStorage keys it already cleared.
- **Copy** added to the already-registered `coaching` namespace, and pushed to Tolgee with English values.

## ⚠️ This does NOT fix the headline symptom — please read

The ticket's triage note asserted the duplicate mounts were "very likely the real visual bug behind 'no way out'". **That is falsified.** The duplicates are real, but *both copies were hidden*, so deduping them changes nothing a user can see.

The actual cause: **`isCoachingMode` is `false` on the client after any page load**, because Pinia's SSR hydration overwrites the store's `localStorage` restore with the SSR `null`. Meanwhile the `coach_wattz_act_as_user` cookie keeps the **server** impersonating. Server-side act-as ON, client-side exit UI OFF — everywhere, on `/dashboard` as well as the team page.

I verified this is **pre-existing**: stashing this entire branch and retesting on pristine `origin/develop`, with cookie and localStorage set, also yields **zero** banners.

Per this ticket's own acceptance criterion 3 ("RECORD that finding and file it separately; do NOT work around it visually") I did not work around it. Filed as **CW-637**.

**Recommendation: land CW-637 with or immediately after this PR.** The confirmation dialog added here tells the user "Exit any time from the banner at the bottom of the screen", which is correct by design but false until CW-637 ships.

## Acceptance criteria

| AC | Status |
|---|---|
| 1. `CoachingBanner` renders exactly once | ✅ verified empirically: 2 stacked banners → 1 |
| 2. Exit affordance visible on `/coaching/teams/{id}` | ❌ blocked by CW-637 |
| 3. If not visible, record + file separately | ✅ CW-637 |
| 4. Eye trigger has label/tooltip + `aria-label` | ✅ |
| 5. Entering act-as is confirmed | ✅ |
| 6. Exit clears cookie + both localStorage keys in one action | ✅ now covered by tests |
| 7. New copy through Tolgee | ✅ |

## Verification

```
pnpm test:unit && pnpm typecheck && pnpm lint
```

- `pnpm test:unit` (bare, no path filter): **387 files / 2656 tests passed**
- `pnpm typecheck`: **exit 0**
- `pnpm lint`: **exit 0** (116 warnings, all pre-existing `vue/require-default-prop` in unrelated email templates)

Manual reproduction on the worktree dev server with a seeded team + two athletes: clicked the eye icon → confirmation appeared with no state written; Cancel and Escape both backed out cleanly; confirming wrote cookie + both localStorage keys and hard-navigated to `/dashboard`.

## UX critique: required — FIX-FIRST → fixed

The `factory-ux-critic` agent returned **FIX-FIRST**. Its major in-scope finding was that my new dialog bullet claimed *"Coach-only pages are restricted while this is on"* — which does **not** hold (`/admin` and `/coaching` render fully while act-as is active). A confirmation dialog making a false safety promise is worse than making none, so **that copy is fixed in this branch**: the bullet now states only what is true (`It stays on until you exit — including after a reload or a new tab.`).

Its other findings were folded into follow-ups rather than absorbed here:
- Missing persistent identity cue (sidebar still shows the coach's name) → added to **CW-637**, since it shares that bug's failure mode.
- Uneven route restriction under act-as, 28px tap target, dialog focus landing on "X" instead of "Cancel" → **CW-639**.

The critic confirmed the acceptance criteria are met, that button emphasis is correct, and that the mobile (375px) card footer handles the new text label without wrapping or overlap.

## Follow-ups filed

- **CW-637** — act-as identity wiped by Pinia SSR hydration, so the exit banner never renders *(the real "no way out"; recommend landing with this PR)*
- **CW-638** — `ImpersonationBanner` has the identical triple-mount defect
- **CW-639** — act-as polish: uneven route restriction, tap target, dialog focus

Screenshots on CW-541.

## Files changed vs Owned Paths

All 8 changed files are within Owned Paths: `app/components/CoachingBanner.vue`, `app/components/coaching/AthleteCard.vue`, `app/stores/coaching.ts`, `app/layouts/default.vue`, `app/layouts/admin.vue`, `app/pages/coaching/index.vue`, `app/i18n/en/coaching.json`, `tests/unit/app/stores/coaching.test.ts`. `app/app.vue` was inspected but needed no change.

## Risks

- `startActingAs()` keeps its name but changed meaning — it now *requests* rather than *commits*. All three call sites are unmodified and behave correctly (they get a confirmation instead of an instant switch), but any future caller expecting the old semantics would need `confirmActingAs()`.
- The confirmation renders from `CoachingBanner`, so that component is now load-bearing for entering act-as, not just exiting it. It is inside `<ClientOnly>` in `app.vue`, which is where act-as state lives anyway.