### PR TITLE
fix(data): read streams through the repository, not the V1 relation (CW-379)

### DIFF
--- a/server/api/analytics/presets/[preset].post.ts
+++ b/server/api/analytics/presets/[preset].post.ts
@@ -13,6 +13,7 @@ import {
   identifyZone
 } from '../../../utils/zones'
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
+import { attachStreamsToWorkouts } from '../../../utils/repositories/workoutStreamRepository'
 
 type PresetRoute =
   | 'compliance'
@@ -846,13 +847,18 @@ async function buildPowerDurationChart(
   presetOptions: Record<string, any>
 ) {
   const mode = presetOptions.mode as string
-  const workouts = await prisma.workout.findMany({
+  // CW-379: `streams` is the legacy V1 relation. Selecting it here made every
+  // team power-duration / weekly-zone preset render empty for athletes whose
+  // streams only exist in WorkoutStreamV2. Fetch the workouts, then let the
+  // repository attach streams from whichever generation holds them.
+  const workoutRecords = await prisma.workout.findMany({
     where: {
       userId: { in: userIds },
       date: { gte: startDate, lte: endDate },
       isDuplicate: false
     },
     select: {
+      id: true,
       userId: true,
       date: true,
       type: true,
@@ -861,18 +867,15 @@ async function buildPowerDurationChart(
       averageWatts: true,
       averageHr: true,
       intensity: true,
-      workAboveFtp: true,
-      streams: {
-        select: {
-          time: true,
-          watts: true,
-          heartrate: true,
-          velocity: true
-        }
-      }
+      workAboveFtp: true
     },
     orderBy: { date: 'asc' }
   })
+
+  // Only time/watts/heartrate/velocity are read below -- all in the
+  // repository's mandatory baseline, so no optional columns are fetched for
+  // what can be an entire roster's worth of workouts.
+  const workouts = await attachStreamsToWorkouts(workoutRecords, { baselineOnly: true })
 
   const userProfiles = await loadUserProfiles(userIds)
 

--- a/server/api/analytics/weekly-zones.get.ts
+++ b/server/api/analytics/weekly-zones.get.ts
@@ -2,6 +2,7 @@ import { defineEventHandler, getQuery, createError } from 'h3'
 import { prisma } from '../../utils/db'
 import { userRepository } from '../../utils/repositories/userRepository'
 import { workoutRepository } from '../../utils/repositories/workoutRepository'
+import { attachStreamsToWorkouts } from '../../utils/repositories/workoutStreamRepository'
 import { sportSettingsRepository } from '../../utils/repositories/sportSettingsRepository'
 import { calculatePowerZones, calculateHrZones } from '../../utils/zones'
 import { getServerSession } from '../../utils/session'
@@ -89,24 +90,27 @@ export default defineEventHandler(async (event) => {
       : calculateHrZones(displayLthr, displayMaxHr)
 
   // 2. Get workouts with streams
-  const workouts = await workoutRepository.getForUser(userId, {
+  //
+  // CW-379: the `streams` relation is the legacy V1 table only, and stream
+  // writes have gone to WorkoutStreamV2 for a while now -- selecting it here
+  // silently returned zero zone time for every V2-only athlete. The repository
+  // reads V2 first and falls back to V1, so both generations aggregate.
+  const workoutRecords = await workoutRepository.getForUser(userId, {
     startDate,
     endDate,
     tags,
     where: sport ? { type: sport } : undefined,
     select: {
+      id: true,
       date: true,
       ftp: true,
-      type: true, // Needed for sport matching
-      streams: {
-        select: {
-          time: true,
-          watts: true,
-          heartrate: true
-        }
-      }
+      type: true // Needed for sport matching
     }
   })
+
+  // Only time/watts/heartrate are read below, all of which are in the
+  // repository's mandatory baseline -- no optional columns needed.
+  const workouts = await attachStreamsToWorkouts(workoutRecords, { baselineOnly: true })
 
   // 3. Initialize buckets
   const weeklyData = new Map<

--- a/server/api/analytics/workout-comparison/intervals.post.ts
+++ b/server/api/analytics/workout-comparison/intervals.post.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { assertWorkoutComparisonAccess } from '../../../utils/analyticsScope'
 import { prisma } from '../../../utils/db'
+import { attachStreamsToWorkouts } from '../../../utils/repositories/workoutStreamRepository'
 
 const schema = z.object({
   comparison: z.object({
@@ -51,20 +52,21 @@ export default defineEventHandler(async (event) => {
   const comparison = result.data.comparison
   const workoutIds = await assertWorkoutComparisonAccess(user.id, comparison.workoutIds)
 
-  const workouts = await prisma.workout.findMany({
+  // CW-379: `streams` only covers the legacy V1 table, so lap comparison came
+  // back "no comparable lap data" for V2-only workouts. `lapSplits` is an
+  // optional column, so it has to be requested explicitly on top of the
+  // repository's baseline.
+  const workoutRecords = await prisma.workout.findMany({
     where: { id: { in: workoutIds } },
     select: {
       id: true,
       title: true,
       date: true,
-      user: { select: { name: true, email: true } },
-      streams: {
-        select: {
-          lapSplits: true
-        }
-      }
+      user: { select: { name: true, email: true } }
     }
   })
+
+  const workouts = await attachStreamsToWorkouts(workoutRecords, { fields: ['lapSplits'] })
 
   const byId = new Map(workouts.map((workout) => [workout.id, workout]))
   const ordered = workoutIds.map((id) => byId.get(id)).filter(Boolean)

--- a/server/api/analytics/workout-explorer/density.post.ts
+++ b/server/api/analytics/workout-explorer/density.post.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { getAccessibleWorkout } from '../../../utils/analyticsScope'
+import { attachStreamToWorkout } from '../../../utils/repositories/workoutStreamRepository'
 
 const schema = z.object({
   analysis: z.object({
@@ -62,21 +63,13 @@ export default defineEventHandler(async (event) => {
   }
 
   const { analysis } = result.data
-  const workout = await getAccessibleWorkout(user.id, analysis.workoutId, {
-    select: {
-      streams: {
-        select: {
-          time: true,
-          distance: true,
-          watts: true,
-          cadence: true,
-          heartrate: true,
-          velocity: true,
-          grade: true
-        }
-      }
-    }
+  // CW-379: `streams` is the legacy V1 relation only -- the density heatmap
+  // 404'd for every athlete whose series are in WorkoutStreamV2.
+  const workoutRecord = await getAccessibleWorkout(user.id, analysis.workoutId, {
+    select: { id: true }
   })
+
+  const workout = workoutRecord ? await attachStreamToWorkout(workoutRecord) : null
 
   if (!workout || !workout.streams) {
     throw createError({ statusCode: 404, statusMessage: 'Workout streams not found' })

--- a/server/api/analytics/workout-explorer/intervals.post.ts
+++ b/server/api/analytics/workout-explorer/intervals.post.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { getAccessibleWorkout } from '../../../utils/analyticsScope'
+import { attachStreamToWorkout } from '../../../utils/repositories/workoutStreamRepository'
 
 const schema = z.object({
   analysis: z.object({
@@ -47,22 +48,23 @@ export default defineEventHandler(async (event) => {
   }
 
   const analysis = result.data.analysis
-  const workout = await getAccessibleWorkout(user.id, analysis.workoutId, {
+  // CW-379: `streams` is the legacy V1 relation only -- V2-only workouts fell
+  // through to "no comparable lap data". attachStreamToWorkout reads V2 first
+  // and falls back to V1.
+  const workoutRecord = await getAccessibleWorkout(user.id, analysis.workoutId, {
     select: {
+      id: true,
       title: true,
       date: true,
-      user: { select: { name: true, email: true } },
-      streams: {
-        select: {
-          lapSplits: true
-        }
-      }
+      user: { select: { name: true, email: true } }
     }
   })
 
-  if (!workout) {
+  if (!workoutRecord) {
     throw createError({ statusCode: 404, statusMessage: 'Workout not found' })
   }
+
+  const workout = await attachStreamToWorkout(workoutRecord)
 
   const splits = toLapArray(workout.streams?.lapSplits)
   if (splits.length === 0) {

--- a/server/api/analytics/workout-explorer/streams.post.ts
+++ b/server/api/analytics/workout-explorer/streams.post.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod/v3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { getAccessibleWorkout } from '../../../utils/analyticsScope'
+import { attachStreamToWorkout } from '../../../utils/repositories/workoutStreamRepository'
 import { lttb } from '../../../utils/analytics/lttb'
 import { calculateVirtualStream, type VirtualField } from '../../../utils/analytics/virtual-streams'
 import { sportSettingsRepository } from '../../../utils/repositories/sportSettingsRepository'
@@ -143,28 +144,21 @@ export default defineEventHandler(async (event) => {
 
   const { analysis } = result.data
   // 1. Fetch Workout and Streams
-  const workout = await getAccessibleWorkout(user.id, analysis.workoutId, {
+  // CW-379: `streams` selects the legacy V1 table only, so the whole workout
+  // explorer 404'd with "Workout streams not found" for athletes whose series
+  // live in WorkoutStreamV2. attachStreamToWorkout prefers V2 and falls back
+  // to V1.
+  const workoutRecord = await getAccessibleWorkout(user.id, analysis.workoutId, {
     select: {
+      id: true,
       title: true,
       date: true,
       type: true,
-      user: { select: { name: true, email: true } },
-      streams: {
-        select: {
-          time: true,
-          distance: true,
-          watts: true,
-          heartrate: true,
-          cadence: true,
-          velocity: true,
-          altitude: true,
-          grade: true,
-          latlng: true,
-          lapSplits: true
-        }
-      }
+      user: { select: { name: true, email: true } }
     }
   })
+
+  const workout = workoutRecord ? await attachStreamToWorkout(workoutRecord) : null
 
   if (!workout || !workout.streams) {
     throw createError({ statusCode: 404, statusMessage: 'Workout streams not found' })

--- a/server/api/analytics/workout-explorer/summary.post.ts
+++ b/server/api/analytics/workout-explorer/summary.post.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v3'
 import { requireAuth } from '../../../utils/auth-guard'
 import { assertSingleWorkoutAccess, getAccessibleWorkout } from '../../../utils/analyticsScope'
 import { prisma } from '../../../utils/db'
+import { attachStreamToWorkout } from '../../../utils/repositories/workoutStreamRepository'
 import { calculateSegmentSummary } from '../../../utils/analytics/segment-summary'
 import { computeMMP } from '../../../utils/analytics/virtual-streams'
 import {
@@ -190,7 +191,9 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const workout = await getAccessibleWorkout(user.id, analysis.workoutId, {
+    // CW-379: `streams` reads the legacy V1 table only, so every advanced
+    // summary mode degraded to "requires stream data" for V2-only workouts.
+    const workoutRecord = await getAccessibleWorkout(user.id, analysis.workoutId, {
       select: {
         id: true,
         type: true,
@@ -201,19 +204,11 @@ export default defineEventHandler(async (event) => {
         powerHrRatio: true,
         variabilityIndex: true,
         decoupling: true,
-        workAboveFtp: true,
-        streams: {
-          select: {
-            time: true,
-            distance: true,
-            watts: true,
-            heartrate: true,
-            cadence: true,
-            velocity: true
-          }
-        }
+        workAboveFtp: true
       }
     })
+
+    const workout = workoutRecord ? await attachStreamToWorkout(workoutRecord) : null
 
     if (!workout || !workout.streams) {
       return {

--- a/server/api/profile/sport-settings/[id]/detect-from-workouts.post.ts
+++ b/server/api/profile/sport-settings/[id]/detect-from-workouts.post.ts
@@ -1,4 +1,5 @@
 import { requireAuth } from '../../../../utils/auth-guard'
+import { attachStreamsToWorkouts } from '../../../../utils/repositories/workoutStreamRepository'
 
 const LOOKBACK_DAYS_DEFAULT = 56
 const LOOKBACK_DAYS_MAX = 180
@@ -152,7 +153,7 @@ export default defineEventHandler(async (event) => {
   fromDate.setUTCDate(fromDate.getUTCDate() - lookbackDays)
 
   const workoutTypeFilter = Array.isArray(sportSetting.types) && sportSetting.types.length > 0
-  const workouts = await prisma.workout.findMany({
+  const workoutRecords = await prisma.workout.findMany({
     where: {
       userId: user.id,
       isDuplicate: false,
@@ -166,18 +167,17 @@ export default defineEventHandler(async (event) => {
       date: true,
       type: true,
       durationSec: true,
-      maxHr: true,
-      streams: {
-        select: {
-          time: true,
-          watts: true,
-          heartrate: true,
-          velocity: true
-        }
-      }
+      maxHr: true
     },
     take: 200
   })
+
+  // CW-379: selecting the `streams` relation only reads the legacy V1 table,
+  // so FTP/LTHR/threshold-pace autodetection reported "no stream data found"
+  // for every athlete whose series are in WorkoutStreamV2.
+  // time/watts/heartrate/velocity are all in the repository's mandatory
+  // baseline, so no optional columns are pulled across 200 workouts.
+  const workouts = await attachStreamsToWorkouts(workoutRecords, { baselineOnly: true })
 
   const ftpCandidates: any[] = []
   const lthrCandidates: any[] = []

--- a/server/api/workouts/[id]/metric-history.get.ts
+++ b/server/api/workouts/[id]/metric-history.get.ts
@@ -1,4 +1,5 @@
 import { getServerSession } from '../../../utils/session'
+import { attachStreamsToWorkouts } from '../../../utils/repositories/workoutStreamRepository'
 
 function normalizeMetricKey(metricKey: string) {
   return metricKey.trim().toLowerCase()
@@ -127,7 +128,7 @@ export default defineEventHandler(async (event) => {
     return { metricKey, activityType: null, points: [] }
   }
 
-  const candidates = await prisma.workout.findMany({
+  const candidateRecords = await prisma.workout.findMany({
     where: {
       userId: workout.userId,
       isDuplicate: false,
@@ -136,14 +137,16 @@ export default defineEventHandler(async (event) => {
       date: { lt: workout.date }
     },
     orderBy: { date: 'desc' },
-    take: limit * 3,
-    include: {
-      streams: {
-        select: {
-          extrasMeta: true
-        }
-      }
-    }
+    take: limit * 3
+  })
+
+  // CW-379: this used to `include: { streams: { select: { extrasMeta: true } } }`,
+  // which reads the legacy V1 table only -- every FIT session-summary metric
+  // (elapsed/timer time, total ascent/descent, calories, TSS) charted as an
+  // empty history for athletes whose streams are in WorkoutStreamV2.
+  // `extrasMeta` is an optional column, so it must be requested explicitly.
+  const candidates = await attachStreamsToWorkouts(candidateRecords, {
+    fields: ['extrasMeta']
   })
 
   const points = candidates

--- a/server/api/workouts/[id]/metric-history.get.ts
+++ b/server/api/workouts/[id]/metric-history.get.ts
@@ -1,5 +1,5 @@
 import { getServerSession } from '../../../utils/session'
-import { attachStreamsToWorkouts } from '../../../utils/repositories/workoutStreamRepository'
+import { workoutStreamRepository } from '../../../utils/repositories/workoutStreamRepository'
 
 function normalizeMetricKey(metricKey: string) {
   return metricKey.trim().toLowerCase()
@@ -144,9 +144,20 @@ export default defineEventHandler(async (event) => {
   // which reads the legacy V1 table only -- every FIT session-summary metric
   // (elapsed/timer time, total ascent/descent, calories, TSS) charted as an
   // empty history for athletes whose streams are in WorkoutStreamV2.
-  // `extrasMeta` is an optional column, so it must be requested explicitly.
-  const candidates = await attachStreamsToWorkouts(candidateRecords, {
-    fields: ['extrasMeta']
+  //
+  // The dedicated single-column read matters here: the only consumer is
+  // getSessionSummaryValue(), which reads `streams.extrasMeta.sessionSummary`
+  // and no series at all, while this query takes `limit * 3` rows (up to 90).
+  // attachStreamsToWorkouts() would drag the mandatory V2 baseline -- six
+  // parallel per-second series per workout -- across all of them for one JSON
+  // blob. Same reasoning as findWattsByWorkoutIds().
+  const extrasMetaByWorkoutId = await workoutStreamRepository.findExtrasMetaByWorkoutIds(
+    candidateRecords.map((candidate) => candidate.id)
+  )
+
+  const candidates = candidateRecords.map((candidate) => {
+    const extrasMeta = extrasMetaByWorkoutId.get(candidate.id)
+    return { ...candidate, streams: extrasMeta == null ? null : { extrasMeta } }
   })
 
   const points = candidates

--- a/server/api/workouts/index.get.ts
+++ b/server/api/workouts/index.get.ts
@@ -1,6 +1,7 @@
 import { requireAuth } from '../../utils/auth-guard'
 import { getEffectiveUserId } from '../../utils/coaching'
 import { parseTagQueryParam } from '../../utils/workout-tags'
+import { workoutStreamRepository } from '../../utils/repositories/workoutStreamRepository'
 
 defineRouteMeta({
   openAPI: {
@@ -176,17 +177,23 @@ export default defineEventHandler(async (event) => {
       },
       aiAnalysisStatus: true,
       isDuplicate: true,
-      summaryPolyline: true,
-      streams: {
-        select: {
-          id: true
-        }
-      }
+      summaryPolyline: true
     }
   })
 
   // Fetch LLM usage for these workouts
   const workoutIds = workouts.map((w) => w.id)
+
+  // CW-379: this used to be `streams: { select: { id: true } }` in the query
+  // above, which only ever saw the legacy V1 table -- so the "Detailed Streams"
+  // badge in the workout list never appeared for athletes whose series live in
+  // WorkoutStreamV2. The repository's presence probe answers "does this workout
+  // have usable stream data?" across both tables in SQL, transferring no series
+  // data at all. The response keeps its `{ id } | null` shape.
+  const streamPresence = await workoutStreamRepository.findManyByWorkoutIds(workoutIds, {
+    fields: []
+  })
+
   const llmUsages = await prisma.llmUsage.findMany({
     where: {
       entityId: { in: workoutIds },
@@ -206,8 +213,10 @@ export default defineEventHandler(async (event) => {
   // Attach usage data to workouts
   return workouts.map((workout) => {
     const usage = usageMap.get(workout.id)
+    const stream = streamPresence.get(workout.id)
     return {
       ...workout,
+      streams: stream ? { id: stream.id } : null,
       llmUsageId: usage?.id,
       feedback: usage?.feedback,
       feedbackText: usage?.feedbackText

--- a/server/api/workouts/index.get.ts
+++ b/server/api/workouts/index.get.ts
@@ -188,8 +188,9 @@ export default defineEventHandler(async (event) => {
   // above, which only ever saw the legacy V1 table -- so the "Detailed Streams"
   // badge in the workout list never appeared for athletes whose series live in
   // WorkoutStreamV2. The repository's presence probe answers "does this workout
-  // have usable stream data?" across both tables in SQL, transferring no series
-  // data at all. The response keeps its `{ id } | null` shape.
+  // have usable stream data?" across both tables in SQL: Postgres still reads
+  // the series to evaluate the predicate, but only a boolean crosses the wire.
+  // The response keeps its `{ id } | null` shape.
   const streamPresence = await workoutStreamRepository.findManyByWorkoutIds(workoutIds, {
     fields: []
   })

--- a/server/utils/ai-tools/workouts.ts
+++ b/server/utils/ai-tools/workouts.ts
@@ -195,24 +195,30 @@ export const workoutTools = (userId: string, timezone: string, aiSettings: AiSet
                 tss: true,
                 structuredWorkout: true
               }
-            },
-            streams: {
-              select: {
-                avgPacePerKm: true,
-                paceVariability: true,
-                hrZoneTimes: true,
-                powerZoneTimes: true,
-                paceZones: true,
-                pacingStrategy: true
-              }
             }
           }
         })
 
         if (fallbackWorkout) {
+          // CW-379: the degraded path used to select the `streams` relation
+          // directly, which reads the legacy V1 table only -- so the coach lost
+          // pace/zone context for V2-only athletes exactly when the primary
+          // path had already failed. Same repository the primary path uses, so
+          // both paths see the same generations of stream data.
+          const withStreams = await attachStreamToWorkout(fallbackWorkout)
           return {
-            ...fallbackWorkout,
+            ...withStreams,
             date: formatUserDate(fallbackWorkout.date, timezone),
+            streams: withStreams.streams
+              ? {
+                  avgPacePerKm: withStreams.streams.avgPacePerKm,
+                  paceVariability: withStreams.streams.paceVariability,
+                  hrZoneTimes: withStreams.streams.hrZoneTimes,
+                  powerZoneTimes: withStreams.streams.powerZoneTimes,
+                  paceZones: withStreams.streams.paceZones,
+                  pacingStrategy: withStreams.streams.pacingStrategy
+                }
+              : null,
             degraded: true
           }
         }

--- a/server/utils/calendar-data.ts
+++ b/server/utils/calendar-data.ts
@@ -10,6 +10,7 @@ import { nutritionRepository } from './repositories/nutritionRepository'
 import { wellnessRepository } from './repositories/wellnessRepository'
 import { calendarNoteRepository } from './repositories/calendarNoteRepository'
 import { workoutRepository } from './repositories/workoutRepository'
+import { workoutStreamRepository } from './repositories/workoutStreamRepository'
 import { applyCanonicalNutritionTargets } from './nutrition/canonical-targets'
 import { getUserNutritionSettings } from './nutrition/settings'
 import { metabolicService } from './services/metabolicService'
@@ -164,12 +165,20 @@ export async function getCalendarDataForUser(
     endDate: rangeEnd,
     orderBy: { date: 'asc' },
     include: {
-      plannedWorkout: true,
-      streams: {
-        select: { id: true }
-      }
+      plannedWorkout: true
     }
   })
+
+  // CW-379: `streams: { select: { id: true } }` used to ride along on the query
+  // above purely to drive the `hasStreams` flag below, but it only ever saw the
+  // legacy V1 table -- so the calendar showed no stream indicator at all for
+  // athletes whose series live in WorkoutStreamV2. The repository's presence
+  // probe evaluates "has usable stream data" over both tables in SQL and
+  // transfers no series data.
+  const workoutsWithStreams = await workoutStreamRepository.findManyByWorkoutIds(
+    workouts.map((w) => w.id),
+    { fields: [] }
+  )
 
   const plannedWorkouts = await prisma.plannedWorkout.findMany({
     where: {
@@ -448,7 +457,7 @@ export async function getCalendarDataForUser(
       commute: w.commute,
       isPrivate: w.isPrivate,
       gearId: w.gearId,
-      hasStreams: !!(w as any).streams,
+      hasStreams: workoutsWithStreams.has(w.id),
       plannedWorkoutId: w.plannedWorkoutId,
       linkedPlannedWorkout: (w as any).plannedWorkout
         ? {

--- a/server/utils/calendar-data.ts
+++ b/server/utils/calendar-data.ts
@@ -173,8 +173,8 @@ export async function getCalendarDataForUser(
   // above purely to drive the `hasStreams` flag below, but it only ever saw the
   // legacy V1 table -- so the calendar showed no stream indicator at all for
   // athletes whose series live in WorkoutStreamV2. The repository's presence
-  // probe evaluates "has usable stream data" over both tables in SQL and
-  // transfers no series data.
+  // probe evaluates "has usable stream data" over both tables in SQL: Postgres
+  // still reads the series to answer it, but only a boolean crosses the wire.
   const workoutsWithStreams = await workoutStreamRepository.findManyByWorkoutIds(
     workouts.map((w) => w.id),
     { fields: [] }

--- a/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/server/utils/repositories/workoutStreamRepository.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { prisma } from '../db'
 import {
@@ -226,6 +229,91 @@ describe('findManyByWorkoutIds', () => {
   })
 })
 
+describe('findManyByWorkoutIds baselineOnly (CW-379)', () => {
+  it('selects the mandatory baseline and no optional columns', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([repairedRow('good-1')])
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['good-1'], {
+      baselineOnly: true
+    })
+
+    const select = db.workoutStreamV2.findMany.mock.calls[0]?.[0].select
+    expect(select).toBeDefined()
+    // The baseline hasUsableStreamData() needs, and nothing beyond it.
+    expect(Object.keys(select).sort()).toEqual(
+      [
+        'createdAt',
+        'heartrate',
+        'hrZoneTimes',
+        'id',
+        'lat',
+        'lng',
+        'powerZoneTimes',
+        'time',
+        'updatedAt',
+        'velocity',
+        'watts',
+        'workoutId'
+      ].sort()
+    )
+    expect(select.cadence).toBeUndefined()
+    expect(select.lapSplits).toBeUndefined()
+
+    // Real series come back -- this is not the presence-only path.
+    expect(streams.get('good-1')?.watts).toEqual([200, 0, 210])
+    expect(db.$queryRaw).not.toHaveBeenCalled()
+  })
+
+  it('does not fall into the presence-only path that `fields: []` triggers', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([repairedRow('good-1')])
+
+    await workoutStreamRepository.findManyByWorkoutIds(['good-1'], { baselineOnly: true })
+
+    // The presence probe is raw SQL and never touches the typed client.
+    expect(db.workoutStreamV2.findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('still falls back to the legacy V1 table when V2 has no usable data', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([])
+    db.workoutStream.findMany.mockResolvedValue([
+      {
+        id: 'v1-1',
+        workoutId: 'good-1',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+        time: [0, 1, 2],
+        heartrate: [130, 131, 132],
+        watts: [180, 185, 190],
+        velocity: null,
+        latlng: null,
+        hrZoneTimes: null,
+        powerZoneTimes: null
+      }
+    ])
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['good-1'], {
+      baselineOnly: true
+    })
+
+    expect(streams.get('good-1')?.watts).toEqual([180, 185, 190])
+    const v1Select = db.workoutStream.findMany.mock.calls[0]?.[0].select
+    expect(v1Select.latlng).toBe(true)
+    expect(v1Select.cadence).toBeUndefined()
+  })
+
+  it('takes precedence over an explicit `fields: []`', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([repairedRow('good-1')])
+
+    const streams = await workoutStreamRepository.findManyByWorkoutIds(['good-1'], {
+      baselineOnly: true,
+      fields: []
+    })
+
+    expect(streams.get('good-1')?.time).toEqual([0, 1, 2])
+    expect(db.$queryRaw).not.toHaveBeenCalled()
+  })
+})
+
 describe('findWattsByWorkoutIds', () => {
   it('recovers watts from a row with NULL elements', async () => {
     db.workoutStreamV2.findMany.mockRejectedValue(decodeError('watts[41]'))
@@ -279,5 +367,189 @@ describe('upsert write guard', () => {
       '[workoutStreamRepository] blocked NULL element in stream write',
       expect.objectContaining({ workoutId: 'workout-1', column: 'cadence', index: 1 })
     )
+  })
+})
+
+/* ------------------------------------------------------------------------- *
+ * CW-379 regression guard: no new raw `streams` relation reads under server/
+ * ------------------------------------------------------------------------- */
+
+/**
+ * Blank out `//` and block comments so the scan below never trips over prose.
+ *
+ * Several of the CW-379 migrations quote the raw read they replaced (`this
+ * used to be streams: { select: { id: true } }`), which is exactly the string
+ * the detector looks for -- and a naive strip would also mangle `https://` in
+ * a string literal. This walks the source instead, tracking string/template
+ * state, and replaces comment bodies with spaces so offsets stay intact.
+ */
+function stripComments(source: string): string {
+  const out: string[] = []
+  let i = 0
+  let quote: string | null = null
+
+  while (i < source.length) {
+    const char = source[i]!
+    const next = source[i + 1]
+
+    if (quote) {
+      if (char === '\\') {
+        out.push(char, source[i + 1] ?? '')
+        i += 2
+        continue
+      }
+      if (char === quote) quote = null
+      out.push(char)
+      i++
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      out.push(char)
+      i++
+      continue
+    }
+
+    if (char === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') {
+        out.push(' ')
+        i++
+      }
+      continue
+    }
+
+    if (char === '/' && next === '*') {
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        out.push(source[i] === '\n' ? '\n' : ' ')
+        i++
+      }
+      out.push(' ', ' ')
+      i += 2
+      continue
+    }
+
+    out.push(char)
+    i++
+  }
+
+  return out.join('')
+}
+
+/**
+ * A Prisma read of the **legacy V1** `streams` relation: `streams: true`, or
+ * `streams: { select|include ... }` inside an `include`/`select` block.
+ *
+ * Deliberately narrow. It must not fire on the things that legitimately spell
+ * `streams:` -- the correct existence filter `streams: { isNot: null }`, the
+ * BullMQ queue snapshot in worker-monitoring.ts, plain property assignment
+ * (`streams: workout.streams`, `streams: null`), or a type annotation.
+ */
+const RAW_STREAMS_RELATION_READ = /\bstreams\s*:\s*(?:true\b|\{\s*(?:select|include)\b)/g
+
+/**
+ * Files still reading the V1 relation directly, each with the reason it is not
+ * fixed here. Every entry is a real bug of the CW-379 class (V2-only athletes
+ * silently get no data) that falls **outside this ticket's Owned Paths** and is
+ * filed separately -- not an approved exception.
+ *
+ * The test below asserts this list is exhaustive *and* that every entry still
+ * violates, so fixing one forces its removal rather than letting the allowlist
+ * rot into a permanent exemption.
+ */
+const KNOWN_UNMIGRATED = new Map<string, string>([
+  [
+    'server/api/performance/ftp-evolution.get.ts',
+    'Two `include: { streams: { select: { watts: true } } }` reads in the FTP estimation and validation queries. Outside CW-379 Owned Paths.'
+  ],
+  [
+    'server/utils/services/deduplicationService.ts',
+    'mergeDuplicateGroup() existence check `streams: { select: { id: true } }`; needs an OR filter over streams/streamsV2. Outside CW-379 Owned Paths.'
+  ],
+  [
+    'server/utils/services/checkin-service.ts',
+    'Daily check-in reads hrZoneTimes/powerZoneTimes off the V1 relation. Outside CW-379 Owned Paths.'
+  ],
+  [
+    'server/utils/workout-insight-email.ts',
+    'Insight email selects the full V1 series set for its charts. Outside CW-379 Owned Paths.'
+  ]
+])
+
+const SERVER_DIR = fileURLToPath(new URL('../..', import.meta.url))
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url))
+
+function collectServerSources(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue
+      collectServerSources(full, found)
+      continue
+    }
+    if (!entry.name.endsWith('.ts')) continue
+    if (entry.name.endsWith('.test.ts')) continue
+    found.push(full)
+  }
+  return found
+}
+
+function findRawStreamReads(): string[] {
+  const offenders: string[] = []
+  for (const file of collectServerSources(SERVER_DIR)) {
+    const source = stripComments(readFileSync(file, 'utf8'))
+    if (RAW_STREAMS_RELATION_READ.test(source)) {
+      offenders.push(relative(REPO_ROOT, file))
+    }
+    RAW_STREAMS_RELATION_READ.lastIndex = 0
+  }
+  return offenders.sort()
+}
+
+describe('no raw V1 `streams` relation reads under server/ (CW-379)', () => {
+  it('detects the raw read shapes and ignores the legitimate ones', () => {
+    const flagged = (source: string) => {
+      RAW_STREAMS_RELATION_READ.lastIndex = 0
+      return RAW_STREAMS_RELATION_READ.test(stripComments(source))
+    }
+
+    // Positive controls -- exactly the bug this ticket swept up.
+    expect(flagged('select: { id: true, streams: { select: { watts: true } } }')).toBe(true)
+    expect(flagged('include: {\n  streams: {\n    select: { lapSplits: true }\n  }\n}')).toBe(true)
+    expect(flagged('include: { streams: true }')).toBe(true)
+
+    // Negative controls -- these must never fail a build.
+    expect(flagged('OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]')).toBe(
+      false
+    )
+    expect(flagged('return { ...workout, streams }')).toBe(false)
+    expect(flagged('streams: workout.streams')).toBe(false)
+    expect(flagged('streams: QueueCounts & { workers: number }')).toBe(false)
+    expect(flagged('streamsV2: { select: { watts: true } }')).toBe(false)
+    // A migration comment quoting the read it removed is prose, not a read.
+    expect(flagged('// this used to be streams: { select: { id: true } }')).toBe(false)
+    expect(flagged('/* streams: { include: { x: true } } */')).toBe(false)
+  })
+
+  it('flags no file outside the documented, separately-filed backlog', () => {
+    const unexpected = findRawStreamReads().filter((file) => !KNOWN_UNMIGRATED.has(file))
+
+    expect(
+      unexpected,
+      'Stream writes go to WorkoutStreamV2 only. Reading the `streams` relation directly sees the ' +
+        'legacy V1 table, so it silently returns nothing for V2-only athletes (CW-377/CW-379). ' +
+        'Read through workoutStreamRepository / attachStreamToWorkout / attachStreamsToWorkouts, ' +
+        'or for a pure existence check use `OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]`.'
+    ).toEqual([])
+  })
+
+  it('keeps the allowlist honest: no entry that no longer violates', () => {
+    const offenders = new Set(findRawStreamReads())
+    const stale = [...KNOWN_UNMIGRATED.keys()].filter((file) => !offenders.has(file))
+
+    expect(
+      stale,
+      'These files no longer read the V1 relation -- drop them from KNOWN_UNMIGRATED.'
+    ).toEqual([])
   })
 })

--- a/server/utils/repositories/workoutStreamRepository.test.ts
+++ b/server/utils/repositories/workoutStreamRepository.test.ts
@@ -325,6 +325,57 @@ describe('findWattsByWorkoutIds', () => {
   })
 })
 
+describe('findExtrasMetaByWorkoutIds (CW-379)', () => {
+  const sessionSummary = { sessionSummary: { totalAscent: 320, totalCalories: 640 } }
+
+  it('reads one column and never the baseline series', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([
+      { workoutId: 'good-1', extrasMeta: sessionSummary }
+    ])
+
+    const extras = await workoutStreamRepository.findExtrasMetaByWorkoutIds(['good-1'])
+
+    expect(extras.get('good-1')).toEqual(sessionSummary)
+    // The whole point: no time/heartrate/watts/velocity/lat/lng for a JSON blob.
+    expect(db.workoutStreamV2.findMany.mock.calls[0]?.[0].select).toEqual({
+      workoutId: true,
+      extrasMeta: true
+    })
+  })
+
+  it('falls back to the legacy V1 table when V2 has no extras metadata', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([{ workoutId: 'good-1', extrasMeta: null }])
+    db.workoutStream.findMany.mockResolvedValue([
+      { workoutId: 'good-1', extrasMeta: sessionSummary }
+    ])
+
+    const extras = await workoutStreamRepository.findExtrasMetaByWorkoutIds(['good-1'])
+
+    expect(extras.get('good-1')).toEqual(sessionSummary)
+    expect(db.workoutStream.findMany.mock.calls[0]?.[0].select).toEqual({
+      workoutId: true,
+      extrasMeta: true
+    })
+  })
+
+  it('omits workouts that have no extras metadata in either table', async () => {
+    db.workoutStreamV2.findMany.mockResolvedValue([{ workoutId: 'good-1', extrasMeta: null }])
+
+    const extras = await workoutStreamRepository.findExtrasMetaByWorkoutIds(['good-1', 'missing-1'])
+
+    expect(extras.size).toBe(0)
+  })
+
+  it('recovers extras metadata from a row the typed client cannot decode', async () => {
+    db.workoutStreamV2.findMany.mockRejectedValue(decodeError('cadence[593]'))
+    db.$queryRaw.mockResolvedValue([{ workoutId: 'bad-1', extrasMeta: sessionSummary }])
+
+    const extras = await workoutStreamRepository.findExtrasMetaByWorkoutIds(['bad-1'])
+
+    expect(extras.get('bad-1')).toEqual(sessionSummary)
+  })
+})
+
 describe('upsert write guard', () => {
   it('never writes a NULL element into a numeric or boolean array', async () => {
     db.workoutStreamV2.upsert.mockResolvedValue({ id: 'stream-1' })
@@ -438,14 +489,30 @@ function stripComments(source: string): string {
 
 /**
  * A Prisma read of the **legacy V1** `streams` relation: `streams: true`, or
- * `streams: { select|include ... }` inside an `include`/`select` block.
+ * `streams: { select|include|omit|where ... }` inside an `include`/`select`
+ * block.
  *
  * Deliberately narrow. It must not fire on the things that legitimately spell
  * `streams:` -- the correct existence filter `streams: { isNot: null }`, the
  * BullMQ queue snapshot in worker-monitoring.ts, plain property assignment
  * (`streams: workout.streams`, `streams: null`), or a type annotation.
  */
-const RAW_STREAMS_RELATION_READ = /\bstreams\s*:\s*(?:true\b|\{\s*(?:select|include)\b)/g
+const RAW_STREAMS_RELATION_READ = /\bstreams\s*:\s*(?:true\b|\{\s*(?:select|include|omit|where)\b)/g
+
+/**
+ * The same bug with a different spelling: going at the legacy V1 table through
+ * the Prisma client directly instead of the relation. There are none of these
+ * under `server/` today outside the repository itself, but `prisma.workoutStream
+ * .findMany({ where: { workoutId: ... } })` would reintroduce exactly the
+ * V2-blind read the relation pattern above was doing.
+ *
+ * The repository is the one place that is *supposed* to touch both tables, so
+ * it is exempt (see REPOSITORY_SOURCE below).
+ */
+const DIRECT_V1_CLIENT_READ = /\bprisma\s*(?:as\s+any\s*\)?\s*)?\.\s*workoutStream\s*\./g
+
+/** The repository itself -- the intended owner of both tables' reads. */
+const REPOSITORY_SOURCE = 'server/utils/repositories/workoutStreamRepository.ts'
 
 /**
  * Files still reading the V1 relation directly, each with the reason it is not
@@ -494,29 +561,45 @@ function collectServerSources(dir: string, found: string[] = []): string[] {
   return found
 }
 
+function matches(pattern: RegExp, source: string): boolean {
+  pattern.lastIndex = 0
+  const hit = pattern.test(source)
+  pattern.lastIndex = 0
+  return hit
+}
+
 function findRawStreamReads(): string[] {
   const offenders: string[] = []
   for (const file of collectServerSources(SERVER_DIR)) {
+    const path = relative(REPO_ROOT, file)
     const source = stripComments(readFileSync(file, 'utf8'))
-    if (RAW_STREAMS_RELATION_READ.test(source)) {
-      offenders.push(relative(REPO_ROOT, file))
+
+    if (matches(RAW_STREAMS_RELATION_READ, source)) {
+      offenders.push(path)
+      continue
     }
-    RAW_STREAMS_RELATION_READ.lastIndex = 0
+    if (path !== REPOSITORY_SOURCE && matches(DIRECT_V1_CLIENT_READ, source)) {
+      offenders.push(path)
+    }
   }
   return offenders.sort()
 }
 
 describe('no raw V1 `streams` relation reads under server/ (CW-379)', () => {
   it('detects the raw read shapes and ignores the legitimate ones', () => {
-    const flagged = (source: string) => {
-      RAW_STREAMS_RELATION_READ.lastIndex = 0
-      return RAW_STREAMS_RELATION_READ.test(stripComments(source))
-    }
+    const flagged = (source: string) =>
+      matches(RAW_STREAMS_RELATION_READ, stripComments(source)) ||
+      matches(DIRECT_V1_CLIENT_READ, stripComments(source))
 
     // Positive controls -- exactly the bug this ticket swept up.
     expect(flagged('select: { id: true, streams: { select: { watts: true } } }')).toBe(true)
     expect(flagged('include: {\n  streams: {\n    select: { lapSplits: true }\n  }\n}')).toBe(true)
     expect(flagged('include: { streams: true }')).toBe(true)
+    expect(flagged('include: { streams: { omit: { latlng: true } } }')).toBe(true)
+    expect(flagged('include: { streams: { where: { id: { not: null } } } }')).toBe(true)
+    // Same bug, different spelling: the V1 table straight off the client.
+    expect(flagged('await prisma.workoutStream.findMany({ where: { workoutId } })')).toBe(true)
+    expect(flagged('(prisma as any).workoutStream.findUnique({ where: { workoutId } })')).toBe(true)
 
     // Negative controls -- these must never fail a build.
     expect(flagged('OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]')).toBe(
@@ -526,6 +609,8 @@ describe('no raw V1 `streams` relation reads under server/ (CW-379)', () => {
     expect(flagged('streams: workout.streams')).toBe(false)
     expect(flagged('streams: QueueCounts & { workers: number }')).toBe(false)
     expect(flagged('streamsV2: { select: { watts: true } }')).toBe(false)
+    // V2 straight off the client is a different (non-V1-blind) concern.
+    expect(flagged('(prisma as any).workoutStreamV2.findMany({})')).toBe(false)
     // A migration comment quoting the read it removed is prose, not a read.
     expect(flagged('// this used to be streams: { select: { id: true } }')).toBe(false)
     expect(flagged('/* streams: { include: { x: true } } */')).toBe(false)
@@ -536,10 +621,11 @@ describe('no raw V1 `streams` relation reads under server/ (CW-379)', () => {
 
     expect(
       unexpected,
-      'Stream writes go to WorkoutStreamV2 only. Reading the `streams` relation directly sees the ' +
-        'legacy V1 table, so it silently returns nothing for V2-only athletes (CW-377/CW-379). ' +
-        'Read through workoutStreamRepository / attachStreamToWorkout / attachStreamsToWorkouts, ' +
-        'or for a pure existence check use `OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]`.'
+      'Stream writes go to WorkoutStreamV2 only. Reading the `streams` relation -- or the ' +
+        '`workoutStream` model off the Prisma client -- sees the legacy V1 table alone, so it ' +
+        'silently returns nothing for V2-only athletes (CW-377/CW-379). Read through ' +
+        'workoutStreamRepository / attachStreamToWorkout / attachStreamsToWorkouts, or for a pure ' +
+        'existence check use `OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]`.'
     ).toEqual([])
   })
 

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -249,6 +249,23 @@ export interface FindManyByWorkoutIdsOptions {
    * `fields: []` if you intend to read anything off the returned stream.
    */
   fields?: readonly WorkoutStreamOptionalField[]
+
+  /**
+   * Fetch exactly the mandatory baseline (REQUIRED_V2_SELECT/REQUIRED_V1_SELECT)
+   * and nothing else.
+   *
+   * `fields` alone cannot express this: `undefined` means "every column" and
+   * `[]` is already taken by the presence-only path, so a caller that reads
+   * only baseline series -- `time`/`heartrate`/`watts`/`velocity`/`latlng` and
+   * the two zone-time blobs -- previously had to either haul every column or
+   * name a throwaway optional field to get a lean select. Several CW-379 call
+   * sites (weekly zone aggregation, FTP/LTHR autodetection, the team
+   * power-duration preset) are exactly that shape, over hundreds of workouts.
+   *
+   * Takes precedence over `fields`, and never routes to the presence path --
+   * the returned streams carry real series data.
+   */
+  baselineOnly?: boolean
 }
 
 /**
@@ -737,12 +754,16 @@ export const workoutStreamRepository = {
     const result = new Map<string, NormalizedStream>()
     if (workoutIds.length === 0) return result
 
-    const fields = options?.fields
+    // `baselineOnly` wins over `fields`: it means "the mandatory baseline and
+    // nothing else", which is an empty optional-field list that must *not* be
+    // read as the presence-only sentinel below.
+    const baselineOnly = options?.baselineOnly === true
+    const fields = baselineOnly ? [] : options?.fields
 
     // `fields: []` == "does this workout have usable streams at all?". Answer
     // it in SQL instead of hauling six per-second arrays per workout across
     // the wire (CW-296).
-    if (fields !== undefined && fields.length === 0) {
+    if (!baselineOnly && fields !== undefined && fields.length === 0) {
       return findStreamPresenceByWorkoutIds(workoutIds)
     }
 

--- a/server/utils/repositories/workoutStreamRepository.ts
+++ b/server/utils/repositories/workoutStreamRepository.ts
@@ -874,6 +874,66 @@ export const workoutStreamRepository = {
     return result
   },
 
+  /**
+   * `extrasMeta`-only bulk read, for the same reason findWattsByWorkoutIds()
+   * exists.
+   *
+   * findManyByWorkoutIds() always fetches the REQUIRED_V2_SELECT baseline so
+   * hasUsableStreamData() can decide V2-vs-V1, which means ~6 parallel series
+   * per workout even when the caller wants a single JSON blob. The FIT
+   * session-summary metric history asks for `extrasMeta` across up to 90
+   * workouts at once and reads no series at all, so the baseline would be the
+   * entire cost -- roughly two million decoded numbers per modal open for a
+   * rider with 1 Hz hour-long files.
+   *
+   * This reads one JSON column and decides the V1 fallback from the presence
+   * of a non-null `extrasMeta`, which is the only signal that matters here.
+   * Workouts with no extras metadata are simply absent from the returned map.
+   */
+  async findExtrasMetaByWorkoutIds(workoutIds: string[]): Promise<Map<string, unknown>> {
+    const result = new Map<string, unknown>()
+    if (workoutIds.length === 0) return result
+
+    const chunks = chunkArray(workoutIds, WORKOUT_ID_CHUNK_SIZE)
+
+    const v2Chunks = await Promise.all(
+      chunks.map((chunk) =>
+        readV2Chunk(chunk, { workoutId: true, extrasMeta: true }, 'findExtrasMetaByWorkoutIds')
+      )
+    )
+
+    for (const record of v2Chunks.flat() as Array<{ workoutId: string; extrasMeta: unknown }>) {
+      if (record.extrasMeta != null) {
+        result.set(record.workoutId, record.extrasMeta)
+      }
+    }
+
+    const missingIds = workoutIds.filter((id) => !result.has(id))
+    if (missingIds.length === 0) return result
+
+    const v1Chunks = await Promise.all(
+      chunkArray(missingIds, WORKOUT_ID_CHUNK_SIZE).map((chunk) =>
+        prisma.workoutStream
+          .findMany({
+            where: { workoutId: { in: chunk } },
+            select: { workoutId: true, extrasMeta: true }
+          })
+          .catch((error) => {
+            logStreamReadFailure('findExtrasMetaByWorkoutIds', 'WorkoutStream', chunk, error)
+            return []
+          })
+      )
+    )
+
+    for (const record of v1Chunks.flat() as Array<{ workoutId: string; extrasMeta: unknown }>) {
+      if (record.extrasMeta != null) {
+        result.set(record.workoutId, record.extrasMeta)
+      }
+    }
+
+    return result
+  },
+
   async updateMetadata(
     workoutId: string,
     data: { hrZoneTimes?: unknown; powerZoneTimes?: unknown }

--- a/server/utils/sharing/image-cache.ts
+++ b/server/utils/sharing/image-cache.ts
@@ -32,6 +32,11 @@ export function buildWorkoutImageCacheKey(input: CacheKeyInput) {
     averageHr: input.workout.averageHr ?? null,
     averageWatts: input.workout.averageWatts ?? null,
     averageSpeed: input.workout.averageSpeed ?? null,
+    // CW-379: not a Prisma read -- `input.workout` is an already-hydrated
+    // object, and its only producer (server/api/share/workouts/[token]/image.get.ts)
+    // builds it with attachStreamToWorkout(), so these series already come from
+    // WorkoutStreamV2 with the legacy V1 fallback. Left as a plain property
+    // read by design; changing it would just re-fetch what the caller has.
     streams: {
       latlng: input.workout.streams?.latlng ?? null,
       heartrate: input.workout.streams?.heartrate ?? null

--- a/server/utils/worker-monitoring.ts
+++ b/server/utils/worker-monitoring.ts
@@ -47,6 +47,10 @@ export type WorkerMonitoringSnapshot = {
   queues: {
     webhook: QueueCounts & { workers: number; isPaused: boolean }
     ping: QueueCounts & { workers: number; isPaused: boolean }
+    // CW-379 note: `streams` here (and in getWorkerMonitoringSnapshot below) is
+    // the BullMQ `streamsQueue` -- job counts for the stream-ingest worker. It
+    // has nothing to do with the Workout `streams` relation or the V1/V2 stream
+    // tables, so there is nothing to migrate onto workoutStreamRepository.
     streams: QueueCounts & { workers: number; isPaused: boolean }
   }
   webhooks: {


### PR DESCRIPTION
Fixes CW-379

## Problem

Stream writes go to `WorkoutStreamV2` only (`workoutStreamRepository.upsert()`), but a dozen read sites still selected the legacy V1 `streams` relation directly via Prisma `include`/`select`. Those sites see an empty table for V2-only athletes and degrade to "no data" rather than erroring — the same silent failure class CW-377 fixed for the power curve. Because nothing throws, these surface as support tickets, not Sentry events.

## Per-call-site triage

| File | Action | Notes |
| :-- | :-- | :-- |
| `server/api/analytics/presets/[preset].post.ts` | **migrated** | `buildPowerDurationChart` → `attachStreamsToWorkouts(..., { baselineOnly: true })`; reads time/watts/heartrate/velocity |
| `server/api/analytics/weekly-zones.get.ts` | **migrated** | `baselineOnly` (time/watts/heartrate) |
| `server/api/analytics/workout-comparison/intervals.post.ts` | **migrated** | `fields: ['lapSplits']` |
| `server/api/analytics/workout-explorer/streams.post.ts` | **migrated** | `attachStreamToWorkout` |
| `server/api/analytics/workout-explorer/summary.post.ts` | **migrated** | `attachStreamToWorkout` (advanced summary modes) |
| `server/api/analytics/workout-explorer/intervals.post.ts` | **migrated** | `attachStreamToWorkout` |
| `server/api/analytics/workout-explorer/density.post.ts` | **migrated** | `attachStreamToWorkout` |
| `server/api/workouts/index.get.ts` | **existence probe** | `findManyByWorkoutIds(ids, { fields: [] })`; response keeps its `{ id } \| null` shape so the "Detailed Streams" badge is unchanged |
| `server/api/workouts/[id]/metric-history.get.ts` | **migrated** | dedicated `findExtrasMetaByWorkoutIds()` — FIT session-summary metrics |
| `server/api/profile/sport-settings/[id]/detect-from-workouts.post.ts` | **migrated** | `baselineOnly` over up to 200 workouts |
| `server/utils/calendar-data.ts` | **existence probe** | `hasStreams` now from the repository presence probe |
| `server/utils/ai-tools/workouts.ts` | **migrated (1 of 5 refs)** | the degraded `catch` fallback was the only raw read; the primary path already used `attachStreamToWorkout` and the other 4 refs read its result |
| `server/utils/sharing/image-cache.ts` | **left as-is, documented** | not a Prisma read — `input.workout` is already hydrated, and its only producer (`share/workouts/[token]/image.get.ts`) uses `attachStreamToWorkout` |
| `server/utils/worker-monitoring.ts` (2 refs) | **left as-is, documented** | both refs are the BullMQ `streamsQueue` snapshot, unrelated to the Workout `streams` relation |

## Repository change

Two additions, both in `workoutStreamRepository.ts`.

`findExtrasMetaByWorkoutIds(workoutIds)` mirrors the existing `findWattsByWorkoutIds` — a single-column bulk read with the V1 fallback, going through `readV2Chunk` so the CW-453 NULL-repair path still applies. `metric-history` originally used `attachStreamsToWorkouts(..., { fields: ['extrasMeta'] })`, which fetches `REQUIRED_V2_SELECT` **plus** `extrasMeta` — six parallel per-second series — for `take: limit * 3` rows (up to 90 workouts), when the only consumer `getSessionSummaryValue` reads no series at all. For a rider with 1 Hz hour-long files that is roughly two million numbers decoded per modal open, against exactly one column in the code it replaced. Caught in review, fixed in `b265cc79`.

`findManyByWorkoutIds` gains a `baselineOnly` option. `fields: []` already means presence-only and `fields: undefined` means every column, so a caller needing exactly the mandatory baseline (time/heartrate/watts/velocity/latlng + zone times) had no way to say so — it would otherwise haul every series column across hundreds of workouts. Additive; existing callers are unaffected.

## Guard (AC 2)

Implemented as a test in `workoutStreamRepository.test.ts` rather than an ESLint rule. It scans `server/**/*.ts` (comments stripped, so migration comments quoting the removed read don't self-trigger) for `streams: true` / `streams: { select|include|omit|where ... }`, plus a second pattern for `prisma.workoutStream.*` — the same V2-blind read with a different spelling — with the repository itself exempt as the intended owner of both tables. There are no direct-client reads under `server/` today, so the allowlist is unchanged by that addition. Checked against an allowlist of four files that still violate **outside this ticket's Owned Paths**, each with its reason. A second test asserts the allowlist has no stale entries, so fixing one forces its removal instead of letting the list rot into a permanent exemption.

An ESLint rule was rejected because those four files would fail the build and adding disables there is outside Owned Paths.

Proven to fire: temporarily reintroducing `streams: { select: { watts: true } }` into `weekly-zones.get.ts` failed the guard with the offending path, and passed again once reverted. Positive/negative control assertions are in the test itself — notably `OR: [{ streams: { isNot: null } }, { streamsV2: { isNot: null } }]` must never be flagged.

Follow-ups filed separately for the four out-of-scope sites: `server/api/performance/ftp-evolution.get.ts` (2 reads), `server/utils/services/deduplicationService.ts`, `server/utils/services/checkin-service.ts`, `server/utils/workout-insight-email.ts`.

## Verification

```
pnpm test:unit && pnpm typecheck && pnpm lint
```

- `pnpm test:unit` (bare, no path filter): **387 files / 2662 tests passed**
- `pnpm typecheck`: exit 0
- `pnpm lint`: 0 errors (116 pre-existing `vue/require-default-prop` warnings)

## Spot-check against a V2-only athlete (AC 3)

The worktree database is a clone of the empty template — it had **no** data, so the production athlete `49dadbeb-…` could not be used. Instead I seeded two workouts with `WorkoutStreamV2` rows and **no** `WorkoutStream` (V1) rows (`v1Rows: 0, v2Rows: 2`) and exercised every migrated endpoint on the worktree dev server. All previously returned nothing for this shape:

| Endpoint | Result |
| :-- | :-- |
| `GET /api/workouts` | `streams: { id: … }` present |
| `GET /api/analytics/weekly-zones` | non-zero power + HR zone time |
| `POST /api/analytics/workout-explorer/streams` | full series returned (previously 404 "Workout streams not found") |
| `POST /api/analytics/workout-explorer/density` | heatmap with real bins (previously 404) |
| `POST /api/analytics/workout-explorer/intervals` | 3 laps |
| `POST /api/analytics/workout-explorer/summary` (`mmp_curve`) | MMP scatter data |
| `POST /api/analytics/workout-comparison/intervals` | both workouts' laps |
| `POST /api/analytics/presets/power-duration` | non-zero Z2–Z5 totals |
| `GET /api/workouts/[id]/metric-history?metricKey=total ascent` | value `320` (comes only from `streams.extrasMeta.sessionSummary`) |
| `POST /api/profile/sport-settings/[id]/detect-from-workouts` | `ftp.available: true` with a real peak-20min source |
| `GET /api/calendar` | `hasStreams: true` for both |

Not exercised over HTTP: the `ai-tools/workouts.ts` degraded path (only reachable when the primary fetch throws).

## Performance notes

Three deliberate changes to query shape, none of them regressions in total work but all worth a reviewer's eye:

- **`workouts/index.get.ts` and `calendar-data.ts` now issue one extra presence query** instead of joining the relation. It is a SQL boolean probe — Postgres still reads the series to evaluate the predicate, but only a boolean crosses the wire, so it should be cheaper than the join it replaced. It is still a second round trip.
- **The four single-workout explorer endpoints fetch every stream column** via `attachStreamToWorkout`, where they previously selected a subset. One row each, and it matches what every other single-workout site in the repo does.
- **`metric-history` reads one column**, via the new `findExtrasMetaByWorkoutIds` rather than the baseline-plus-`extrasMeta` shape the first revision used. See the repository section above.

The three `baselineOnly` sites do pull `lat`/`lng`/zone-times they never read. That is inherent to the repository's V2-vs-V1 decision (`hasUsableStreamData` inspects those columns) rather than something introduced here, so it is left alone.

## Notes

- Files changed are all within the ticket's Owned Paths. `eslint.config.mjs` was in Owned Paths but is untouched — the guard is a test, per the reasoning above.
- Per CW-453/CW-582, some `WorkoutStreamV2` rows in production still have NULL elements pending backfill; migrating a call site fixes the V1/V2 gap but those rows may still legitimately return empty. Out of scope here.
- UX critique: skipped — backend data-access change, no UI surface modified.
