### PR TITLE
fix(infra): make the trigger/ import guard catch typo'd export names (CW-605)

### DIFF
--- a/tests/unit/trigger/imports.test.ts
+++ b/tests/unit/trigger/imports.test.ts
@@ -26,9 +26,17 @@
  *                            skipped: they are erased at runtime and have nothing to check.
  *   3. TASKS ARE EXPORTED  — every `task({ id: '...' })` declared in the source is reachable as a
  *                            runtime export. A task that is defined but not exported never
- *                            registers with Trigger.dev. This also keeps check 2's discovery
- *                            honest: the expectation comes from the source, so if export
- *                            detection ever breaks, this fails loudly instead of passing vacuously.
+ *                            registers with Trigger.dev. Because that expectation is source-derived
+ *                            and non-empty, it also keeps the *runtime-export detector* honest.
+ *                            It says nothing about check 2, though: `readNamedBindings` and
+ *                            `readDeclaredTaskIds` are independent parsers, so a regression in the
+ *                            former is completely invisible here.
+ *
+ * The source parsers themselves are guarded by the discovery tripwire ('discovery itself found
+ * something to check'), which asserts all three discovery outputs are non-trivial. Every per-module
+ * check iterates over data produced at collection time, so a parser that silently returned nothing
+ * would leave all 75 module tests green while asserting nothing — the exact failure this file
+ * exists to eliminate, reproduced one level up. The tripwire is what makes that impossible.
  *
  * MAINTENANCE
  * -----------
@@ -214,11 +222,29 @@ function describeAvailable(name: string, available: string[]): string {
 }
 
 describe('trigger/ module guard', () => {
-  test('finds the trigger modules on disk', () => {
-    // A tripwire for the discovery itself: an empty or obviously truncated list would make every
-    // other test in this file pass while checking nothing.
+  test('discovery itself found something to check', () => {
+    // Tripwire over all three discovery outputs — the file list AND both source parsers. Every
+    // per-module check below iterates over data produced at collection time, so a detector that
+    // silently returned nothing (a TypeScript API change, or a future "simplification" of the
+    // isTypeOnly filters) would leave all 75 module tests green while asserting nothing at all.
+    //
+    // Thresholds sit well below the current actuals — 75 modules, 913 named bindings, 66 task ids
+    // — so ordinary churn never trips them, but a collapsed detector does.
     expect(modules.length).toBeGreaterThan(50)
     expect(modules.map((m) => m.rel)).toContain('trigger/garmin-backfill.ts')
+
+    const namedBindingCount = modules.reduce(
+      (total, module) =>
+        total + module.namedBindings.reduce((count, use) => count + use.names.length, 0),
+      0
+    )
+    expect(namedBindingCount).toBeGreaterThan(500)
+
+    const declaredTaskIdCount = modules.reduce(
+      (total, module) => total + module.declaredTaskIds.length,
+      0
+    )
+    expect(declaredTaskIdCount).toBeGreaterThan(40)
   })
 
   test.each(modules.map((module) => [module.rel, module] as const))(

--- a/tests/unit/trigger/imports.test.ts
+++ b/tests/unit/trigger/imports.test.ts
@@ -1,66 +1,288 @@
+/**
+ * Static guard for `trigger/` — the only automated coverage those files have.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `trigger/` is outside every tsconfig project (CW-560), so `pnpm typecheck` does not see it.
+ * These are Trigger.dev tasks that run against production data, so this test is the sole gate
+ * standing between a broken module and production.
+ *
+ * WHAT IT GUARANTEES (and why a bare `await import()` is not enough)
+ * -----------------------------------------------------------------
+ * The previous version of this test imported a hardcoded list of modules and asserted only that
+ * the import did not throw. That caught a bad *module specifier* but not a bad *export name*:
+ * esbuild lowers `import { Foo } from 'bar'` to a namespace property access, so a typo'd export
+ * name binds `undefined` and throws only at call time — in production, on whichever branch first
+ * touches it (CW-512: `AbortTaskRunError`, reached only by a user with no Garmin integration).
+ *
+ * So this file asserts three things per module, and derives everything from disk and from the
+ * source itself — there is no hand-maintained list to forget to update (CW-605):
+ *
+ *   1. MODULE RESOLVES     — the module imports without throwing. Catches bad module specifiers
+ *                            and import-time crashes.
+ *   2. BINDINGS EXIST      — every value-level named import (and named re-export) in the source
+ *                            actually exists on the module it is imported from. Catches the
+ *                            typo'd export name that check 1 is blind to. Type-only imports are
+ *                            skipped: they are erased at runtime and have nothing to check.
+ *   3. TASKS ARE EXPORTED  — every `task({ id: '...' })` declared in the source is reachable as a
+ *                            runtime export. A task that is defined but not exported never
+ *                            registers with Trigger.dev. This also keeps check 2's discovery
+ *                            honest: the expectation comes from the source, so if export
+ *                            detection ever breaks, this fails loudly instead of passing vacuously.
+ *
+ * MAINTENANCE
+ * -----------
+ * Nothing here needs updating when a task is added, renamed or deleted. If CW-560 lands and
+ * `trigger/` is genuinely typechecked, checks 1 and 2 become redundant and this file can be
+ * reduced to check 3 (or deleted); until then it is the only thing covering these files.
+ */
 import { describe, test, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 
-const triggers = [
-  'adapt-training-plan',
-  'adjust-structured-workout',
-  'analyze-last-3-nutrition',
-  'analyze-last-3-workouts',
-  'analyze-last-7-nutrition',
-  'analyze-nutrition',
-  'analyze-plan-adherence',
-  'analyze-wellness',
-  'analyze-workout',
-  'autodetect-intervals-profile',
-  'daily-checkin',
-  'daily-coach',
-  'deduplicate-workouts',
-  'delete-user-account',
-  'garmin-backfill',
-  'generate-ad-hoc-workout',
-  'generate-athlete-profile',
-  'generate-custom-report',
-  'generate-implementation-guide',
-  'generate-recommendations',
-  'generate-report',
-  'generate-score-explanations',
-  'generate-structured-workout',
-  'generate-training-block',
-  'generate-weekly-plan',
-  'generate-weekly-report',
-  'generate-workout-messages',
-  'hello-world',
-  'ingest-all',
-  'ingest-fit-file',
-  'ingest-fitbit',
-  'ingest-hevy',
-  'ingest-liftosaur',
-  'ingest-intervals-streams',
-  'ingest-intervals',
-  'ingest-oura',
-  'ingest-strava-streams',
-  'ingest-strava',
-  'ingest-whoop',
-  'ingest-withings',
-  'ingest-yazio',
-  'init',
-  'process-sync-queue',
-  'queues',
-  'recommend-today-activity',
-  'review-goals',
-  'sentry-error-test',
-  'suggest-goals'
-]
+const testDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(testDir, '../../..')
+const triggerDir = path.join(repoRoot, 'trigger')
 
-describe('Trigger Imports', () => {
-  triggers.forEach((trigger) => {
-    test(`should import ${trigger}.ts without error`, async () => {
-      try {
-        await import(`../../../trigger/${trigger}.ts`)
-        expect(true).toBe(true)
-      } catch (error) {
-        console.error(`Failed to import trigger/${trigger}:`, error)
-        throw error
+interface NamedBindingUse {
+  /** Module specifier exactly as written in the source. */
+  specifier: string
+  /** Names expected to exist on that module (the *exported* name, not the local alias). */
+  names: string[]
+}
+
+interface TriggerModule {
+  /** Repo-relative path, used as the test name so a failure names the module. */
+  rel: string
+  /** Absolute path, used for the dynamic import. */
+  abs: string
+  namedBindings: NamedBindingUse[]
+  /** Task ids declared in the source, e.g. `task({ id: 'garmin-backfill' })`. */
+  declaredTaskIds: string[]
+}
+
+/** Every real module under `trigger/`, found on disk rather than listed by hand. */
+function collectModuleFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      found.push(...collectModuleFiles(abs))
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      found.push(abs)
+    }
+  }
+  return found
+}
+
+/**
+ * Value-level named imports/re-exports in a source file.
+ *
+ * Type-only forms are dropped — both `import type { A } from 'x'` and the inline
+ * `import { type A, b } from 'x'` — because they are erased before the module ever runs.
+ */
+function readNamedBindings(source: ts.SourceFile): NamedBindingUse[] {
+  const uses: NamedBindingUse[] = []
+
+  for (const statement of source.statements) {
+    let clause: ts.NamedImports | ts.NamedExports | undefined
+    let moduleSpecifier: ts.Expression | undefined
+
+    if (ts.isImportDeclaration(statement)) {
+      const importClause = statement.importClause
+      if (!importClause || importClause.isTypeOnly) continue
+      const bindings = importClause.namedBindings
+      if (!bindings || !ts.isNamedImports(bindings)) continue
+      clause = bindings
+      moduleSpecifier = statement.moduleSpecifier
+    } else if (ts.isExportDeclaration(statement)) {
+      if (statement.isTypeOnly || !statement.moduleSpecifier) continue
+      const exportClause = statement.exportClause
+      if (!exportClause || !ts.isNamedExports(exportClause)) continue
+      clause = exportClause
+      moduleSpecifier = statement.moduleSpecifier
+    } else {
+      continue
+    }
+
+    if (!moduleSpecifier || !ts.isStringLiteral(moduleSpecifier)) continue
+
+    // `propertyName` is set only when the binding is aliased (`import { a as b }`), and it holds
+    // the name on the *source* module — which is the one that has to exist.
+    const names = clause.elements
+      .filter((element) => !element.isTypeOnly)
+      .map((element) => (element.propertyName ?? element.name).text)
+
+    if (names.length > 0) uses.push({ specifier: moduleSpecifier.text, names })
+  }
+
+  return uses
+}
+
+/** Task ids declared in the source: any `…task({ id: '<literal>' })` call. */
+function readDeclaredTaskIds(source: ts.SourceFile): string[] {
+  const ids: string[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression
+      const calleeName = ts.isPropertyAccessExpression(callee)
+        ? callee.name.text
+        : ts.isIdentifier(callee)
+          ? callee.text
+          : ''
+
+      if (/task$/i.test(calleeName)) {
+        const [config] = node.arguments
+        if (config && ts.isObjectLiteralExpression(config)) {
+          for (const property of config.properties) {
+            if (
+              ts.isPropertyAssignment(property) &&
+              ts.isIdentifier(property.name) &&
+              property.name.text === 'id' &&
+              ts.isStringLiteral(property.initializer)
+            ) {
+              ids.push(property.initializer.text)
+            }
+          }
+        }
       }
-    }, 30000)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(source)
+  return ids
+}
+
+const modules: TriggerModule[] = collectModuleFiles(triggerDir)
+  .sort()
+  .map((abs) => {
+    const source = ts.createSourceFile(
+      abs,
+      readFileSync(abs, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    )
+    return {
+      rel: path.relative(repoRoot, abs),
+      abs,
+      namedBindings: readNamedBindings(source),
+      declaredTaskIds: readDeclaredTaskIds(source)
+    }
+  })
+
+/**
+ * Load a module namespace once and reuse it. Everything here is already in the module graph by
+ * the time we look at it (the trigger module that imports it has been loaded), so this is a cache
+ * hit rather than a second evaluation.
+ */
+const namespaces = new Map<string, Promise<Record<string, unknown>>>()
+
+function loadNamespace(id: string): Promise<Record<string, unknown>> {
+  let pending = namespaces.get(id)
+  if (!pending) {
+    pending = import(/* @vite-ignore */ id) as Promise<Record<string, unknown>>
+    namespaces.set(id, pending)
+  }
+  return pending
+}
+
+/** Relative specifiers must be resolved against the importing file, not against this test. */
+function resolveSpecifier(fromFile: string, specifier: string): string {
+  return specifier.startsWith('.') ? path.resolve(path.dirname(fromFile), specifier) : specifier
+}
+
+function describeAvailable(name: string, available: string[]): string {
+  const lowered = name.toLowerCase()
+  const near = available.filter(
+    (candidate) =>
+      candidate.toLowerCase().includes(lowered) || lowered.includes(candidate.toLowerCase())
+  )
+  if (near.length > 0) return `did you mean ${near.map((n) => `'${n}'`).join(', ')}?`
+  const shown = [...available].sort().slice(0, 12)
+  const suffix =
+    available.length > shown.length ? `, …+${available.length - shown.length} more` : ''
+  return `exports: ${shown.map((n) => `'${n}'`).join(', ')}${suffix}`
+}
+
+describe('trigger/ module guard', () => {
+  test('finds the trigger modules on disk', () => {
+    // A tripwire for the discovery itself: an empty or obviously truncated list would make every
+    // other test in this file pass while checking nothing.
+    expect(modules.length).toBeGreaterThan(50)
+    expect(modules.map((m) => m.rel)).toContain('trigger/garmin-backfill.ts')
+  })
+
+  test.each(modules.map((module) => [module.rel, module] as const))(
+    '%s imports cleanly, and every imported binding and declared task exists',
+    async (rel, module) => {
+      // 1. MODULE RESOLVES — a bad module specifier or an import-time crash fails here.
+      const namespace = (await import(/* @vite-ignore */ module.abs)) as Record<string, unknown>
+
+      // 2. BINDINGS EXIST — the check a bare import cannot make.
+      const missing: string[] = []
+      for (const use of module.namedBindings) {
+        const id = resolveSpecifier(module.abs, use.specifier)
+        let target: Record<string, unknown>
+        try {
+          target = await loadNamespace(id)
+        } catch (error) {
+          missing.push(
+            `  from '${use.specifier}' — module failed to load: ${(error as Error).message}`
+          )
+          continue
+        }
+        const available = Object.keys(target)
+        for (const name of use.names) {
+          if (!(name in target)) {
+            missing.push(
+              `  { ${name} } from '${use.specifier}' — ${describeAvailable(name, available)}`
+            )
+          }
+        }
+      }
+      if (missing.length > 0) {
+        throw new Error(
+          `${rel} imports ${missing.length} binding(s) that do not exist.\n` +
+            `These bind to undefined at runtime and throw only when the code path is reached:\n` +
+            missing.join('\n')
+        )
+      }
+
+      // 3. TASKS ARE EXPORTED — a task defined but not exported never registers with Trigger.dev.
+      const exportedTaskIds = Object.values(namespace)
+        .map((value) => (value as { id?: unknown } | null)?.id)
+        .filter((id): id is string => typeof id === 'string')
+      const unexported = module.declaredTaskIds.filter((id) => !exportedTaskIds.includes(id))
+      if (unexported.length > 0) {
+        throw new Error(
+          `${rel} declares task id(s) ${unexported.map((id) => `'${id}'`).join(', ')} ` +
+            `but does not export them (exported task ids: ` +
+            `${exportedTaskIds.map((id) => `'${id}'`).join(', ') || 'none'}).`
+        )
+      }
+    },
+    30000
+  )
+
+  test('task ids are unique across trigger/', () => {
+    const seen = new Map<string, string[]>()
+    for (const module of modules) {
+      for (const id of module.declaredTaskIds) {
+        seen.set(id, [...(seen.get(id) ?? []), module.rel])
+      }
+    }
+    const duplicates = [...seen.entries()].filter(([, files]) => files.length > 1)
+    expect(duplicates.map(([id, files]) => `'${id}' declared in ${files.join(' and ')}`)).toEqual(
+      []
+    )
   })
 })


### PR DESCRIPTION
Fixes CW-605

## Route decision

CW-605 offers two routes and says to close it as superseded if the CW-560 tsconfig route is chosen. **CW-560 is still `Todo` and unassigned**, so that route is not landing now — and CW-605's Owned Paths are a single test file. Implemented the per-module export-assertion route here. CW-560 remains the stronger fix and is unaffected; the file's header comment says explicitly what becomes redundant if CW-560 lands.

## Problem

`trigger/` is outside every tsconfig project (CW-560), so `pnpm typecheck` does not see it. `tests/unit/trigger/imports.test.ts` was the only automated guard on those production modules — and it asserted only that a **hardcoded list of 48 modules** imported without throwing.

That catches a bad module *specifier* but not a bad *export name*. esbuild lowers `import { Foo } from 'bar'` to a namespace property access, so a typo'd export binds `undefined` and throws only at call time — CW-512's case, where `AbortTaskRunError` was reachable only by a user with no Garmin integration.

## Change

The module list is now derived from disk (`trigger/**/*.ts`, excluding `*.test.ts`/`*.d.ts`), and each module is checked three ways:

1. **Module resolves** — imports without throwing (catches bad specifiers, import-time crashes).
2. **Bindings exist** — every value-level named import and named re-export in the source actually exists on the module it comes from, verified by parsing the source with the TypeScript parser and inspecting the target namespace. Type-only forms (`import type {}` and inline `{ type A }`) are skipped: they are erased before the module runs. **This is the check that closes the gap.**
3. **Tasks are exported** — every `task({ id })` declared in the source is reachable as a runtime export. A task defined but not exported never registers with Trigger.dev. Because that expectation is source-derived and non-empty, it also keeps the **runtime-export detector** honest — but only that one. It says nothing about check 2: `readNamedBindings` and `readDeclaredTaskIds` are independent parsers, so a regression in the former is invisible to check 3. (An earlier revision of this PR body and the file header both overclaimed here; corrected in `6c0945c7`.)

Plus: task ids are asserted unique across `trigger/`, and a **discovery tripwire** guards all three discovery outputs — see below.

### The discovery layer is guarded too (review finding F1)

Every per-module check iterates over data produced at collection time. So if `readNamedBindings` ever silently returned `[]` — a TypeScript API change, or a future "simplification" of the `isTypeOnly` filters — check 2 would have nothing to iterate, all 75 module tests would still pass, and the suite would be green at 77/77 while checking nothing. That is the same defect this ticket exists to eliminate, reproduced one level up in the fix for it.

The tripwire now asserts all three discovery outputs are non-trivial, with thresholds well below the current actuals (75 modules, 913 named bindings, 66 task ids) so ordinary churn cannot trip them:

| Collapsed detector | Result |
| --- | --- |
| `readNamedBindings` → `[]` | **fails** — `AssertionError: expected 0 to be greater than 500`, other 76 tests still pass |
| `readDeclaredTaskIds` → `[]` | **fails** — `AssertionError: expected 0 to be greater than 40`, other 76 tests still pass |

"76 tests still pass" is the point: without the tripwire, a collapsed parser was entirely green.

Nothing needs updating when a task is added or renamed — which is exactly why `garmin-backfill` was missing from the hardcoded array.

**Coverage: 48 → 75 modules** (68 top-level + 7 under `trigger/utils`).

## Negative controls — the guard proven to fail

Each fault was injected into `trigger/garmin-backfill.ts`, the suite run, then reverted.

| Injected fault | Old guard | New guard |
| --- | --- | --- |
| `from '@trigger.dev/sdk/v3-NONEXISTENT'` (bad specifier) | fails | **fails** — 1 failed / 76 passed |
| `import { AbortTaskRunErrorTYPO }` from the **valid** module | **passes, 48/48** (re-confirmed on this branch) | **fails** — 1 failed / 76 passed |
| task declared but not exported (`export const` → `const`) | passes | **fails** — 1 failed / 76 passed |

The typo'd-export failure, naming the module:

```
FAIL tests/unit/trigger/imports.test.ts > trigger/ module guard >
  trigger/garmin-backfill.ts imports cleanly, and every imported binding and declared task exists
Error: trigger/garmin-backfill.ts imports 1 binding(s) that do not exist.
These bind to undefined at runtime and throw only when the code path is reached:
  { AbortTaskRunErrorTYPO } from '@trigger.dev/sdk/v3' — did you mean 'AbortTaskRunError', 'task'?
```

The old-guard row is not quoted from the ticket: the pre-change test file was restored from `HEAD` alongside the same injected typo and observed passing 48/48 on this branch.

## Verification

`pnpm test:unit` — run **bare**, no path filter, on the committed (post-prettier) content:

```
Test Files  390 passed (390)
     Tests  2721 passed (2721)
  Duration  58.93s
```

`pnpm lint` — 0 errors (116 pre-existing `vue/require-default-prop` warnings, none in this file).

## Notes

- **Runtime (CW-636):** the file covers 27 more modules and does strictly more work, but standalone duration is unchanged in practice — 5.47s before, 4.88s after on a warm cache. Target namespaces are already in the module graph when inspected, so they are cache hits, and the TypeScript parse is parse-only (no typecheck).
- **Count confirmed, not repeated:** the ticket's "13 modules uncovered" is correct as defined — 20 top-level modules were absent from the hardcoded array, 7 of which had a dedicated `tests/unit/trigger/<name>.test.ts`, leaving 13 with neither: `execute-chat-turn`, `generate-fueling-plan`, `ingest-polar`, `ingest-rouvy`, `ingest-rouvy-fit`, `ingest-strava-activity`, `ingest-ultrahuman`, `nutrition-last-call`, `poll-ultrahuman`, `process-resend-webhook`, `schedule-onboarding-drip`, `summarize-chat`, `types`.
- **Files vs Owned Paths:** exactly `tests/unit/trigger/imports.test.ts`, nothing else. No `trigger/` file is modified by this PR — the fault injections were reverted and `git status` verified clean after each.
- **Follow-ups filed, deliberately not fixed here** (review findings F2–F5): CW-663 (dynamic destructured imports are invisible to check 2), CW-664 (the `/task$/i` callee match could fail a future build on legitimate code), CW-665 (two polish items).
- **Risk:** check 2 resolves each specifier from the test file rather than from the importing module (relative specifiers are re-resolved against the importer first). All non-relative specifiers in `trigger/` are plain npm packages — no `#imports`/`~` aliases — so there is no importer-relative resolution to get wrong today.

UX critique: skipped — test tooling, no user-facing surface.
