### PR TITLE
fix(infra): install native deps from prebuilt binaries only (CW-618)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
+; Allowlist of packages permitted to run install/build scripts at all. This is a
+; yes/no switch per package -- it cannot constrain *how* a package builds itself.
+; The container build additionally requires the native modules here to come from
+; published prebuilt binaries and refuses a from-source compile; see Dockerfile
+; (stage `deps`) and CW-618 before changing native-dependency build policy.
 only-built-dependencies[]=@parcel/watcher
 only-built-dependencies[]=@prisma/client
 only-built-dependencies[]=@prisma/engines

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,21 @@ else
   export npm_config_node_gyp PATH
 fi
 
+# --- Layer 0: assert the side-effect cache really is off ---------------------
+# PNPM_CONFIG_SIDE_EFFECTS_CACHE is an env-var spelling of pnpm's
+# `side-effects-cache` setting. If a future pnpm renames or drops it, the ENV
+# above becomes a silent no-op and the shared /pnpm/store cache mount quietly
+# turns back into a way for a bad built artifact to outlive a `--no-cache`
+# rebuild. Silent is the failure mode this whole file exists to remove, so check
+# it. (`undefined` here means "not set" -- i.e. the env var did not take.)
+side_effects_cache="$(pnpm config get side-effects-cache 2>/dev/null | tail -n 1)"
+if [ "$side_effects_cache" != "false" ]; then
+  echo "ERROR (CW-618): expected pnpm side-effects-cache=false, got '${side_effects_cache}'." >&2
+  echo "PNPM_CONFIG_SIDE_EFFECTS_CACHE no longer maps to that setting. Find its current" >&2
+  echo "name and update the ENV, or a bad native binary can survive a --no-cache build." >&2
+  exit 1
+fi
+
 pnpm install --frozen-lockfile --ignore-scripts
 
 # --- Layer 2: retry the prebuilt fetch before giving up ----------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,142 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml .npmrc* pnpm-workspace.yaml* ./
 COPY prisma ./prisma/
 COPY prisma.config.ts ./
