### PR TITLE
fix(analytics): validate power-curve freshness against a settled best (CW-380)

### DIFF
--- a/server/api/workouts/power-curve.get.ts
+++ b/server/api/workouts/power-curve.get.ts
@@ -170,16 +170,20 @@ export default defineEventHandler(async (event) => {
     fallbackLastValidatingByDuration?: Map<number, Date | null>
   ) => {
     const bestByDuration = new Map<number, { watts: number; date: Date | null }>()
-    const lastValidatingByDuration = new Map<number, Date | null>()
+    const effortsByDuration = new Map<number, Array<{ watts: number; date: Date }>>()
 
     DURATIONS.forEach((duration) => {
       bestByDuration.set(duration, { watts: 0, date: null })
-      lastValidatingByDuration.set(duration, null)
+      effortsByDuration.set(duration, [])
     })
 
+    // Pass 1: collect every workout's best effort per duration, and the overall
+    // best for this workout set.
     workouts.forEach((workout) => {
       const watts = wattsByWorkoutId.get(workout.id)
       if (!watts || watts.length === 0) return
+
+      const workoutDate = new Date(workout.date)
 
       DURATIONS.forEach((duration) => {
         const best = calculateBestPowerForDuration(watts, duration)
@@ -187,19 +191,37 @@ export default defineEventHandler(async (event) => {
 
         const current = bestByDuration.get(duration)
         if (current && best > current.watts) {
-          bestByDuration.set(duration, { watts: best, date: new Date(workout.date) })
+          bestByDuration.set(duration, { watts: best, date: workoutDate })
         }
 
-        const referenceBest = allTimeBestByDuration?.get(duration) || best
-        const threshold = referenceBest * VALIDATION_PCT
-        if (best >= threshold) {
-          const existing = lastValidatingByDuration.get(duration)
-          const workoutDate = new Date(workout.date)
-          if (!existing || workoutDate > existing) {
-            lastValidatingByDuration.set(duration, workoutDate)
-          }
-        }
+        effortsByDuration.get(duration)?.push({ watts: best, date: workoutDate })
       })
+    })
+
+    // Pass 2: validate against a *settled* reference best. The all-time curve is
+    // built first, with no `allTimeBestByDuration`, so comparing each effort to a
+    // running/own value would let every workout validate itself (CW-380) and
+    // collapse `lastValidatingDate` to the date of the most recent ride with
+    // power. Falling back to this set's own final best keeps the all-time curve's
+    // freshness meaning "how long since a near-best effort", which is also what
+    // makes it a sound fallback for the current curve.
+    const lastValidatingByDuration = new Map<number, Date | null>()
+
+    DURATIONS.forEach((duration) => {
+      const referenceBest =
+        allTimeBestByDuration?.get(duration) || bestByDuration.get(duration)?.watts || 0
+
+      let lastValidating: Date | null = null
+
+      if (referenceBest > 0) {
+        const threshold = referenceBest * VALIDATION_PCT
+        for (const effort of effortsByDuration.get(duration) || []) {
+          if (effort.watts < threshold) continue
+          if (!lastValidating || effort.date > lastValidating) lastValidating = effort.date
+        }
+      }
+
+      lastValidatingByDuration.set(duration, lastValidating)
     })
 
     return DURATIONS.map((duration) => {

--- a/tests/unit/server/api/workouts/power-curve.test.ts
+++ b/tests/unit/server/api/workouts/power-curve.test.ts
@@ -155,4 +155,95 @@ describe('GET /api/workouts/power-curve', () => {
     expect(allTime300?.freshnessState).toBe('stale')
     expect(allTime300?.daysSince).toBeGreaterThanOrEqual(399)
   })
+
+  it('does not report a duration as fresh just because the athlete rode recently (CW-380)', async () => {
+    // Regression guard for CW-380: the all-time curve was built with no
+    // reference best, so every workout validated against its own value and
+    // `lastValidatingDate` collapsed to the date of the most recent ride with
+    // power. That date then leaked into the current curve as the fallback, so a
+    // near-best effort a year ago plus an easy ride last week rendered `fresh`.
+    const handler = await getHandler()
+    const recent = { id: 'workout-recent', date: daysAgo(7) }
+    const old = { id: 'workout-old', date: daysAgo(400) }
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([recent] as any) // current 90-day window: easy riding only
+      .mockResolvedValueOnce([recent, old] as any) // all-time
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([
+        ['workout-recent', steadyRide(250)],
+        ['workout-old', steadyRide(320)]
+      ])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    // The all-time curve describes recency of a near-best effort, not of riding.
+    const allTime300 = result.allTime.find((p: any) => p.duration === 300)
+    expect(allTime300?.watts).toBe(320)
+    expect(allTime300?.daysSince).toBeGreaterThanOrEqual(399)
+    expect(allTime300?.freshnessState).toBe('stale')
+
+    // 250W is below 97% of the 320W all-time best, so the current period holds no
+    // validating effort and must not inherit a "fresh" state from the fallback.
+    const current300 = result.current.find((p: any) => p.duration === 300)
+    expect(current300?.watts).toBe(250)
+    expect(current300?.freshnessState).not.toBe('fresh')
+    expect(current300?.freshnessState).toBe('stale')
+    expect(current300?.daysSince).toBeGreaterThanOrEqual(399)
+  })
+
+  it('keeps a duration fresh when a recent effort is within the validation threshold (CW-380)', async () => {
+    const handler = await getHandler()
+    const recent = { id: 'workout-recent', date: daysAgo(7) }
+    const old = { id: 'workout-old', date: daysAgo(400) }
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([recent] as any)
+      .mockResolvedValueOnce([recent, old] as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([
+        ['workout-recent', steadyRide(315)], // 98.4% of the 320W all-time best
+        ['workout-old', steadyRide(320)]
+      ])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    const current300 = result.current.find((p: any) => p.duration === 300)
+    expect(current300?.freshnessState).toBe('fresh')
+    expect(current300?.daysSince).toBeLessThanOrEqual(8)
+
+    // The all-time curve sees the same validating effort, so it is fresh too.
+    const allTime300 = result.allTime.find((p: any) => p.duration === 300)
+    expect(allTime300?.freshnessState).toBe('fresh')
+    expect(allTime300?.daysSince).toBeLessThanOrEqual(8)
+  })
+
+  it('measures all-time freshness against the all-time best, not each workout in isolation (CW-380)', async () => {
+    // Only the all-time curve is exercised here (no current-period workouts), so
+    // a regression cannot hide behind the current curve's own validation pass.
+    const handler = await getHandler()
+    const workouts = [
+      { id: 'workout-peak', date: daysAgo(500) },
+      { id: 'workout-easy', date: daysAgo(3) }
+    ]
+
+    vi.mocked(workoutRepository.getForUser)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce(workouts as any)
+    vi.mocked(workoutStreamRepository.findWattsByWorkoutIds).mockResolvedValue(
+      new Map([
+        ['workout-peak', steadyRide(400)],
+        ['workout-easy', steadyRide(180)]
+      ])
+    )
+
+    const result = await handler({ query: { days: 90 } } as any)
+
+    const allTime300 = result.allTime.find((p: any) => p.duration === 300)
+    expect(allTime300?.watts).toBe(400)
+    expect(allTime300?.lastValidatingDate?.getTime()).toBe(workouts[0].date.getTime())
+    expect(allTime300?.freshnessState).toBe('stale')
+  })
 })


### PR DESCRIPTION
Fixes CW-380

## Problem

`processWorkoutsToCurve()` in `server/api/workouts/power-curve.get.ts` validated each effort with:

```ts
const referenceBest = allTimeBestByDuration?.get(duration) || best
```

The all-time curve is built **first**, with `allTimeBestByDuration` undefined, so `referenceBest` fell back to `best` — the workout's own value — and `best >= best * 0.97` is true for every workout with any power at that duration. Every workout validated itself, and the all-time `lastValidatingDate` collapsed to *the date of the most recent workout with power data*, for every duration.

That date was then passed to the current curve as `fallbackLastValidatingByDuration`. So a duration **not** validated in the selected period — precisely the case the freshness feature exists to flag — inherited it and rendered `fresh` (blue). A duration the athlete had not gone near in a year showed fresh as long as they rode last week, and the "add short validation efforts" tip in `PerformancePowerCurveCard.vue` could effectively never fire.

## Semantics decision

**The all-time curve's own freshness is now measured against the all-time best, in a second pass.**

`processWorkoutsToCurve` is split into two passes:

1. Collect each workout's best effort per duration, and the set's overall best.
2. Compute `lastValidatingDate` against a **settled** reference best: `allTimeBestByDuration` when supplied (current curve), otherwise this workout set's own final best (all-time curve).

Reasoning:

- It is the only reading under which the number means anything. "Days since a near-best effort" is the question the UI asks; validating an effort against itself answers "days since you last rode", which the curve already conveys elsewhere.
- It makes the all-time date a **sound fallback**. The current curve falls back to the all-time `lastValidatingDate` when the period holds no validating effort; that is only correct if the all-time date marks a genuine near-best effort. It now does, so the fallback degrades to "last time you were near your best, whenever that was" instead of resetting the clock on every ride.
- It matches what `cli/debug/curve-freshness.ts` already does — that tool computes the all-time best in a first loop and validates in a second, so it never had this flaw. **Checked and left untouched**; the ticket said "likely", and it turned out not to.
- No threshold or state boundaries changed: `VALIDATION_PCT` (97%) and the 30/90-day fresh/aging thresholds are as before.

## Evidence the reproduction was red first

The regression test was written before the fix and confirmed failing against the current code:

```
× does not report a duration as fresh just because the athlete rode recently (CW-380)
AssertionError: expected 7 to be greater than or equal to 399
× measures all-time freshness against the all-time best, not each workout in isolation (CW-380)
AssertionError: expected 1786447781186 to be 1743506981186
```

A 400-day-old 320W effort plus a 7-day-old 250W ride reported the all-time 5-minute point as `daysSince: 7` — the recent ride's date — and both curves rendered `fresh`. After the fix both report `stale` at ~400 days.

Note that the companion happy-path test ("keeps a duration fresh when a recent effort is within the validation threshold") **passed against the broken code**, which is exactly why the ticket called for the negative case.

## Tests added

- `does not report a duration as fresh just because the athlete rode recently (CW-380)` — recent riding, no recent near-best effort; asserts neither the all-time nor the current 5-minute point is `fresh`.
- `keeps a duration fresh when a recent effort is within the validation threshold (CW-380)` — guards against over-correcting into never-fresh.
- `measures all-time freshness against the all-time best, not each workout in isolation (CW-380)` — all-time curve only, so a regression cannot hide behind the current curve's own validation pass.

## Verification

```
pnpm test:unit && pnpm typecheck
```

`pnpm test:unit` run **bare** (no path filter): **387 files, 2659 tests passed**. `pnpm typecheck` exit 0.

## Files vs Owned Paths

| File | Owned |
| :--- | :--- |
| `server/api/workouts/power-curve.get.ts` | yes |
| `tests/unit/server/api/workouts/power-curve.test.ts` | yes |
| `cli/debug/curve-freshness.ts` | owned, **not modified** — already correct |

Nothing outside Owned Paths was touched.

## Risks

- Behaviour change is intentional and one-directional: durations that previously read `fresh` on the strength of unrelated recent riding will now read `aging`/`stale` until a genuine near-best effort lands. Athletes who train close to their bests see no change.
- The `fallbackLastValidatingByDuration` plumbing is unchanged — only the value flowing through it is now meaningful.
- Pass 1 now retains one `{ watts, date }` entry per workout per duration (10 durations x the 2-year workout set) rather than folding on the fly. Bounded and small; the O(n) stream scan that dominates cost is unchanged.

UX critique: skipped — no flow or layout change; corrects an existing status value.