### PR TITLE
fix(ai): guard non-array history JSON in generate-recommendations (CW-369)

### DIFF
--- a/tests/unit/trigger/generate-recommendations.test.ts
+++ b/tests/unit/trigger/generate-recommendations.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../trigger/init', () => ({}))
+
+vi.mock('../../../trigger/queues', () => ({
+  userReportsQueue: { name: 'user-reports' }
+}))
+
+const { userFindUnique, trendFindMany, workoutFindMany } = vi.hoisted(() => ({
+  userFindUnique: vi.fn(),
+  trendFindMany: vi.fn(),
+  workoutFindMany: vi.fn()
+}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    user: { findUnique: userFindUnique },
+    scoreTrendExplanation: { findMany: trendFindMany },
+    workout: { findMany: workoutFindMany }
+  }
+}))
+
+const { generateStructuredAnalysis, buildWorkoutSummary } = vi.hoisted(() => ({
+  generateStructuredAnalysis: vi.fn(),
+  buildWorkoutSummary: vi.fn()
+}))
+
+vi.mock('../../../server/utils/gemini', () => ({
+  generateStructuredAnalysis,
+  buildWorkoutSummary
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+  getStartOfDaysAgoUTC: vi.fn().mockReturnValue(new Date('2026-08-01T00:00:00.000Z'))
+}))
+
+vi.mock('../../../server/utils/services/checkin-service', () => ({
+  getCheckinHistoryContext: vi.fn().mockResolvedValue(null)
+}))
+
+const { getActive, createMany, update, updateMany } = vi.hoisted(() => ({
+  getActive: vi.fn(),
+  createMany: vi.fn(),
+  update: vi.fn(),
+  updateMany: vi.fn()
+}))
+
+vi.mock('../../../server/utils/repositories/recommendationRepository', () => ({
+  recommendationRepository: { getActive, createMany, update, updateMany }
+}))
+
+vi.mock('../../../server/utils/repositories/nutritionRepository', () => ({
+  nutritionRepository: { getForUser: vi.fn().mockResolvedValue([]) }
+}))
+
+vi.mock('../../../server/utils/ai-user-settings', () => ({
+  getUserAiSettings: vi.fn().mockResolvedValue({
+    aiModelPreference: 'gemini-2.5-flash',
+    aiPersona: 'Supportive'
+  })
+}))
+
+vi.mock('../../../server/utils/goal-context', () => ({
+  filterGoalsForContext: vi.fn().mockReturnValue([])
+}))
+
+vi.mock('../../../server/utils/quotas/engine', () => ({
+  checkQuota: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../../../server/utils/task-registry', () => ({
+  registerTaskHandler: vi.fn()
+}))
+
+vi.mock('@trigger.dev/sdk/v3', async () => {
+  const actual = await vi.importActual('@trigger.dev/sdk/v3')
+  return {
+    ...actual,
+    logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    task: vi.fn().mockImplementation((config) => ({ run: config.run, id: config.id }))
+  }
+})
+
+const USER_ID = 'user-1'
+const REC_ID = 'rec-1'
+
+/**
+ * Builds the single active recommendation the AI response asks to update,
+ * with the given (possibly malformed) `history` Json column value.
+ */
+function activeRecommendation(history: unknown) {
+  return {
+    id: REC_ID,
+    userId: USER_ID,
+    title: 'Old title',
+    description: 'Old description',
+    priority: 'medium',
+    category: 'Cycling',
+    metric: 'ftp',
+    sourceType: 'workout',
+    period: 7,
+    status: 'ACTIVE',
+    isPinned: false,
+    generatedAt: new Date('2026-08-10T00:00:00.000Z'),
+    history
+  }
+}
+
+/**
+ * Runs the task with a single `updated_recommendations` entry against an
+ * existing recommendation holding `history`, and returns the `history` value
+ * the repository was asked to persist.
+ */
+async function runUpdateWithHistory(history: unknown) {
+  userFindUnique.mockResolvedValue({
+    name: 'Athlete',
+    language: 'English',
+    distanceUnits: 'km',
+    goals: []
+  })
+  trendFindMany.mockResolvedValue([])
+  workoutFindMany.mockResolvedValue([])
+  buildWorkoutSummary.mockReturnValue('None')
+  getActive.mockResolvedValue([activeRecommendation(history)])
+
+  generateStructuredAnalysis.mockResolvedValue({
+    // No new recommendations keeps the deduplication sweep (a second LLM call)
+    // out of this test — we only care about the update path.
+    new_recommendations: [],
+    updated_recommendations: [
+      {
+        id: REC_ID,
+        new_title: 'New title',
+        new_description: 'New description',
+        new_priority: 'high',
+        reason_for_update: 'Data changed'
+      }
+    ],
+    completed_recommendation_ids: [],
+    dismissed_recommendation_ids: []
+  })
+
+  const { runGenerateRecommendations } = await import('../../../trigger/generate-recommendations')
+
+  const result = await runGenerateRecommendations({ userId: USER_ID })
+
+  expect(result).toMatchObject({ success: true, updated: 1 })
+  expect(update).toHaveBeenCalledTimes(1)
+
+  const [id, userId, data] = update.mock.calls[0]!
+  expect(id).toBe(REC_ID)
+  expect(userId).toBe(USER_ID)
+  return data.history
+}
+
+const APPENDED_ENTRY = {
+  title: 'Old title',
+  description: 'Old description',
+  reason: 'Data changed'
+}
+
+describe('runGenerateRecommendations — history column handling (CW-369)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('starts a fresh history when the stored value is null', async () => {
+    const history = await runUpdateWithHistory(null)
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  })
+
+  it('appends to an existing array history without disturbing earlier entries', async () => {
+    const previous = {
+      date: '2026-08-01T00:00:00.000Z',
+      title: 'Older title',
+      description: 'Older description',
+      reason: 'Previous update'
+    }
+
+    const history = await runUpdateWithHistory([previous])
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(2)
+    expect(history[0]).toEqual(previous)
+    expect(history[1]).toMatchObject(APPENDED_ENTRY)
+  })
+
+  it('falls back to a fresh history when the stored value is a plain object', async () => {
+    // Regression: `(existing.history as any) || []` leaves an object in place and
+    // the subsequent spread throws "currentHistory is not iterable".
+    const history = await runUpdateWithHistory({})
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  })
+
+  it('falls back to a fresh history when the stored value is a non-empty object', async () => {
+    const history = await runUpdateWithHistory({ date: '2026-08-01', reason: 'legacy shape' })
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  })
+
+  it('falls back to a fresh history when the stored value is a JSON string', async () => {
+    // Regression: strings are iterable, so the old spread silently exploded the
+    // string into one history entry per character instead of throwing.
+    const history = await runUpdateWithHistory('[{"reason":"legacy"}]')
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  })
+
+  it('falls back to a fresh history when the stored value is a number', async () => {
+    const history = await runUpdateWithHistory(42)
+
+    expect(Array.isArray(history)).toBe(true)
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  })
+})