-RUN --mount=type=cache,id=pnpm-v3,target=/pnpm/store pnpm install --frozen-lockfile --ignore-scripts && pnpm rebuild better-sqlite3 bcrypt && pnpm prisma generate
+# Native modules are installed from published prebuilt binaries ONLY. Compiling
+# from source is not an automatic fallback here; it is opt-in and validated (see
+# ALLOW_NATIVE_SOURCE_BUILD below). See CW-618, and the CW-617 outage it prevents.
+#
+# better-sqlite3's install script is `prebuild-install || node-gyp rebuild --release`.
+# The `||` means ANY failure of the prebuilt download -- including a transient
+# `socket hang up` -- silently swaps in a completely different code path: a
+# from-source compile against whatever toolchain this image happens to have.
+#
+# That path does not work here, and it never did. Compiling better-sqlite3 from
+# source on this image reproducibly yields a binary that loads and queries fine
+# but aborts during Node's environment cleanup:
+#
+#     node::RemoveEnvironmentCleanupHook ... at ../src/api/hooks.cc:142
+#     Assertion failed: (env) != nullptr
+#     Statement::~Statement() [.../better_sqlite3.node]      -> exit 134
+#
+# That is the CW-617 outage, reproduced on demand while verifying CW-618. Because
+# the abort happens at process exit rather than at install, the deps layer looked
+# healthy and `pnpm build` died minutes later pointing at Node internals; the
+# deploy workflow's `cache-to: mode=max` then baked the broken artifact into the
+# shared registry cache and every later build inherited it. So the fallback was
+# not merely unvalidated -- it could not have produced a working image.
+#
+# pnpm's `onlyBuiltDependencies` (.npmrc) / `allowBuilds` (pnpm-workspace.yaml)
+# allowlists cannot express this policy: they only decide *whether* a package may
+# run its install script, not which branch of that script runs. `pnpm rebuild`
+# re-runs the same script string. Hence this wrapper, which enforces the policy in
+# three independent layers:
+#   1. a `node-gyp` guard (via `npm_config_node_gyp` and PATH) turns the silent
+#      fallback into a hard, self-explaining failure in seconds. This covers every
+#      native dependency, present and future, not just the two named below.
+#   2. the prebuilt fetch is retried with backoff, so a genuine network blip costs
+#      seconds instead of a red build.
+#   3. the installed binaries are asserted prebuilt and then actually exercised,
+#      so a broken artifact fails HERE instead of in an unrelated later step.
+#
+# Side-effect caching is disabled because /pnpm/store is a shared BuildKit cache
+# mount: without this, a bad built artifact could survive a `--no-cache` rebuild.
+ENV PNPM_CONFIG_SIDE_EFFECTS_CACHE="false"
+# Escape hatch, for a future native dependency whose prebuilt binary is genuinely
+# unavailable: `--build-arg ALLOW_NATIVE_SOURCE_BUILD=1` permits a from-source
+# compile. It is opt-in and logged rather than silent, and the smoke test below
+# still gates the layer either way -- the property the original `||` lacked.
+#
+# It will NOT rescue better-sqlite3. Verified: with this flag set, the compile
+# succeeds and the smoke test then aborts with exit 134 exactly as above. That is
+# the correct outcome -- a broken binary must not reach the registry cache -- but
+# it means the only real fix for a failed prebuilt fetch is to retry the build.
+# Never set this as the default.
+ARG ALLOW_NATIVE_SOURCE_BUILD=0
+RUN --mount=type=cache,id=pnpm-v3,target=/pnpm/store <<'EOS'
+set -eu
+
+# --- Layer 1: refuse to compile native modules from source -------------------
+if [ "${ALLOW_NATIVE_SOURCE_BUILD}" = "1" ]; then
+  echo "WARNING (CW-618): ALLOW_NATIVE_SOURCE_BUILD=1 -- native modules may be compiled"
+  echo "from source. This is opt-in and deliberate; the smoke test still gates the layer."
+else
+  guard_dir="$(mktemp -d)"
+  {
+    echo '#!/bin/sh'
+    echo 'echo "" >&2'
+    echo 'echo "ERROR (CW-618): node-gyp was invoked while installing a native dependency." >&2'
+    echo 'echo "This image installs native modules from prebuilt binaries only. A from-source" >&2'
+    echo 'echo "build of better-sqlite3 on this image reliably produces a binary that aborts" >&2'
+    echo 'echo "during Node environment cleanup (exit 134). That was the CW-617 outage, and" >&2'
+    echo 'echo "it is why this build refuses to compile rather than quietly falling back." >&2'
+    echo 'echo "" >&2'
+    echo 'echo "Reaching node-gyp means no prebuilt binary could be obtained, which is almost" >&2'
+    echo 'echo "always a transient network failure: RERUN THE BUILD. If it keeps happening," >&2'
+    echo 'echo "the prebuilt binary is genuinely missing for this platform/Node ABI, which" >&2'
+    echo 'echo "needs a real decision -- see ALLOW_NATIVE_SOURCE_BUILD in the Dockerfile." >&2'
+    echo 'exit 1'
+  } > "$guard_dir/node-gyp"
+  chmod +x "$guard_dir/node-gyp"
+  # Two interception points are needed, and neither alone is sufficient:
+  #   * `npm_config_node_gyp` is what pnpm's lifecycle runner honours. pnpm bundles
+  #     its own node-gyp and injects it, so a bare PATH entry is ignored -- this is
+  #     the one that catches better-sqlite3's `|| node-gyp rebuild --release`.
+  #   * PATH catches packages that shell out to `node-gyp` directly, which is what
+  #     bcrypt's `node-gyp-build` does (node-gyp is not in its dependency tree).
+  npm_config_node_gyp="$guard_dir/node-gyp"
+  PATH="$guard_dir:$PATH"
+  export npm_config_node_gyp PATH
+fi
+
+pnpm install --frozen-lockfile --ignore-scripts
+
+# --- Layer 2: retry the prebuilt fetch before giving up ----------------------
+attempt=1
+until pnpm rebuild better-sqlite3 bcrypt; do
+  if [ "$attempt" -ge 3 ]; then
+    echo "ERROR (CW-618): prebuilt native binaries could not be installed after ${attempt} attempts." >&2
+    exit 1
+  fi
+  echo "Prebuilt native binary install failed (attempt ${attempt} of 3); retrying..." >&2
+  sleep "$((attempt * 5))"
+  attempt="$((attempt + 1))"
+done
+
+# --- Layer 3a: assert the artifacts are prebuilt, not compiled ---------------
+# Defence in depth behind the guard above, in case a package ever reaches gyp
+# by some route neither hook covers. node-gyp leaves build/Makefile,
+# build/config.gypi and build/Release/obj.target; prebuild-install and
+# node-gyp-build never create any of them.
+if [ "${ALLOW_NATIVE_SOURCE_BUILD}" != "1" ]; then
+  for pkg in better-sqlite3 bcrypt; do
+    if [ -e "node_modules/${pkg}/build/Makefile" ] \
+      || [ -e "node_modules/${pkg}/build/config.gypi" ] \
+      || [ -d "node_modules/${pkg}/build/Release/obj.target" ]; then
+      echo "ERROR (CW-618): ${pkg} was compiled from source; refusing to build this layer." >&2
+      exit 1
+    fi
+  done
+fi
+
+# --- Layer 3b: prove the binaries actually work ------------------------------
+node -e "
+  const Database = require('better-sqlite3');
+  const closed = new Database(':memory:');
+  if (closed.prepare('select 1 as ok').get().ok !== 1) throw new Error('better-sqlite3 returned an unexpected result');
+  closed.close();
+  // Deliberately left open: the CW-617 binary aborted in a Statement destructor
+  // during Node's environment cleanup, which only runs at process exit.
+  const open = new Database(':memory:');
+  open.prepare('select 1 as ok').get();
+  const bcrypt = require('bcrypt');
+  if (!bcrypt.compareSync('cw-618', bcrypt.hashSync('cw-618', 4))) throw new Error('bcrypt hash/compare roundtrip failed');
+  console.log('native dependency smoke test: ok');
+"
+
+pnpm prisma generate
+
+if [ -n "${guard_dir:-}" ]; then rm -rf "$guard_dir"; fi
+EOS
 
 # Stage 2: Build the application
 FROM base AS builder

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# Allowlist of packages permitted to run install/build scripts at all. This is a
+# yes/no switch per package -- it cannot constrain *how* a package builds itself.
+# The container build additionally requires the native modules here to come from
+# published prebuilt binaries and refuses a from-source compile; see Dockerfile
+# (stage `deps`) and CW-618 before changing native-dependency build policy.
 allowBuilds:
   '@parcel/watcher': true
   '@prisma/client': true


