### PR TITLE
fix(data): skip duplicate groups whose workouts vanish mid-merge (CW-262)

### DIFF
--- a/server/utils/services/deduplicationService.ts
+++ b/server/utils/services/deduplicationService.ts
@@ -470,18 +470,37 @@ export const deduplicationService = {
 
     // Execute all database updates in a transaction.
     //
-    // Every write below targets a single row by id, and all of them write plain
-    // scalar columns (`completed`/`completionStatus`, `workoutId`,
-    // `completenessScore` and the merged metric fields, `isDuplicate`/
-    // `duplicateOf`) — there is no nested relation `connect` anywhere in the
-    // block. That is what makes the `P2025` catch below safe to keep narrow:
+    // No write below uses a nested relation `connect`; they set plain scalar
+    // columns (`completed`/`completionStatus`, `workoutId`, `completenessScore`
+    // and the merged metric fields, `isDuplicate`/`duplicateOf`) on rows selected
+    // by a unique `where` — by `id`, or by the unique `workoutId` on
+    // `WorkoutStream`. The one `updateMany` reports a `count` instead of raising
+    // when it matches nothing. That is what keeps the `P2025` catch below narrow:
     // with no `connect`, "required record not found" can only mean the row named
-    // in the `where` is gone, i.e. the group we were handed is stale. A missing
-    // *referenced* row (e.g. a `plannedWorkoutId` whose planned workout was
-    // deleted) surfaces as a foreign-key violation, `P2003`, and still throws.
+    // in the `where` is gone, i.e. the group we were handed is stale.
+    //
+    // Ordering matters. Steps 2-4 write `bestWorkout.id` into a foreign key, so
+    // if the primary workout has been deleted concurrently they fail with a
+    // foreign-key violation (`P2003`) — which this catch deliberately does not
+    // swallow — rather than the `P2025` that identifies the stale group. Worse,
+    // the "does the primary already have streams/exercises?" guards in steps 3
+    // and 4 *open* those transfer paths when the primary is gone, because its own
+    // `WorkoutStream`/`WorkoutExercise` rows cascade away with it. Step 1
+    // therefore runs first and makes the primary's existence a precondition
+    // enforced by the `P2025` catch, before anything depends on it. This is free
+    // inside an atomic block: `completenessScore` is derived from the in-memory
+    // `{ ...bestWorkout, ...updates }` and reads nothing the later steps write.
     try {
       await prisma.$transaction(async (tx) => {
-        // 1. Update planned workout status if linked
+        // 1. Update primary workout with merged fields and completeness score.
+        //    Kept first so a deleted primary surfaces as P2025 here — see above.
+        updates.completenessScore = this.calculateCompletenessScore({ ...bestWorkout, ...updates })
+        await tx.workout.update({
+          where: { id: group.bestWorkoutId },
+          data: updates
+        })
+
+        // 2. Update planned workout status if linked
         if (plannedWorkoutToUpdateId) {
           await tx.plannedWorkout.update({
             where: { id: plannedWorkoutToUpdateId },
@@ -492,7 +511,7 @@ export const deduplicationService = {
           })
         }
 
-        // 2. Stream Transfer Logic
+        // 3. Stream Transfer Logic
         // Check if bestWorkout already has streams in DB to avoid collision
         const existingBestStream = await tx.workoutStream.findUnique({
           where: { workoutId: bestWorkout.id },
@@ -513,7 +532,7 @@ export const deduplicationService = {
           }
         }
 
-        // 3. Exercise Transfer Logic
+        // 4. Exercise Transfer Logic
         // Move exercise records if primary has none
         const existingBestExercises = await tx.workoutExercise.count({
           where: { workoutId: bestWorkout.id }
@@ -534,13 +553,6 @@ export const deduplicationService = {
           }
         }
 
-        // 4. Update primary workout with merged fields and completeness score
-        updates.completenessScore = this.calculateCompletenessScore({ ...bestWorkout, ...updates })
-        await tx.workout.update({
-          where: { id: group.bestWorkoutId },
-          data: updates
-        })
-
         // 5. Mark duplicates with both boolean and explicit link
         for (const id of group.toDelete) {
           await tx.workout.update({
@@ -554,17 +566,20 @@ export const deduplicationService = {
       })
     } catch (error) {
       if (isRecordNotFoundError(error)) {
-        // A workout named by this group was deleted between group computation
-        // and now. The transaction rolled back in full, so there is nothing
-        // half-merged to repair: skip the group and let the caller carry on with
-        // the rest of the batch. Retrying here would fail identically — the
-        // group itself is stale — so recovery is left to the next run, which
-        // recomputes groups from live rows.
+        // A record named by this group was deleted between group computation and
+        // now: the primary workout, one of the duplicates, or the planned workout
+        // being linked (`Workout.plannedWorkout` is optional and nullable, so its
+        // target can disappear on its own). The transaction rolled back in full,
+        // so there is nothing half-merged to repair: skip the group and let the
+        // caller carry on with the rest of the batch. Retrying here would fail
+        // identically — the group itself is stale — so recovery is left to the
+        // next run, which recomputes groups from live rows.
         logger.warn(
-          'Skipping duplicate group: a workout in it was deleted while the merge was running',
+          'Skipping duplicate group: a record it names was deleted while the merge was running',
           {
             bestWorkoutId: group.bestWorkoutId,
-            duplicateIds: group.toDelete
+            duplicateIds: group.toDelete,
+            plannedWorkoutId: plannedWorkoutToUpdateId
           }
         )
         return { deletedCount: 0, keptCount: 0, skipped: true }

--- a/server/utils/services/deduplicationService.ts
+++ b/server/utils/services/deduplicationService.ts
@@ -9,6 +9,26 @@ export interface DuplicateGroup {
   toDelete: string[]
 }
 
+export interface MergeDuplicateGroupResult {
+  deletedCount: number
+  keptCount: number
+  /** True when the group was abandoned because it no longer describes the database. */
+  skipped?: boolean
+}
+
+/**
+ * Prisma raises `P2025` ("An operation failed because it depends on one or more
+ * records that were required but not found") when a `where`-targeted row no
+ * longer exists. Matched by `code` rather than `instanceof` because the concrete
+ * error class differs between the query engines and is re-wrapped by the driver
+ * adapter — same duck-typing the rest of the codebase uses (see
+ * `server/api/auth/[...].ts`, `server/api/webhooks/revenuecat.post.ts`,
+ * `trigger/ingest-intervals.ts`).
+ */
+function isRecordNotFoundError(error: unknown): boolean {
+  return (error as { code?: string } | null)?.code === 'P2025'
+}
+
 export const deduplicationService = {
   /**
    * Identifies duplicate groups from a list of workouts.
@@ -344,8 +364,16 @@ export const deduplicationService = {
 
   /**
    * Executes the merge logic for a duplicate group.
+   *
+   * The group is computed *before* this call (see `findDuplicateGroups`, invoked
+   * once per run from `trigger/deduplicate-workouts.ts`), so by the time the
+   * merge transaction runs, any workout it names may already have been deleted —
+   * by the user, or by a concurrent dedup/ingest path working the same workouts.
+   * That is an expected concurrent-modification outcome, not a failure: the
+   * group is skipped so the rest of the batch still merges, and the next run
+   * recomputes the group from live rows without the deleted workout.
    */
-  async mergeDuplicateGroup(group: DuplicateGroup) {
+  async mergeDuplicateGroup(group: DuplicateGroup): Promise<MergeDuplicateGroupResult> {
     if (group.toDelete.length === 0) return { deletedCount: 0, keptCount: 1 }
 
     const duplicatesToDelete = await prisma.workout.findMany({
@@ -440,77 +468,110 @@ export const deduplicationService = {
       }
     }
 
-    // Execute all database updates in a transaction
-    await prisma.$transaction(async (tx) => {
-      // 1. Update planned workout status if linked
-      if (plannedWorkoutToUpdateId) {
-        await tx.plannedWorkout.update({
-          where: { id: plannedWorkoutToUpdateId },
-          data: {
-            completed: true,
-            completionStatus: 'COMPLETED'
-          }
+    // Execute all database updates in a transaction.
+    //
+    // Every write below targets a single row by id, and all of them write plain
+    // scalar columns (`completed`/`completionStatus`, `workoutId`,
+    // `completenessScore` and the merged metric fields, `isDuplicate`/
+    // `duplicateOf`) — there is no nested relation `connect` anywhere in the
+    // block. That is what makes the `P2025` catch below safe to keep narrow:
+    // with no `connect`, "required record not found" can only mean the row named
+    // in the `where` is gone, i.e. the group we were handed is stale. A missing
+    // *referenced* row (e.g. a `plannedWorkoutId` whose planned workout was
+    // deleted) surfaces as a foreign-key violation, `P2003`, and still throws.
+    try {
+      await prisma.$transaction(async (tx) => {
+        // 1. Update planned workout status if linked
+        if (plannedWorkoutToUpdateId) {
+          await tx.plannedWorkout.update({
+            where: { id: plannedWorkoutToUpdateId },
+            data: {
+              completed: true,
+              completionStatus: 'COMPLETED'
+            }
+          })
+        }
+
+        // 2. Stream Transfer Logic
+        // Check if bestWorkout already has streams in DB to avoid collision
+        const existingBestStream = await tx.workoutStream.findUnique({
+          where: { workoutId: bestWorkout.id },
+          select: { id: true }
         })
-      }
 
-      // 2. Stream Transfer Logic
-      // Check if bestWorkout already has streams in DB to avoid collision
-      const existingBestStream = await tx.workoutStream.findUnique({
-        where: { workoutId: bestWorkout.id },
-        select: { id: true }
-      })
-
-      if (!existingBestStream) {
-        // Find a donor that has streams
-        const donorWithStreams = duplicatesToDelete.find((w) => w.streams)
-        if (donorWithStreams) {
-          logger.log(
-            `Transferring streams from duplicate ${donorWithStreams.id} to best workout ${bestWorkout.id}`
-          )
-          await tx.workoutStream.update({
-            where: { workoutId: donorWithStreams.id },
-            data: { workoutId: bestWorkout.id }
-          })
+        if (!existingBestStream) {
+          // Find a donor that has streams
+          const donorWithStreams = duplicatesToDelete.find((w) => w.streams)
+          if (donorWithStreams) {
+            logger.log(
+              `Transferring streams from duplicate ${donorWithStreams.id} to best workout ${bestWorkout.id}`
+            )
+            await tx.workoutStream.update({
+              where: { workoutId: donorWithStreams.id },
+              data: { workoutId: bestWorkout.id }
+            })
+          }
         }
-      }
 
-      // 3. Exercise Transfer Logic
-      // Move exercise records if primary has none
-      const existingBestExercises = await tx.workoutExercise.count({
-        where: { workoutId: bestWorkout.id }
-      })
+        // 3. Exercise Transfer Logic
+        // Move exercise records if primary has none
+        const existingBestExercises = await tx.workoutExercise.count({
+          where: { workoutId: bestWorkout.id }
+        })
 
-      if (existingBestExercises === 0) {
-        const donorWithExercises = duplicatesList.find((w) => w.exercises && w.exercises.length > 0)
-        if (donorWithExercises) {
-          logger.log(
-            `Transferring exercises from duplicate ${donorWithExercises.id} to best workout ${bestWorkout.id}`
+        if (existingBestExercises === 0) {
+          const donorWithExercises = duplicatesList.find(
+            (w) => w.exercises && w.exercises.length > 0
           )
-          await tx.workoutExercise.updateMany({
-            where: { workoutId: donorWithExercises.id },
-            data: { workoutId: bestWorkout.id }
-          })
+          if (donorWithExercises) {
+            logger.log(
+              `Transferring exercises from duplicate ${donorWithExercises.id} to best workout ${bestWorkout.id}`
+            )
+            await tx.workoutExercise.updateMany({
+              where: { workoutId: donorWithExercises.id },
+              data: { workoutId: bestWorkout.id }
+            })
+          }
         }
-      }
 
-      // 4. Update primary workout with merged fields and completeness score
-      updates.completenessScore = this.calculateCompletenessScore({ ...bestWorkout, ...updates })
-      await tx.workout.update({
-        where: { id: group.bestWorkoutId },
-        data: updates
-      })
-
-      // 5. Mark duplicates with both boolean and explicit link
-      for (const id of group.toDelete) {
+        // 4. Update primary workout with merged fields and completeness score
+        updates.completenessScore = this.calculateCompletenessScore({ ...bestWorkout, ...updates })
         await tx.workout.update({
-          where: { id },
-          data: {
-            isDuplicate: true,
-            duplicateOf: group.bestWorkoutId
-          }
+          where: { id: group.bestWorkoutId },
+          data: updates
         })
+
+        // 5. Mark duplicates with both boolean and explicit link
+        for (const id of group.toDelete) {
+          await tx.workout.update({
+            where: { id },
+            data: {
+              isDuplicate: true,
+              duplicateOf: group.bestWorkoutId
+            }
+          })
+        }
+      })
+    } catch (error) {
+      if (isRecordNotFoundError(error)) {
+        // A workout named by this group was deleted between group computation
+        // and now. The transaction rolled back in full, so there is nothing
+        // half-merged to repair: skip the group and let the caller carry on with
+        // the rest of the batch. Retrying here would fail identically — the
+        // group itself is stale — so recovery is left to the next run, which
+        // recomputes groups from live rows.
+        logger.warn(
+          'Skipping duplicate group: a workout in it was deleted while the merge was running',
+          {
+            bestWorkoutId: group.bestWorkoutId,
+            duplicateIds: group.toDelete
+          }
+        )
+        return { deletedCount: 0, keptCount: 0, skipped: true }
       }
-    })
+
+      throw error
+    }
 
     // Update local bestWorkout object for consistency if needed by caller
     Object.assign(bestWorkout, updates)

--- a/tests/unit/server/utils/services/deduplicationService.test.ts
+++ b/tests/unit/server/utils/services/deduplicationService.test.ts
@@ -246,11 +246,27 @@ class PrismaRecordNotFoundError extends Error {
 }
 
 /**
+ * `WorkoutStream.workoutId` and `WorkoutExercise.workoutId` are foreign keys to
+ * `Workout.id`, so a transfer that points them at a deleted primary is rejected
+ * by the constraint rather than by a missing target row — a different code, and
+ * one the service must keep surfacing.
+ */
+class PrismaForeignKeyError extends Error {
+  code = 'P2003'
+
+  constructor(subject: string) {
+    super(`Foreign key constraint violated on the constraint: \`${subject}\``)
+    this.name = 'PrismaClientKnownRequestError'
+  }
+}
+
+/**
  * Minimal stand-in for the interactive transaction client, backed by a set of
- * workout ids that still exist. Any `workout.update` aimed at an id outside that
- * set fails the way Prisma does. Rollback is not modelled: the assertions are
- * about what the service does with the error, and the real transaction discards
- * every write in the block regardless.
+ * workout ids that still exist. Writes aimed at an id outside that set fail the
+ * way Prisma does: `P2025` when the row being *updated* is gone, `P2003` when
+ * the row being *referenced* is gone. Rollback is not modelled: the assertions
+ * are about what the service does with the error, and the real transaction
+ * discards every write in the block regardless.
  */
 function createTransactionDouble(liveWorkoutIds: string[]) {
   const live = new Set(liveWorkoutIds)
@@ -263,12 +279,29 @@ function createTransactionDouble(liveWorkoutIds: string[]) {
   const tx = {
     plannedWorkout: { update: vi.fn(async () => ({})) },
     workoutStream: {
+      // Null either way in these fixtures: the primary has no stream of its own,
+      // and when the primary is deleted its stream row cascades away with it
+      // (`onDelete: Cascade`). Both answers open the transfer path below.
       findUnique: vi.fn(async () => null),
-      update: vi.fn(async () => ({}))
+      update: vi.fn(async ({ where, data }: any) => {
+        if (!live.has(where.workoutId)) {
+          throw new PrismaRecordNotFoundError(`stream of workout ${where.workoutId}`)
+        }
+        if (!live.has(data.workoutId)) {
+          throw new PrismaForeignKeyError('WorkoutStream_workoutId_fkey')
+        }
+        return { workoutId: data.workoutId }
+      })
     },
     workoutExercise: {
+      // Zero either way, for the same cascade reason as the stream lookup.
       count: vi.fn(async () => 0),
-      updateMany: vi.fn(async () => ({ count: 0 }))
+      updateMany: vi.fn(async ({ data }: any) => {
+        if (!live.has(data.workoutId)) {
+          throw new PrismaForeignKeyError('WorkoutExercise_workoutId_fkey')
+        }
+        return { count: 1 }
+      })
     },
     workout: { update: workoutUpdate }
   }
@@ -276,15 +309,22 @@ function createTransactionDouble(liveWorkoutIds: string[]) {
   return { live, tx, workoutUpdate }
 }
 
-function installTransactionDouble(liveWorkoutIds: string[]) {
-  const double = createTransactionDouble(liveWorkoutIds)
+function installTransactionDouble(options: {
+  liveWorkoutIds: string[]
+  duplicateHasStreams?: boolean
+}) {
+  const double = createTransactionDouble(options.liveWorkoutIds)
 
   // `mergeDuplicateGroup` re-reads the duplicates just before the transaction;
   // rows deleted in the meantime are simply absent from the result.
   vi.mocked(prisma.workout.findMany).mockImplementation((async ({ where }: any) =>
     (where.id.in as string[])
       .filter((id) => double.live.has(id))
-      .map((id) => ({ id, plannedWorkoutId: null, streams: null }))) as any)
+      .map((id) => ({
+        id,
+        plannedWorkoutId: null,
+        streams: options.duplicateHasStreams ? { id: `stream-of-${id}` } : null
+      }))) as any)
 
   vi.mocked(prisma.$transaction as any).mockImplementation(async (callback: any) =>
     callback(double.tx)
@@ -293,7 +333,11 @@ function installTransactionDouble(liveWorkoutIds: string[]) {
   return double
 }
 
-function buildGroup(primaryId: string, duplicateId: string) {
+function buildGroup(
+  primaryId: string,
+  duplicateId: string,
+  duplicateOverrides: Record<string, unknown> = {}
+) {
   return {
     workouts: [
       {
@@ -312,7 +356,8 @@ function buildGroup(primaryId: string, duplicateId: string) {
         date: new Date('2026-03-09T10:01:00Z'),
         durationSec: 3610,
         plannedWorkoutId: null,
-        averageHr: 150
+        averageHr: 150,
+        ...duplicateOverrides
       }
     ],
     bestWorkoutId: primaryId,
@@ -328,7 +373,7 @@ describe('deduplicationService.mergeDuplicateGroup concurrent deletion', () => {
   it('skips the group when the primary workout is deleted before the merge transaction', async () => {
     const group = buildGroup('best-gone', 'duplicate-1')
     // Primary already deleted; the duplicate is still there.
-    const { workoutUpdate } = installTransactionDouble(['duplicate-1'])
+    const { workoutUpdate } = installTransactionDouble({ liveWorkoutIds: ['duplicate-1'] })
 
     const result = await deduplicationService.mergeDuplicateGroup(group)
 
@@ -346,7 +391,7 @@ describe('deduplicationService.mergeDuplicateGroup concurrent deletion', () => {
   it('skips the group when a non-primary member is deleted before the merge transaction', async () => {
     const group = buildGroup('best-1', 'duplicate-gone')
     // Primary survives; the duplicate is gone, so it only fails at step 5.
-    const { workoutUpdate } = installTransactionDouble(['best-1'])
+    const { workoutUpdate } = installTransactionDouble({ liveWorkoutIds: ['best-1'] })
 
     const result = await deduplicationService.mergeDuplicateGroup(group)
 
@@ -360,11 +405,9 @@ describe('deduplicationService.mergeDuplicateGroup concurrent deletion', () => {
     const staleGroup = buildGroup('stale-best', 'stale-duplicate')
     const healthyGroup = buildGroup('healthy-best', 'healthy-duplicate')
 
-    const { workoutUpdate } = installTransactionDouble([
-      'stale-duplicate',
-      'healthy-best',
-      'healthy-duplicate'
-    ])
+    const { workoutUpdate } = installTransactionDouble({
+      liveWorkoutIds: ['stale-duplicate', 'healthy-best', 'healthy-duplicate']
+    })
 
     // Mirrors the per-group loop in `trigger/deduplicate-workouts.ts`: it has no
     // error handling of its own, so a throw from any group aborts the batch.
@@ -388,9 +431,39 @@ describe('deduplicationService.mergeDuplicateGroup concurrent deletion', () => {
     })
   })
 
+  it('skips the group when the primary is deleted and a surviving duplicate has streams', async () => {
+    const group = buildGroup('best-gone', 'duplicate-1')
+    // The primary is gone, so its own stream row has cascaded away and the
+    // "does the primary already have streams?" guard opens the transfer path.
+    // Transferring the duplicate's stream would point an FK at a deleted
+    // workout, which is a P2003 — not the P2025 that identifies a stale group.
+    const { tx } = installTransactionDouble({
+      liveWorkoutIds: ['duplicate-1'],
+      duplicateHasStreams: true
+    })
+
+    const result = await deduplicationService.mergeDuplicateGroup(group)
+
+    expect(result).toEqual({ deletedCount: 0, keptCount: 0, skipped: true })
+    // The group is abandoned before the transfer is ever attempted.
+    expect(tx.workoutStream.update).not.toHaveBeenCalled()
+  })
+
+  it('skips the group when the primary is deleted and a surviving duplicate has exercises', async () => {
+    const group = buildGroup('best-gone', 'duplicate-1', {
+      exercises: [{ id: 'exercise-1' }]
+    })
+    const { tx } = installTransactionDouble({ liveWorkoutIds: ['duplicate-1'] })
+
+    const result = await deduplicationService.mergeDuplicateGroup(group)
+
+    expect(result).toEqual({ deletedCount: 0, keptCount: 0, skipped: true })
+    expect(tx.workoutExercise.updateMany).not.toHaveBeenCalled()
+  })
+
   it('still surfaces database failures that are not a missing target row', async () => {
     const group = buildGroup('best-1', 'duplicate-1')
-    const { tx } = installTransactionDouble(['best-1', 'duplicate-1'])
+    const { tx } = installTransactionDouble({ liveWorkoutIds: ['best-1', 'duplicate-1'] })
 
     const constraintViolation = Object.assign(new Error('Unique constraint failed'), {
       code: 'P2002'

--- a/tests/unit/server/utils/services/deduplicationService.test.ts
+++ b/tests/unit/server/utils/services/deduplicationService.test.ts
@@ -7,7 +7,11 @@ vi.mock('../../../../../server/utils/db', () => ({
   prisma: {
     plannedWorkout: {
       findMany: vi.fn()
-    }
+    },
+    workout: {
+      findMany: vi.fn()
+    },
+    $transaction: vi.fn()
   }
 }))
 
@@ -24,7 +28,9 @@ vi.mock('../../../../../server/utils/date', () => ({
 
 vi.mock('@trigger.dev/sdk/v3', () => ({
   logger: {
-    log: vi.fn()
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
   }
 }))
 
@@ -216,5 +222,183 @@ describe('deduplicationService.findProposedLink', () => {
       }
     })
     expect(result).toEqual({ id: 'planned-1', title: 'VO2 Max Mixer' })
+  })
+})
+
+/**
+ * CW-262 — duplicate groups are computed once per run, before any merge
+ * transaction opens (`findDuplicateGroups` in `trigger/deduplicate-workouts.ts`).
+ * A workout named by a group can therefore be deleted before its merge runs —
+ * by the user, or by a concurrent dedup/ingest path — and Prisma answers the
+ * `where`-targeted update with `P2025`, rolling the whole merge back
+ * (Sentry `COACH-WATTS-WEB-H`).
+ */
+class PrismaRecordNotFoundError extends Error {
+  code = 'P2025'
+
+  constructor(subject: string) {
+    super(
+      'An operation failed because it depends on one or more records that were required but ' +
+        `not found. No record was found for an update. (${subject})`
+    )
+    this.name = 'PrismaClientKnownRequestError'
+  }
+}
+
+/**
+ * Minimal stand-in for the interactive transaction client, backed by a set of
+ * workout ids that still exist. Any `workout.update` aimed at an id outside that
+ * set fails the way Prisma does. Rollback is not modelled: the assertions are
+ * about what the service does with the error, and the real transaction discards
+ * every write in the block regardless.
+ */
+function createTransactionDouble(liveWorkoutIds: string[]) {
+  const live = new Set(liveWorkoutIds)
+
+  const workoutUpdate = vi.fn(async ({ where }: any) => {
+    if (!live.has(where.id)) throw new PrismaRecordNotFoundError(`workout ${where.id}`)
+    return { id: where.id }
+  })
+
+  const tx = {
+    plannedWorkout: { update: vi.fn(async () => ({})) },
+    workoutStream: {
+      findUnique: vi.fn(async () => null),
+      update: vi.fn(async () => ({}))
+    },
+    workoutExercise: {
+      count: vi.fn(async () => 0),
+      updateMany: vi.fn(async () => ({ count: 0 }))
+    },
+    workout: { update: workoutUpdate }
+  }
+
+  return { live, tx, workoutUpdate }
+}
+
+function installTransactionDouble(liveWorkoutIds: string[]) {
+  const double = createTransactionDouble(liveWorkoutIds)
+
+  // `mergeDuplicateGroup` re-reads the duplicates just before the transaction;
+  // rows deleted in the meantime are simply absent from the result.
+  vi.mocked(prisma.workout.findMany).mockImplementation((async ({ where }: any) =>
+    (where.id.in as string[])
+      .filter((id) => double.live.has(id))
+      .map((id) => ({ id, plannedWorkoutId: null, streams: null }))) as any)
+
+  vi.mocked(prisma.$transaction as any).mockImplementation(async (callback: any) =>
+    callback(double.tx)
+  )
+
+  return double
+}
+
+function buildGroup(primaryId: string, duplicateId: string) {
+  return {
+    workouts: [
+      {
+        id: primaryId,
+        source: 'garmin',
+        type: 'Ride',
+        date: new Date('2026-03-09T10:00:00Z'),
+        durationSec: 3600,
+        // Pre-linked so the merge does not go looking for a planned workout.
+        plannedWorkoutId: 'planned-existing'
+      },
+      {
+        id: duplicateId,
+        source: 'strava',
+        type: 'Ride',
+        date: new Date('2026-03-09T10:01:00Z'),
+        durationSec: 3610,
+        plannedWorkoutId: null,
+        averageHr: 150
+      }
+    ],
+    bestWorkoutId: primaryId,
+    toDelete: [duplicateId]
+  }
+}
+
+describe('deduplicationService.mergeDuplicateGroup concurrent deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips the group when the primary workout is deleted before the merge transaction', async () => {
+    const group = buildGroup('best-gone', 'duplicate-1')
+    // Primary already deleted; the duplicate is still there.
+    const { workoutUpdate } = installTransactionDouble(['duplicate-1'])
+
+    const result = await deduplicationService.mergeDuplicateGroup(group)
+
+    expect(result).toEqual({ deletedCount: 0, keptCount: 0, skipped: true })
+    expect(workoutUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'best-gone' } })
+    )
+    // Step 5 never runs, so the surviving duplicate is not flagged against a
+    // primary that no longer exists.
+    expect(workoutUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'duplicate-1' } })
+    )
+  })
+
+  it('skips the group when a non-primary member is deleted before the merge transaction', async () => {
+    const group = buildGroup('best-1', 'duplicate-gone')
+    // Primary survives; the duplicate is gone, so it only fails at step 5.
+    const { workoutUpdate } = installTransactionDouble(['best-1'])
+
+    const result = await deduplicationService.mergeDuplicateGroup(group)
+
+    expect(result).toEqual({ deletedCount: 0, keptCount: 0, skipped: true })
+    expect(workoutUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'duplicate-gone' } })
+    )
+  })
+
+  it('keeps merging the remaining groups of the run after a stale group is skipped', async () => {
+    const staleGroup = buildGroup('stale-best', 'stale-duplicate')
+    const healthyGroup = buildGroup('healthy-best', 'healthy-duplicate')
+
+    const { workoutUpdate } = installTransactionDouble([
+      'stale-duplicate',
+      'healthy-best',
+      'healthy-duplicate'
+    ])
+
+    // Mirrors the per-group loop in `trigger/deduplicate-workouts.ts`: it has no
+    // error handling of its own, so a throw from any group aborts the batch.
+    const results = []
+    for (const group of [staleGroup, healthyGroup]) {
+      results.push(await deduplicationService.mergeDuplicateGroup(group))
+    }
+
+    expect(results[0]).toEqual({ deletedCount: 0, keptCount: 0, skipped: true })
+    expect(results[1]).toEqual({ deletedCount: 1, keptCount: 1 })
+
+    expect(workoutUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'healthy-best' },
+        data: expect.objectContaining({ averageHr: 150 })
+      })
+    )
+    expect(workoutUpdate).toHaveBeenCalledWith({
+      where: { id: 'healthy-duplicate' },
+      data: { isDuplicate: true, duplicateOf: 'healthy-best' }
+    })
+  })
+
+  it('still surfaces database failures that are not a missing target row', async () => {
+    const group = buildGroup('best-1', 'duplicate-1')
+    const { tx } = installTransactionDouble(['best-1', 'duplicate-1'])
+
+    const constraintViolation = Object.assign(new Error('Unique constraint failed'), {
+      code: 'P2002'
+    })
+    tx.workout.update.mockRejectedValueOnce(constraintViolation as never)
+
+    await expect(deduplicationService.mergeDuplicateGroup(group)).rejects.toThrow(
+      'Unique constraint failed'
+    )
   })
 })


### PR DESCRIPTION
Fixes CW-262

## Problem

`deduplicationService.mergeDuplicateGroup()` throws Prisma `P2025` from `tx.workout.update({ where: { id: group.bestWorkoutId } })` (Sentry `COACH-WATTS-WEB-H`, 14 occurrences, ongoing).

Duplicate groups are computed once per run — `findDuplicateGroups()` in `trigger/deduplicate-workouts.ts`, before any merge transaction opens — and then merged one group at a time. A workout named by a group can be deleted in the window between: by the user, or by a concurrent dedup/ingest path working the same workouts. Prisma answers the `where`-targeted update with `P2025`, the transaction rolls back, and because the per-group loop has no error handling of its own, the throw aborts the whole `deduplicate-workouts` run — the remaining, perfectly mergeable groups are lost too.

## Fix

Two parts.

### 1. Skip the stale group instead of throwing

A narrow `P2025` catch around `prisma.$transaction`. The stale group is skipped with a `{ deletedCount: 0, keptCount: 0, skipped: true }` result and a `logger.warn`, so the caller's loop continues with the rest of the batch. Recovery is left to the next run, which recomputes groups from live rows without the deleted workout — retrying in place would fail identically, since it is the group that is stale, not the operation.

Two things keep this from hiding real failures:

- **Matched by `error.code`, not `instanceof`.** The concrete Prisma error class differs by query engine and is re-wrapped by the driver adapter. Same duck-typing as `server/api/auth/[...].ts`, `server/api/webhooks/revenuecat.post.ts`, and `trigger/ingest-intervals.ts` (CW-410).
- **The catch is narrow by construction.** No write in the block uses a nested relation `connect`; each sets plain scalar columns on a row selected by a unique `where` (by `id`, or by the unique `workoutId` on `WorkoutStream`), and the single `updateMany` reports a `count` rather than raising when it matches nothing. So `P2025` here can only mean the row named in the `where` is gone.

The transaction rolls back in full before the catch runs, so there is never a half-merged group to repair.

### 2. Update the primary workout first, so the race actually lands on `P2025`

Merge review caught that part 1 alone was not sufficient. The stream and exercise transfer steps write `bestWorkout.id` into a foreign key:

```ts
await tx.workoutStream.update({ where: { workoutId: donor.id },   data: { workoutId: bestWorkout.id } })
await tx.workoutExercise.updateMany({ where: { workoutId: donor.id }, data: { workoutId: bestWorkout.id } })
```

`WorkoutStream.workout` and `WorkoutExercise.workout` are both `onDelete: Cascade`, so when the primary is deleted concurrently **its own stream and exercise rows cascade away with it**. The `existingBestStream === null` / `existingBestExercises === 0` guards therefore *open* the transfer paths precisely when the primary is gone. The transfer then points an FK at a deleted `Workout` → `P2003` → correctly declined by the narrow catch → rethrown → batch aborted. Same CW-262 symptom, new signature.

Both paths are live in production: `trigger/deduplicate-workouts.ts` loads `exercises: { select: { id: true } }` and attaches streams, so those donor lookups are real. The original 14 Sentry hits landed on the primary update only because those particular groups had no stream or exercise donor.

The fix is to move the primary `workout.update` to the **top** of the transaction. That makes the primary's existence a precondition enforced by the `P2025` catch, before anything depends on it. It is semantically free inside an atomic block: `updates.completenessScore` is derived from the in-memory `{ ...bestWorkout, ...updates }` and `calculateCompletenessScore` reads nothing the later steps write.

### Minor, same branch

- The catch can legitimately fire for a deleted **planned** workout — `Workout.plannedWorkout` is optional with no `onDelete`, so `tx.plannedWorkout.update` can raise `P2025` on its own. Behaviour was already correct (benign, self-healing), but the warn message said "a workout in it was deleted" and carried only workout ids, sending a debugger to the wrong table. It now says "a record it names" and includes `plannedWorkoutId`.
- Corrected the block comment's premise: two writes target by unique `workoutId` rather than `id`, and one is an `updateMany`. The `P2025` conclusion holds either way, but that comment is the justification a future reader will trust.

## Tests

`tests/unit/server/utils/services/deduplicationService.test.ts` gains six cases, driven by a transaction double backed by a set of still-live workout ids. The double raises `P2025` when the row being *updated* is gone and `P2003` when the row being *referenced* is gone.

1. `bestWorkoutId` deleted before the transaction — clean skip, and the surviving duplicate is not flagged against a primary that no longer exists.
2. A non-primary group member deleted — fails later, at the final step, clean skip.
3. Batch continuation — a stale group followed by a healthy one in the same loop; the healthy group still merges its fields and marks its duplicate.
4. **Primary deleted with a surviving duplicate that has streams** — the transfer path is open, and the group is abandoned before the transfer is attempted.
5. **Primary deleted with a surviving duplicate that has exercises** — same, via `updateMany`.
6. A non-`P2025` database failure (`P2002`) still propagates.

## Verification

`pnpm test:unit`, run bare with no path filter:

```
Test Files  390 passed (390)
     Tests  2698 passed (2698)
  Duration  67.90s
```

`pnpm typecheck` (exit 0) and `eslint` on the changed files are also clean.

**Evidence the tests fail pre-fix.** Cases 1-3, with the service stashed to its original state:

```
Tests  3 failed | 11 passed (14)

FAIL > skips the group when the primary workout is deleted before the merge transaction
PrismaClientKnownRequestError: ... No record was found for an update. (workout best-gone)
 ❯ server/utils/services/deduplicationService.ts:498:24

FAIL > skips the group when a non-primary member is deleted before the merge transaction
PrismaClientKnownRequestError: ... No record was found for an update. (workout duplicate-gone)
 ❯ server/utils/services/deduplicationService.ts:505:26

FAIL > keeps merging the remaining groups of the run after a stale group is skipped
PrismaClientKnownRequestError: ... No record was found for an update. (workout stale-best)
 ❯ server/utils/services/deduplicationService.ts:498:24
```

Line 498 is exactly the frame in the Sentry report.

Cases 4-5, against the previous commit's ordering (catch in place, primary update still last):

```
Tests  2 failed | 14 passed (16)

FAIL > skips the group when the primary is deleted and a surviving duplicate has streams
PrismaClientKnownRequestError: Foreign key constraint violated on the constraint: `WorkoutStream_workoutId_fkey`
 ❯ server/utils/services/deduplicationService.ts:509:36

FAIL > skips the group when the primary is deleted and a surviving duplicate has exercises
PrismaClientKnownRequestError: Foreign key constraint violated on the constraint: `WorkoutExercise_workoutId_fkey`
 ❯ server/utils/services/deduplicationService.ts:530:38
```

Lines 509 and 530 are the two FK writes flagged in review. Case 6 passes before and after by design — it pins the catch's narrowness rather than the fix.

## Scope

Files changed match the ticket's Owned Paths exactly:

- `server/utils/services/deduplicationService.ts`
- `tests/unit/server/utils/services/deduplicationService.test.ts`

`trigger/deduplicate-workouts.ts` is untouched — batch continuation is achieved entirely by the service resolving instead of throwing, which is why the loop is mirrored in test 3 rather than modified.

## Risks

- A group whose primary or member vanishes is now merged one run later instead of failing loudly. Deliberate, and self-healing: the group no longer exists in the recomputed set once the deleted workout is gone.
- The return type gains an optional `skipped` flag. Both existing callers (`trigger/deduplicate-workouts.ts`, `cli/debug/deduplicate.ts`) read only `deletedCount`/`keptCount` and are unaffected.
- A skipped group is not surfaced in the task output or the dedup modal, so a user can see "deleted: 1" with nothing saying a second group was abandoned. Strictly better than the old whole-run failure, and filed separately as CW-662.
- CW-310 (transaction-start timeout) owns the same `prisma.$transaction` block. Its scope is untouched here, but the block is now wrapped in a `try`/`catch` **and** its steps reordered, so that work should branch after this lands. Noted on the ticket.

UX critique: skipped — background task, no user-facing surface.
