### PR TITLE
fix(infra): pin deploy builds to the shadow runner pool (CW-608)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,17 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     needs: ci
-    # Pin to Linux self-hosted runner pool. Bare `self-hosted` can also match
-    # `mac-mini`, which fails GHCR push with anonymous-token 403.
-    runs-on: [self-hosted, Linux]
+    # Pin to the `shadow` build pool (`watt-mind-shadow-1..4`) — NOT the generic
+    # `[self-hosted, Linux]`, which also matches `watt-mind-lab-smoke-1..6`. Those
+    # are 4 vCPU / 15 GB smoke-check boxes with no swap and no Docker cleanup; a
+    # `nuxt build` there starves the host and hangs (CW-608, 2026-08-12: a ~5-min
+    # build ran 45+ min on `lab-smoke-4` and never finished). Combined with the
+    # `cancel-in-progress: false` concurrency group above, one such hang blocks
+    # every subsequent deploy on the branch until someone cancels it by hand.
+    # `docker` is not a sufficient label either — it matches lab-1/lab-2/web-1.
+    # `shadow` matches the build pool exactly. Bare `self-hosted` would also match
+    # `mac-mini`, which fails GHCR push with an anonymous-token 403.
+    runs-on: [self-hosted, shadow]
     timeout-minutes: 60
     # NOTE (CW-129): this must be the environment that actually has
     # DOKPLOY_WEBHOOK_URL configured (Settings > Environments). Environment

--- a/.github/workflows/reusable-trigger-deploy.yml
+++ b/.github/workflows/reusable-trigger-deploy.yml
@@ -45,8 +45,10 @@ on:
 jobs:
   deploy:
     name: Deploy Trigger.dev Tasks
-    # Keep Trigger deploys on the Linux self-hosted runner pool.
-    runs-on: [self-hosted, Linux]
+    # Pin to the `shadow` build pool, same reasoning as deploy.yml (CW-608): the
+    # generic `[self-hosted, Linux]` also matches the `watt-mind-lab-smoke-*`
+    # pool, which is sized for curl/smoke checks and starves under a real build.
+    runs-on: [self-hosted, shadow]
     timeout-minutes: 30
     environment: ${{ inputs.environment }}
     # Job-level (not workflow-level) so the group stays distinct from the caller's


### PR DESCRIPTION
Fixes CW-608

## Problem

`deploy.yml` and `reusable-trigger-deploy.yml` both used the generic `runs-on: [self-hosted, Linux]`. GitHub matches **any** runner carrying both labels, which includes `watt-mind-lab-smoke-1..6` — 4 vCPU / 15 GB boxes provisioned for lightweight curl/smoke checks, with no swap and no automated Docker/buildx cleanup.

On 2026-08-12 a `develop` deploy landed on `watt-mind-lab-smoke-4`. The `nuxt build` inside the Docker build step went to D-state holding 9.1 GB RSS (55.6% of host memory), load average hit 59 on 4 cores, and the Docker daemon stopped answering API calls. A ~5-minute build ran 45+ minutes and never completed.

Because `deploy.yml`'s concurrency group uses `cancel-in-progress: false` (deliberately, so a half-pushed image is never left behind), that one hang blocked **every** subsequent deploy on the branch — four merged commits sat undeployed until the run was cancelled by hand. The same misroute on `master` would block a **production** deploy identically. Production was spared only because that run happened to be on `develop`.

This is not a rare edge case, it is a coin flip that has been landing heads: the most recent successful `develop` deploy (run `31787423423`) landed on `watt-mind-shadow-1` purely by luck.

## Change

Pin both jobs to `runs-on: [self-hosted, shadow]`. Two lines of config; the rest of the diff is the comment explaining why, so this does not get "simplified" back later.

## Runner labels — verified against the live org API, not the docs

I re-queried `gh api orgs/watt-mind/actions/runners` rather than trusting `docs/guides/github-runners.md`, whose per-runner section is stale (it omits `shadow` from `watt-mind-shadow-1`, contradicting its own prescription).

| runner | labels |
| --- | --- |
| `watt-mind-shadow-1..4` | `self-hosted, X64, e2e, Linux, playwright, docker, shadow` |
| `watt-mind-lab-smoke-1..6` | `self-hosted, X64, Linux, lab, light, smoke-test` |
| `watt-mind-lab-1` | `self-hosted, X64, e2e, Linux, docker, lab` |
| `watt-mind-lab-2` | `self-hosted, X64, e2e, Linux, playwright, docker, lab` |
| `watt-mind-web-1` | `self-hosted, X64, Linux, docker` |
| `watt-mind-mac-mini` | `self-hosted, macOS, X64, ios, android, fastlane, mobile` |