### PR DESCRIPTION
Fixes CW-618

## The policy decision, and why

**A failed `prebuild-install` now fails the build loudly. There is no automatic from-source fallback.**

The ticket asked me to decide between failing loudly and keeping a fallback, and noted that failing loudly is "defensible" for a reproducible container build. Verification turned that from a judgement call into a straightforward one:

**A from-source build of `better-sqlite3` on this image does not work — reproducibly.** Compiling it deliberately (`ALLOW_NATIVE_SOURCE_BUILD=1`) and then running the smoke test gives:

```
#  node[205]: void node::RemoveEnvironmentCleanupHook(...) at ../src/api/hooks.cc:142
#  Assertion failed: (env) != nullptr

 2: node::RemoveEnvironmentCleanupHook(...) [node]
 3: Statement::~Statement() [.../better-sqlite3/build/Release/better_sqlite3.node]
Aborted                                                            -> exit 134
```

That is the CW-617 outage, reproduced on demand. It was not bad luck on 2026-08-12 — the fallback path is simply broken on this image, every time. So the `||` could never have produced a working image; on any prebuilt-fetch failure it was guaranteed to swap a working binary for a broken one and report success.

Given that, a fallback has no upside to trade against. A retry costs seconds; the fallback cost a multi-day blocked deploy pipeline.

## What changed

`Dockerfile` (stage `deps`) — the install step is now:

1. **Guard.** `npm_config_node_gyp` (and `PATH`) point at a script that refuses to compile and explains why. Turns the silent code-path swap into a hard failure in ~1 second, and covers any native dependency, not just these two.
2. **Retry.** The prebuilt fetch is retried 3× with backoff (5s, 10s), so a genuine network blip costs seconds instead of a red build.
3. **Validate.** `side-effects-cache` is read back and asserted `false` (an unchecked ENV that silently stopped working would quietly reopen the shared-store vector). The installed artifacts are asserted prebuilt (no `build/Makefile`, `build/config.gypi`, `build/Release/obj.target`), then *actually exercised*: open an in-memory database, prepare and run a statement, close it, leave a second one alive so the destructor runs at process teardown — the exact path that aborted — plus a `bcrypt` hash/compare roundtrip. A broken binary now fails in the deps layer instead of in `pnpm build` minutes later.

`ALLOW_NATIVE_SOURCE_BUILD=1` remains as an explicit, logged opt-in for a future dependency whose prebuilt binary is genuinely missing. The smoke test still gates the layer, so it cannot ship a bad binary — verified, it aborts at exit 134 for `better-sqlite3` exactly as it should.