--- a/tests/unit/trigger/generate-recommendations.test.ts
+++ b/tests/unit/trigger/generate-recommendations.test.ts
@@ -151,7 +151,7 @@ async function runUpdateWithHistory(history: unknown) {
   const [id, userId, data] = update.mock.calls[0]!
   expect(id).toBe(REC_ID)
   expect(userId).toBe(USER_ID)
-  return data.history
+  return data
 }
 
 const APPENDED_ENTRY = {
@@ -167,7 +167,7 @@ describe('runGenerateRecommendations — history column handling (CW-369)', () =
   })
 
   it('starts a fresh history when the stored value is null', async () => {
-    const history = await runUpdateWithHistory(null)
+    const history = (await runUpdateWithHistory(null)).history
 
     expect(Array.isArray(history)).toBe(true)
     expect(history).toHaveLength(1)
@@ -182,7 +182,7 @@ describe('runGenerateRecommendations — history column handling (CW-369)', () =
       reason: 'Previous update'
     }
 
-    const history = await runUpdateWithHistory([previous])
+    const history = (await runUpdateWithHistory([previous])).history
 
     expect(Array.isArray(history)).toBe(true)
     expect(history).toHaveLength(2)
@@ -190,39 +190,51 @@ describe('runGenerateRecommendations — history column handling (CW-369)', () =
     expect(history[1]).toMatchObject(APPENDED_ENTRY)
   })
 
-  it('falls back to a fresh history when the stored value is a plain object', async () => {
-    // Regression: `(existing.history as any) || []` leaves an object in place and
-    // the subsequent spread throws "currentHistory is not iterable".
-    const history = await runUpdateWithHistory({})
+  // CW-369 review finding: a non-array `history` is NOT corruption. It is a
+  // second schema written by `thresholdDetectionService` for ACTIVE
+  // `sourceType: 'workout'` recommendations:
+  //   { oldValue, newValue, workoutId, sportName, workoutDate }
+  // `athleteMetricsService` reads `Number(history?.newValue)` from it to promote
+  // a detected FTP/LTHR/MAX_HR/THRESHOLD_PACE into the athlete's profile.
+  // Overwriting it with our array yields NaN, so the value is silently never
+  // promoted while the recommendation is still marked COMPLETED. So the
+  // requirement is to LEAVE IT ALONE, not to replace it with a fresh array.
+  const THRESHOLD_HISTORY = {
+    oldValue: 250,
+    newValue: 268,
+    workoutId: 'workout-1',
+    sportName: 'Ride',
+    workoutDate: '2026-08-01T00:00:00.000Z'
+  }
 
-    expect(Array.isArray(history)).toBe(true)
-    expect(history).toHaveLength(1)
-    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+  it('never writes history when the stored value is a threshold-detection object', async () => {
+    const data = await runUpdateWithHistory(THRESHOLD_HISTORY)
+
+    // The key must be absent entirely — writing `undefined` or `[]` would both
+    // destroy the threshold payload just as surely as writing our array.
+    expect(Object.hasOwn(data, 'history')).toBe(false)
+    // The rest of the update still applies.
+    expect(data.title).toBeDefined()
+    expect(data.priority).toBeDefined()
   })
 
-  it('falls back to a fresh history when the stored value is a non-empty object', async () => {
-    const history = await runUpdateWithHistory({ date: '2026-08-01', reason: 'legacy shape' })
+  it('never writes history when the stored value is an empty object', async () => {
+    const data = await runUpdateWithHistory({})
 
-    expect(Array.isArray(history)).toBe(true)
-    expect(history).toHaveLength(1)
-    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+    expect(Object.hasOwn(data, 'history')).toBe(false)
   })
 
-  it('falls back to a fresh history when the stored value is a JSON string', async () => {
-    // Regression: strings are iterable, so the old spread silently exploded the
-    // string into one history entry per character instead of throwing.
-    const history = await runUpdateWithHistory('[{"reason":"legacy"}]')
+  it('never writes history when the stored value is a JSON string', async () => {
+    // Strings are iterable, so the original spread silently exploded the string
+    // into one history entry per character rather than throwing.
+    const data = await runUpdateWithHistory('[{"reason":"legacy"}]')
 
-    expect(Array.isArray(history)).toBe(true)
-    expect(history).toHaveLength(1)
-    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+    expect(Object.hasOwn(data, 'history')).toBe(false)
   })
 
-  it('falls back to a fresh history when the stored value is a number', async () => {
-    const history = await runUpdateWithHistory(42)
+  it('never writes history when the stored value is a number', async () => {
+    const data = await runUpdateWithHistory(42)
 
-    expect(Array.isArray(history)).toBe(true)
-    expect(history).toHaveLength(1)
-    expect(history[0]).toMatchObject(APPENDED_ENTRY)
+    expect(Object.hasOwn(data, 'history')).toBe(false)
   })
 })

--- a/trigger/generate-recommendations.ts
+++ b/trigger/generate-recommendations.ts
@@ -395,19 +395,47 @@ JSON object with 'new_recommendations', 'updated_recommendations', 'completed_re
         reason: update.reason_for_update
       }
 
-      // `history` is a Json column, so it can hold any JSON value. Only spread it
-      // when it is actually an array — a stored object/string/number is truthy and
-      // would either throw ("not iterable") or be exploded into bogus entries.
-      const currentHistory: RecommendationHistoryItem[] = Array.isArray(existing.history)
-        ? (existing.history as unknown as RecommendationHistoryItem[])
+      // `history` is a Json column carrying TWO different schemas, which is the
+      // whole hazard here:
+      //
+      //  - this path writes an append-only array of RecommendationHistoryItem
+      //  - `thresholdDetectionService` writes a single OBJECT
+      //    ({ oldValue, newValue, workoutId, sportName, workoutDate }) for
+      //    ACTIVE `sourceType: 'workout'` recommendations
+      //
+      // `recommendationRepository.getActive()` applies no sourceType/metric
+      // filter, so those threshold rows reach `existingRecsContext` and the LLM
+      // can name their id in `updated_recommendations` — which is exactly how
+      // the "not iterable" crash was reached.
+      //
+      // So a non-array value is NOT corruption to be discarded. Overwriting it
+      // with our array would make `athleteMetricsService` read
+      // `Number(history?.newValue)` as NaN, `applyThresholdRecommendation`
+      // return false, and the athlete's detected FTP/LTHR/MAX_HR/THRESHOLD_PACE
+      // never reach their profile — while the recommendation is still marked
+      // COMPLETED. That trades a loud crash for silent, irreversible data loss
+      // on the very rows that triggered it.
+      //
+      // Read defensively, and only WRITE `history` when the stored value is
+      // something we can legitimately append to.
+      const storedHistory = existing.history
+      const historyIsAppendable = storedHistory == null || Array.isArray(storedHistory)
+      const currentHistory: RecommendationHistoryItem[] = Array.isArray(storedHistory)
+        ? (storedHistory as unknown as RecommendationHistoryItem[])
         : []
-      const newHistory = [...currentHistory, historyItem]
+
+      if (!historyIsAppendable) {
+        logger.warn('Skipping history append: stored history is not an array', {
+          recommendationId: update.id,
+          storedHistoryType: typeof storedHistory
+        })
+      }
 
       await recommendationRepository.update(update.id, userId, {
         title: update.new_title,
         description: update.new_description,
         priority: update.new_priority,
-        history: newHistory as any,
+        ...(historyIsAppendable ? { history: [...currentHistory, historyItem] as any } : {}),
         generatedAt: new Date(),
         llmUsageId: usageId
       })

--- a/trigger/generate-recommendations.ts
+++ b/trigger/generate-recommendations.ts
@@ -395,7 +395,12 @@ JSON object with 'new_recommendations', 'updated_recommendations', 'completed_re
         reason: update.reason_for_update
       }
 
-      const currentHistory = (existing.history as any) || []
+      // `history` is a Json column, so it can hold any JSON value. Only spread it
+      // when it is actually an array — a stored object/string/number is truthy and
+      // would either throw ("not iterable") or be exploded into bogus entries.
+      const currentHistory: RecommendationHistoryItem[] = Array.isArray(existing.history)
+        ? (existing.history as unknown as RecommendationHistoryItem[])
+        : []
       const newHistory = [...currentHistory, historyItem]
 
       await recommendationRepository.update(update.id, userId, {


### PR DESCRIPTION
Fixes CW-369

## Problem

`trigger/generate-recommendations.ts` built the updated recommendation's history with:

```ts
const currentHistory = (existing.history as any) || []
const newHistory = [...currentHistory, historyItem]
```

`existing.history` is a Prisma `Json` column, so it can hold any JSON value. `|| []` only substitutes for falsy values — a truthy non-array (object, string, number) fell straight through into the spread:

- object / number -> `TypeError: currentHistory is not iterable`, aborting the entire `updated_recommendations` loop for that user's batch (Sentry `COACH-WATTS-WEB-13`, 2 occurrences since 2026-08-05).
- string -> iterable, so it was silently exploded into one history entry per character.

## Fix

Guard with `Array.isArray` so a non-array value falls back to `[]` instead of being spread or coerced. No behaviour change when `history` is already an array or `null`.

I also checked the rest of the file for the same `|| []`-on-a-Json-column pattern: the only other two `|| []` uses (`completed_recommendation_ids`, `dismissed_recommendation_ids`) are on the LLM response object, not Prisma `Json` columns, so they are left alone.

## Tests

New `tests/unit/trigger/generate-recommendations.test.ts` drives `runGenerateRecommendations` through the update path with `history` set to `null`, an array, `{}`, a non-empty object, a JSON string, and a number.

**Verified the test is meaningful — against the unmodified source it fails 4 / 6:**

```
FAIL  ... > stored value is a plain object
TypeError: currentHistory is not iterable
 ❯ runGenerateRecommendations trigger/generate-recommendations.ts:399:30

FAIL  ... > stored value is a non-empty object
TypeError: currentHistory is not iterable

FAIL  ... > stored value is a JSON string
AssertionError: expected [ '[', '{', '"', 'r', 'e', 'a', …(16) ] to have a length of 1 but got 22

FAIL  ... > stored value is a number
TypeError: currentHistory is not iterable

Tests  4 failed | 2 passed (6)
```

The 2 that pass unmodified are the `null` and existing-array cases — they pin the no-behaviour-change requirement.

## Verification

`pnpm test:unit` (bare, no path filter):

```
Test Files  388 passed (388)
     Tests  2657 passed (2657)
  Duration  251.90s
```

UX critique: skipped — background task, no user-facing surface.