### PR TITLE
fix(integrations): survive Intervals integration deleted mid-sync (CW-410)

### DIFF
--- a/tests/unit/trigger/ingest-intervals.test.ts
+++ b/tests/unit/trigger/ingest-intervals.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * CW-410 — the Intervals.icu ingestion task must survive the user disconnecting
+ * the integration while a sync is in flight (or queued for retry).
+ *
+ * Two Sentry issues (COACH-WATTS-WEB-1A / -19) were the same event: attempt 1
+ * got past the `findUnique`, ran the sync, then blew up in the `finally` block
+ * with a Prisma `P2025` (masking the real error); the retry re-fetched, found
+ * nothing, and threw a plain `Error` on every remaining attempt.
+ */
+
+const {
+  integrationFindUnique,
+  integrationUpdate,
+  syncPlannedWorkouts,
+  syncActivities,
+  syncWellness,
+  syncProfile,
+  calculateFuelingPlanForDate,
+  getUserTimezone,
+  shouldIngestWellness,
+  isNutritionTrackingEnabled,
+  yieldTaskHeartbeat,
+  registerTaskHandler,
+  loggerError
+} = vi.hoisted(() => ({
+  integrationFindUnique: vi.fn(),
+  integrationUpdate: vi.fn(),
+  syncPlannedWorkouts: vi.fn(),
+  syncActivities: vi.fn(),
+  syncWellness: vi.fn(),
+  syncProfile: vi.fn(),
+  calculateFuelingPlanForDate: vi.fn(),
+  getUserTimezone: vi.fn(),
+  shouldIngestWellness: vi.fn(),
+  isNutritionTrackingEnabled: vi.fn(),
+  yieldTaskHeartbeat: vi.fn(),
+  registerTaskHandler: vi.fn(),
+  loggerError: vi.fn()
+}))
+
+vi.mock('../../../trigger/init', () => ({}))
+
+vi.mock('../../../trigger/queues', () => ({
+  userIngestionQueue: { name: 'user-ingestion' }
+}))
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+  task: vi.fn().mockImplementation((config: any) => ({ id: config.id, run: config.run })),
+  logger: { log: vi.fn(), warn: vi.fn(), error: loggerError }
+}))
+
+vi.mock('../../../server/utils/db', () => ({
+  prisma: {
+    integration: {
+      findUnique: integrationFindUnique,
+      update: integrationUpdate
+    }
+  }
+}))
+
+vi.mock('../../../server/utils/services/intervalsService', () => ({
+  IntervalsService: {
+    syncPlannedWorkouts,
+    syncActivities,
+    syncWellness,
+    syncProfile
+  }
+}))
+
+vi.mock('../../../server/utils/services/metabolicService', () => ({
+  metabolicService: { calculateFuelingPlanForDate }
+}))
+
+vi.mock('../../../server/utils/date', () => ({
+  getUserTimezone,
+  getEndOfDayUTC: vi.fn(() => new Date('2026-01-31T23:59:59.000Z')),
+  getUserLocalDate: vi.fn(() => new Date('2026-01-15T00:00:00.000Z'))
+}))
+
+vi.mock('../../../server/utils/integration-settings', () => ({ shouldIngestWellness }))
+
+vi.mock('../../../server/utils/nutrition/feature', () => ({ isNutritionTrackingEnabled }))
+
+vi.mock('../../../server/utils/task-runtime', () => ({ yieldTaskHeartbeat }))
+
+vi.mock('../../../server/utils/task-registry', () => ({ registerTaskHandler }))
+
+const PAYLOAD = {
+  userId: 'user-1',
+  startDate: '2026-01-01T00:00:00.000Z',
+  endDate: '2026-01-31T00:00:00.000Z'
+}
+
+const INTEGRATION = { id: 'integration-1', settings: {} }
+
+/** Prisma's "record required but not found" — what a deleted row raises. */
+function recordNotFoundError() {
+  return Object.assign(
+    new Error(
+      'An operation failed because it depends on one or more records that were required but not found.'
+    ),
+    { code: 'P2025' }
+  )
+}
+
+async function importTask() {
+  return await import('../../../trigger/ingest-intervals')
+}
+
+describe('runIngestIntervals — integration disconnected mid-sync (CW-410)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    integrationFindUnique.mockResolvedValue(INTEGRATION)
+    integrationUpdate.mockResolvedValue(INTEGRATION)
+    syncPlannedWorkouts.mockResolvedValue({ plannedWorkouts: 1, events: 2, notes: 3 })
+    syncActivities.mockResolvedValue(4)
+    syncWellness.mockResolvedValue(5)
+    getUserTimezone.mockResolvedValue('Europe/Budapest')
+    shouldIngestWellness.mockReturnValue(false)
+    isNutritionTrackingEnabled.mockResolvedValue(false)
+    yieldTaskHeartbeat.mockResolvedValue(undefined)
+  })
+
+  it('exits cleanly without throwing when the integration no longer exists', async () => {
+    integrationFindUnique.mockResolvedValue(null)
+
+    const { runIngestIntervals } = await importTask()
+
+    const result = await runIngestIntervals(PAYLOAD)
+
+    expect(result).toMatchObject({
+      success: false,
+      counts: {},
+      userId: PAYLOAD.userId
+    })
+    expect(result.message).toMatch(/not found/i)
+    // Nothing was attempted against the missing row, and nothing was synced —
+    // so nothing can throw and trigger the retry storm.
+    expect(integrationUpdate).not.toHaveBeenCalled()
+    expect(syncPlannedWorkouts).not.toHaveBeenCalled()
+    expect(syncActivities).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when the row is deleted between the fetch and the finally update', async () => {
+    // The initial SYNCING write lands; the finalizing write finds the row gone.
+    integrationUpdate
+      .mockResolvedValueOnce(INTEGRATION)
+      .mockRejectedValueOnce(recordNotFoundError())
+
+    const { runIngestIntervals } = await importTask()
+
+    const result = await runIngestIntervals(PAYLOAD)
+
+    expect(result).toMatchObject({
+      success: true,
+      counts: { workouts: 4, plannedWorkouts: 1, events: 2 }
+    })
+    expect(integrationUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a P2025 in the finally block mask the real ingestion error', async () => {
+    const realError = new Error('Intervals.icu API returned 502')
+    syncActivities.mockRejectedValue(realError)
+    integrationUpdate
+      .mockResolvedValueOnce(INTEGRATION)
+      .mockRejectedValueOnce(recordNotFoundError())
+
+    const { runIngestIntervals } = await importTask()
+
+    // The original failure must be what propagates — not the P2025 from the
+    // finally block, which is what Sentry was actually capturing.
+    await expect(runIngestIntervals(PAYLOAD)).rejects.toThrow('Intervals.icu API returned 502')
+  })
+
+  it('skips the sync when the row is deleted before the SYNCING status write', async () => {
+    integrationUpdate.mockRejectedValueOnce(recordNotFoundError())
+
+    const { runIngestIntervals } = await importTask()
+
+    const result = await runIngestIntervals(PAYLOAD)
+
+    expect(result).toMatchObject({ success: false, counts: {} })
+    expect(syncPlannedWorkouts).not.toHaveBeenCalled()
+    expect(syncActivities).not.toHaveBeenCalled()
+  })
+
+  it('still surfaces a non-P2025 failure of the finalizing write when the sync succeeded', async () => {
+    const dbDown = new Error('connection terminated unexpectedly')
+    integrationUpdate.mockResolvedValueOnce(INTEGRATION).mockRejectedValueOnce(dbDown)
+
+    const { runIngestIntervals } = await importTask()
+
+    await expect(runIngestIntervals(PAYLOAD)).rejects.toThrow('connection terminated unexpectedly')
+  })
+
+  it('logs but does not mask the ingestion error when the finalizing write fails for another reason', async () => {
+    const realError = new Error('Intervals.icu API returned 502')
+    syncActivities.mockRejectedValue(realError)
+    integrationUpdate
+      .mockResolvedValueOnce(INTEGRATION)
+      .mockRejectedValueOnce(new Error('connection terminated unexpectedly'))
+
+    const { runIngestIntervals } = await importTask()
+
+    await expect(runIngestIntervals(PAYLOAD)).rejects.toThrow('Intervals.icu API returned 502')
+    expect(loggerError).toHaveBeenCalled()
+  })
+})