`PNPM_CONFIG_SIDE_EFFECTS_CACHE=false` is set in the image. `/pnpm/store` is a **shared BuildKit cache mount**, so pnpm's side-effect cache was a second way a bad built artifact could survive even a `--no-cache` rebuild. Container-only; local dev is unaffected. The build now **reads the setting back** (`pnpm config get side-effects-cache`) and fails if it is not `false`, so a future pnpm rename cannot turn this into a silent no-op — verified both directions: `false` as shipped, `undefined` correctly aborts the build.

`.npmrc` and `pnpm-workspace.yaml` get a **comment only** (see the enforcement note below).

## Verification

Every test below runs the **real** Dockerfile block, extracted verbatim into the test image — not a copy.

| # | Scenario | Expected | Result |
| :- | :-- | :-- | :-- |
| A | Happy path, `--no-cache --target deps`, linux/arm64 | prebuilt, validated | **PASS** — fetch 0.7s, `native dependency smoke test: ok` |
| A2 | Happy path, `--no-cache --target deps`, **linux/amd64** (prod platform) | prebuilt, validated | **PASS** — `native dependency smoke test: ok` |
| A3 | Ticket's `docker run` verification command | `ok` | **PASS** |
| **B** | **`prebuild-install` fails, network up — the 2026-08-12 condition** | loud failure, no compile | **FAILS LOUDLY in 17s** — guard fires, 3 attempts, no compile |
| **D** | **Network genuinely blocked** (`--network=none`, prebuild cache cleared) | loud failure, no compile | **FAILS LOUDLY in 19s** — `getaddrinfo EAI_AGAIN github.com`, 3 attempts |
| E | Backstop assertion (planted node-gyp artifact) | fail | **FAILS in 2.2s** — assertion is not dead code |
| F | Escape hatch `ALLOW_NATIVE_SOURCE_BUILD=1` | compiles, then smoke test rejects it | **exit 134** — smoke test catches the broken binary |
| **C** | **Control: the OLD command, same simulated failure** | reproduces the defect | **`pnpm rebuild` reported SUCCESS (exit 0)** with `Makefile`, `config.gypi`, `deps` left in `build/` — silently compiled from source |

Test C is the point of the whole ticket: under the old command a prebuilt-fetch failure produced a **green install step** and a from-source binary. Test B is the same condition under the new code, failing in 17 seconds with an actionable message.

Test B output:

```
better-sqlite3 install: simulated failure: socket hang up
better-sqlite3 install: ERROR (CW-618): node-gyp was invoked while installing a native dependency.
better-sqlite3 install: This image installs native modules from prebuilt binaries only. A from-source
better-sqlite3 install: build of better-sqlite3 on this image reliably produces a binary that aborts
better-sqlite3 install: during Node environment cleanup (exit 134). That was the CW-617 outage, and
better-sqlite3 install: it is why this build refuses to compile rather than quietly falling back.
Prebuilt native binary install failed (attempt 1 of 3); retrying...
[...]
ERROR (CW-618): prebuilt native binaries could not be installed after 3 attempts.
```

### The fallback test earned its keep

My first implementation guarded `node-gyp` with a `PATH` shim. **The happy-path build passed and it looked correct — and the guard was completely inert.** pnpm bundles its own `node-gyp` and injects it into the lifecycle environment, so the `PATH` entry is never consulted; `better-sqlite3` compiled from source anyway and was only stopped 7.5 minutes later by the backstop assertion.

The fix is `npm_config_node_gyp`, which pnpm's lifecycle runner does honour. Both hooks are now set, and neither alone is sufficient — `PATH` is what catches `bcrypt`'s `node-gyp-build`, which shells out to a bare `node-gyp`. The ticket's warning that "a green happy-path build proves almost nothing" was exactly right.

## Acceptance criteria