`[self-hosted, shadow]` matches `watt-mind-shadow-1..4` and nothing else. `[self-hosted, docker]` would **not** be sufficient — it also matches `lab-1`, `lab-2` and `web-1`.

## Audit of every workflow (AC2) — no edits needed outside Owned Paths

| workflow | `runs-on` | status |
| --- | --- | --- |
| `deploy.yml` | `[self-hosted, shadow]` | fixed here |
| `reusable-trigger-deploy.yml` | `[self-hosted, shadow]` | fixed here |
| `ci.yml` (x4 jobs) | `[self-hosted, shadow]` | already correct |
| `security.yml` | `[self-hosted, shadow]` | already correct |
| `jules.yml` | `[self-hosted, shadow]` | already correct |
| `publish-mcp.yml` | `[self-hosted, shadow]` | already correct |
| `linear-post-merge.yml` | `[self-hosted, shadow]` | already correct |
| `e2e.yml` | `[self-hosted, e2e]` | already correct (the reference pattern) |

These two files were the last users of the generic form. After this PR **no workflow in the repo can be scheduled onto the smoke pool.**

## Verification

Static only — see the honest caveat below.

- All 8 workflow files parse as YAML.
- Resolved every job's `runs-on` against the live runner label set: every job matches ≥1 runner (nothing made unschedulable), and no job in `deploy.yml` / `reusable-trigger-deploy.yml` matches any runner carrying `smoke-test`.
- `deploy.yml` job graph intact: `ci` (reusable → `ci.yml`) → `build-and-deploy` (`needs: ci`). Unchanged.
- `actionlint` reports no findings on either file beyond `label "shadow" is unknown`, which is pre-existing and repo-wide (untouched `ci.yml` emits the same warning 4x). There is no `.github/actionlint.yaml` declaring the custom labels and actionlint is not wired into CI, so this is not a regression — filed as a follow-up.
- Nothing else in either file changed: no step, secret, environment, concurrency or timeout was touched.

### What remains unproven until this merges

**A deploy-workflow change cannot be fully verified without deploying, and I did not trigger a production or staging deploy to test it.** The ticket's verification command requires a real post-merge run:

```bash
gh run list --branch develop --workflow "Build and Deploy to Dokploy" --limit 1 --json databaseId -q '.[0].databaseId' \
  | xargs -I{} gh api repos/watt-mind/coach/actions/runs/{}/jobs -q '.jobs[] | "\(.name): \(.runner_name)"'
```

**Whoever merges this should run that on the first `develop` deploy afterwards and confirm `Build and Deploy` reports a `watt-mind-shadow-*` runner.** My label-matching check is a static simulation of GitHub's scheduler, not the scheduler itself. The residual risk is low but real: if all four `shadow` runners are busy, deploys now **queue** for the shadow pool instead of spilling onto lab/web runners. That is the intended trade (queuing beats a 45-minute hang that blocks the branch), but it does narrow the pool from ~11 eligible Linux runners to 4, and `shadow` is also the pool `ci.yml` and `e2e.yml` draw from.

## Deliberate scope decisions

**The `pnpm` `dest` fix from CW-630 was NOT applied — and `deploy.yml` does not need it.** I checked specifically: `deploy.yml` has **no `pnpm/action-setup` step at all** (its `build-and-deploy` job is checkout → buildx → GHCR login → metadata → docker build/push → webhook → Discord; the pnpm work happens inside the Docker build). Its `ci` job delegates to `ci.yml`, which already carries the `dest: ${{ runner.temp }}/setup-pnpm` fix from #567. So there is no shared-home collision exposure in this file to fix.

`reusable-trigger-deploy.yml` *does* use `pnpm/action-setup` with the default `dest`, and pinning it to `shadow` here does move it into the shared-home pool. I deliberately left it alone: that is **CW-631's** scope, it is a dormant workflow (Trigger.dev deploys are disabled and nothing in the repo calls it), so the exposure is currently theoretical. Recorded on CW-631 so it is fixed before the workflow is ever re-enabled.

**CW-617's scope was not implemented.** CW-617 (`no-cache` dispatch input, conditional `cache-to`) shares `deploy.yml` as an Owned Path and is still `Todo`/unassigned. I stayed off it. My change touches only lines 27-29; CW-617's work is at lines 85-86 (`cache-from` / `cache-to`) and the `on:` block — no overlap, so it should rebase cleanly. Noted on CW-617.

UX critique: skipped — deploy workflow configuration, no user-facing surface.

## Follow-ups filed

- Wedged runners from the incident (`lab-smoke-2`, `lab-smoke-4`) have since recovered — all 6 smoke runners now report `online / busy=false`. No action needed.
- A repo-level guard so this cannot regress by omission (AC4) is filed separately rather than bolted on here.