--- a/trigger/ingest-intervals.ts
+++ b/trigger/ingest-intervals.ts
@@ -18,6 +18,89 @@ type IngestIntervalsPayload = {
   manualSync?: boolean
 }
 
+/**
+ * Prisma raises `P2025` ("An operation failed because it depends on one or more
+ * records that were required but not found") when a `where`-targeted row no
+ * longer exists. Matched by `code` rather than `instanceof` because the concrete
+ * error class differs between the query engines and is re-wrapped by the driver
+ * adapter — same duck-typing the rest of the codebase uses (see
+ * `server/api/auth/[...].ts`, `server/api/webhooks/revenuecat.post.ts`).
+ */
+function isRecordNotFoundError(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === 'P2025'
+}
+
+/**
+ * Result returned when the Intervals.icu integration row is gone.
+ *
+ * A user disconnecting the integration while a sync is in flight (or queued for
+ * retry) is expected behaviour, not a failure: throwing here would re-run the
+ * task up to `maxAttempts` more times and file an identical Sentry event on
+ * every attempt. We deliberately return a normal result rather than raising a
+ * framework-level "do not retry" signal — the self-hosted BullMQ worker does not
+ * honour `AbortTaskRunError` (CW-602), whereas a plain resolved value is
+ * terminal on every driver.
+ */
+function integrationDisconnectedResult(
+  payload: Pick<IngestIntervalsPayload, 'userId' | 'startDate' | 'endDate'>
+): IngestionResult {
+  return {
+    success: false,
+    counts: {},
+    message: 'Intervals.icu integration not found for user; it was disconnected. Skipping sync.',
+    userId: payload.userId,
+    startDate: payload.startDate,
+    endDate: payload.endDate
+  }
+}
+
+/**
+ * Writes the terminal sync status back onto the integration row.
+ *
+ * Runs from a `finally` block, so it must not throw for the ordinary
+ * disconnect race: a throw inside `finally` *replaces* whichever exception was
+ * already propagating, which is how the original ingestion error got masked by
+ * a `P2025`. Non-`P2025` failures are still surfaced when the sync itself
+ * succeeded (nothing is being masked in that case).
+ */
+async function finalizeSyncStatus(
+  integrationId: string,
+  outcome: { syncSucceeded: boolean; syncErrorMessage: string | null }
+): Promise<void> {
+  const { syncSucceeded, syncErrorMessage } = outcome
+
+  try {
+    await prisma.integration.update({
+      where: { id: integrationId },
+      data: {
+        syncStatus: syncSucceeded ? 'SUCCESS' : 'FAILED',
+        lastSyncAt: syncSucceeded ? new Date() : undefined,
+        errorMessage: syncSucceeded ? null : syncErrorMessage,
+        ...(syncSucceeded ? { initialSyncCompleted: true } : {})
+      }
+    })
+  } catch (error) {
+    if (isRecordNotFoundError(error)) {
+      logger.log(
+        'Intervals.icu integration was disconnected during sync; skipping sync-status update',
+        { integrationId }
+      )
+      return
+    }
+
+    if (!syncSucceeded) {
+      // An error from the try block is already propagating — never mask it.
+      logger.error('Failed to record Intervals.icu sync failure status', {
+        integrationId,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return
+    }
+
+    throw error
+  }
+}
+
 export async function runIngestIntervals(
   payload: IngestIntervalsPayload
 ): Promise<IngestionResult> {
@@ -36,14 +119,31 @@ export async function runIngestIntervals(
   })
 
   if (!integration) {
-    throw new Error('Intervals integration not found for user')
+    logger.log('Intervals.icu integration not found for user; skipping ingestion', {
+      userId,
+      startDate,
+      endDate
+    })
+    return integrationDisconnectedResult(payload)
   }
 
-  // Update sync status
-  await prisma.integration.update({
-    where: { id: integration.id },
-    data: { syncStatus: 'SYNCING' }
-  })
+  // Update sync status. The row can be deleted between the fetch above and this
+  // write if the user disconnects mid-flight — that is a clean skip, not a failure.
+  try {
+    await prisma.integration.update({
+      where: { id: integration.id },
+      data: { syncStatus: 'SYNCING' }
+    })
+  } catch (error) {
+    if (isRecordNotFoundError(error)) {
+      logger.log(
+        'Intervals.icu integration was disconnected before the sync started; skipping ingestion',
+        { userId, integrationId: integration.id }
+      )
+      return integrationDisconnectedResult(payload)
+    }
+    throw error
+  }
 
   let syncSucceeded = false
   let syncErrorMessage: string | null = null
@@ -142,15 +242,7 @@ export async function runIngestIntervals(
 
     throw error
   } finally {
-    await prisma.integration.update({
-      where: { id: integration.id },
-      data: {
-        syncStatus: syncSucceeded ? 'SUCCESS' : 'FAILED',
-        lastSyncAt: syncSucceeded ? new Date() : undefined,
-        errorMessage: syncSucceeded ? null : syncErrorMessage,
-        ...(syncSucceeded ? { initialSyncCompleted: true } : {})
-      }
-    })
+    await finalizeSyncStatus(integration.id, { syncSucceeded, syncErrorMessage })
   }
 }
 


### PR DESCRIPTION
Fixes CW-410

Sentry `COACH-WATTS-WEB-1A` / `COACH-WATTS-WEB-19` are the same event (same BullMQ `jobId` 6817, same `trace_id`): a user disconnected their Intervals.icu integration while a sync was in flight, and `ingest-intervals` threw twice for it.

## What was wrong

1. **Attempt 1** got past `findUnique` with a row that still existed, ran the sync, then hit `prisma.integration.update` in the `finally` block after the row had been deleted → Prisma `P2025`. Because a throw inside `finally` *replaces* whatever exception is already propagating, this also **masked** the original try-block error.
2. **The retry** re-fetched from the top, got `null`, and threw a plain `Error`. Nothing marks that terminal, so the task was rescheduled up to `maxAttempts` more times — one identical Sentry event per attempt, for what is simply a disconnected integration.

## What changed (`trigger/ingest-intervals.ts`)

- `!integration` now logs and returns a normal `IngestionResult` (`success: false`, empty counts, explanatory `message`) instead of throwing. A resolved value is terminal on every driver, so there is no retry storm and no Sentry event.
- The `finally` block moved into a `finalizeSyncStatus()` helper that swallows **only** `P2025` (logged), and — for any other failure — declines to throw when an error from the try block is already propagating, so the real ingestion error is never masked. A non-`P2025` failure with a successful sync still throws, so genuine DB problems stay visible.
- The pre-`try` `syncStatus: 'SYNCING'` write had the same unguarded race window (row deleted between `findUnique` and that update). It now takes the same clean-skip path on `P2025`.

`P2025` is matched by `code` rather than `instanceof`, matching existing usage in `server/api/auth/[...].ts` and `server/api/webhooks/revenuecat.post.ts` — the concrete error class differs by query engine and is re-wrapped by the driver adapter.

### Note on "mark the job non-retryable"

The ticket offered `AbortTaskRunError` as an alternative. Deliberately **not** used: CW-602 found that the self-hosted BullMQ worker ignores it, so it would only appear to work. Returning a resolved value achieves the same terminal outcome without depending on `cli/worker/start.ts` (outside this ticket's Owned Paths).

## Verification

```
pnpm test:unit
Test Files  389 passed (389)
     Tests  2668 passed (2668)
```

`pnpm typecheck` also clean.

### Tests fail against the unmodified function

Confirmed by stashing only `trigger/ingest-intervals.ts` and re-running the new spec — **5 of 6 fail pre-fix**:

```
× exits cleanly without throwing when the integration no longer exists
× does not throw when the row is deleted between the fetch and the finally update
× does not let a P2025 in the finally block mask the real ingestion error
× skips the sync when the row is deleted before the SYNCING status write
× logs but does not mask the ingestion error when the finalizing write fails for another reason
 Tests  5 failed | 1 passed (6)
```

The sixth ("still surfaces a non-P2025 failure of the finalizing write when the sync succeeded") passes both before and after by design — it is the guard that the fix does not over-swallow real database errors.

## Files vs Owned Paths

Exactly the two owned paths, nothing else:
- `trigger/ingest-intervals.ts`
- `tests/unit/trigger/ingest-intervals.test.ts` (new)

## Risks

- The not-found case now reports as a completed run rather than a failed one. `ingest-all` reads `run.ok` and `output.counts` (empty here) and `dashboard.vue`'s `handleIngestTaskComplete` ignores the output, so the visible change is that a disconnected integration no longer raises a "Sync Failed" toast — which is the correct outcome. No consumer reads `IngestionResult.success` for this task.
- `finalizeSyncStatus` swallows non-`P2025` finalizer errors when the sync already failed. That is intentional (the real error must win) and the failure is logged via `logger.error`.

UX critique: skipped — background task, no user-facing surface.