- **Decide the policy** — fail loudly. Reasoning above.
- **Retry before falling through** — 3 attempts with backoff. (Kept even though there is no fallback: it is what keeps a transient blip from becoming a red build.)
- **Validate the artifact** — layers 3a + 3b, and they run even on the opt-in compile path.
- **Same treatment for `bcrypt` and any other native dep** — done, and the guard is generic rather than per-package. Worth noting: `bcrypt@6.0.0` does **not** use node-pre-gyp as the ticket assumed; its install script is `node-gyp-build`, which loads a prebuild **shipped inside the npm tarball**. It performs no network fetch at install time (verified: it installs cleanly with `--network=none`) and so was never exposed to the network-blip path — but it does fall back to `node-gyp` if the shipped prebuild fails to load, so it is guarded too.
- **Confirm the approach can be enforced** — `onlyBuiltDependencies` (`.npmrc`) and `allowBuilds` (`pnpm-workspace.yaml`) **cannot** express this. They are per-package yes/no switches for whether an install script may run at all; they cannot constrain which branch of the script runs, and `pnpm rebuild` re-runs the same script string. A wrapper step is required, which is what this is. Both files gain a comment saying so, so the next person to edit those lists knows the Dockerfile enforces more. (`pnpm patch` would work but needs a `patches/` file outside this ticket's Owned Paths, and would need re-creating on every `better-sqlite3` bump.)
- **Consider pinning/vendoring the prebuilts** — analysed, not done here:
  - `bcrypt` is already effectively vendored (prebuilds ride in the npm tarball, served from the pnpm store).
  - `better-sqlite3` fetches from github.com release assets. Committing the `.node` binary means a ~2 MB per-arch binary in git re-vendored on every `better-sqlite3`/Node-ABI bump; an internal mirror needs infra outside this repo. Both need paths outside Owned Paths.
  - A cheaper option surfaced during testing: `prebuild-install` caches downloads in `~/.npm/_prebuilds`, so a BuildKit cache mount there would remove the CDN from the repeat-build path entirely. It also adds another shared-cache persistence vector — the exact class of problem CW-617 was — though layers 3a/3b now validate whatever comes out of it. Filed as **CW-646** rather than bundled into this change.

## Risks

- **This is a real behaviour change on the critical deploy path.** A prebuilt fetch that fails 3× in a row now fails the build instead of silently compiling. That is the intent, but it means a sustained github.com release-asset outage blocks deploys until it recovers. The mitigation is that the old behaviour did not actually produce working images anyway — it produced green builds that died later.
- **The guard depends on pnpm honouring `npm_config_node_gyp`.** Verified on pnpm 11.17.0. A future pnpm could change this; layer 3a is the backstop and would still fail the build, just slowly (after the compile) rather than in a second. That degradation is safe, not silent.
- **Local verification was on Docker for Mac.** The happy path was built on both linux/arm64 and linux/amd64 (prod's platform); the fallback tests B/C/D/E/F ran on arm64, but nothing they exercise is arch-specific, and the arch-dependent facts (both prebuilts resolve for Node 24 / ABI 137 on linux-x64) were verified directly in a linux/amd64 container.
- The heredoc `RUN` needs BuildKit 0.11+. **Checked on the actual runner** — see below. No `# syntax=` directive was added deliberately: pinning the frontend would pull `docker/dockerfile:1` from Docker Hub on every build, adding a *new* third-party network dependency at image-build time, which is the failure class this ticket exists to remove. Given the measured versions there is nothing to protect against.

## Heredoc `RUN` — verified on the deploy runner

`deploy.yml` pins to `runs-on: [self-hosted, shadow]` (CW-608), i.e. the `watt-mind-shadow-1..4` pool on one host. Read-only inspection of that host:

| | version | heredoc needs |
| :-- | :-- | :-- |
| `docker-container` builders (`moby/buildkit:buildx-stable-1`, what `setup-buildx-action` creates) | **BuildKit v0.32.2** | ≥ 0.11 |
| `default` docker-driver builder | **BuildKit v0.26.3** | ≥ 0.11 |
| Docker engine | 29.1.5 | ≥ 23 |

Also relevant to the `keep-state: true` concern: **no builder named `coach` currently exists on that host** (`ERROR: no builder "coach" found`; only two auto-named `builder-<uuid>` instances). So the next deploy creates it fresh from `buildx-stable-1` — it cannot be a stale builder predating heredoc support. Every builder on the host is far above the threshold either way.

Nothing was changed, restarted or recreated on the runner; this was `docker buildx ls` / `inspect` only.

## Scope

Files changed: `Dockerfile`, `.npmrc`, `pnpm-workspace.yaml` — exactly the ticket's Owned Paths, nothing else. `.github/workflows/deploy.yml` (the `no-cache` dispatch input and conditional `cache-to`, still open under CW-617) is deliberately untouched.

Follow-ups filed: **CW-646** (vendor/mirror the prebuilt), **CW-647** (the `python3 make g++` toolchain is now unreachable by default — evaluate dropping it), **CW-649** (`Dockerfile.e2e:18` still carries the identical defect, on the separate `lab` e2e hosts), **CW-650** (the native-build allowlist is duplicated across `.npmrc`, `pnpm-workspace.yaml` and `package.json` with nothing keeping them in sync).

UX critique: skipped — container build configuration, no user-facing surface.
