### PR TITLE
fix(ai): bound athlete-profile schema free-text fields (CW-368)

### DIFF
--- a/tests/unit/trigger/generate-athlete-profile-schema.test.ts
+++ b/tests/unit/trigger/generate-athlete-profile-schema.test.ts
@@ -11,9 +11,20 @@ import { athleteProfileSchema } from '../../../trigger/generate-athlete-profile'
  * `AI_JSONParseError: Unterminated string in JSON` and the entire otherwise
  * complete analysis was discarded.
  *
- * `maxLength` is what the model is *asked* to honour, not a hard guarantee — a
- * generative model can still overrun it. These tests pin the constraint being
- * declared at all, which is what was missing.
+ * SCOPE — THIS FILE TESTS DECLARATION, NOT ENFORCEMENT.
+ *
+ * Nothing enforces `maxLength` at runtime: `@ai-sdk/google` strips it from the
+ * request (its schema converter allowlists `minLength` but not `maxLength`), and
+ * `generateStructuredAnalysis` calls `generateObject` without a `validate`
+ * option, so responses are never length-checked. A green run here does **not**
+ * mean an over-long value is impossible — only that the schema still declares
+ * the intent and still carries the conciseness wording.
+ *
+ * That wording is the part that actually works. The provider does forward
+ * `description`, so the description assertions below cover the real mitigation;
+ * the `maxLength` assertions cover machine-readable intent and forward-compat
+ * for whenever real enforcement lands. See the header comment on
+ * `athleteProfileSchema` for the full detail.
  */
 
 type JsonSchemaNode = {
@@ -38,7 +49,15 @@ function at(path: string): JsonSchemaNode {
   return node
 }
 
-/** Every free-text string node in the schema, keyed by its path. */
+/**
+ * Every free-text string node in the schema, keyed by its path.
+ *
+ * Traverses `properties` and single-schema `items` only. It does **not** descend
+ * into `anyOf` / `oneOf` / `allOf` / `$ref` / `additionalProperties` / tuple-form
+ * (array) `items`. None of those appear in `athleteProfileSchema` today, so the
+ * walk is currently exhaustive — but a future field added under any of them
+ * would escape this guard silently. Extend the walker if you introduce one.
+ */
 function freeTextStrings(
   node: JsonSchemaNode,
   path = '',
@@ -59,8 +78,8 @@ const explanationJsonBlocks = [
   'athlete_scores/recovery_capacity_explanation_json'
 ]
 
-describe('athleteProfileSchema — free-text length bounds (CW-368)', () => {
-  it('bounds every free-text string field, so no field can run away unbounded', () => {
+describe('athleteProfileSchema — declared free-text length intent (CW-368)', () => {
+  it('declares a maxLength on every free-text string field, leaving none unbounded', () => {
     const unbounded = freeTextStrings(schema)
       .filter(([, node]) => typeof node.maxLength !== 'number')
       .map(([path]) => path)
@@ -68,32 +87,39 @@ describe('athleteProfileSchema — free-text length bounds (CW-368)', () => {
     expect(unbounded, `free-text fields missing maxLength:\n${unbounded.join('\n')}`).toEqual([])
   })
 
-  it.each(explanationJsonBlocks)('%s bounds its section titles well under 100 chars', (block) => {
-    const title = at(`${block}/sections/[]/title`)
+  it.each(explanationJsonBlocks)(
+    '%s declares a section-title maxLength well under 100 chars',
+    (block) => {
+      const title = at(`${block}/sections/[]/title`)
 
-    expect(title.maxLength).toBeTypeOf('number')
-    expect(title.maxLength).toBeLessThan(100)
-    expect(title.maxLength).toBeGreaterThan(0)
-  })
+      expect(title.maxLength).toBeTypeOf('number')
+      expect(title.maxLength).toBeLessThan(100)
+      expect(title.maxLength).toBeGreaterThan(0)
+    }
+  )
 
   it.each(explanationJsonBlocks)(
     '%s tells the model a section title is a heading, not a paragraph',
     (block) => {
       const description = at(`${block}/sections/[]/title`).description ?? ''
 
-      // The field that actually failed in production must carry explicit
-      // conciseness guidance, not just a machine-readable bound.
+      // This is the assertion that covers the *working* mitigation: the provider
+      // forwards `description` but strips `maxLength`, so this wording is what
+      // actually reaches Gemini and steers the field that failed in production.
       expect(description).toMatch(/not a sentence or a paragraph/i)
       expect(description).toMatch(/max 80 characters/i)
     }
   )
 
-  it.each(explanationJsonBlocks)('%s bounds the remaining free-text fields', (block) => {
-    expect(at(`${block}/executive_summary`).maxLength).toBe(500)
-    expect(at(`${block}/sections/[]/analysis_points/[]`).maxLength).toBe(400)
-    expect(at(`${block}/recommendations/[]/title`).maxLength).toBe(80)
-    expect(at(`${block}/recommendations/[]/description`).maxLength).toBe(500)
-  })
+  it.each(explanationJsonBlocks)(
+    '%s declares a maxLength on its other free-text fields',
+    (block) => {
+      expect(at(`${block}/executive_summary`).maxLength).toBe(500)
+      expect(at(`${block}/sections/[]/analysis_points/[]`).maxLength).toBe(400)
+      expect(at(`${block}/recommendations/[]/title`).maxLength).toBe(80)
+      expect(at(`${block}/recommendations/[]/description`).maxLength).toBe(500)
+    }
+  )
 
   it('keeps short-label fields shorter than prose fields', () => {
     const sectionTitle = at('athlete_scores/current_fitness_explanation_json/sections/[]/title')
@@ -102,14 +128,14 @@ describe('athleteProfileSchema — free-text length bounds (CW-368)', () => {
     expect(sectionTitle.maxLength!).toBeLessThan(summary.maxLength!)
   })
 
-  it('bounds the top-level narrative fields too', () => {
+  it('declares a maxLength on the top-level narrative fields too', () => {
     expect(at('title').maxLength).toBe(120)
     expect(at('executive_summary').maxLength).toBe(600)
     expect(at('current_fitness/status_label').maxLength).toBe(60)
     expect(at('current_fitness/key_points/[]').maxLength).toBe(300)
   })
 
-  it('bounds the flat score explanation strings', () => {
+  it('declares a maxLength on the flat score explanation strings', () => {
     for (const field of [
       'current_fitness_explanation',
       'recovery_capacity_explanation',

--- a/tests/unit/trigger/generate-athlete-profile-schema.test.ts
+++ b/tests/unit/trigger/generate-athlete-profile-schema.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { athleteProfileSchema } from '../../../trigger/generate-athlete-profile'
+
+/**
+ * Regression guard for CW-368.
+ *
+ * The model returned several hundred KB of run-on prose for
+ * `current_fitness_explanation_json.sections[].title` — a field meant to hold a
+ * short heading. The response was cut off mid-string when the output token
+ * budget ran out, so `generateObject` threw
+ * `AI_JSONParseError: Unterminated string in JSON` and the entire otherwise
+ * complete analysis was discarded.
+ *
+ * `maxLength` is what the model is *asked* to honour, not a hard guarantee — a
+ * generative model can still overrun it. These tests pin the constraint being
+ * declared at all, which is what was missing.
+ */
+
+type JsonSchemaNode = {
+  type?: string
+  enum?: unknown[]
+  maxLength?: number
+  description?: string
+  properties?: Record<string, JsonSchemaNode>
+  items?: JsonSchemaNode
+}
+
+const schema = athleteProfileSchema as unknown as JsonSchemaNode
+
+/** Resolve a slash-separated path through `properties` / `items`. */
+function at(path: string): JsonSchemaNode {
+  let node: JsonSchemaNode = schema
+  for (const segment of path.split('/')) {
+    const next = segment === '[]' ? node.items : node.properties?.[segment]
+    expect(next, `missing schema node at "${path}" (segment "${segment}")`).toBeDefined()
+    node = next as JsonSchemaNode
+  }
+  return node
+}
+
+/** Every free-text string node in the schema, keyed by its path. */
+function freeTextStrings(
+  node: JsonSchemaNode,
+  path = '',
+  found: Array<[string, JsonSchemaNode]> = []
+): Array<[string, JsonSchemaNode]> {
+  if (node.type === 'string' && !node.enum) found.push([path, node])
+  if (node.properties) {
+    for (const [key, child] of Object.entries(node.properties)) {
+      freeTextStrings(child, path ? `${path}/${key}` : key, found)
+    }
+  }
+  if (node.items) freeTextStrings(node.items, `${path}/[]`, found)
+  return found
+}
+
+const explanationJsonBlocks = [
+  'athlete_scores/current_fitness_explanation_json',
+  'athlete_scores/recovery_capacity_explanation_json'
+]
+
+describe('athleteProfileSchema — free-text length bounds (CW-368)', () => {
+  it('bounds every free-text string field, so no field can run away unbounded', () => {
+    const unbounded = freeTextStrings(schema)
+      .filter(([, node]) => typeof node.maxLength !== 'number')
+      .map(([path]) => path)
+
+    expect(unbounded, `free-text fields missing maxLength:\n${unbounded.join('\n')}`).toEqual([])
+  })
+
+  it.each(explanationJsonBlocks)('%s bounds its section titles well under 100 chars', (block) => {
+    const title = at(`${block}/sections/[]/title`)
+
+    expect(title.maxLength).toBeTypeOf('number')
+    expect(title.maxLength).toBeLessThan(100)
+    expect(title.maxLength).toBeGreaterThan(0)
+  })
+
+  it.each(explanationJsonBlocks)(
+    '%s tells the model a section title is a heading, not a paragraph',
+    (block) => {
+      const description = at(`${block}/sections/[]/title`).description ?? ''
+
+      // The field that actually failed in production must carry explicit
+      // conciseness guidance, not just a machine-readable bound.
+      expect(description).toMatch(/not a sentence or a paragraph/i)
+      expect(description).toMatch(/max 80 characters/i)
+    }
+  )
+
+  it.each(explanationJsonBlocks)('%s bounds the remaining free-text fields', (block) => {
+    expect(at(`${block}/executive_summary`).maxLength).toBe(500)
+    expect(at(`${block}/sections/[]/analysis_points/[]`).maxLength).toBe(400)
+    expect(at(`${block}/recommendations/[]/title`).maxLength).toBe(80)
+    expect(at(`${block}/recommendations/[]/description`).maxLength).toBe(500)
+  })
+
+  it('keeps short-label fields shorter than prose fields', () => {
+    const sectionTitle = at('athlete_scores/current_fitness_explanation_json/sections/[]/title')
+    const summary = at('athlete_scores/current_fitness_explanation_json/executive_summary')
+
+    expect(sectionTitle.maxLength!).toBeLessThan(summary.maxLength!)
+  })
+
+  it('bounds the top-level narrative fields too', () => {
+    expect(at('title').maxLength).toBe(120)
+    expect(at('executive_summary').maxLength).toBe(600)
+    expect(at('current_fitness/status_label').maxLength).toBe(60)
+    expect(at('current_fitness/key_points/[]').maxLength).toBe(300)
+  })
+
+  it('bounds the flat score explanation strings', () => {
+    for (const field of [
+      'current_fitness_explanation',
+      'recovery_capacity_explanation',
+      'nutrition_compliance_explanation',
+      'training_consistency_explanation',
+      'hr_power_alignment_explanation'
+    ]) {
+      expect(at(`athlete_scores/${field}`).maxLength, field).toBe(800)
+    }
+  })
+})

--- a/trigger/generate-athlete-profile.ts
+++ b/trigger/generate-athlete-profile.ts
@@ -34,8 +34,20 @@ import { bodyMetricResolver } from '../server/utils/services/bodyMetricResolver'
 
 import { registerTaskHandler } from '../server/utils/task-registry'
 
-// Athlete Profile schema for structured JSON output
-const athleteProfileSchema = {
+// Athlete Profile schema for structured JSON output.
+//
+// Every free-text string field declares an explicit `maxLength` and states the
+// expected length in its `description`. Without those bounds a single runaway
+// field (in production: `current_fitness_explanation_json.sections[].title`,
+// which came back as several hundred KB of repetitive prose) exhausts the output
+// token budget, the response is cut off mid-string, and `generateObject` throws
+// `AI_JSONParseError: Unterminated string in JSON` — discarding the entire
+// otherwise-complete analysis. See CW-368.
+//
+// `maxLength` is guidance the model is asked to honour, not a hard guarantee, so
+// keep the limits generous enough that a well-behaved response never bumps into
+// them while still ruling out paragraph-length output in a label field.
+export const athleteProfileSchema = {
   type: 'object',
   properties: {
     type: {
@@ -45,15 +57,19 @@ const athleteProfileSchema = {
     },
     title: {
       type: 'string',
-      description: 'Profile title'
+      maxLength: 120,
+      description: 'Profile title — a short headline, not a sentence (max 120 characters)'
     },
     generated_date: {
       type: 'string',
-      description: 'Date profile was generated'
+      maxLength: 40,
+      description: 'Date profile was generated (max 40 characters)'
     },
     executive_summary: {
       type: 'string',
-      description: "2-3 sentence overview of the athlete's current status"
+      maxLength: 600,
+      description:
+        "2-3 sentence overview of the athlete's current status (max 600 characters, not a multi-paragraph essay)"
     },
     current_fitness: {
       type: 'object',
@@ -66,12 +82,14 @@ const athleteProfileSchema = {
         },
         status_label: {
           type: 'string',
-          description: 'Display label for status'
+          maxLength: 60,
+          description: 'Display label for status — a few words, not a sentence (max 60 characters)'
         },
         key_points: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Key fitness indicators (each as separate item, 1-2 sentences)'
+          items: { type: 'string', maxLength: 300 },
+          description:
+            'Key fitness indicators (each as separate item, 1-2 sentences, max 300 characters per item)'
         }
       },
       required: ['status', 'status_label', 'key_points']
@@ -82,17 +100,18 @@ const athleteProfileSchema = {
       properties: {
         training_style: {
           type: 'string',
-          description: 'Training approach description'
+          maxLength: 300,
+          description: 'Training approach description, 1-2 sentences (max 300 characters)'
         },
         strengths: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Key strengths in training'
+          items: { type: 'string', maxLength: 200 },
+          description: 'Key strengths in training (max 200 characters per item)'
         },
         areas_for_development: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Areas that need attention'
+          items: { type: 'string', maxLength: 200 },
+          description: 'Areas that need attention (max 200 characters per item)'
         }
       },
       required: ['training_style', 'strengths', 'areas_for_development']
@@ -103,20 +122,23 @@ const athleteProfileSchema = {
       properties: {
         recovery_pattern: {
           type: 'string',
-          description: 'Overall recovery trend'
+          maxLength: 300,
+          description: 'Overall recovery trend, 1-2 sentences (max 300 characters)'
         },
         hrv_trend: {
           type: 'string',
-          description: 'HRV trend analysis'
+          maxLength: 300,
+          description: 'HRV trend analysis, 1-2 sentences (max 300 characters)'
         },
         sleep_quality: {
           type: 'string',
-          description: 'Sleep quality assessment'
+          maxLength: 300,
+          description: 'Sleep quality assessment, 1-2 sentences (max 300 characters)'
         },
         key_observations: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Important recovery observations'
+          items: { type: 'string', maxLength: 300 },
+          description: 'Important recovery observations (max 300 characters per item)'
         }
       },
       required: ['recovery_pattern', 'key_observations']
@@ -127,20 +149,24 @@ const athleteProfileSchema = {
       properties: {
         nutrition_pattern: {
           type: 'string',
-          description: 'Overall nutrition trend and consistency'
+          maxLength: 300,
+          description: 'Overall nutrition trend and consistency, 1-2 sentences (max 300 characters)'
         },
         caloric_balance: {
           type: 'string',
-          description: 'Assessment of caloric intake relative to training demands'
+          maxLength: 300,
+          description:
+            'Assessment of caloric intake relative to training demands, 1-2 sentences (max 300 characters)'
         },
         macro_distribution: {
           type: 'string',
-          description: 'Protein/carbs/fat balance assessment'
+          maxLength: 300,
+          description: 'Protein/carbs/fat balance assessment, 1-2 sentences (max 300 characters)'
         },
         key_observations: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Important nutrition observations'
+          items: { type: 'string', maxLength: 300 },
+          description: 'Important nutrition observations (max 300 characters per item)'
         }
       },
       required: ['nutrition_pattern', 'key_observations']
@@ -159,17 +185,25 @@ const athleteProfileSchema = {
           items: {
             type: 'object',
             properties: {
-              date: { type: 'string' },
-              title: { type: 'string' },
-              key_insight: { type: 'string' }
+              date: { type: 'string', maxLength: 40, description: 'Workout date' },
+              title: {
+                type: 'string',
+                maxLength: 120,
+                description: 'Workout title — a short label, not a sentence (max 120 characters)'
+              },
+              key_insight: {
+                type: 'string',
+                maxLength: 300,
+                description: '1-2 sentence insight about the workout (max 300 characters)'
+              }
             }
           },
           description: 'Highlighted workouts with insights'
         },
         patterns: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Performance patterns observed'
+          items: { type: 'string', maxLength: 300 },
+          description: 'Performance patterns observed (max 300 characters per item)'
         }
       },
       required: ['trend', 'patterns']
@@ -180,8 +214,8 @@ const athleteProfileSchema = {
       properties: {
         recurring_themes: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Common themes from recent recommendations'
+          items: { type: 'string', maxLength: 200 },
+          description: 'Common themes from recent recommendations (max 200 characters per item)'
         },
         action_items: {
           type: 'array',
@@ -189,7 +223,11 @@ const athleteProfileSchema = {
             type: 'object',
             properties: {
               priority: { type: 'string', enum: ['high', 'medium', 'low'] },
-              action: { type: 'string' }
+              action: {
+                type: 'string',
+                maxLength: 300,
+                description: 'A single concrete action, 1-2 sentences (max 300 characters)'
+              }
             }
           },
           description: 'Prioritized action items'
@@ -203,17 +241,18 @@ const athleteProfileSchema = {
       properties: {
         current_focus: {
           type: 'string',
-          description: 'What should be the focus right now'
+          maxLength: 400,
+          description: 'What should be the focus right now, 1-3 sentences (max 400 characters)'
         },
         limitations: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Current limitations or constraints'
+          items: { type: 'string', maxLength: 200 },
+          description: 'Current limitations or constraints (max 200 characters per item)'
         },
         opportunities: {
           type: 'array',
-          items: { type: 'string' },
-          description: 'Training opportunities'
+          items: { type: 'string', maxLength: 200 },
+          description: 'Training opportunities (max 200 characters per item)'
         }
       },
       required: ['current_focus']
@@ -231,24 +270,38 @@ const athleteProfileSchema = {
         },
         current_fitness_explanation: {
           type: 'string',
-          description: 'Brief summary of current fitness level'
+          maxLength: 800,
+          description: 'Brief summary of current fitness level (max 800 characters)'
         },
         current_fitness_explanation_json: {
           type: 'object',
           description: 'Structured explanation of current fitness',
           properties: {
-            executive_summary: { type: 'string', description: '2-3 sentence overview' },
+            executive_summary: {
+              type: 'string',
+              maxLength: 500,
+              description: '2-3 sentence overview (max 500 characters)'
+            },
             sections: {
               type: 'array',
               items: {
                 type: 'object',
                 properties: {
-                  title: { type: 'string' },
+                  title: {
+                    type: 'string',
+                    maxLength: 80,
+                    description:
+                      'Short section label of a few words, e.g. "Aerobic Base" — a heading, not a sentence or a paragraph (max 80 characters)'
+                  },
                   status: {
                     type: 'string',
                     enum: ['excellent', 'good', 'moderate', 'needs_improvement']
                   },
-                  analysis_points: { type: 'array', items: { type: 'string' } }
+                  analysis_points: {
+                    type: 'array',
+                    items: { type: 'string', maxLength: 400 },
+                    description: 'Analysis points, each 1-2 sentences (max 400 characters per item)'
+                  }
                 }
               }
             },
@@ -257,8 +310,17 @@ const athleteProfileSchema = {
               items: {
                 type: 'object',
                 properties: {
-                  title: { type: 'string' },
-                  description: { type: 'string' },
+                  title: {
+                    type: 'string',
+                    maxLength: 80,
+                    description:
+                      'Short recommendation label of a few words — a heading, not a sentence or a paragraph (max 80 characters)'
+                  },
+                  description: {
+                    type: 'string',
+                    maxLength: 500,
+                    description: '1-3 sentences describing the recommendation (max 500 characters)'
+                  },
                   priority: { type: 'string', enum: ['high', 'medium', 'low'] }
                 }
               }
@@ -274,24 +336,38 @@ const athleteProfileSchema = {
         },
         recovery_capacity_explanation: {
           type: 'string',
-          description: 'Brief summary of recovery capacity'
+          maxLength: 800,
+          description: 'Brief summary of recovery capacity (max 800 characters)'
         },
         recovery_capacity_explanation_json: {
           type: 'object',
           description: 'Structured explanation of recovery capacity',
           properties: {
-            executive_summary: { type: 'string', description: '2-3 sentence overview' },
+            executive_summary: {
+              type: 'string',
+              maxLength: 500,
+              description: '2-3 sentence overview (max 500 characters)'
+            },
             sections: {
               type: 'array',
               items: {
                 type: 'object',
                 properties: {
-                  title: { type: 'string' },
+                  title: {
+                    type: 'string',
+                    maxLength: 80,
+                    description:
+                      'Short section label of a few words, e.g. "Sleep Consistency" — a heading, not a sentence or a paragraph (max 80 characters)'
+                  },
                   status: {
                     type: 'string',
                     enum: ['excellent', 'good', 'moderate', 'needs_improvement']
                   },
-                  analysis_points: { type: 'array', items: { type: 'string' } }
+                  analysis_points: {
+                    type: 'array',
+                    items: { type: 'string', maxLength: 400 },
+                    description: 'Analysis points, each 1-2 sentences (max 400 characters per item)'
+                  }
                 }
               }
             },
@@ -300,8 +376,17 @@ const athleteProfileSchema = {
               items: {
                 type: 'object',
                 properties: {
-                  title: { type: 'string' },
-                  description: { type: 'string' },
+                  title: {
+                    type: 'string',
+                    maxLength: 80,
+                    description:
+                      'Short recommendation label of a few words — a heading, not a sentence or a paragraph (max 80 characters)'
+                  },
+                  description: {
+                    type: 'string',
+                    maxLength: 500,
+                    description: '1-3 sentences describing the recommendation (max 500 characters)'
+                  },
                   priority: { type: 'string', enum: ['high', 'medium', 'low'] }
                 }
               }
@@ -317,8 +402,9 @@ const athleteProfileSchema = {
         },
         nutrition_compliance_explanation: {
           type: 'string',
+          maxLength: 800,
           description:
-            "Detailed explanation of nutrition quality: calorie adherence patterns, macro balance, meal timing, and specific improvements needed (e.g., 'Increase protein to 2g/kg', 'Improve pre-workout carb intake')"
+            "Detailed explanation of nutrition quality: calorie adherence patterns, macro balance, meal timing, and specific improvements needed (e.g., 'Increase protein to 2g/kg', 'Improve pre-workout carb intake'). A few sentences, max 800 characters"
         },
         training_consistency: {
           type: 'number',
@@ -328,8 +414,9 @@ const athleteProfileSchema = {
         },
         training_consistency_explanation: {
           type: 'string',
+          maxLength: 800,
           description:
-            "Detailed explanation of training consistency: weekly adherence patterns, missed sessions analysis, and strategies for improvement (e.g., 'Set specific training times', 'Prepare gear night before')"
+            "Detailed explanation of training consistency: weekly adherence patterns, missed sessions analysis, and strategies for improvement (e.g., 'Set specific training times', 'Prepare gear night before'). A few sentences, max 800 characters"
         },
         hr_power_alignment: {
           type: 'number',
@@ -339,8 +426,9 @@ const athleteProfileSchema = {
         },
         hr_power_alignment_explanation: {
           type: 'string',
+          maxLength: 800,
           description:
-            "Detailed explanation of HR/Power alignment: analysis of decoupling, HR drift in different activities, and zone correlation (e.g., 'Significant decoupling on long rides', 'MTB power surges not reflected in HR')"
+            "Detailed explanation of HR/Power alignment: analysis of decoupling, HR drift in different activities, and zone correlation (e.g., 'Significant decoupling on long rides', 'MTB power surges not reflected in HR'). A few sentences, max 800 characters"
         }
       },
       required: [

--- a/trigger/generate-athlete-profile.ts
+++ b/trigger/generate-athlete-profile.ts
@@ -36,17 +36,43 @@ import { registerTaskHandler } from '../server/utils/task-registry'
 
 // Athlete Profile schema for structured JSON output.
 //
-// Every free-text string field declares an explicit `maxLength` and states the
-// expected length in its `description`. Without those bounds a single runaway
-// field (in production: `current_fitness_explanation_json.sections[].title`,
-// which came back as several hundred KB of repetitive prose) exhausts the output
-// token budget, the response is cut off mid-string, and `generateObject` throws
-// `AI_JSONParseError: Unterminated string in JSON` — discarding the entire
-// otherwise-complete analysis. See CW-368.
+// Why the length wording exists (CW-368): a single runaway field — in
+// production `current_fitness_explanation_json.sections[].title`, which came
+// back as several hundred KB of repetitive prose — exhausts the output token
+// budget, the response is cut off mid-string, and `generateObject` throws
+// `AI_JSONParseError: Unterminated string in JSON`, discarding the entire
+// otherwise-complete analysis. Sentry COACH-WATTS-WEB-12.
 //
-// `maxLength` is guidance the model is asked to honour, not a hard guarantee, so
-// keep the limits generous enough that a well-behaved response never bumps into
-// them while still ruling out paragraph-length output in a label field.
+// READ THIS BEFORE TRUSTING `maxLength` HERE.
+//
+// The `maxLength` keys below are **declarative intent only — nothing enforces
+// them at either end**:
+//
+//   1. `@ai-sdk/google` strips them before the request is sent.
+//      `convertJSONSchemaToOpenAPISchema` destructures a strict allowlist
+//      (`type, description, required, properties, items, allOf, anyOf, oneOf,
+//      format, const, minLength, enum`). Note `minLength` is forwarded and
+//      `maxLength` is not; `grep -c maxLength` over the provider's `dist/`
+//      returns 0. Gemini never sees these numbers.
+//   2. Nothing validates the response locally either. `generateStructuredAnalysis`
+//      (`server/utils/gemini.ts`) calls `generateObject` with
+//      `schema: jsonSchema(schema)` and no `validate` option, so there is no
+//      post-parse length check.
+//
+// **The `description` text is the entire working mitigation.** The provider
+// *does* forward `description`, so wording like "a heading, not a sentence or a
+// paragraph (max 80 characters)" is what actually steers the model. Treat those
+// strings as load-bearing prompt content: if you shorten or genericise them you
+// remove the only thing standing between this task and the crash above.
+//
+// The `maxLength` keys are kept deliberately, as machine-readable intent, as the
+// thing the schema-walk regression test pins, and so the bounds are already
+// correct if/when real enforcement lands (post-parse truncation or a `validate`
+// fn — tracked separately, since `generateStructuredAnalysis` is shared by ~45
+// call sites). Keep them accurate; just do not mistake them for a guarantee.
+//
+// Limits are generous enough that a well-behaved response never bumps into them
+// while still ruling out paragraph-length output in a label field.
 export const athleteProfileSchema = {
   type: 'object',
   properties: {


### PR DESCRIPTION
Fixes CW-368

## Problem

Sentry `COACH-WATTS-WEB-12` (5 occurrences since 2026-08-05, still recurring). The model returned several hundred KB of repetitive run-on motivational prose for `current_fitness_explanation_json.sections[].title` — a field meant to hold a short section heading. The output token budget ran out mid-string, so `generateObject` threw `AI_JSONParseError: Unterminated string in JSON`, surfaced as `AI_NoObjectGeneratedError`. The entire otherwise-complete analysis was discarded.

Root cause: nothing in `athleteProfileSchema` bounded those fields — no `maxLength`, and no conciseness guidance in the `description` telling the model that `title` is a label rather than a paragraph.

## What actually mitigates the crash — read this before trusting `maxLength`

**The rewritten `description` wording is the entire working mitigation. The `maxLength` keys are declarative intent only; nothing enforces them at runtime.** Verified in this repo:

- **The provider strips `maxLength` before the request is sent.** `@ai-sdk/google`'s `convertJSONSchemaToOpenAPISchema` destructures a strict allowlist — `type, description, required, properties, items, allOf, anyOf, oneOf, format, const, minLength, enum`. `minLength` is forwarded; `maxLength` is not. `grep -c maxLength` over the provider's `dist/` returns **0**. Gemini never sees the numbers.
- **Nothing validates the response locally either.** `server/utils/gemini.ts:965` calls `generateObject` with `schema: jsonSchema(schema)` and no `validate` option, so there is no post-parse length check.
- **`description` *is* forwarded** (provider `dist/index.js:344`). So wording like *"a heading, not a sentence or a paragraph (max 80 characters)"* is what reaches the model and steers the field that failed.

This is documented at the schema header and in the test file, so the next person investigating a recurrence doesn't read `maxLength: 80` beside a green regression test and conclude the bound is live. The `maxLength` keys are kept deliberately: machine-readable intent, the thing the schema-walk test pins, and correct-by-construction if real enforcement lands. Real enforcement is tracked in **CW-657**.

## Change

`trigger/generate-athlete-profile.ts` only. Every free-text string field in `athleteProfileSchema` now declares a `maxLength` **and** states the expected length in its `description`.

Both `*_explanation_json` blocks (`current_fitness_explanation_json`, `recovery_capacity_explanation_json`) get identical treatment:

| Field | `maxLength` |
| :-- | --: |
| `sections[].title` | 80 |
| `recommendations[].title` | 80 |
| `sections[].analysis_points[]` | 400 |
| `executive_summary` | 500 |
| `recommendations[].description` | 500 |

Bounds are applied across the **whole** schema, not just the field that failed — `key_points`, `strengths`, `patterns`, `limitations`, the flat `*_explanation` strings, etc. were all equally unbounded and any one of them reproduces the same truncation. `enum` fields and numbers are untouched.

`athleteProfileSchema` is now exported so the regression test can read it.

## Test

New `tests/unit/trigger/generate-athlete-profile-schema.test.ts` (10 cases). Tests **declaration, not enforcement** — named and documented accordingly.

The strongest guard walks the entire schema and fails with a path list if *any* free-text string (`type: 'string'` without an `enum`) lacks a `maxLength`, so a future field added without a bound breaks the build. The description assertions are the ones covering the actually-working mitigation.

Known walker limitation, noted in-file: it traverses `properties` and single-schema `items` only, not `anyOf` / `oneOf` / `allOf` / `$ref` / `additionalProperties` / tuple-form `items`. None appear in this schema today, so the walk is currently exhaustive.

## Verification

```
pnpm test:unit          # bare, no path filter
  Test Files  388 passed (388)
       Tests  2666 passed (2666)

pnpm typecheck          # clean
pnpm exec eslint <changed files>   # clean
```

Existing athlete-profile tests pass unchanged.

## Files changed vs Owned Paths

| File | Owned? |
| :-- | :-- |
| `trigger/generate-athlete-profile.ts` | yes |
| `tests/unit/trigger/generate-athlete-profile-schema.test.ts` | yes (corresponding test file) |

Nothing outside Owned Paths was touched. `server/utils/gemini.ts` and the provider `dist/` were read for verification only.

## Risks

Low. Schema-only change to the prompt/response shape for one background task; no runtime, DB, or API-surface change. The `description` edits do change what is sent to Gemini — that is the intended mechanism.

**This reduces the likelihood of the crash; it does not close it.** Watch `COACH-WATTS-WEB-12` rather than closing it on this merge. No repair/truncation logic was added to `generateStructuredAnalysis` — shared by ~45 call sites, out of scope, tracked as CW-657.

## Follow-ups filed

- **CW-657** — `maxLength` is inert repo-wide; real enforcement (post-parse truncation and/or a `validate` fn). This is the ticket that would make the bounds live.
- **CW-651** (High) — `nutrition_compliance_explanation_json` / `training_consistency_explanation_json` are read back into `user.*ExplanationJson` but never declared in the schema. Prisma treats `undefined` in `update.data` as *skip*, so those columns are never populated and stay `NULL`. Consumed by `performance/index.vue`, `PerformanceScoresCard.vue`, and `chatContextService.ts` — the chat assistant is missing that context for every athlete. Pre-existing.
- **CW-652** — `generate-score-explanations.ts` has the same unbounded shape in two more schemas.
- **CW-653** — the two `*_explanation_json` blocks are byte-identical duplicates; deliberately not refactored here.

UX critique: skipped — background task, no user-facing surface.
